### PR TITLE
[codex] fix context token usage display

### DIFF
--- a/web/src/components/chat/composer-types.ts
+++ b/web/src/components/chat/composer-types.ts
@@ -34,6 +34,7 @@ export interface ComposerContextUsage {
   percent?: number;
   model?: string;
   compressions?: number;
+  estimated?: boolean;
 }
 
 export interface ComposerSubmitPayload {

--- a/web/src/components/chat/goose-composer-context.tsx
+++ b/web/src/components/chat/goose-composer-context.tsx
@@ -76,11 +76,15 @@ export function ContextIndicator({
   const rawPercent = contextUsagePercent(usage);
   const percent = Math.max(0, Math.min(100, rawPercent ?? 0));
   const risk = contextUsageRisk(usage);
+  const usedLabel = formatTokenCount(usage.used);
+  const estimatedPrefix = usage.estimated && typeof usage.used === "number" ? "约 " : "";
   const label = usage.max
-    ? `${formatTokenCount(usage.used ?? 0)} / ${formatTokenCount(usage.max)}`
-    : formatTokenCount(usage.used);
+    ? `${estimatedPrefix}${usedLabel} / ${formatTokenCount(usage.max)}`
+    : `${estimatedPrefix}${usedLabel}`;
   const displayPercent = rawPercent ?? percent;
-  const percentLabel = `${displayPercent > 0 && displayPercent < 10 ? displayPercent.toFixed(1) : Math.round(displayPercent)}%`;
+  const percentLabel = rawPercent === undefined
+    ? "-"
+    : `${displayPercent > 0 && displayPercent < 10 ? displayPercent.toFixed(1) : Math.round(displayPercent)}%`;
   const contextTitle = usage.model
     ? `${usage.model} · 上下文窗口 ${label}`
     : `上下文窗口 ${label}`;
@@ -127,6 +131,9 @@ export function ContextIndicator({
             <span>{label}</span>
             <span>{percentLabel}</span>
           </span>
+          {usage.estimated ? (
+            <span className={s.contextPopoverMeta}>按当前消息内容估算</span>
+          ) : null}
           {typeof usage.compressions === "number" && usage.compressions > 0 ? (
             <span className={s.contextPopoverMeta}>已压缩 {usage.compressions} 次</span>
           ) : null}

--- a/web/src/components/chat/message-timeline.test.tsx
+++ b/web/src/components/chat/message-timeline.test.tsx
@@ -28,4 +28,34 @@ describe("MessageTimeline", () => {
     expect(html).toContain("qwen3.6-plus");
     expect(html).not.toContain("deepseek-v4-flash");
   });
+
+  it("shows live context tokens instead of cumulative session totals", () => {
+    const messages: ChatMessage[] = [
+      {
+        id: "assistant-1",
+        role: "assistant",
+        createdAt: 1,
+        status: "streaming",
+        blocks: [{ type: "progress", text: "正在分析项目..." }],
+      },
+    ];
+
+    const html = ReactDOMServer.renderToStaticMarkup(
+      <MessageTimeline
+        messages={messages}
+        turnStartedAt={1}
+        sessionUsage={{
+          model: "deepseek-v4-flash",
+          total: 1_033_698,
+          input: 1_027_212,
+          output: 6_486,
+          context_used: 87_382,
+        } as any}
+      />,
+    );
+
+    expect(html).toContain("87.4k tokens");
+    expect(html).not.toContain("1.0M tokens");
+  });
+
 });

--- a/web/src/components/chat/message-timeline.tsx
+++ b/web/src/components/chat/message-timeline.tsx
@@ -98,8 +98,6 @@ interface ProgressBlockProps {
 
 function ProgressBlock({ turnStartedAt, sessionUsage, progressModel, progressText }: ProgressBlockProps) {
   const [elapsed, setElapsed] = useState(0);
-  const peakTokensRef = useRef(0);
-
   useEffect(() => {
     if (!turnStartedAt) return;
     setElapsed(Date.now() - turnStartedAt);
@@ -113,13 +111,12 @@ function ProgressBlock({ turnStartedAt, sessionUsage, progressModel, progressTex
   const elapsedSeconds = Math.floor(elapsed / 1000);
   const showLongHint = elapsedSeconds >= LONG_THINKING_THRESHOLD_S;
 
-  const rawTotal =
-    sessionUsage?.total ??
-    ((sessionUsage?.input ?? 0) + (sessionUsage?.output ?? 0) || undefined);
-  if (rawTotal && rawTotal > peakTokensRef.current) {
-    peakTokensRef.current = rawTotal;
-  }
-  const tokenValue = peakTokensRef.current > 0 ? peakTokensRef.current : undefined;
+  const tokenValue =
+    typeof sessionUsage?.context_used === "number" &&
+    Number.isFinite(sessionUsage.context_used) &&
+    sessionUsage.context_used > 0
+      ? sessionUsage.context_used
+      : undefined;
   const model = progressModel || sessionUsage?.model;
 
   return (

--- a/web/src/lib/context-usage.test.ts
+++ b/web/src/lib/context-usage.test.ts
@@ -1,7 +1,9 @@
 import { describe, expect, it } from "vitest";
 import {
+  buildComposerContextUsage,
   contextUsagePercent,
   contextUsageRisk,
+  estimateRenderedContextTokens,
 } from "./context-usage";
 
 describe("context usage helpers", () => {
@@ -17,5 +19,51 @@ describe("context usage helpers", () => {
     expect(contextUsageRisk({ percent: 84 })).toBe("ok");
     expect(contextUsageRisk({ percent: 85 })).toBe("warning");
     expect(contextUsageRisk({ percent: 100 })).toBe("danger");
+  });
+
+  it("estimates rendered chat content instead of accumulated billing totals", () => {
+    const estimated = estimateRenderedContextTokens([
+      { text: "a".repeat(80_000) },
+      { text: "b".repeat(40_000), tools: [{ name: "read", summary: "c".repeat(4_000) }] },
+    ]);
+
+    const usage = buildComposerContextUsage({
+      live: { context_used: 0, context_max: 1_000_000, context_percent: 0 },
+      modelInfo: { model: "qwen3.6-plus", effective_context_length: 1_000_000 },
+      session: {
+        model: "qwen3.6-plus",
+        input_tokens: 900_000,
+        output_tokens: 120_000,
+      },
+      estimatedUsed: estimated,
+    });
+
+    expect(usage?.used).toBe(estimated);
+    expect(usage?.used).toBeGreaterThan(30_000);
+    expect(usage?.used).toBeLessThan(40_000);
+    expect(usage?.estimated).toBe(true);
+    expect(usage?.used).not.toBe(1_020_000);
+  });
+
+  it("prefers live context usage over estimates", () => {
+    const usage = buildComposerContextUsage({
+      live: {
+        model: "deepseek-v4-flash",
+        context_used: 42_000,
+        context_max: 128_000,
+        context_percent: 33,
+        compressions: 2,
+      },
+      estimatedUsed: 30_000,
+    });
+
+    expect(usage).toMatchObject({
+      used: 42_000,
+      max: 128_000,
+      percent: 33,
+      model: "deepseek-v4-flash",
+      compressions: 2,
+      estimated: false,
+    });
   });
 });

--- a/web/src/lib/context-usage.ts
+++ b/web/src/lib/context-usage.ts
@@ -9,8 +9,136 @@ export type ContextRisk = "unknown" | "ok" | "warning" | "danger";
 export const CONTEXT_WARNING_PERCENT = 85;
 export const CONTEXT_DANGER_PERCENT = 100;
 
+const ESTIMATE_CHARS_PER_TOKEN = 4;
+const ESTIMATE_MESSAGE_OVERHEAD_TOKENS = 8;
+
 function finiteNumber(value: unknown): number | undefined {
   return typeof value === "number" && Number.isFinite(value) ? value : undefined;
+}
+
+function positiveNumber(value: unknown): number | undefined {
+  const num = finiteNumber(value);
+  return num !== undefined && num > 0 ? num : undefined;
+}
+
+function firstPositive(...values: unknown[]): number | undefined {
+  for (const value of values) {
+    const num = positiveNumber(value);
+    if (num !== undefined) return num;
+  }
+  return undefined;
+}
+
+function stringSize(value: unknown): number {
+  if (typeof value === "string") return value.length;
+  if (value == null) return 0;
+  try {
+    return JSON.stringify(value).length;
+  } catch {
+    return String(value).length;
+  }
+}
+
+export interface ContextEstimateTool {
+  name?: string;
+  context?: string;
+  preview?: string;
+  summary?: string;
+  error?: string;
+  arguments?: unknown;
+}
+
+export interface ContextEstimateMessage {
+  text?: string;
+  tools?: readonly ContextEstimateTool[];
+}
+
+export interface ComposerContextUsageLike extends ContextUsageLike {
+  model?: string;
+  compressions?: number;
+  estimated?: boolean;
+}
+
+export interface BuildComposerContextUsageParams {
+  live?: {
+    model?: string;
+    context_used?: number;
+    context_max?: number;
+    context_percent?: number;
+    compressions?: number;
+  } | null;
+  modelInfo?: {
+    model?: string;
+    effective_context_length?: number;
+    auto_context_length?: number;
+  } | null;
+  session?: {
+    model?: string;
+    [key: string]: unknown;
+  } | null;
+  selectedModel?: {
+    model?: string;
+  } | null;
+  selectedContextMax?: number;
+  estimatedUsed?: number;
+}
+
+export function estimateRenderedContextTokens(
+  messages: readonly ContextEstimateMessage[],
+): number | undefined {
+  if (!messages.length) return undefined;
+
+  let total = 0;
+  for (const message of messages) {
+    let chars = stringSize(message.text);
+    for (const tool of message.tools ?? []) {
+      chars += stringSize(tool.name);
+      chars += stringSize(tool.context);
+      chars += stringSize(tool.preview);
+      chars += stringSize(tool.summary);
+      chars += stringSize(tool.error);
+      chars += stringSize(tool.arguments);
+    }
+    if (chars > 0) {
+      total += Math.ceil(chars / ESTIMATE_CHARS_PER_TOKEN) + ESTIMATE_MESSAGE_OVERHEAD_TOKENS;
+    }
+  }
+
+  return total > 0 ? total : undefined;
+}
+
+export function buildComposerContextUsage({
+  live,
+  modelInfo,
+  session,
+  selectedModel,
+  selectedContextMax,
+  estimatedUsed,
+}: BuildComposerContextUsageParams): ComposerContextUsageLike | null {
+  const liveUsed = positiveNumber(live?.context_used);
+  const fallbackEstimate = liveUsed === undefined ? positiveNumber(estimatedUsed) : undefined;
+  const used = liveUsed ?? fallbackEstimate;
+  const max = firstPositive(
+    selectedContextMax,
+    live?.context_max,
+    modelInfo?.effective_context_length,
+    modelInfo?.auto_context_length,
+  );
+  const compressions = positiveNumber(live?.compressions);
+  const model = selectedModel?.model ?? live?.model ?? session?.model ?? modelInfo?.model;
+
+  if (!live && !modelInfo && !session && !selectedModel && used === undefined && max === undefined) {
+    return null;
+  }
+
+  return {
+    used,
+    max,
+    percent: liveUsed !== undefined ? finiteNumber(live?.context_percent) : undefined,
+    model,
+    compressions,
+    estimated: liveUsed === undefined && fallbackEstimate !== undefined,
+  };
 }
 
 export function contextUsagePercent(usage: ContextUsageLike | null | undefined): number | undefined {

--- a/web/src/routes/detail.tsx
+++ b/web/src/routes/detail.tsx
@@ -19,6 +19,10 @@ import { readSessionModelOverride } from "@/lib/session-model-override";
 import { prepareComposerPrompt } from "@/lib/composer-prompt";
 import { formatElapsedTimer } from "@/lib/format";
 import { getGatewayClient } from "@/lib/gateway-client";
+import {
+  buildComposerContextUsage,
+  estimateRenderedContextTokens,
+} from "@/lib/context-usage";
 import { resolveModelContextWindow } from "@/lib/model-context";
 import { sessionDisplayTitle } from "@/lib/session-title";
 import {
@@ -302,37 +306,22 @@ export function DetailRoute() {
   const timelineStatus =
     runtime.statusMessage ||
     (runtimeIsBusy && chatMessages.length === 0 ? "任务运行中，等待输出…" : undefined);
-  // session.usage 在刚 resume 的 gw session 上会返回 context_used=0（因为 gw
-  // 只跟踪当前 live session 的累计用量，resume 后是新 gw session_id），但
-  // REST /api/sessions/{id} 的 input_tokens+output_tokens 是该持久化 session
-  // 的全部历史。0 是"还没数据"哨兵——用 ?? 会把 0 当 truthy 卡住，必须显式
-  // 把 0 视为 undefined 才能 fall through 到 REST。compressions 同理。
-  const liveUsed = sessionUsage?.context_used && sessionUsage.context_used > 0
-    ? sessionUsage.context_used
-    : undefined;
-  const liveCompressions = sessionUsage?.compressions && sessionUsage.compressions > 0
-    ? sessionUsage.compressions
-    : undefined;
-  const contextUsage = sessionUsage || modelInfo || sessionData
-    ? {
-        used:
-          liveUsed ??
-          (sessionData?.input_tokens || sessionData?.output_tokens
-            ? (sessionData.input_tokens ?? 0) + (sessionData.output_tokens ?? 0)
-            : undefined),
-        max:
-          selectedContextMax ??
-          sessionUsage?.context_max ??
-          // effective = max(config_context_length, auto_context_length)，是上游
-          // 算好的权威值；auto 在探测失败时会回落到 256k，必须排在 effective 之后
-          // 否则会把"探测失败兜底"误当成模型真实上限。
-          modelInfo?.effective_context_length ??
-          modelInfo?.auto_context_length,
-        percent: liveUsed ? sessionUsage?.context_percent : undefined,
-        model: selectedModel?.model ?? sessionUsage?.model ?? sessionData?.model ?? modelInfo?.model,
-        compressions: liveCompressions,
-      }
-    : null;
+  // `session.usage.context_used` 是运行时回报的当前上下文窗口用量，最准确。
+  // 刚 resume 的 gw session 可能暂时返回 0，此时只能用当前已渲染消息做近似估算。
+  // 不要再回退到 REST `input_tokens + output_tokens`：那是会话累计账单用量，
+  // 多轮对话会重复计算历史 prompt，30K 级别上下文很容易被显示成 1M+。
+  const estimatedContextUsed = useMemo(
+    () => estimateRenderedContextTokens(chatMessages),
+    [chatMessages],
+  );
+  const contextUsage = buildComposerContextUsage({
+    live: sessionUsage,
+    modelInfo,
+    session: sessionData,
+    selectedModel,
+    selectedContextMax,
+    estimatedUsed: estimatedContextUsed,
+  });
 
   return (
     <div className={s.page}>


### PR DESCRIPTION
## Summary

修复会话详情页中上下文 token 显示被严重放大的问题。

## Root cause

详情页和运行中进度块此前会在拿不到实时上下文用量时使用累计的会话/API token 字段，例如 `input_tokens + output_tokens` 或 `sessionUsage.total`。这些字段是计费或多次 API 调用累计口径，会在工具循环中重复计入历史 prompt，因此 30K 到 100K 级别的当前上下文会被显示成 1M+。

## Changes

- 优先使用 gateway 返回的 `context_used` 作为当前上下文窗口用量。
- 当 live `context_used` 暂不可用时，详情页按当前渲染消息内容做保守估算，并在 UI 中标注为估算值。
- 修复“思考中”进度块右侧 token 计数，避免继续展示累计 `sessionUsage.total`。
- 补充测试覆盖累计 token 不应被当作上下文用量的场景。

## Validation

- `pnpm typecheck`
- `pnpm test:unit`
- `cargo check`
