### PR TITLE
[codex] stop owned runtime on app exit

### DIFF
--- a/src/main.rs
+++ b/src/main.rs
@@ -8,12 +8,13 @@
 
 use std::fs;
 use std::path::{Path, PathBuf};
+use std::sync::atomic::Ordering;
 
 use hermes_agent_cn::commands;
 use hermes_agent_cn::commands::profiles::read_active_profile_sticky;
 use hermes_agent_cn::process::{dashboard, runtime};
 use hermes_agent_cn::state::{AppState, DashboardHandle};
-use tauri::Emitter;
+use tauri::{Emitter, Manager};
 
 /// Emit a "runtime-status" event for the frontend overlay to consume.
 /// Phases (in order along the happy path):
@@ -26,6 +27,38 @@ fn emit_runtime_status(app: &tauri::AppHandle, phase: &str, message: &str) {
         "runtime-status",
         serde_json::json!({ "phase": phase, "message": message }),
     );
+}
+
+fn shutdown_owned_runtime(app: &tauri::AppHandle, reason: &str) {
+    let state = app.state::<AppState>();
+    let (sse_stop, mut dashboard_handle) = match state.inner.lock() {
+        Ok(mut inner) => (inner.gateway_sse_stop.take(), inner.dashboard_handle.take()),
+        Err(err) => {
+            log::error!("Failed to lock app state during runtime shutdown: {}", err);
+            return;
+        }
+    };
+
+    if let Some(stop) = sse_stop {
+        stop.store(true, Ordering::Relaxed);
+    }
+
+    if let Some(ref mut handle) = dashboard_handle {
+        if handle.owns_process {
+            log::info!(
+                "Stopping owned Hermes dashboard runtime at {} ({})",
+                handle.api_base_url,
+                reason
+            );
+        } else {
+            log::info!(
+                "Desktop does not own dashboard at {}; skipping process stop ({})",
+                handle.api_base_url,
+                reason
+            );
+        }
+        handle.stop();
+    }
 }
 
 async fn install_bundled_runtime_for_bootstrap(
@@ -587,6 +620,11 @@ fn main() {
                 log::info!("Main window destroyed");
             }
         })
-        .run(tauri::generate_context!())
-        .expect("error while running Hermes Agent 中文社区桌面版");
+        .build(tauri::generate_context!())
+        .expect("error while building Hermes Agent 中文社区桌面版")
+        .run(|app_handle, event| {
+            if let tauri::RunEvent::Exit = event {
+                shutdown_owned_runtime(app_handle, "app exit");
+            }
+        });
 }

--- a/src/state.rs
+++ b/src/state.rs
@@ -32,6 +32,11 @@ pub struct DashboardHandle {
 impl DashboardHandle {
     /// Gracefully stop the dashboard process if we own it.
     pub fn stop(&mut self) {
+        if !self.owns_process {
+            self.child = None;
+            return;
+        }
+
         if let Some(ref mut child) = self.child {
             let _ = child.kill();
             let _ = child.wait();


### PR DESCRIPTION
## Summary

This PR fixes the immediate runtime leak reported by users: when the Tauri desktop app exits, it now explicitly stops the Desktop-owned Hermes dashboard/runtime instead of relying on `Drop` cleanup.

## Root cause

The app previously stored the spawned dashboard process in `DashboardHandle` and expected `DashboardHandle::drop()` to clean it up. Tauri's `App::run(...)` exit path can terminate the process directly, so normal Rust destructors are not a reliable lifecycle hook for child-process cleanup.

## Changes

- Switch the Tauri entrypoint from `Builder::run(...)` shorthand to `build(...).run(...)` so app lifecycle events can be observed.
- Add `shutdown_owned_runtime(...)` and invoke it on `tauri::RunEvent::Exit`.
- Stop the SSE proxy before stopping the dashboard/runtime handle.
- Guard `DashboardHandle::stop()` so it only kills processes that the desktop owns.

## Follow-up

The broader lifecycle hardening plan is tracked in #16. That follow-up covers process-tree cleanup, graceful shutdown before force-kill, orphan managed-runtime ownership markers, and future tray close-vs-quit semantics.

## Validation

- `pnpm typecheck`
- `pnpm test:unit`
- `cargo fmt --check`
- `cargo check`
- `cargo test --all-features`
