### PR TITLE
[codex] add macOS release signing

### DIFF
--- a/.github/workflows/release-desktop.yml
+++ b/.github/workflows/release-desktop.yml
@@ -119,10 +119,30 @@ jobs:
         if: matrix.runner == 'windows-latest'
         run: node scripts/stage-bundled-runtime.mjs --tag "${{ github.event.inputs.bundled_runtime_tag || 'latest' }}" --platform win32 --arch x64
 
+      - name: Prepare macOS signing credentials
+        if: matrix.runner == 'macos-14'
+        shell: bash
+        env:
+          APPLE_API_KEY: ${{ secrets.APPLE_API_KEY }}
+          APPLE_API_PRIVATE_KEY: ${{ secrets.APPLE_API_PRIVATE_KEY }}
+        run: |
+          test -n "$APPLE_API_KEY"
+          test -n "$APPLE_API_PRIVATE_KEY"
+
+          mkdir -p "$RUNNER_TEMP/appstoreconnect/private_keys"
+          printf '%s\n' "$APPLE_API_PRIVATE_KEY" > "$RUNNER_TEMP/appstoreconnect/private_keys/AuthKey_${APPLE_API_KEY}.p8"
+          chmod 600 "$RUNNER_TEMP/appstoreconnect/private_keys/AuthKey_${APPLE_API_KEY}.p8"
+
       - name: Build + upload installers
         uses: tauri-apps/tauri-action@v0
         env:
           GITHUB_TOKEN: ${{ secrets.GITHUB_TOKEN }}
+          APPLE_CERTIFICATE: ${{ secrets.APPLE_CERTIFICATE }}
+          APPLE_CERTIFICATE_PASSWORD: ${{ secrets.APPLE_CERTIFICATE_PASSWORD }}
+          APPLE_SIGNING_IDENTITY: ${{ secrets.APPLE_SIGNING_IDENTITY }}
+          APPLE_API_KEY: ${{ secrets.APPLE_API_KEY }}
+          APPLE_API_ISSUER: ${{ secrets.APPLE_API_ISSUER }}
+          APPLE_API_KEY_PATH: ${{ runner.temp }}/appstoreconnect/private_keys/AuthKey_${{ secrets.APPLE_API_KEY }}.p8
         with:
           # tauri-action looks up the tag from this input. On a push:tags
           # trigger it falls back to GITHUB_REF, but we pass it explicitly
@@ -149,3 +169,39 @@ jobs:
           # Mark SemVer prerelease tags as prerelease on GitHub Releases.
           prerelease: ${{ contains(github.ref_name, '-alpha') || contains(github.ref_name, '-beta') || contains(github.ref_name, '-rc') }}
           args: --target ${{ matrix.target }}
+
+      - name: Notarize, staple, verify, and reupload macOS DMG
+        if: matrix.runner == 'macos-14'
+        shell: bash
+        env:
+          GH_TOKEN: ${{ secrets.GITHUB_TOKEN }}
+          RELEASE_TAG: ${{ github.event.inputs.tag || github.ref_name }}
+          APPLE_API_KEY: ${{ secrets.APPLE_API_KEY }}
+          APPLE_API_ISSUER: ${{ secrets.APPLE_API_ISSUER }}
+          APPLE_API_KEY_PATH: ${{ runner.temp }}/appstoreconnect/private_keys/AuthKey_${{ secrets.APPLE_API_KEY }}.p8
+        run: |
+          set -euo pipefail
+          shopt -s nullglob
+
+          dmgs=(target/${{ matrix.target }}/release/bundle/dmg/*.dmg)
+          if [ ${#dmgs[@]} -eq 0 ]; then
+            echo "No macOS DMG bundle found" >&2
+            exit 1
+          fi
+
+          for dmg in "${dmgs[@]}"; do
+            echo "Notarizing final DMG: $dmg"
+            xcrun notarytool submit "$dmg" \
+              --key "$APPLE_API_KEY_PATH" \
+              --key-id "$APPLE_API_KEY" \
+              --issuer "$APPLE_API_ISSUER" \
+              --wait
+
+            xcrun stapler staple "$dmg"
+            xcrun stapler validate "$dmg"
+            spctl -a -vvv -t open --context context:primary-signature "$dmg"
+
+            # tauri-action already uploaded the first DMG. Replace it with the
+            # final notarized + stapled DMG so the release asset is the one users download.
+            gh release upload "$RELEASE_TAG" "$dmg" --clobber
+          done

--- a/.github/workflows/release-desktop.yml
+++ b/.github/workflows/release-desktop.yml
@@ -136,7 +136,7 @@ jobs:
       - name: Build + upload installers
         uses: tauri-apps/tauri-action@v0
         env:
-          GITHUB_TOKEN: ${{ secrets.GITHUB_TOKEN }}
+          GITHUB_TOKEN: ${{ secrets.RELEASE_TOKEN || github.token }}
           APPLE_CERTIFICATE: ${{ secrets.APPLE_CERTIFICATE }}
           APPLE_CERTIFICATE_PASSWORD: ${{ secrets.APPLE_CERTIFICATE_PASSWORD }}
           APPLE_SIGNING_IDENTITY: ${{ secrets.APPLE_SIGNING_IDENTITY }}
@@ -174,7 +174,7 @@ jobs:
         if: matrix.runner == 'macos-14'
         shell: bash
         env:
-          GH_TOKEN: ${{ secrets.GITHUB_TOKEN }}
+          GH_TOKEN: ${{ secrets.RELEASE_TOKEN || github.token }}
           RELEASE_TAG: ${{ github.event.inputs.tag || github.ref_name }}
           APPLE_API_KEY: ${{ secrets.APPLE_API_KEY }}
           APPLE_API_ISSUER: ${{ secrets.APPLE_API_ISSUER }}


### PR DESCRIPTION
## What changed

- Add macOS Developer ID signing credentials to the release workflow environment.
- Write the App Store Connect API key to a temporary `.p8` file during release jobs.
- Notarize, staple, verify, and re-upload the generated macOS DMG asset after `tauri-action` builds it.
- Allow an optional `RELEASE_TOKEN` override while keeping the default `github.token` path.

## Why

The release workflow could build installers, but the macOS package path needed explicit Developer ID signing and notarization handling for outside-App-Store distribution. Protected `main` also requires these workflow changes to land through PR instead of direct push.

## Verification

- Release workflow run `26227330428` completed successfully for tag `v0.1.0`.
- Published macOS DMG was validated locally with `xcrun stapler validate` and `spctl`, showing `source=Notarized Developer ID`.
- Published release: https://github.com/Eynzof/hermes-agent-cn-desktop/releases/tag/v0.1.0

## Notes

`RELEASE_TOKEN` is optional fallback support only. The temporary token secret used for the one-off release was removed after the successful run.
