### PR TITLE
[codex] fix async SSE RPC session resume

### DIFF
--- a/web/src/lib/gateway-sse-client.test.ts
+++ b/web/src/lib/gateway-sse-client.test.ts
@@ -78,6 +78,12 @@ function installRuntimeStub(token = "test-token", apiBase = "http://127.0.0.1:91
   (window as any).location = { href: `${apiBase}/`, search: "" };
 }
 
+async function flushMicrotasks(times = 4): Promise<void> {
+  for (let i = 0; i < times; i += 1) {
+    await Promise.resolve();
+  }
+}
+
 beforeEach(() => {
   MockEventSource.instances = [];
   (globalThis as any).EventSource = MockEventSource;
@@ -316,6 +322,105 @@ describe("GatewaySseClient", () => {
     });
 
     await expect(request).rejects.toThrow(/session not found/);
+  });
+
+  it("rejects async RPC requests when the native SSE stream closes", async () => {
+    const client = new GatewaySseClient();
+    const connectP = client.connect();
+    const es = MockEventSource.instances[0];
+    es.emitNamed("client_id", { client_id: "cid-close" });
+    await connectP;
+
+    globalThis.fetch = vi.fn(async (_url: string, init: RequestInit) => {
+      const body = JSON.parse(String(init.body));
+      return new Response(
+        JSON.stringify({
+          jsonrpc: "2.0",
+          id: body.id,
+          result: { accepted: true, async: true },
+        }),
+        { status: 200 },
+      );
+    }) as any;
+
+    let observed = "pending";
+    const request = client.request("session.resume", { session_id: "persist-close" });
+    request.then(
+      () => { observed = "resolved"; },
+      (error) => { observed = `rejected:${error.message}`; },
+    );
+    await vi.waitFor(() => expect(globalThis.fetch).toHaveBeenCalledOnce());
+    await flushMicrotasks();
+
+    es.emitError();
+    await flushMicrotasks();
+
+    expect(observed).toBe("rejected:SSE connection closed");
+  });
+
+  it("rejects async RPC requests when the Tauri SSE proxy closes", async () => {
+    vi.useRealTimers();
+    const listeners = new Map<string, (event: { payload: string }) => void>();
+    const refreshGatewayUrl = vi.fn(async () => ({
+      gatewayUrl: "ws://127.0.0.1:9119/api/ws?token=fresh-token",
+      sessionToken: "fresh-token",
+    }));
+    const requestProxy = vi.fn(async () => ({
+      ok: true,
+      status: 200,
+      statusText: "OK",
+      headers: {},
+      body: JSON.stringify({
+        jsonrpc: "2.0",
+        id: "ignored",
+        result: { accepted: true, async: true },
+      }),
+    }));
+
+    (window as any).__TAURI_INTERNALS__ = {};
+    window.__HERMES_RUNTIME__ = {
+      platform: "tauri",
+      apiBaseUrl: "http://127.0.0.1:9119",
+      gatewayUrl: "ws://127.0.0.1:9119/api/ws?token=stale-token",
+      sessionToken: "stale-token",
+      transport: "sse",
+    };
+    window.__HERMES_SESSION_TOKEN__ = "stale-token";
+    window.hermesDesktop = {
+      windowType: "tauri",
+      refreshGatewayUrl,
+      request: requestProxy,
+    };
+
+    tauriMocks.listen.mockImplementation(
+      async (eventName: string, cb: (event: { payload: string }) => void) => {
+        listeners.set(eventName, cb);
+        return vi.fn();
+      },
+    );
+    tauriMocks.invoke.mockResolvedValue(undefined);
+
+    const client = new GatewaySseClient();
+    const connectP = client.connect({ timeoutMs: 5_000 });
+    await vi.waitFor(() => expect(tauriMocks.invoke).toHaveBeenCalledOnce());
+    listeners.get("gateway-sse-event")?.({
+      payload: JSON.stringify({ client_id: "cid-tauri-close" }),
+    });
+    await connectP;
+
+    let observed = "pending";
+    const request = client.request("session.resume", { session_id: "persist-tauri-close" });
+    request.then(
+      () => { observed = "resolved"; },
+      (error) => { observed = `rejected:${error.message}`; },
+    );
+    await vi.waitFor(() => expect(requestProxy).toHaveBeenCalledOnce());
+    await flushMicrotasks();
+
+    listeners.get("gateway-sse-error")?.({ payload: "SSE stream ended" });
+    await flushMicrotasks();
+
+    expect(observed).toBe("rejected:SSE connection closed");
   });
 
   it("uses one Tauri SSE proxy connection across repeated RPC requests", async () => {

--- a/web/src/lib/gateway-sse-client.test.ts
+++ b/web/src/lib/gateway-sse-client.test.ts
@@ -222,6 +222,102 @@ describe("GatewaySseClient", () => {
     await expect(client.request("foo")).rejects.toThrow(/unknown method: foo/);
   });
 
+  it("waits for the matching SSE response when RPC returns an async ack", async () => {
+    const client = new GatewaySseClient();
+    const connectP = client.connect();
+    const es = MockEventSource.instances[0];
+    es.emitNamed("client_id", { client_id: "cid-async" });
+    await connectP;
+
+    globalThis.fetch = vi.fn(async (_url: string, init: RequestInit) => {
+      const body = JSON.parse(String(init.body));
+      return new Response(
+        JSON.stringify({
+          jsonrpc: "2.0",
+          id: body.id,
+          result: { accepted: true, async: true },
+        }),
+        { status: 200 },
+      );
+    }) as any;
+
+    const request = client.request<{ session_id: string; resumed: string }>(
+      "session.resume",
+      { session_id: "persist-1" },
+    );
+    await vi.waitFor(() => expect(globalThis.fetch).toHaveBeenCalledOnce());
+    const posted = JSON.parse(String((globalThis.fetch as any).mock.calls[0][1].body));
+
+    es.emitMessage({
+      jsonrpc: "2.0",
+      id: posted.id,
+      result: { session_id: "gw-1", resumed: "persist-1" },
+    });
+
+    await expect(request).resolves.toEqual({ session_id: "gw-1", resumed: "persist-1" });
+  });
+
+  it("uses an early SSE response if it arrives before the async ack is parsed", async () => {
+    const client = new GatewaySseClient();
+    const connectP = client.connect();
+    const es = MockEventSource.instances[0];
+    es.emitNamed("client_id", { client_id: "cid-race" });
+    await connectP;
+
+    globalThis.fetch = vi.fn(async (_url: string, init: RequestInit) => {
+      const body = JSON.parse(String(init.body));
+      es.emitMessage({
+        jsonrpc: "2.0",
+        id: body.id,
+        result: { session_id: "gw-race", resumed: "persist-race" },
+      });
+      return new Response(
+        JSON.stringify({
+          jsonrpc: "2.0",
+          id: body.id,
+          result: { accepted: true, async: true },
+        }),
+        { status: 200 },
+      );
+    }) as any;
+
+    await expect(
+      client.request("session.resume", { session_id: "persist-race" }),
+    ).resolves.toEqual({ session_id: "gw-race", resumed: "persist-race" });
+  });
+
+  it("rejects async RPC requests when the SSE response is an error", async () => {
+    const client = new GatewaySseClient();
+    const connectP = client.connect();
+    const es = MockEventSource.instances[0];
+    es.emitNamed("client_id", { client_id: "cid-error" });
+    await connectP;
+
+    globalThis.fetch = vi.fn(async (_url: string, init: RequestInit) => {
+      const body = JSON.parse(String(init.body));
+      return new Response(
+        JSON.stringify({
+          jsonrpc: "2.0",
+          id: body.id,
+          result: { accepted: true, async: true },
+        }),
+        { status: 200 },
+      );
+    }) as any;
+
+    const request = client.request("session.resume", { session_id: "missing" });
+    await vi.waitFor(() => expect(globalThis.fetch).toHaveBeenCalledOnce());
+    const posted = JSON.parse(String((globalThis.fetch as any).mock.calls[0][1].body));
+
+    es.emitMessage({
+      jsonrpc: "2.0",
+      id: posted.id,
+      error: { code: 4007, message: "session not found" },
+    });
+
+    await expect(request).rejects.toThrow(/session not found/);
+  });
+
   it("uses one Tauri SSE proxy connection across repeated RPC requests", async () => {
     vi.useRealTimers();
     const listeners = new Map<string, (event: { payload: string }) => void>();

--- a/web/src/lib/gateway-sse-client.ts
+++ b/web/src/lib/gateway-sse-client.ts
@@ -64,6 +64,12 @@ interface RpcAsyncAck {
   async: true;
 }
 
+interface PendingRpcResponse {
+  resolve: (value: unknown) => void;
+  reject: (error: Error) => void;
+  timer: ReturnType<typeof setTimeout>;
+}
+
 function isAsyncAck(result: unknown): result is RpcAsyncAck {
   return (
     typeof result === "object" &&
@@ -72,6 +78,8 @@ function isAsyncAck(result: unknown): result is RpcAsyncAck {
     (result as RpcAsyncAck).async === true
   );
 }
+
+const MAX_EARLY_RPC_RESPONSES = 100;
 
 export class GatewaySseClient implements GatewayClientLike {
   private eventSource: EventSource | null = null;
@@ -85,6 +93,8 @@ export class GatewaySseClient implements GatewayClientLike {
   private autoReconnect = false;
   private intentionalClose = false;
   private tauriProxyConnected = false;
+  private pendingRpcResponses = new Map<string, PendingRpcResponse>();
+  private earlyRpcResponses = new Map<string, any>();
 
   get state(): ConnectionState {
     return this._state;
@@ -288,6 +298,7 @@ export class GatewaySseClient implements GatewayClientLike {
     try {
       tauriErrorUnlisten?.();
     } catch {}
+    this.rejectPendingRpcResponses("SSE connection closed");
   }
 
   // --- events ---
@@ -338,6 +349,12 @@ export class GatewaySseClient implements GatewayClientLike {
   }
 
   private handleFrame(frame: any): void {
+    const rpcId = this.rpcResponseId(frame);
+    if (rpcId) {
+      this.handleRpcResponse(rpcId, frame);
+      return;
+    }
+
     if (frame?.method === "event" && frame.params) {
       const ev = parseGatewayEvent({
         type: frame.params.type,
@@ -346,6 +363,81 @@ export class GatewaySseClient implements GatewayClientLike {
       });
       this.emit(ev);
     }
+  }
+
+  private rpcResponseId(frame: any): string | null {
+    if (!frame || typeof frame !== "object") return null;
+    const id = frame.id;
+    if (typeof id !== "string" && typeof id !== "number") return null;
+    if (!Object.prototype.hasOwnProperty.call(frame, "result") &&
+      !Object.prototype.hasOwnProperty.call(frame, "error")) {
+      return null;
+    }
+    return String(id);
+  }
+
+  private handleRpcResponse(id: string, frame: any): void {
+    const pending = this.pendingRpcResponses.get(id);
+    if (!pending) {
+      this.earlyRpcResponses.set(id, frame);
+      while (this.earlyRpcResponses.size > MAX_EARLY_RPC_RESPONSES) {
+        const oldest = this.earlyRpcResponses.keys().next().value;
+        if (!oldest) break;
+        this.earlyRpcResponses.delete(oldest);
+      }
+      return;
+    }
+
+    this.pendingRpcResponses.delete(id);
+    clearTimeout(pending.timer);
+    this.resolveRpcResponseFrame(frame, pending.resolve, pending.reject);
+  }
+
+  private resolveRpcResponseFrame(
+    frame: any,
+    resolve: (value: unknown) => void,
+    reject: (error: Error) => void,
+  ): void {
+    if (frame?.error) {
+      const msg = frame.error.message ?? `RPC error ${frame.error.code}`;
+      reject(new Error(msg));
+      return;
+    }
+    resolve(frame?.result);
+  }
+
+  private waitForAsyncRpcResponse<T>(
+    id: string,
+    method: string,
+    timeoutMs: number,
+  ): Promise<T> {
+    const early = this.earlyRpcResponses.get(id);
+    if (early) {
+      this.earlyRpcResponses.delete(id);
+      return new Promise<T>((resolve, reject) => {
+        this.resolveRpcResponseFrame(early, resolve as (value: unknown) => void, reject);
+      });
+    }
+
+    return new Promise<T>((resolve, reject) => {
+      const timer = window.setTimeout(() => {
+        this.pendingRpcResponses.delete(id);
+        reject(new Error(`RPC timeout waiting for async response: ${method}`));
+      }, timeoutMs);
+      this.pendingRpcResponses.set(id, {
+        resolve: resolve as (value: unknown) => void,
+        reject,
+        timer,
+      });
+    });
+  }
+
+  private rejectPendingRpcResponses(message: string): void {
+    for (const [, pending] of this.pendingRpcResponses) {
+      clearTimeout(pending.timer);
+      pending.reject(new Error(message));
+    }
+    this.pendingRpcResponses.clear();
   }
 
   // --- RPC ---
@@ -430,6 +522,9 @@ export class GatewaySseClient implements GatewayClientLike {
     if (parsed?.error) {
       const msg = parsed.error.message ?? `RPC error ${parsed.error.code}`;
       throw new Error(msg);
+    }
+    if (isAsyncAck(parsed?.result)) {
+      return await this.waitForAsyncRpcResponse<T>(id, method, timeoutMs);
     }
     return parsed.result as T;
   }

--- a/web/src/lib/gateway-sse-client.ts
+++ b/web/src/lib/gateway-sse-client.ts
@@ -227,6 +227,7 @@ export class GatewaySseClient implements GatewayClientLike {
           }
           this.eventSource = null;
           this.clientId = null;
+          this.rejectPendingRpcResponses("SSE connection closed");
           this.emitDisconnect();
           this.setState("closed");
           // Browser native reconnect already gave up. If autoReconnect is on,
@@ -419,6 +420,10 @@ export class GatewaySseClient implements GatewayClientLike {
       });
     }
 
+    if (!this.hasOpenAsyncRpcStream()) {
+      return Promise.reject(new Error("SSE connection closed"));
+    }
+
     return new Promise<T>((resolve, reject) => {
       const timer = window.setTimeout(() => {
         this.pendingRpcResponses.delete(id);
@@ -438,6 +443,12 @@ export class GatewaySseClient implements GatewayClientLike {
       pending.reject(new Error(message));
     }
     this.pendingRpcResponses.clear();
+  }
+
+  private hasOpenAsyncRpcStream(): boolean {
+    if (!this.clientId) return false;
+    if (isTauriProduction()) return this.tauriProxyConnected;
+    return !!this.eventSource && this.eventSource.readyState !== EventSource.CLOSED;
   }
 
   // --- RPC ---
@@ -589,6 +600,7 @@ export class GatewaySseClient implements GatewayClientLike {
         } else {
           this.tauriProxyConnected = false;
           this.clientId = null;
+          this.rejectPendingRpcResponses("SSE connection closed");
           try {
             this.tauriUnlisten?.();
           } catch {}


### PR DESCRIPTION
## What changed

- Teach `GatewaySseClient` to treat `{ accepted: true, async: true }` as an async JSON-RPC acknowledgement instead of a final RPC result.
- Correlate the eventual SSE JSON-RPC response by request id, including the race where the SSE response arrives before the POST ack is parsed.
- Reject pending async RPCs on SSE teardown and add regression coverage for success, early-response, and error paths.

## Why

Fixes #29. In Tauri production mode the desktop app defaults to SSE+POST. The runtime dispatches slow handlers such as `session.resume` asynchronously: `/api/v2/rpc` returns an ack immediately, then sends the real `SessionResumeResult` over the SSE stream. The client already had an `isAsyncAck` helper but did not wait for the follow-up frame, so resumed historical sessions could fail with a leaked Zod `session_id Required` validation error when sending the next prompt.

## Validation

- `pnpm typecheck`
- `pnpm test:unit`
- `cargo check`
