### PR TITLE
[codex] refine desktop style polish

### DIFF
--- a/web/src/components/app-shell/app-top-bar.module.css
+++ b/web/src/components/app-shell/app-top-bar.module.css
@@ -21,27 +21,43 @@
 .brand {
   display: flex;
   align-items: center;
-  gap: 8px;
+  gap: 7px;
   width: calc(var(--h-sidebar-w) - 30px);
+  height: 44px;
+  padding: 0 2px 0 4px;
   flex-shrink: 0;
-  font-family: var(--h-font-brand);
-  font-style: normal;
-  font-size: 17px;
-  font-weight: 400;
   color: var(--h-text);
-  letter-spacing: -0.02em;
+  text-decoration: none;
   user-select: none;
+  cursor: pointer;
+  -webkit-app-region: no-drag;
+  border-radius: 8px;
+  transition: none;
 }
 
 .brandMark {
   display: block;
   flex-shrink: 0;
-  border-radius: 5px;
+  border-radius: 8px;
+}
+
+.brandText {
+  min-width: 0;
+  flex: 1;
+  display: grid;
+  gap: 4px;
 }
 
 .wordmark {
+  font-family: var(--h-font-ui);
+  font-size: 13px;
+  font-weight: 700;
+  font-style: normal;
+  letter-spacing: -0.02em;
   white-space: nowrap;
-  line-height: 1;
+  line-height: 1.18;
+  overflow: hidden;
+  text-overflow: ellipsis;
 }
 
 .wordmark em {
@@ -49,15 +65,44 @@
   font-style: normal;
 }
 
-.ver {
-  font-family: var(--h-font-cn);
-  font-size: 10.5px;
-  font-weight: 600;
-  color: var(--h-text-2);
-  font-style: normal;
-  letter-spacing: 0.04em;
+.brandMeta {
+  display: flex;
+  align-items: center;
+  gap: 2px;
+  min-width: 0;
+  line-height: 1.25;
   white-space: nowrap;
-  transform: translateY(1.5px);
+}
+
+.edition {
+  flex-shrink: 0;
+  color: color-mix(in srgb, var(--h-text) 76%, var(--h-text-3));
+  font-family: var(--h-font-cn);
+  font-size: 9.5px;
+  font-weight: 650;
+  letter-spacing: 0.035em;
+}
+
+.metaDot {
+  flex-shrink: 0;
+  color: color-mix(in srgb, var(--h-accent) 58%, var(--h-text-3));
+  font-family: var(--h-font-mono);
+  font-size: 10px;
+  line-height: 1;
+}
+
+.site {
+  flex-shrink: 0;
+  min-width: 0;
+  color: color-mix(in srgb, var(--h-accent) 52%, var(--h-text-3));
+  font-family: var(--h-font-mono);
+  font-size: 8.5px;
+  font-weight: 500;
+  letter-spacing: 0.005em;
+  line-height: 1.2;
+  overflow: visible;
+  text-overflow: clip;
+  white-space: nowrap;
 }
 
 .nav {

--- a/web/src/components/app-shell/app-top-bar.tsx
+++ b/web/src/components/app-shell/app-top-bar.tsx
@@ -1,3 +1,4 @@
+import type { MouseEvent } from "react";
 import { useNavigate, useLocation } from "react-router-dom";
 import { Moon, Search, Sun } from "lucide-react";
 import { useTheme } from "@hermes/shared-ui";
@@ -6,6 +7,8 @@ import { ProfileSelector } from "@/components/sidebar/profile-selector";
 import { TOP_TABS } from "./use-active-top-tab";
 import s from "./app-top-bar.module.css";
 
+const PRACTICE_GUIDES_URL = "https://hermesagent.org.cn/practice-guides";
+
 export function AppTopBar() {
   const navigate = useNavigate();
   const location = useLocation();
@@ -13,20 +16,39 @@ export function AppTopBar() {
   const nextTheme = themeConfig.theme === "dark" ? "light" : "dark";
   const ThemeIcon = themeConfig.theme === "dark" ? Sun : Moon;
   const themeToggleLabel = themeConfig.theme === "dark" ? "切换到浅色模式" : "切换到深色模式";
+  const openPracticeGuides = (event: MouseEvent<HTMLAnchorElement>) => {
+    event.preventDefault();
+    window.open(PRACTICE_GUIDES_URL, "_blank", "noopener,noreferrer");
+  };
 
   return (
     <header className={s.topbar} data-window-drag data-tauri-drag-region="deep">
-      <div className={s.brand} aria-label="Hermes Agent 中文社区桌面版">
+      <a
+        className={s.brand}
+        aria-label="打开 Hermes Agent 实践指南"
+        href={PRACTICE_GUIDES_URL}
+        target="_blank"
+        rel="noopener noreferrer"
+        title="打开 Hermes Agent 实践指南"
+        onClick={openPracticeGuides}
+        data-no-drag
+      >
         <HermesLogoMark
           className={s.brandMark}
-          size={22}
+          size={30}
           tone={themeConfig.theme === "light" ? "dark" : "light"}
         />
-        <span className={s.wordmark}>
-          Hermes <em>Agent</em>
+        <span className={s.brandText}>
+          <span className={s.wordmark}>
+            Hermes <em>Agent</em>
+          </span>
+          <span className={s.brandMeta}>
+            <span className={s.edition}>中文社区桌面版</span>
+            <span className={s.metaDot} aria-hidden="true">·</span>
+            <span className={s.site}>hermesagent.org.cn</span>
+          </span>
         </span>
-        <span className={s.ver}>中文社区桌面版</span>
-      </div>
+      </a>
 
       <nav className={s.nav} aria-label="主导航">
         {TOP_TABS.map((tab) => (

--- a/web/src/components/app-shell/app-top-bar.tsx
+++ b/web/src/components/app-shell/app-top-bar.tsx
@@ -7,7 +7,11 @@ import { ProfileSelector } from "@/components/sidebar/profile-selector";
 import { TOP_TABS } from "./use-active-top-tab";
 import s from "./app-top-bar.module.css";
 
-const PRACTICE_GUIDES_URL = "https://hermesagent.org.cn/practice-guides";
+const DESKTOP_VERSION = import.meta.env.VITE_HERMES_DESKTOP_VERSION || "0.1.0";
+const DESKTOP_VERSION_PARAM = DESKTOP_VERSION.startsWith("v") || DESKTOP_VERSION.startsWith("V")
+  ? DESKTOP_VERSION
+  : `v${DESKTOP_VERSION}`;
+const BRAND_URL = `https://hermesagent.org.cn?source=cn_desktop&version=${encodeURIComponent(DESKTOP_VERSION_PARAM)}`;
 
 export function AppTopBar() {
   const navigate = useNavigate();
@@ -16,21 +20,21 @@ export function AppTopBar() {
   const nextTheme = themeConfig.theme === "dark" ? "light" : "dark";
   const ThemeIcon = themeConfig.theme === "dark" ? Sun : Moon;
   const themeToggleLabel = themeConfig.theme === "dark" ? "切换到浅色模式" : "切换到深色模式";
-  const openPracticeGuides = (event: MouseEvent<HTMLAnchorElement>) => {
+  const openBrandSite = (event: MouseEvent<HTMLAnchorElement>) => {
     event.preventDefault();
-    window.open(PRACTICE_GUIDES_URL, "_blank", "noopener,noreferrer");
+    window.open(BRAND_URL, "_blank", "noopener,noreferrer");
   };
 
   return (
     <header className={s.topbar} data-window-drag data-tauri-drag-region="deep">
       <a
         className={s.brand}
-        aria-label="打开 Hermes Agent 实践指南"
-        href={PRACTICE_GUIDES_URL}
+        aria-label="打开 Hermes Agent 中文社区官网"
+        href={BRAND_URL}
         target="_blank"
         rel="noopener noreferrer"
-        title="打开 Hermes Agent 实践指南"
-        onClick={openPracticeGuides}
+        title="打开 Hermes Agent 中文社区官网"
+        onClick={openBrandSite}
         data-no-drag
       >
         <HermesLogoMark

--- a/web/src/components/chat/goose-composer-model-picker.tsx
+++ b/web/src/components/chat/goose-composer-model-picker.tsx
@@ -647,7 +647,8 @@ function ModelPickerBody({
                     >
                       <ChevronRight
                         aria-hidden="true"
-                        style={{ transform: moreExpanded ? "rotate(90deg)" : undefined }}
+                        className={s.mpGroupChevron}
+                        data-expanded={moreExpanded ? "true" : undefined}
                       />
                       <span>{GROUP_LABELS.more.name} · {visible.more.length} 项</span>
                       <span className={s.mpGroupSub}>{GROUP_LABELS.more.subtitle}</span>

--- a/web/src/components/chat/goose-composer.module.css
+++ b/web/src/components/chat/goose-composer.module.css
@@ -684,12 +684,17 @@
   color: var(--h-text);
 }
 
-.mpGroupCollapsible svg {
+.mpGroupChevron {
   width: 12px;
   height: 12px;
   stroke-width: 1.6;
   flex: 0 0 auto;
+  transform: translateY(3px);
   transition: transform 0.12s ease;
+}
+
+.mpGroupChevron[data-expanded="true"] {
+  transform: translateY(3px) rotate(90deg);
 }
 
 .mpCard {

--- a/web/vite-env.d.ts
+++ b/web/vite-env.d.ts
@@ -2,4 +2,5 @@
 
 interface ImportMetaEnv {
   readonly VITE_HERMES_BUILD_COMMIT?: string;
+  readonly VITE_HERMES_DESKTOP_VERSION?: string;
 }

--- a/web/vite.config.ts
+++ b/web/vite.config.ts
@@ -1,6 +1,7 @@
 import { defineConfig } from "vite";
 import react from "@vitejs/plugin-react";
 import { execSync } from "node:child_process";
+import { readFileSync } from "node:fs";
 import { mkdir, readFile, writeFile } from "fs/promises";
 import { homedir } from "os";
 import { dirname, join, resolve } from "path";
@@ -86,6 +87,16 @@ function gitShortCommit(): string {
     }).trim();
   } catch {
     return "unknown";
+  }
+}
+
+function desktopAppVersion(): string {
+  if (process.env.HERMES_DESKTOP_APP_VERSION) return process.env.HERMES_DESKTOP_APP_VERSION;
+  try {
+    const pkg = JSON.parse(readFileSync(resolve(__dirname, "..", "package.json"), "utf8")) as { version?: unknown };
+    return typeof pkg.version === "string" && pkg.version.trim() ? pkg.version.trim() : "0.1.0";
+  } catch {
+    return "0.1.0";
   }
 }
 
@@ -251,6 +262,7 @@ export default defineConfig({
   plugins: [react(), hermesTokenPlugin(), hermesSessionLogPlugin(), hermesSessionArchivePlugin()],
   define: {
     "import.meta.env.VITE_HERMES_BUILD_COMMIT": JSON.stringify(gitShortCommit()),
+    "import.meta.env.VITE_HERMES_DESKTOP_VERSION": JSON.stringify(desktopAppVersion()),
   },
   resolve: {
     alias: {


### PR DESCRIPTION
## Summary

- Refine the top-left desktop brand area into a compact two-line entry that exposes `hermesagent.org.cn` and links to the community site.
- Add build-time desktop app version injection so the brand link includes `source=cn_desktop` and an automatic `version=v...` query parameter.
- Align the model picker “更多” collapsible chevron with its label while preserving the rotate animation.

## Why

This keeps the desktop shell branding visually consistent while giving the website a stable source/version signal for routing or analytics.

## Validation

- `pnpm --filter @hermes/web typecheck`
- Verified the rendered brand link resolves to `https://hermesagent.org.cn?source=cn_desktop&version=v0.1.0` in local dev.
