### PR TITLE
[codex] fix open desktop issue regressions

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -1610,6 +1610,7 @@ dependencies = [
  "ed25519-dalek",
  "env_logger",
  "futures-util",
+ "libc",
  "log",
  "objc2",
  "objc2-foundation",
@@ -1633,6 +1634,7 @@ dependencies = [
  "tokio",
  "url",
  "urlencoding",
+ "windows-sys 0.61.2",
  "wiremock",
  "zip",
 ]

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -39,6 +39,14 @@ futures-util = "0.3"
 thiserror = "2"
 once_cell = "1"
 rusqlite = { version = "0.32", features = ["bundled"] }
+libc = "0.2"
+
+[target.'cfg(target_os = "windows")'.dependencies]
+windows-sys = { version = "0.61", features = [
+    "Win32_Foundation",
+    "Win32_Security",
+    "Win32_System_JobObjects",
+] }
 
 [target.'cfg(target_os = "macos")'.dependencies]
 objc2 = "0.6"

--- a/packages/protocol/src/channels.ts
+++ b/packages/protocol/src/channels.ts
@@ -101,6 +101,8 @@ export interface RuntimeProcessInfo {
   commandLine?: string;
   gatewayRuntimeDir?: string;
   gatewayLockDir?: string;
+  ownershipMarkerPath?: string;
+  ownershipState?: string;
   sessionTokenPresent: boolean;
   gatewaySseProxyActive: boolean;
 }

--- a/src/commands/profiles.rs
+++ b/src/commands/profiles.rs
@@ -9,6 +9,7 @@
 
 use std::fs;
 use std::path::{Path, PathBuf};
+use std::sync::atomic::Ordering;
 use std::sync::LazyLock;
 
 use regex::Regex;
@@ -215,8 +216,12 @@ async fn do_switch_profile(
                 }
             }
         };
+        if let Some(stop) = inner.gateway_sse_stop.take() {
+            stop.store(true, Ordering::Relaxed);
+        }
+        let session_token = inner.session_token.clone();
         if let Some(ref mut handle) = inner.dashboard_handle {
-            handle.stop();
+            handle.stop_with_token(session_token.as_deref());
         }
         inner.dashboard_handle = None;
     }

--- a/src/commands/runtime_manager.rs
+++ b/src/commands/runtime_manager.rs
@@ -38,6 +38,8 @@ pub fn runtime_info(state: State<'_, AppState>) -> Result<runtime::RuntimeInfo, 
                 command_line,
                 gateway_runtime_dir: handle.gateway_runtime_dir.clone(),
                 gateway_lock_dir: handle.gateway_lock_dir.clone(),
+                ownership_marker_path: handle.ownership_marker_path.clone(),
+                ownership_state: handle.ownership_state.clone(),
                 session_token_present: inner.session_token.is_some(),
                 gateway_sse_proxy_active: inner
                     .gateway_sse_stop
@@ -142,9 +144,13 @@ pub async fn runtime_rollback(
 async fn restart_dashboard(state: &State<'_, AppState>) -> Result<(), AppError> {
     let (host, port, hermes_home) = {
         let mut inner = state.inner.lock()?;
-        // Stop existing
+        // Stop existing dashboard and any long-lived SSE proxy before swapping runtime.
+        if let Some(stop) = inner.gateway_sse_stop.take() {
+            stop.store(true, Ordering::Relaxed);
+        }
+        let session_token = inner.session_token.clone();
         if let Some(ref mut handle) = inner.dashboard_handle {
-            handle.stop();
+            handle.stop_with_token(session_token.as_deref());
         }
         inner.dashboard_handle = None;
 

--- a/src/main.rs
+++ b/src/main.rs
@@ -8,6 +8,7 @@
 
 use std::fs;
 use std::path::{Path, PathBuf};
+use std::sync::atomic::Ordering;
 
 use hermes_agent_cn::commands;
 use hermes_agent_cn::commands::profiles::read_active_profile_sticky;
@@ -65,6 +66,42 @@ async fn install_bundled_runtime_for_bootstrap(
     true
 }
 
+fn shutdown_owned_runtime(app: &tauri::AppHandle, reason: &str) {
+    use tauri::Manager;
+
+    let state = app.state::<AppState>();
+    let (sse_stop, mut dashboard_handle, session_token) = match state.inner.lock() {
+        Ok(mut inner) => (
+            inner.gateway_sse_stop.take(),
+            inner.dashboard_handle.take(),
+            inner.session_token.clone(),
+        ),
+        Err(err) => {
+            log::warn!(
+                "Failed to lock app state during {} shutdown: {}",
+                reason,
+                err
+            );
+            return;
+        }
+    };
+
+    if let Some(stop) = sse_stop {
+        stop.store(true, Ordering::Relaxed);
+    }
+
+    if let Some(ref mut handle) = dashboard_handle {
+        log::info!(
+            "Stopping desktop-owned dashboard during {} (api={}, owns_process={}, marker={:?})",
+            reason,
+            handle.api_base_url,
+            handle.owns_process,
+            handle.ownership_marker_path
+        );
+        handle.stop_with_token(session_token.as_deref());
+    }
+}
+
 fn create_and_return(path: PathBuf) -> PathBuf {
     let _ = fs::create_dir_all(&path);
     path
@@ -95,7 +132,7 @@ fn main() {
 
     let app_state = AppState::new();
 
-    tauri::Builder::default()
+    let app = tauri::Builder::default()
         .plugin(tauri_plugin_dialog::init())
         .plugin(tauri_plugin_shell::init())
         .plugin(tauri_plugin_fs::init())
@@ -173,6 +210,9 @@ fn main() {
                             command_args: vec![],
                             gateway_runtime_dir: None,
                             gateway_lock_dir: None,
+                            ownership_marker_path: None,
+                            ownership_state: Some("external-dev".to_string()),
+                            job_handle: None,
                             child: None,
                         }
                     } else {
@@ -322,6 +362,9 @@ fn main() {
                         command_args: vec![],
                         gateway_runtime_dir: None,
                         gateway_lock_dir: None,
+                        ownership_marker_path: None,
+                        ownership_state: Some("external-dev".to_string()),
+                        job_handle: None,
                         child: None,
                     }
                 } else {
@@ -593,6 +636,12 @@ fn main() {
                 log::info!("Main window destroyed");
             }
         })
-        .run(tauri::generate_context!())
-        .expect("error while running Hermes Agent 中文社区桌面版");
+        .build(tauri::generate_context!())
+        .expect("error while building Hermes Agent 中文社区桌面版");
+
+    app.run(|app_handle, event| {
+        if let tauri::RunEvent::Exit = event {
+            shutdown_owned_runtime(app_handle, "app exit");
+        }
+    });
 }

--- a/src/process/dashboard.rs
+++ b/src/process/dashboard.rs
@@ -3,23 +3,31 @@
 // Replaces hermes-cn-ui-v1/apps/desktop/src/main/hermes-process.ts.
 // Responsible for probing, spawning, and managing the hermes dashboard subprocess.
 
+use std::fs;
+use std::io::Write;
+use std::net::{TcpStream, ToSocketAddrs};
 use std::path::PathBuf;
 use std::process::{Child, Command, Stdio};
 use std::sync::LazyLock;
-use std::time::{Duration, Instant};
+use std::time::{Duration, Instant, SystemTime, UNIX_EPOCH};
 use std::{
     io::{BufRead, BufReader, Read},
     thread,
 };
 
 use regex::Regex;
+use serde::{Deserialize, Serialize};
 
 use crate::error::AppError;
-use crate::state::DashboardHandle;
+use crate::state::{DashboardHandle, DashboardJobHandle};
 
 const DASHBOARD_READY_TIMEOUT: Duration = Duration::from_secs(25);
 const PROBE_TIMEOUT: Duration = Duration::from_millis(900);
 const SESSION_TOKEN_TIMEOUT: Duration = Duration::from_millis(1200);
+const SHUTDOWN_HTTP_TIMEOUT: Duration = Duration::from_millis(800);
+const GRACEFUL_SHUTDOWN_TIMEOUT: Duration = Duration::from_millis(1800);
+const FORCE_SHUTDOWN_TIMEOUT: Duration = Duration::from_millis(1200);
+const OWNERSHIP_MARKER_SCHEMA_VERSION: u32 = 1;
 pub const DEFAULT_DESKTOP_DASHBOARD_PORT: u16 = 9120;
 const DASHBOARD_PORT_FALLBACK_LIMIT: u16 = 20;
 static SESSION_TOKEN_RE: LazyLock<Regex> = LazyLock::new(|| {
@@ -38,6 +46,38 @@ static SESSION_TOKEN_HTTP_CLIENT: LazyLock<reqwest::Client> = LazyLock::new(|| {
         .expect("valid dashboard session token HTTP client")
 });
 
+#[derive(Debug, Clone, Serialize, Deserialize)]
+#[serde(rename_all = "camelCase")]
+pub struct DashboardOwnershipMarker {
+    pub schema_version: u32,
+    pub run_id: String,
+    pub desktop_pid: u32,
+    pub dashboard_pid: u32,
+    pub api_base_url: String,
+    pub hermes_home: String,
+    pub runtime_root: String,
+    pub gateway_runtime_dir: String,
+    pub started_at_ms: u128,
+    #[serde(skip_serializing_if = "Option::is_none")]
+    pub runtime_version: Option<String>,
+}
+
+#[derive(Debug, Clone, Copy, PartialEq, Eq)]
+enum MarkerOwnerState {
+    Missing,
+    LiveDesktopOwner,
+    StaleDesktopOwner,
+    NotThisDashboard,
+}
+
+pub fn ownership_marker_path() -> PathBuf {
+    crate::process::runtime::runtime_root().join("desktop-owner.json")
+}
+
+pub fn ownership_marker_path_display() -> String {
+    ownership_marker_path().to_string_lossy().to_string()
+}
+
 /// Build the base URL for a dashboard at the given host and port.
 pub fn dashboard_base_url(host: &str, port: u16) -> String {
     format!("http://{}:{}", host, port)
@@ -52,6 +92,311 @@ fn fallback_ports(start: u16) -> Vec<u16> {
         ports.push(port);
     }
     ports
+}
+
+fn now_millis() -> u128 {
+    SystemTime::now()
+        .duration_since(UNIX_EPOCH)
+        .unwrap_or_default()
+        .as_millis()
+}
+
+fn read_ownership_marker() -> Option<DashboardOwnershipMarker> {
+    let path = ownership_marker_path();
+    let content = fs::read_to_string(path).ok()?;
+    serde_json::from_str(&content).ok()
+}
+
+fn write_ownership_marker(marker: &DashboardOwnershipMarker) -> Result<(), String> {
+    let path = ownership_marker_path();
+    if let Some(parent) = path.parent() {
+        fs::create_dir_all(parent).map_err(|e| e.to_string())?;
+    }
+    let json = serde_json::to_string_pretty(marker).map_err(|e| e.to_string())?;
+    fs::write(path, format!("{}\n", json)).map_err(|e| e.to_string())
+}
+
+pub fn remove_ownership_marker_path(path: Option<&str>) {
+    let marker_path = path
+        .map(PathBuf::from)
+        .unwrap_or_else(ownership_marker_path);
+    if let Err(err) = fs::remove_file(&marker_path) {
+        if err.kind() != std::io::ErrorKind::NotFound {
+            log::warn!(
+                "Failed to remove dashboard ownership marker {}: {}",
+                marker_path.display(),
+                err
+            );
+        }
+    }
+}
+
+fn same_path(left: &str, right: &str) -> bool {
+    let left = fs::canonicalize(left).unwrap_or_else(|_| PathBuf::from(left));
+    let right = fs::canonicalize(right).unwrap_or_else(|_| PathBuf::from(right));
+    left == right
+}
+
+fn marker_owner_state(
+    marker: Option<&DashboardOwnershipMarker>,
+    api_base_url: &str,
+    hermes_home: &str,
+) -> MarkerOwnerState {
+    let Some(marker) = marker else {
+        return MarkerOwnerState::Missing;
+    };
+    if marker.schema_version != OWNERSHIP_MARKER_SCHEMA_VERSION
+        || marker.api_base_url != api_base_url
+        || !same_path(&marker.hermes_home, hermes_home)
+    {
+        return MarkerOwnerState::NotThisDashboard;
+    }
+    if pid_is_running(marker.desktop_pid) {
+        MarkerOwnerState::LiveDesktopOwner
+    } else {
+        MarkerOwnerState::StaleDesktopOwner
+    }
+}
+
+#[cfg(unix)]
+fn pid_is_running(pid: u32) -> bool {
+    if pid == 0 {
+        return false;
+    }
+    let rc = unsafe { libc::kill(pid as libc::pid_t, 0) };
+    rc == 0 || std::io::Error::last_os_error().raw_os_error() == Some(libc::EPERM)
+}
+
+#[cfg(windows)]
+fn pid_is_running(pid: u32) -> bool {
+    if pid == 0 {
+        return false;
+    }
+    let filter = format!("PID eq {}", pid);
+    let Ok(output) = Command::new("tasklist")
+        .args(["/FI", &filter, "/FO", "CSV", "/NH"])
+        .output()
+    else {
+        return false;
+    };
+    String::from_utf8_lossy(&output.stdout).contains(&pid.to_string())
+}
+
+#[cfg(not(any(unix, windows)))]
+fn pid_is_running(_pid: u32) -> bool {
+    false
+}
+
+fn wait_for_child_exit(child: &mut Child, timeout: Duration) -> bool {
+    let start = Instant::now();
+    while start.elapsed() < timeout {
+        match child.try_wait() {
+            Ok(Some(_)) => return true,
+            Ok(None) => thread::sleep(Duration::from_millis(80)),
+            Err(_) => return true,
+        }
+    }
+    false
+}
+
+fn request_dashboard_shutdown(api_base_url: &str, session_token: Option<&str>) -> bool {
+    let shutdown_url = format!("{}/api/shutdown", api_base_url.trim_end_matches('/'));
+    let parsed = match url::Url::parse(&shutdown_url) {
+        Ok(url) => url,
+        Err(err) => {
+            log::debug!("Invalid dashboard shutdown URL {}: {}", shutdown_url, err);
+            return false;
+        }
+    };
+    if parsed.scheme() != "http" {
+        log::debug!(
+            "Skipping dashboard graceful shutdown for unsupported scheme {}",
+            parsed.scheme()
+        );
+        return false;
+    }
+    let Some(host) = parsed.host_str() else {
+        return false;
+    };
+    let port = parsed.port_or_known_default().unwrap_or(80);
+    let path = match parsed.query() {
+        Some(query) => format!("{}?{}", parsed.path(), query),
+        None => parsed.path().to_string(),
+    };
+
+    let mut stream = match TcpStream::connect_timeout(
+        &(host, port)
+            .to_socket_addrs()
+            .ok()
+            .and_then(|mut addrs| addrs.next())
+            .unwrap_or_else(|| std::net::SocketAddr::from(([127, 0, 0, 1], 0))),
+        SHUTDOWN_HTTP_TIMEOUT,
+    ) {
+        Ok(stream) => stream,
+        Err(err) => {
+            log::debug!("Dashboard graceful shutdown endpoint unavailable: {}", err);
+            return false;
+        }
+    };
+    let _ = stream.set_read_timeout(Some(SHUTDOWN_HTTP_TIMEOUT));
+    let _ = stream.set_write_timeout(Some(SHUTDOWN_HTTP_TIMEOUT));
+
+    let mut request = format!(
+        "POST {} HTTP/1.1\r\nHost: {}:{}\r\nAccept: application/json\r\nContent-Length: 0\r\nConnection: close\r\n",
+        path, host, port
+    );
+    if let Some(token) = session_token.filter(|token| !token.is_empty()) {
+        request.push_str(&format!(
+            "Authorization: Bearer {}\r\nX-Hermes-Session-Token: {}\r\n",
+            token, token
+        ));
+    }
+    request.push_str("\r\n");
+
+    if let Err(err) = stream.write_all(request.as_bytes()) {
+        log::debug!("Dashboard graceful shutdown request failed: {}", err);
+        return false;
+    }
+    let mut response = String::new();
+    if let Err(err) = stream.read_to_string(&mut response) {
+        log::debug!("Dashboard graceful shutdown response failed: {}", err);
+        return false;
+    }
+    let status = response
+        .lines()
+        .next()
+        .and_then(|line| line.split_whitespace().nth(1))
+        .and_then(|code| code.parse::<u16>().ok())
+        .unwrap_or(0);
+    if (200..300).contains(&status) {
+        true
+    } else {
+        if status != 404 {
+            log::debug!(
+                "Dashboard graceful shutdown endpoint returned HTTP {}",
+                status
+            );
+        }
+        false
+    }
+}
+
+#[cfg(unix)]
+fn signal_process_group(pid: u32, signal: libc::c_int) {
+    if pid == 0 {
+        return;
+    }
+    let pgid = -(pid as libc::pid_t);
+    let rc = unsafe { libc::kill(pgid, signal) };
+    if rc != 0 {
+        log::debug!(
+            "Failed to signal dashboard process group {} with {}: {}",
+            pid,
+            signal,
+            std::io::Error::last_os_error()
+        );
+    }
+}
+
+#[cfg(not(unix))]
+fn signal_process_group(_pid: u32, _signal: i32) {}
+
+#[cfg(windows)]
+fn create_dashboard_job(child: &Child) -> Result<DashboardJobHandle, String> {
+    use std::os::windows::io::AsRawHandle;
+    use windows_sys::Win32::Foundation::{CloseHandle, HANDLE};
+    use windows_sys::Win32::System::JobObjects::{
+        AssignProcessToJobObject, CreateJobObjectW, JobObjectExtendedLimitInformation,
+        SetInformationJobObject, JOBOBJECT_EXTENDED_LIMIT_INFORMATION,
+        JOB_OBJECT_LIMIT_KILL_ON_JOB_CLOSE,
+    };
+
+    let job = unsafe { CreateJobObjectW(std::ptr::null(), std::ptr::null()) };
+    if job.is_null() {
+        return Err(std::io::Error::last_os_error().to_string());
+    }
+
+    let mut info = JOBOBJECT_EXTENDED_LIMIT_INFORMATION::default();
+    info.BasicLimitInformation.LimitFlags = JOB_OBJECT_LIMIT_KILL_ON_JOB_CLOSE;
+    let set_ok = unsafe {
+        SetInformationJobObject(
+            job,
+            JobObjectExtendedLimitInformation,
+            &info as *const _ as *const _,
+            std::mem::size_of_val(&info) as u32,
+        )
+    };
+    if set_ok == 0 {
+        let err = std::io::Error::last_os_error().to_string();
+        unsafe { CloseHandle(job) };
+        return Err(err);
+    }
+
+    let process = child.as_raw_handle() as HANDLE;
+    let assign_ok = unsafe { AssignProcessToJobObject(job, process) };
+    if assign_ok == 0 {
+        let err = std::io::Error::last_os_error().to_string();
+        unsafe { CloseHandle(job) };
+        return Err(err);
+    }
+
+    Ok(unsafe { DashboardJobHandle::from_raw(job) })
+}
+
+#[cfg(windows)]
+fn force_kill_process_tree(pid: u32) {
+    if pid == 0 {
+        return;
+    }
+    let pid_arg = pid.to_string();
+    let _ = Command::new("taskkill")
+        .args(["/PID", &pid_arg, "/T", "/F"])
+        .stdout(Stdio::null())
+        .stderr(Stdio::null())
+        .status();
+}
+
+pub fn terminate_owned_dashboard_tree(
+    api_base_url: &str,
+    child: Option<&mut Child>,
+    fallback_pid: Option<u32>,
+    session_token: Option<&str>,
+) {
+    let _ = request_dashboard_shutdown(api_base_url, session_token);
+
+    if let Some(child) = child {
+        if wait_for_child_exit(child, GRACEFUL_SHUTDOWN_TIMEOUT) {
+            return;
+        }
+        let pid = child.id();
+        #[cfg(unix)]
+        signal_process_group(pid, libc::SIGTERM);
+        if wait_for_child_exit(child, FORCE_SHUTDOWN_TIMEOUT) {
+            return;
+        }
+        #[cfg(unix)]
+        signal_process_group(pid, libc::SIGKILL);
+        #[cfg(windows)]
+        force_kill_process_tree(pid);
+        let _ = child.kill();
+        let _ = child.wait();
+        return;
+    }
+
+    if let Some(pid) = fallback_pid {
+        #[cfg(unix)]
+        {
+            signal_process_group(pid, libc::SIGTERM);
+            thread::sleep(GRACEFUL_SHUTDOWN_TIMEOUT);
+            if pid_is_running(pid) {
+                signal_process_group(pid, libc::SIGKILL);
+            }
+        }
+        #[cfg(windows)]
+        {
+            force_kill_process_tree(pid);
+        }
+    }
 }
 
 /// Check if a dashboard is reachable at the given base URL.
@@ -188,6 +533,8 @@ struct SpawnedDashboard {
     command_args: Vec<String>,
     gateway_runtime_dir: String,
     gateway_lock_dir: String,
+    ownership_marker_path: String,
+    job_handle: Option<DashboardJobHandle>,
 }
 
 fn env_flag(name: &str) -> bool {
@@ -290,16 +637,64 @@ fn spawn_dashboard(options: &EnsureDashboardOptions) -> Result<SpawnedDashboard,
         .env("HERMES_GATEWAY_RUNTIME_DIR", &gateway_runtime_dir);
     cmd.stdout(Stdio::piped()).stderr(Stdio::piped());
 
+    #[cfg(unix)]
+    {
+        use std::os::unix::process::CommandExt;
+        // Put the dashboard in its own process group so shutdown can target
+        // gateway/MCP/worker descendants without touching unrelated user
+        // processes.
+        cmd.process_group(0);
+    }
+
     // Windows: hide the console window for the child process
     #[cfg(target_os = "windows")]
     {
         use std::os::windows::process::CommandExt;
-        cmd.creation_flags(0x08000000); // CREATE_NO_WINDOW
+        const CREATE_NO_WINDOW: u32 = 0x08000000;
+        const CREATE_NEW_PROCESS_GROUP: u32 = 0x00000200;
+        cmd.creation_flags(CREATE_NO_WINDOW | CREATE_NEW_PROCESS_GROUP);
     }
 
     let mut child = cmd
         .spawn()
         .map_err(|e| AppError::DashboardStartup(e.to_string()))?;
+    let job_handle = {
+        #[cfg(windows)]
+        {
+            match create_dashboard_job(&child) {
+                Ok(job) => Some(job),
+                Err(err) => {
+                    log::warn!("Failed to attach dashboard to Windows Job Object: {}", err);
+                    None
+                }
+            }
+        }
+        #[cfg(not(windows))]
+        {
+            None
+        }
+    };
+    let api_base_url = dashboard_base_url(&options.host, options.port);
+    let marker_path = ownership_marker_path_display();
+    let runtime_version =
+        crate::process::runtime::read_current_record().map(|record| record.runtime_version);
+    let marker = DashboardOwnershipMarker {
+        schema_version: OWNERSHIP_MARKER_SCHEMA_VERSION,
+        run_id: format!("{}-{}", std::process::id(), now_millis()),
+        desktop_pid: std::process::id(),
+        dashboard_pid: child.id(),
+        api_base_url,
+        hermes_home: options.hermes_home.clone(),
+        runtime_root: crate::process::runtime::runtime_root()
+            .to_string_lossy()
+            .to_string(),
+        gateway_runtime_dir: gateway_runtime_dir.to_string_lossy().to_string(),
+        started_at_ms: now_millis(),
+        runtime_version,
+    };
+    if let Err(err) = write_ownership_marker(&marker) {
+        log::warn!("Failed to write dashboard ownership marker: {}", err);
+    }
     drain_dashboard_output(&mut child);
     Ok(SpawnedDashboard {
         child,
@@ -307,6 +702,8 @@ fn spawn_dashboard(options: &EnsureDashboardOptions) -> Result<SpawnedDashboard,
         command_args: prefix_args,
         gateway_runtime_dir: gateway_runtime_dir.to_string_lossy().to_string(),
         gateway_lock_dir: gateway_lock_dir.to_string_lossy().to_string(),
+        ownership_marker_path: marker_path,
+        job_handle,
     })
 }
 
@@ -377,20 +774,52 @@ pub async fn ensure_hermes_dashboard(
     // is serving the same isolated runtime HERMES_HOME and supports the
     // desktop-required routes. This keeps hot reload / second launch usable
     // without falling back to a user-installed ~/.hermes or PATH runtime.
-    let primary_occupied = probe_dashboard(&api_base_url).await;
+    let mut primary_occupied = probe_dashboard(&api_base_url).await;
+    let ownership_marker = read_ownership_marker();
+    let primary_marker_state = marker_owner_state(
+        ownership_marker.as_ref(),
+        &api_base_url,
+        &options.hermes_home,
+    );
+    if primary_occupied && primary_marker_state == MarkerOwnerState::StaleDesktopOwner {
+        if let Some(marker) = ownership_marker.as_ref() {
+            log::warn!(
+                "Found stale desktop-owned dashboard marker for {}; cleaning orphan pid {}",
+                api_base_url,
+                marker.dashboard_pid
+            );
+            terminate_owned_dashboard_tree(
+                &marker.api_base_url,
+                None,
+                Some(marker.dashboard_pid),
+                None,
+            );
+            remove_ownership_marker_path(None);
+            tokio::time::sleep(Duration::from_millis(350)).await;
+            primary_occupied = probe_dashboard(&api_base_url).await;
+            if primary_occupied {
+                return Err(AppError::DashboardStartup(format!(
+                    "{} is still occupied after cleaning a stale desktop-owned runtime. Stop the remaining process and retry.",
+                    api_base_url
+                )));
+            }
+        }
+    }
     let can_reuse_existing = true;
     if primary_occupied
         && can_reuse_existing
         && dashboard_is_compatible(&api_base_url, &options.hermes_home).await
     {
+        let ownership_state = match primary_marker_state {
+            MarkerOwnerState::LiveDesktopOwner => "attached-live-desktop-owner",
+            MarkerOwnerState::Missing => "attached-compatible-unmarked",
+            MarkerOwnerState::NotThisDashboard => "attached-compatible-unmatched-marker",
+            MarkerOwnerState::StaleDesktopOwner => "attached-stale-cleanup-failed",
+        };
         log::info!(
-            "Reusing compatible dashboard at {}{}",
+            "Reusing compatible dashboard at {} ({})",
             api_base_url,
-            if options.allow_external_agent {
-                " (external agent explicitly allowed)"
-            } else {
-                " (fixed-port managed dev)"
-            }
+            ownership_state
         );
         return Ok(DashboardHandle {
             api_base_url,
@@ -399,6 +828,9 @@ pub async fn ensure_hermes_dashboard(
             command_args: vec![],
             gateway_runtime_dir: None,
             gateway_lock_dir: None,
+            ownership_marker_path: Some(ownership_marker_path_display()),
+            ownership_state: Some(ownership_state.to_string()),
+            job_handle: None,
             child: None,
         });
     }
@@ -437,6 +869,9 @@ pub async fn ensure_hermes_dashboard(
                         command_args: vec![],
                         gateway_runtime_dir: None,
                         gateway_lock_dir: None,
+                        ownership_marker_path: Some(ownership_marker_path_display()),
+                        ownership_state: Some("attached-compatible-fallback".to_string()),
+                        job_handle: None,
                         child: None,
                     });
                 }
@@ -463,8 +898,9 @@ pub async fn ensure_hermes_dashboard(
     let ready = wait_for_dashboard(&child_url, &mut child_opt).await;
     if !ready {
         if let Some(ref mut c) = child_opt {
-            let _ = c.kill();
+            terminate_owned_dashboard_tree(&child_url, Some(c), None, None);
         }
+        remove_ownership_marker_path(Some(&spawned.ownership_marker_path));
         return Err(AppError::DashboardStartup(format!(
             "Not ready at {} within {}s",
             child_url,
@@ -480,6 +916,9 @@ pub async fn ensure_hermes_dashboard(
         command_args: spawned.command_args,
         gateway_runtime_dir: Some(spawned.gateway_runtime_dir),
         gateway_lock_dir: Some(spawned.gateway_lock_dir),
+        ownership_marker_path: Some(spawned.ownership_marker_path),
+        ownership_state: Some("owned".to_string()),
+        job_handle: spawned.job_handle,
         child: child_opt,
     })
 }
@@ -564,5 +1003,66 @@ mod tests {
         // Only http/https are rewritten — anything else passes through.
         let out = build_gateway_url("file:///local", None);
         assert_eq!(out, "file:///local/api/ws");
+    }
+
+    fn test_marker(
+        desktop_pid: u32,
+        api_base_url: &str,
+        hermes_home: &str,
+    ) -> DashboardOwnershipMarker {
+        DashboardOwnershipMarker {
+            schema_version: OWNERSHIP_MARKER_SCHEMA_VERSION,
+            run_id: "test-run".to_string(),
+            desktop_pid,
+            dashboard_pid: 0,
+            api_base_url: api_base_url.to_string(),
+            hermes_home: hermes_home.to_string(),
+            runtime_root: "/tmp/hermes-runtime-test".to_string(),
+            gateway_runtime_dir: "/tmp/hermes-runtime-test/gateway".to_string(),
+            started_at_ms: 1,
+            runtime_version: Some("test".to_string()),
+        }
+    }
+
+    #[test]
+    fn marker_owner_state_detects_live_and_stale_desktop_owner() {
+        let temp = tempfile::tempdir().expect("tempdir");
+        let home = temp.path().join("home");
+        std::fs::create_dir_all(&home).expect("home");
+        let home = home.to_string_lossy().to_string();
+        let api_base_url = "http://127.0.0.1:9120";
+
+        let live = test_marker(std::process::id(), api_base_url, &home);
+        assert_eq!(
+            marker_owner_state(Some(&live), api_base_url, &home),
+            MarkerOwnerState::LiveDesktopOwner
+        );
+
+        let stale = test_marker(0, api_base_url, &home);
+        assert_eq!(
+            marker_owner_state(Some(&stale), api_base_url, &home),
+            MarkerOwnerState::StaleDesktopOwner
+        );
+    }
+
+    #[test]
+    fn marker_owner_state_rejects_unmatched_dashboard_scope() {
+        let temp = tempfile::tempdir().expect("tempdir");
+        let home = temp.path().join("home");
+        let other_home = temp.path().join("other-home");
+        std::fs::create_dir_all(&home).expect("home");
+        std::fs::create_dir_all(&other_home).expect("other");
+        let home = home.to_string_lossy().to_string();
+        let other_home = other_home.to_string_lossy().to_string();
+        let marker = test_marker(std::process::id(), "http://127.0.0.1:9120", &home);
+
+        assert_eq!(
+            marker_owner_state(Some(&marker), "http://127.0.0.1:9121", &home),
+            MarkerOwnerState::NotThisDashboard
+        );
+        assert_eq!(
+            marker_owner_state(Some(&marker), "http://127.0.0.1:9120", &other_home),
+            MarkerOwnerState::NotThisDashboard
+        );
     }
 }

--- a/src/process/runtime.rs
+++ b/src/process/runtime.rs
@@ -168,6 +168,10 @@ pub struct RuntimeProcessInfo {
     pub gateway_runtime_dir: Option<String>,
     #[serde(skip_serializing_if = "Option::is_none")]
     pub gateway_lock_dir: Option<String>,
+    #[serde(skip_serializing_if = "Option::is_none")]
+    pub ownership_marker_path: Option<String>,
+    #[serde(skip_serializing_if = "Option::is_none")]
+    pub ownership_state: Option<String>,
     pub session_token_present: bool,
     pub gateway_sse_proxy_active: bool,
 }

--- a/src/state.rs
+++ b/src/state.rs
@@ -11,6 +11,42 @@ use std::sync::atomic::AtomicBool;
 use std::sync::Arc;
 use std::sync::Mutex;
 
+/// Windows Job Object handle used to bind the dashboard process tree to the
+/// desktop lifecycle. On non-Windows this is a zero-sized placeholder so the
+/// DashboardHandle shape stays uniform across platforms.
+pub struct DashboardJobHandle {
+    #[cfg(windows)]
+    raw: windows_sys::Win32::Foundation::HANDLE,
+}
+
+impl DashboardJobHandle {
+    /// Take ownership of a valid Windows Job Object handle.
+    ///
+    /// # Safety
+    ///
+    /// `raw` must be a live Job Object handle owned by the caller, and it must
+    /// not be closed elsewhere after this wrapper is constructed.
+    #[cfg(windows)]
+    pub unsafe fn from_raw(raw: windows_sys::Win32::Foundation::HANDLE) -> Self {
+        Self { raw }
+    }
+}
+
+#[cfg(windows)]
+unsafe impl Send for DashboardJobHandle {}
+
+impl Drop for DashboardJobHandle {
+    fn drop(&mut self) {
+        #[cfg(windows)]
+        unsafe {
+            if !self.raw.is_null() {
+                let _ = windows_sys::Win32::Foundation::CloseHandle(self.raw);
+                self.raw = std::ptr::null_mut();
+            }
+        }
+    }
+}
+
 /// Handle to a running hermes dashboard subprocess.
 pub struct DashboardHandle {
     /// Base URL of the dashboard API (e.g. "http://127.0.0.1:9120").
@@ -25,18 +61,43 @@ pub struct DashboardHandle {
     pub gateway_runtime_dir: Option<String>,
     /// Runtime-scoped lock directory injected into the dashboard environment.
     pub gateway_lock_dir: Option<String>,
+    /// Path to the desktop ownership marker, when the dashboard is managed or attached.
+    pub ownership_marker_path: Option<String>,
+    /// Diagnostic ownership state: owned, attached, orphan-cleaned, etc.
+    pub ownership_state: Option<String>,
+    /// Windows Job Object keeping the owned runtime process tree tied to this handle.
+    pub job_handle: Option<DashboardJobHandle>,
     /// The child process, if we own it.
     pub child: Option<Child>,
 }
 
 impl DashboardHandle {
-    /// Gracefully stop the dashboard process if we own it.
+    /// Stop the dashboard process tree if we own it.
     pub fn stop(&mut self) {
-        if let Some(ref mut child) = self.child {
-            let _ = child.kill();
-            let _ = child.wait();
+        self.stop_with_token(None);
+    }
+
+    /// Stop the dashboard process tree if we own it, first trying the
+    /// dashboard's protected shutdown endpoint when a session token is known.
+    pub fn stop_with_token(&mut self, session_token: Option<&str>) {
+        if !self.owns_process {
+            self.child = None;
+            return;
         }
+        let fallback_pid = self.child.as_ref().map(|child| child.id());
+        crate::process::dashboard::terminate_owned_dashboard_tree(
+            &self.api_base_url,
+            self.child.as_mut(),
+            fallback_pid,
+            session_token,
+        );
         self.child = None;
+        self.job_handle = None;
+        self.owns_process = false;
+        crate::process::dashboard::remove_ownership_marker_path(
+            self.ownership_marker_path.as_deref(),
+        );
+        self.ownership_state = Some("stopped".to_string());
     }
 }
 

--- a/web/src/components/chat/goose-composer-context.tsx
+++ b/web/src/components/chat/goose-composer-context.tsx
@@ -60,7 +60,7 @@ export function contextRiskText(risk: ContextRisk, active: boolean): string {
       ? "上下文已超出模型窗口，当前响应可能卡住，或使用上下文更大的模型。"
       : "上下文已超出模型窗口，等待 Hermes 自动压缩或返回错误，或使用上下文更大的模型。";
   }
-  if (risk === "warning") return "上下文接近 Hermes 自动压缩阈值。";
+  if (risk === "warning") return "上下文接近 Hermes 自动压缩阈值，触发后会显示已压缩次数。";
   return "";
 }
 
@@ -132,7 +132,7 @@ export function ContextIndicator({
             <span>{percentLabel}</span>
           </span>
           {usage.estimated ? (
-            <span className={s.contextPopoverMeta}>按当前消息内容估算</span>
+            <span className={s.contextPopoverMeta}>按当前已渲染消息估算，不使用累计账单 tokens</span>
           ) : null}
           {typeof usage.compressions === "number" && usage.compressions > 0 ? (
             <span className={s.contextPopoverMeta}>已压缩 {usage.compressions} 次</span>

--- a/web/src/components/chat/message-adapter.test.ts
+++ b/web/src/components/chat/message-adapter.test.ts
@@ -156,6 +156,85 @@ describe("message adapter", () => {
     });
   });
 
+  it("hides image transport context when rendering stored user prompts", () => {
+    const message = hermesUIMessageToChatMessage(uiMessage({
+      id: "stored-user-image",
+      role: "user",
+      parts: [{
+        type: "text",
+        text: [
+          "[Hermes UI Image]",
+          "name=ga.png",
+          "description:",
+          "This image shows a Google Analytics dashboard.",
+          "[/Hermes UI Image]",
+          "",
+          "阅读这张图片的内容",
+        ].join("\n"),
+      }],
+    }));
+
+    expect(message?.text).toBe("阅读这张图片的内容\n\n附件：ga.png");
+  });
+
+  it("deduplicates stored image transport prompts against live display prompts", () => {
+    const stored = [
+      uiMessage({
+        id: "stored-user-image",
+        role: "user",
+        parts: [{
+          type: "text",
+          text: [
+            "[The user attached an image but analysis failed.]",
+            "[You can examine it with vision_analyze using image_url: /Users/enzo/Downloads/ga.png]",
+            "",
+            "[Hermes UI Workspace]",
+            "workspace=/Users/enzo/Documents/GithubProjects/hermes/hermes-agent-cn-desktop",
+            "instruction=Treat this as the active workspace/root for file paths and shell commands.",
+            "[/Hermes UI Workspace]",
+            "",
+            "[Hermes UI Image]",
+            "name=ga.png",
+            "description:",
+            "[User attached image: ga.png]",
+            "[/Hermes UI Image]",
+            "",
+            "看一下这张图里面是什么内容",
+          ].join("\n"),
+        }],
+      }),
+      uiMessage({
+        id: "stored-assistant-image",
+        role: "assistant",
+        parts: [{ type: "text", text: "我已经阅读了这张图片。" }],
+      }),
+    ];
+    const live = [
+      uiMessage({
+        id: "live-user-image",
+        role: "user",
+        parts: [{ type: "text", text: "看一下这张图里面是什么内容\n\n附件：ga.png" }],
+      }),
+      uiMessage({
+        id: "live-assistant-image",
+        role: "assistant",
+        parts: [{ type: "text", text: "我已经阅读了这张图片。" }],
+      }),
+    ];
+
+    const merged = mergeHermesUIMessages(stored, live);
+    const chat = hermesUIMessagesToChatMessages(merged);
+
+    expect(merged.map((message) => message.id)).toEqual([
+      "live-user-image",
+      "live-assistant-image",
+    ]);
+    expect(chat.map((message) => message.text)).toEqual([
+      "看一下这张图里面是什么内容\n\n附件：ga.png",
+      "我已经阅读了这张图片。",
+    ]);
+  });
+
   it("keeps canonical progress as a streaming progress block", () => {
     const message = hermesUIMessageToChatMessage(uiMessage({
       id: "live-assistant-1",

--- a/web/src/components/chat/message-adapter.ts
+++ b/web/src/components/chat/message-adapter.ts
@@ -603,7 +603,7 @@ function looseComparableText(value: string | undefined): string {
 }
 
 function canonicalText(message: HermesUIMessage): string {
-  return comparableText(textFromParts(message.parts) ?? noticeTextFromParts(message.parts));
+  return comparableText(normalizeContent(textFromParts(message.parts) ?? noticeTextFromParts(message.parts)));
 }
 
 function canonicalReasoning(message: HermesUIMessage): string {

--- a/web/src/lib/composer-prompt.test.ts
+++ b/web/src/lib/composer-prompt.test.ts
@@ -1,0 +1,67 @@
+import { describe, expect, it, vi } from "vitest";
+import { prepareComposerPrompt, stripHermesUiWorkspaceContext } from "./composer-prompt";
+
+describe("composer prompt preparation", () => {
+  it("includes image attach/vision text in the transport prompt but hides it from display text", async () => {
+    const result = await prepareComposerPrompt(
+      "s1",
+      {
+        text: "这张图说明了什么？",
+        attachments: [{
+          id: "a1",
+          source: "path",
+          path: "/tmp/screenshot.png",
+          name: "screenshot.png",
+          kind: "image",
+          status: "ready",
+        }],
+      },
+      {
+        attachImage: vi.fn(async () => ({ attached: true, text: "图中是一张任务管理看板。", name: "screenshot.png" })),
+        detectDroppedPath: vi.fn(),
+      },
+    );
+
+    expect(result.promptText).toContain("[Hermes UI Image]");
+    expect(result.promptText).toContain("图中是一张任务管理看板。");
+    expect(result.promptText.endsWith("这张图说明了什么？")).toBe(true);
+    expect(result.displayText).toBe("这张图说明了什么？\n\n附件：screenshot.png");
+    expect(stripHermesUiWorkspaceContext(result.promptText)).toBe(result.displayText);
+  });
+
+  it("hides legacy image analysis prompt blocks from rendered stored user messages", () => {
+    const legacyPrompt = [
+      "[User attached image: ga.png]",
+      "This image shows a Google Analytics 4 dashboard.",
+      "",
+      "Header Section",
+      "Navigation and metrics are visible.",
+      "",
+      "阅读这张图片的内容",
+    ].join("\n");
+
+    expect(stripHermesUiWorkspaceContext(legacyPrompt)).toBe("阅读这张图片的内容\n\n附件：ga.png");
+  });
+
+  it("hides image fallback preamble plus internal image/workspace blocks from stored prompts", () => {
+    const storedPrompt = [
+      "[The user attached an image but analysis failed.]",
+      "[You can examine it with vision_analyze using image_url: /Users/enzo/Downloads/ga.png]",
+      "",
+      "[Hermes UI Workspace]",
+      "workspace=/Users/enzo/Documents/GithubProjects/hermes/hermes-agent-cn-desktop",
+      "instruction=Treat this as the active workspace/root for file paths and shell commands.",
+      "[/Hermes UI Workspace]",
+      "",
+      "[Hermes UI Image]",
+      "name=ga.png",
+      "description:",
+      "[User attached image: ga.png]",
+      "[/Hermes UI Image]",
+      "",
+      "看一下这张图里面是什么内容",
+    ].join("\n");
+
+    expect(stripHermesUiWorkspaceContext(storedPrompt)).toBe("看一下这张图里面是什么内容\n\n附件：ga.png");
+  });
+});

--- a/web/src/lib/composer-prompt.ts
+++ b/web/src/lib/composer-prompt.ts
@@ -8,6 +8,11 @@ import type { AttachmentUploadResult, ImageAttachResult, InputDetectDropResult }
 const WORKSPACE_BLOCK_START = "[Hermes UI Workspace]";
 const WORKSPACE_BLOCK_END = "[/Hermes UI Workspace]";
 const WORKSPACE_BLOCK_RE = /\n?\[Hermes UI Workspace\]\nworkspace=[^\n]*\ninstruction=[\s\S]*?\n\[\/Hermes UI Workspace\]\n?/g;
+const IMAGE_BLOCK_START = "[Hermes UI Image]";
+const IMAGE_BLOCK_END = "[/Hermes UI Image]";
+const IMAGE_BLOCK_RE = /\n?\[Hermes UI Image\]\nname=([^\n]*)\ndescription:\n[\s\S]*?\n\[\/Hermes UI Image\]\n?/g;
+const IMAGE_FALLBACK_PREAMBLE_RE = /\n?\[The user attached an image(?: but analysis failed)?\.\]\n\[You can examine it with vision_analyze using image_url: [^\]\n]+\]\n?/g;
+const LEGACY_IMAGE_BLOCK_RE = /^\s*\[User attached image: ([^\]\n]+)\]\n[\s\S]*$/;
 
 const IMAGE_EXTENSIONS = new Set([
   ".apng",
@@ -36,8 +41,43 @@ export function fileNameFromPath(path: string): string {
   return normalized.split("/").pop() || path;
 }
 
+function attachmentSuffix(labels: string[]): string {
+  return `附件：${labels.join("、")}`;
+}
+
+function sanitizeContextValue(value: string): string {
+  return value.replace(/[\r\n]+/g, " ").trim();
+}
+
+function stripLegacyImageContext(value: string, labels: string[]): string {
+  const match = value.match(LEGACY_IMAGE_BLOCK_RE);
+  if (!match) return value;
+
+  const label = match[1]?.trim();
+  if (label) labels.push(label);
+
+  const body = value.replace(/^\s*\[User attached image: [^\]\n]+\]\n/, "");
+  const lastSeparator = body.lastIndexOf("\n\n");
+  return lastSeparator >= 0 ? body.slice(lastSeparator + 2) : "";
+}
+
 export function stripHermesUiWorkspaceContext(text: string | null | undefined): string {
-  return (text ?? "").replace(WORKSPACE_BLOCK_RE, "").trimEnd();
+  let value = (text ?? "")
+    .replace(IMAGE_FALLBACK_PREAMBLE_RE, "")
+    .replace(WORKSPACE_BLOCK_RE, "");
+  const imageLabels: string[] = [];
+
+  value = value.replace(IMAGE_BLOCK_RE, (_block, label: string) => {
+    const name = label.trim();
+    if (name) imageLabels.push(name);
+    return "\n";
+  });
+  value = stripLegacyImageContext(value, imageLabels).trim();
+
+  if (imageLabels.length === 0) return value.trimEnd();
+
+  const suffix = attachmentSuffix(imageLabels);
+  return value ? `${value}\n\n${suffix}` : suffix;
 }
 
 function buildWorkspaceContext(workspacePath?: string): string {
@@ -126,6 +166,16 @@ export async function prepareComposerPrompt(
         const attached = await helpers.attachImage(sessionId, path);
         if (attached.attached === false) {
           throw new Error(attached.text || "图片附件未能添加");
+        }
+        if (attached.text?.trim()) {
+          const label = attached.name || uploadedName || attachment.name || fileNameFromPath(path);
+          parts.push([
+            IMAGE_BLOCK_START,
+            `name=${sanitizeContextValue(label)}`,
+            "description:",
+            attached.text.trim(),
+            IMAGE_BLOCK_END,
+          ].join("\n"));
         }
         helpers.onAttachmentUpdate?.(attachment.id, { status: "done", progress: 100 });
         continue;

--- a/web/src/lib/config-update.test.ts
+++ b/web/src/lib/config-update.test.ts
@@ -1,0 +1,35 @@
+import { describe, expect, it } from "vitest";
+import { buildNestedConfigUpdate, mergeConfigUpdate } from "./config-update";
+
+describe("config update helpers", () => {
+  it("builds a nested patch for dotted schema keys", () => {
+    expect(buildNestedConfigUpdate("agent.context_window", 32000)).toEqual({
+      agent: { context_window: 32000 },
+    });
+  });
+
+  it("merges a single field edit into the full config without dropping custom models", () => {
+    const current = {
+      model: { provider: "custom:local", default: "local-chat" },
+      providers: {
+        "custom:local": {
+          name: "Local",
+          base_url: "http://127.0.0.1:11434/v1",
+          model: "local-chat",
+        },
+      },
+      agent: { context_window: 16000, image_input_mode: "text" },
+    };
+
+    const next = mergeConfigUpdate(
+      current,
+      buildNestedConfigUpdate("agent.context_window", 64000),
+    );
+
+    expect(next).toEqual({
+      ...current,
+      agent: { context_window: 64000, image_input_mode: "text" },
+    });
+    expect(next.providers["custom:local"].model).toBe("local-chat");
+  });
+});

--- a/web/src/lib/config-update.ts
+++ b/web/src/lib/config-update.ts
@@ -1,0 +1,35 @@
+function isPlainObject(value: unknown): value is Record<string, unknown> {
+  return Boolean(value) && typeof value === "object" && !Array.isArray(value);
+}
+
+export function buildNestedConfigUpdate(key: string, value: unknown): Record<string, unknown> {
+  const parts = key.split(".").filter(Boolean);
+  if (parts.length === 0) return {};
+  if (parts.length === 1) return { [parts[0]!]: value };
+  const root: Record<string, unknown> = {};
+  let cur = root;
+  for (let i = 0; i < parts.length - 1; i += 1) {
+    const part = parts[i]!;
+    const next: Record<string, unknown> = {};
+    cur[part] = next;
+    cur = next;
+  }
+  cur[parts[parts.length - 1]!] = value;
+  return root;
+}
+
+export function mergeConfigUpdate<T extends Record<string, unknown>>(
+  current: T,
+  patch: Record<string, unknown>,
+): T {
+  const merge = (base: unknown, next: unknown): unknown => {
+    if (!isPlainObject(base) || !isPlainObject(next)) return next;
+    const out: Record<string, unknown> = { ...base };
+    for (const [key, value] of Object.entries(next)) {
+      out[key] = key in out ? merge(out[key], value) : value;
+    }
+    return out;
+  };
+
+  return merge(current, patch) as T;
+}

--- a/web/src/lib/workspaces.test.ts
+++ b/web/src/lib/workspaces.test.ts
@@ -25,6 +25,31 @@ describe("workspace persistence helpers", () => {
     expect(workspaceNameFromPath("/Users/claw/Project")).toBe("Project");
   });
 
+
+  it("ignores malformed persisted workspace values from older builds", () => {
+    __resetUiStoreForTests({
+      "hermes-cn-ui.workspaceProjects": [
+        { path: ["/Users/claw/OldA", "/Users/claw/OldB"], name: { label: "old" } },
+        { path: "/Users/claw/Project", name: 42, createdAt: "bad", updatedAt: null },
+      ],
+      "hermes-cn-ui.sessionWorkspaces": {
+        "session-1": ["/Users/claw/OldA"],
+        "session-2": "/Users/claw/Project",
+      },
+    });
+
+    expect(normalizeWorkspacePath(["/Users/claw/OldA"])).toBe("");
+    expect(readWorkspaceProjects()).toEqual([
+      expect.objectContaining({
+        path: "/Users/claw/Project",
+        name: "Project",
+      }),
+    ]);
+    expect(readSessionWorkspaceMap()).toEqual({
+      "session-2": "/Users/claw/Project",
+    });
+  });
+
   it("stores workspace projects without duplicating equivalent paths", () => {
     rememberWorkspaceProject("/Users/claw/Project/");
     rememberWorkspaceProject("/Users/claw/Project", "Renamed");

--- a/web/src/lib/workspaces.ts
+++ b/web/src/lib/workspaces.ts
@@ -12,8 +12,8 @@ const WORKSPACE_PROJECTS_STORAGE_KEY = "hermes-cn-ui.workspaceProjects";
 const SESSION_WORKSPACE_STORAGE_KEY = "hermes-cn-ui.sessionWorkspaces";
 const WORKSPACE_CHANGED_EVENT = "hermes-cn-ui.workspaces.changed";
 
-export function normalizeWorkspacePath(path: string | null | undefined): string {
-  return (path ?? "").trim().replace(/\/+$/, "");
+export function normalizeWorkspacePath(path: unknown): string {
+  return typeof path === "string" ? path.trim().replace(/\/+$/, "") : "";
 }
 
 export function workspaceNameFromPath(path: string): string {
@@ -36,6 +36,10 @@ function writeJSON(key: string, value: unknown): void {
   emitWorkspaceChange();
 }
 
+function isRecord(value: unknown): value is Record<string, unknown> {
+  return Boolean(value) && typeof value === "object" && !Array.isArray(value);
+}
+
 export function readWorkspacePath(): string {
   return normalizeWorkspacePath(readUiValue(WORKSPACE_STORAGE_KEY, ""));
 }
@@ -51,17 +55,22 @@ export function writeWorkspacePath(path: string): void {
 }
 
 export function readWorkspaceProjects(): WorkspaceProject[] {
-  const raw = readJSON<WorkspaceProject[]>(WORKSPACE_PROJECTS_STORAGE_KEY, []);
+  const rawValue = readJSON<unknown>(WORKSPACE_PROJECTS_STORAGE_KEY, []);
+  const raw = Array.isArray(rawValue) ? rawValue : [];
   const seen = new Set<string>();
   return raw.flatMap((item) => {
-    const path = normalizeWorkspacePath(item?.path);
+    if (!isRecord(item)) return [];
+    const path = normalizeWorkspacePath(item.path);
     if (!path || seen.has(path)) return [];
     seen.add(path);
+    const name = typeof item.name === "string" ? item.name.trim() : "";
+    const createdAt = typeof item.createdAt === "number" && Number.isFinite(item.createdAt) ? item.createdAt : Date.now();
+    const updatedAt = typeof item.updatedAt === "number" && Number.isFinite(item.updatedAt) ? item.updatedAt : Date.now();
     return [{
       path,
-      name: item.name?.trim() || workspaceNameFromPath(path),
-      createdAt: Number.isFinite(item.createdAt) ? item.createdAt : Date.now(),
-      updatedAt: Number.isFinite(item.updatedAt) ? item.updatedAt : Date.now(),
+      name: name || workspaceNameFromPath(path),
+      createdAt,
+      updatedAt,
     }];
   });
 }
@@ -73,15 +82,16 @@ export function rememberWorkspaceProject(path: string, name?: string): Workspace
   const now = Date.now();
   const projects = readWorkspaceProjects();
   const existing = projects.find((item) => item.path === normalized);
+  const displayName = typeof name === "string" ? name.trim() : "";
   const nextProject: WorkspaceProject = existing
     ? {
         ...existing,
-        name: name?.trim() || existing.name || workspaceNameFromPath(normalized),
+        name: displayName || existing.name || workspaceNameFromPath(normalized),
         updatedAt: now,
       }
     : {
         path: normalized,
-        name: name?.trim() || workspaceNameFromPath(normalized),
+        name: displayName || workspaceNameFromPath(normalized),
         createdAt: now,
         updatedAt: now,
       };
@@ -113,7 +123,8 @@ export function removeWorkspaceProject(path: string): void {
 }
 
 export function readSessionWorkspaceMap(): Record<string, string> {
-  const raw = readJSON<Record<string, string>>(SESSION_WORKSPACE_STORAGE_KEY, {});
+  const raw = readJSON<unknown>(SESSION_WORKSPACE_STORAGE_KEY, {});
+  if (!isRecord(raw)) return {};
   return Object.fromEntries(
     Object.entries(raw).flatMap(([sessionId, path]) => {
       const normalized = normalizeWorkspacePath(path);

--- a/web/src/routes/settings.tsx
+++ b/web/src/routes/settings.tsx
@@ -528,6 +528,8 @@ export function AboutSection({ showHeading = true }: SettingsSectionProps) {
             <RuntimeField label="档案" value={process?.currentProfile ?? rendererRuntime?.currentProfile ?? "—"} />
             <RuntimeField label="Session Token" value={process?.sessionTokenPresent ? "已注入" : "未注入 / dev proxy"} />
             <RuntimeField label="SSE 代理" value={process?.gatewaySseProxyActive ? "连接中" : "未连接或浏览器直连"} />
+            <RuntimeField label="Ownership" value={process?.ownershipState ?? "—"} mono />
+            <RuntimeField label="Ownership Marker" value={process?.ownershipMarkerPath ?? "—"} mono wide />
             <RuntimeField label="HERMES_HOME" value={process?.hermesHome || hermesHomePath || "—"} mono wide />
           </div>
           {process?.commandLine && (

--- a/web/src/routes/settings.tsx
+++ b/web/src/routes/settings.tsx
@@ -27,6 +27,7 @@ import {
 } from "@/hooks/use-runtime-update";
 import { showReasoningAtom } from "@/stores/ui";
 import { postJSON } from "@/lib/transport";
+import { buildNestedConfigUpdate, mergeConfigUpdate } from "@/lib/config-update";
 import type { ConfigSchemaField, RuntimeInfo, RuntimeUpdateCheckResult } from "@hermes/protocol";
 import { CopyButton } from "@/components/ui/copy-button";
 import s from "./settings.module.css";
@@ -142,7 +143,7 @@ export function ConfigSection({ showHeading = true }: SettingsSectionProps) {
             fieldKey={key}
             field={field}
             value={getNestedValue(config, key)}
-            onSave={(val) => saveConfig.mutate(buildConfigUpdate(key, val))}
+            onSave={(val) => saveConfig.mutate(mergeConfigUpdate(config, buildNestedConfigUpdate(key, val)))}
             showCategory={isSearching}
           />
         ))}
@@ -862,19 +863,6 @@ function FieldRow({ label, value, onChange, placeholder }: {
 function getNestedValue(obj: any, path: string): any {
   if (!obj) return undefined;
   return path.split(".").reduce((o, k) => o?.[k], obj);
-}
-
-function buildConfigUpdate(key: string, value: any): Record<string, any> {
-  const parts = key.split(".");
-  if (parts.length === 1) return { [key]: value };
-  const root: any = {};
-  let cur = root;
-  for (let i = 0; i < parts.length - 1; i++) {
-    cur[parts[i]] = {};
-    cur = cur[parts[i]];
-  }
-  cur[parts[parts.length - 1]] = value;
-  return root;
 }
 
 function groupBy<T>(arr: T[], fn: (item: T) => string): Record<string, T[]> {

--- a/web/src/stores/chat.test.ts
+++ b/web/src/stores/chat.test.ts
@@ -700,6 +700,59 @@ describe("startPromptAtom", () => {
     expect(runtime.streamStatus).toBe("streaming");
   });
 
+
+  it("does not recover from stored reasoning/tools when the stored final text is still missing", () => {
+    const store = createStore();
+
+    store.set(startPromptAtom, { sessionId: "s1", text: "总结", now: 1_000 });
+    store.set(chatRuntimeBySessionAtom, (state) => {
+      let rt = state.s1;
+      rt = reduceGatewayEvent(rt, {
+        type: "reasoning.delta",
+        session_id: "s1",
+        payload: { text: "先检查。" },
+      }, 1_500);
+      rt = reduceGatewayEvent(rt, {
+        type: "tool.start",
+        session_id: "s1",
+        payload: { tool_id: "t1", name: "read", context: "a.txt" },
+      }, 1_600);
+      rt = reduceGatewayEvent(rt, {
+        type: "tool.complete",
+        session_id: "s1",
+        payload: { tool_id: "t1", summary: "ok" },
+      }, 1_700);
+      rt = reduceGatewayEvent(rt, {
+        type: "message.delta",
+        session_id: "s1",
+        payload: { text: "最终回答不要消失。" },
+      }, 1_800);
+      return { ...state, s1: rt };
+    });
+
+    store.set(recoverCompletedTurnFromStoredMessagesAtom, {
+      sessionId: "s1",
+      now: 2_000,
+      storedMessages: [
+        runtimeMessage({
+          id: "stored-no-final-text-yet",
+          sessionId: "s1",
+          role: "assistant",
+          status: "complete",
+          createdAt: 1_900,
+          parts: [
+            { type: "reasoning", text: "先检查。" },
+            { type: "tool", toolCallId: "t1", name: "read", state: "done", output: "ok", startedAt: 1_600, completedAt: 1_700 },
+          ],
+        }),
+      ],
+    });
+
+    const runtime = store.get(chatRuntimeBySessionAtom).s1;
+    expect(runtime.streamStatus).toBe("streaming");
+    expect(textFromParts(assistantMessage(runtime).parts)).toBe("最终回答不要消失。");
+  });
+
   it("recovers a stale streaming assistant when stored messages already completed the turn", () => {
     const store = createStore();
 

--- a/web/src/stores/chat.ts
+++ b/web/src/stores/chat.ts
@@ -833,6 +833,9 @@ function isRecoverableStoredAssistant(
   if (liveText && storedText) {
     return liveText === storedText || (liveText.length >= 4 && storedText.includes(liveText));
   }
+  if (liveText && !storedText) {
+    return false;
+  }
 
   const liveReasoning = looseComparableText(reasoningFromParts(withoutProgressParts(liveAssistant.parts)));
   const storedReasoning = looseComparableText(reasoningFromParts(storedAssistant.parts));


### PR DESCRIPTION
## Summary

This PR collects the remaining desktop fixes from the `codex/fix-open-issues` workspace on top of the latest `main`.

It tightens managed runtime lifecycle handling so desktop-owned dashboard processes and their child process trees are cleaned up reliably across app exit, profile switching, runtime update, and rollback. It also adds Windows Job Object binding for owned dashboard processes, keeps process-group/taskkill fallbacks, and records ownership diagnostics for stale managed runtime cleanup.

It also fixes several UI regressions found while testing open issues: config updates now preserve existing nested config such as custom providers, image attachment transport context is hidden from rendered chat history while still being sent to Hermes, legacy image prompt formats are normalized for deduplication, malformed persisted workspace values no longer crash the page, and stored assistant recovery no longer overwrites live final text with reasoning/tool-only persisted rows.

## Validation

- `pnpm typecheck`
- `pnpm test:unit`
- `cargo check`
- Manual desktop testing of image-reading sessions, including `20260522_154732_f49ad3`
