### PR TITLE
[codex] Sign bundled macOS runtime payload

### DIFF
--- a/.github/workflows/release-desktop.yml
+++ b/.github/workflows/release-desktop.yml
@@ -143,15 +143,51 @@ jobs:
         if: matrix.runner == 'macos-14'
         shell: bash
         env:
+          APPLE_CERTIFICATE: ${{ secrets.APPLE_CERTIFICATE }}
+          APPLE_CERTIFICATE_PASSWORD: ${{ secrets.APPLE_CERTIFICATE_PASSWORD }}
+          APPLE_SIGNING_IDENTITY: ${{ secrets.APPLE_SIGNING_IDENTITY }}
           APPLE_API_KEY: ${{ secrets.APPLE_API_KEY }}
           APPLE_API_PRIVATE_KEY: ${{ secrets.APPLE_API_PRIVATE_KEY }}
         run: |
+          test -n "$APPLE_CERTIFICATE"
+          test -n "$APPLE_CERTIFICATE_PASSWORD"
+          test -n "$APPLE_SIGNING_IDENTITY"
           test -n "$APPLE_API_KEY"
           test -n "$APPLE_API_PRIVATE_KEY"
 
           mkdir -p "$RUNNER_TEMP/appstoreconnect/private_keys"
           printf '%s\n' "$APPLE_API_PRIVATE_KEY" > "$RUNNER_TEMP/appstoreconnect/private_keys/AuthKey_${APPLE_API_KEY}.p8"
           chmod 600 "$RUNNER_TEMP/appstoreconnect/private_keys/AuthKey_${APPLE_API_KEY}.p8"
+
+          signing_keychain_password="$(uuidgen)"
+          signing_keychain="$RUNNER_TEMP/hermes-signing.keychain-db"
+          certificate_path="$RUNNER_TEMP/hermes-apple-certificate.p12"
+
+          security create-keychain -p "$signing_keychain_password" "$signing_keychain"
+          security set-keychain-settings -lut 21600 "$signing_keychain"
+          security unlock-keychain -p "$signing_keychain_password" "$signing_keychain"
+
+          printf '%s' "$APPLE_CERTIFICATE" | base64 --decode > "$certificate_path"
+          security import "$certificate_path" \
+            -P "$APPLE_CERTIFICATE_PASSWORD" \
+            -A \
+            -t cert \
+            -f pkcs12 \
+            -k "$signing_keychain"
+          security set-key-partition-list \
+            -S apple-tool:,apple: \
+            -s \
+            -k "$signing_keychain_password" \
+            "$signing_keychain"
+          security list-keychains -d user -s "$signing_keychain" $(security list-keychains -d user | tr -d '"')
+          security find-identity -v -p codesigning "$signing_keychain"
+
+      - name: Sign bundled macOS runtime payload
+        if: matrix.runner == 'macos-14'
+        shell: bash
+        env:
+          APPLE_SIGNING_IDENTITY: ${{ secrets.APPLE_SIGNING_IDENTITY }}
+        run: scripts/sign-macos-runtime-payload.sh
 
       - name: Build + upload installers
         uses: tauri-apps/tauri-action@v0
@@ -205,11 +241,38 @@ jobs:
 
           for dmg in "${dmgs[@]}"; do
             echo "Notarizing final DMG: $dmg"
+            submit_json="$RUNNER_TEMP/notary-submit-$(basename "$dmg").json"
             xcrun notarytool submit "$dmg" \
               --key "$APPLE_API_KEY_PATH" \
               --key-id "$APPLE_API_KEY" \
               --issuer "$APPLE_API_ISSUER" \
-              --wait
+              --wait \
+              --output-format json | tee "$submit_json"
+
+            submission_id="$(python3 - "$submit_json" <<'PY'
+          import json, sys
+          with open(sys.argv[1], "r", encoding="utf-8") as fh:
+              print(json.load(fh).get("id", ""))
+          PY
+          )"
+            submission_status="$(python3 - "$submit_json" <<'PY'
+          import json, sys
+          with open(sys.argv[1], "r", encoding="utf-8") as fh:
+              print(json.load(fh).get("status", ""))
+          PY
+          )"
+
+            if [ "$submission_status" != "Accepted" ]; then
+              echo "Notarization failed with status: $submission_status" >&2
+              if [ -n "$submission_id" ]; then
+                xcrun notarytool log "$submission_id" \
+                  --key "$APPLE_API_KEY_PATH" \
+                  --key-id "$APPLE_API_KEY" \
+                  --issuer "$APPLE_API_ISSUER" \
+                  --output-format json | tee "$RUNNER_TEMP/notary-log-$submission_id.json" || true
+              fi
+              exit 1
+            fi
 
             xcrun stapler staple "$dmg"
             xcrun stapler validate "$dmg"

--- a/docs/macos-signing-and-notarization.md
+++ b/docs/macos-signing-and-notarization.md
@@ -64,7 +64,7 @@ APPLE_API_PRIVATE_KEY       AuthKey_<KEY_ID>.p8 的完整文本内容
 
 发版入口是 `.github/workflows/release-desktop.yml`。它在推送 `v*` tag 时运行，也支持手动 `workflow_dispatch` 指定 tag。macOS job 运行在 `macos-14`，目标架构是 `aarch64-apple-darwin`。
 
-流程大致是：先安装 Node、pnpm、Rust 和 Tauri 依赖，再拉取 `hermes-agent-cn` 对应 runtime manifest 的 Dashboard 前端、内置技能以及 macOS arm64 runtime manifest，并把 runtime zip 展开成 `Contents/Resources/bundled-runtime/hermes-agent-cn-runtime-darwin-arm64/`。macOS 不能把原始 runtime zip 直接塞进 app 资源里，因为 notary 会递归扫描 zip 内的 `.so`、`Python.framework` 等 Mach-O 文件；展开后让 Tauri 的应用签名流程覆盖这些文件，再对最终 `.dmg` 做公证。
+流程大致是：先安装 Node、pnpm、Rust 和 Tauri 依赖，再拉取 `hermes-agent-cn` 对应 runtime manifest 的 Dashboard 前端、内置技能以及 macOS arm64 runtime manifest，并把 runtime zip 展开成 `Contents/Resources/bundled-runtime/hermes-agent-cn-runtime-darwin-arm64/`。macOS 不能把原始 runtime zip 直接塞进 app 资源里，因为 notary 会递归扫描 zip 内的 `.so`、`Python.framework` 等 Mach-O 文件；展开后的 runtime payload 还要在进入 Tauri 打包前用 Developer ID 重新签名，把上游 PyInstaller 产物里的 ad-hoc 签名替换成带 timestamp 的 Developer ID 签名，然后再对最终 `.dmg` 做公证。
 
 Tauri 构建结束后，workflow 会对最终 `.dmg` 做一次显式公证、staple 和验证：
 

--- a/scripts/sign-macos-runtime-payload.sh
+++ b/scripts/sign-macos-runtime-payload.sh
@@ -1,0 +1,69 @@
+#!/usr/bin/env bash
+set -euo pipefail
+
+runtime_dir="${1:-static/bundled-runtime/hermes-agent-cn-runtime-darwin-arm64}"
+identity="${APPLE_SIGNING_IDENTITY:-}"
+
+if [[ ! -d "$runtime_dir" ]]; then
+  echo "Bundled macOS runtime payload not found: $runtime_dir" >&2
+  exit 1
+fi
+
+if [[ -z "$identity" ]]; then
+  identity="$(
+    security find-identity -v -p codesigning 2>/dev/null \
+      | sed -n 's/.*"\(Developer ID Application:[^"]*\)".*/\1/p' \
+      | head -n 1
+  )"
+fi
+
+if [[ -z "$identity" ]]; then
+  echo "APPLE_SIGNING_IDENTITY is empty and no Developer ID Application identity was found" >&2
+  exit 1
+fi
+
+sign_args=(--force --sign "$identity")
+if [[ "$identity" != "-" ]]; then
+  sign_args+=(--timestamp --options runtime)
+fi
+
+is_macho() {
+  file "$1" | grep -q 'Mach-O'
+}
+
+echo "Signing bundled macOS runtime payload with identity: $identity"
+echo "Runtime payload: $runtime_dir"
+
+macho_count=0
+while IFS= read -r -d '' path; do
+  case "$path" in
+    *.framework/*) continue ;;
+  esac
+  if is_macho "$path"; then
+    codesign "${sign_args[@]}" "$path"
+    macho_count=$((macho_count + 1))
+  fi
+done < <(find "$runtime_dir" -type f -print0)
+
+framework_count=0
+while IFS= read -r -d '' framework; do
+  codesign "${sign_args[@]}" --deep "$framework"
+  framework_count=$((framework_count + 1))
+done < <(find "$runtime_dir" -type d -name '*.framework' -print0)
+
+echo "Signed $macho_count Mach-O files and $framework_count framework bundles."
+
+while IFS= read -r -d '' path; do
+  case "$path" in
+    *.framework/*) continue ;;
+  esac
+  if is_macho "$path"; then
+    codesign --verify --strict --verbose=2 "$path"
+  fi
+done < <(find "$runtime_dir" -type f -print0)
+
+while IFS= read -r -d '' framework; do
+  codesign --verify --deep --strict --verbose=2 "$framework"
+done < <(find "$runtime_dir" -type d -name '*.framework' -print0)
+
+echo "Bundled macOS runtime payload signing verification passed."


### PR DESCRIPTION
v0.1.3 的 macOS job 已经不再在 app 里保留 runtime zip，但最终 notarization 仍返回 `Invalid`。现有 workflow 没有打印 `notarytool log`，所以失败后只看到 stapler 的 Error 65，排查成本太高。

这个 PR 做两件事：
- 在 macOS staging 后、Tauri 打包前，把展开后的 `static/bundled-runtime/hermes-agent-cn-runtime-darwin-arm64/` 里的 Mach-O 文件和 framework 用 Developer ID 重新签名，并带 `--timestamp --options runtime`，替换上游 runtime 产物里的 ad-hoc 签名。
- notarization 改成 JSON 输出；如果 Apple 返回非 Accepted，立刻拉取并打印 `notarytool log <submission-id>`，不再继续执行 stapler，从而下次能直接看到 Apple issues。

本地验证：
- `bash -n scripts/sign-macos-runtime-payload.sh`
- workflow YAML 可解析
- 用临时 Mach-O 文件跑了脚本 smoke test，ad-hoc identity 下签名和 verify 通过。