### PR TITLE
[codex] Fix macOS Python framework runtime signing

### DIFF
--- a/scripts/sign-macos-runtime-payload.sh
+++ b/scripts/sign-macos-runtime-payload.sh
@@ -31,39 +31,64 @@ is_macho() {
   file "$1" | grep -q 'Mach-O'
 }
 
+sign_macho() {
+  local path="$1"
+  case "$path" in
+    *.framework/*)
+      # PyInstaller's Python.framework is not laid out like a normal Apple
+      # framework: it has real Mach-O copies directly under the framework root
+      # instead of the usual symlink structure. Running codesign on those paths
+      # makes codesign try to treat the parent directory as a framework bundle
+      # and fail with "bundle format is ambiguous". Sign a temporary bare
+      # Mach-O copy, then copy the signed bytes back.
+      local tmp_dir tmp_file
+      tmp_dir="$(mktemp -d)"
+      tmp_file="$tmp_dir/$(basename "$path")"
+      cp -p "$path" "$tmp_file"
+      codesign "${sign_args[@]}" "$tmp_file"
+      cp -p "$tmp_file" "$path"
+      rm -rf "$tmp_dir"
+      ;;
+    *)
+      codesign "${sign_args[@]}" "$path"
+      ;;
+  esac
+}
+
+verify_macho() {
+  local path="$1"
+  case "$path" in
+    *.framework/*)
+      local tmp_dir tmp_file
+      tmp_dir="$(mktemp -d)"
+      tmp_file="$tmp_dir/$(basename "$path")"
+      cp -p "$path" "$tmp_file"
+      codesign --verify --strict --verbose=2 "$tmp_file"
+      rm -rf "$tmp_dir"
+      ;;
+    *)
+      codesign --verify --strict --verbose=2 "$path"
+      ;;
+  esac
+}
+
 echo "Signing bundled macOS runtime payload with identity: $identity"
 echo "Runtime payload: $runtime_dir"
 
 macho_count=0
 while IFS= read -r -d '' path; do
-  case "$path" in
-    *.framework/*) continue ;;
-  esac
   if is_macho "$path"; then
-    codesign "${sign_args[@]}" "$path"
+    sign_macho "$path"
     macho_count=$((macho_count + 1))
   fi
 done < <(find "$runtime_dir" -type f -print0)
 
-framework_count=0
-while IFS= read -r -d '' framework; do
-  codesign "${sign_args[@]}" --deep "$framework"
-  framework_count=$((framework_count + 1))
-done < <(find "$runtime_dir" -type d -name '*.framework' -print0)
-
-echo "Signed $macho_count Mach-O files and $framework_count framework bundles."
+echo "Signed $macho_count Mach-O files."
 
 while IFS= read -r -d '' path; do
-  case "$path" in
-    *.framework/*) continue ;;
-  esac
   if is_macho "$path"; then
-    codesign --verify --strict --verbose=2 "$path"
+    verify_macho "$path"
   fi
 done < <(find "$runtime_dir" -type f -print0)
-
-while IFS= read -r -d '' framework; do
-  codesign --verify --deep --strict --verbose=2 "$framework"
-done < <(find "$runtime_dir" -type d -name '*.framework' -print0)
 
 echo "Bundled macOS runtime payload signing verification passed."


### PR DESCRIPTION
v0.1.4 的 macOS job 没有进入 Tauri 打包，而是在 `Sign bundled macOS runtime payload` 步骤失败。失败点是 `static/bundled-runtime/hermes-agent-cn-runtime-darwin-arm64/_internal/Python.framework: bundle format is ambiguous`。

原因是 PyInstaller 带出来的 `Python.framework` 不是标准 Apple framework symlink 布局，里面有真实 Mach-O 副本。直接对 framework 目录或 framework 内路径执行 codesign 时，codesign 会尝试按 bundle/framework 解析并报 ambiguous。

本 PR 调整签名脚本：
- 不再直接签 `*.framework` 目录。
- 对 `*.framework/*` 下的 Mach-O，先复制到临时目录作为 bare Mach-O 签名，再把签名后的 bytes 复制回原路径。
- verify 也对 framework 内 Mach-O 使用同样的临时 bare Mach-O 路径，避免 codesign 的 bundle 解析歧义。

本地验证：
- `bash -n scripts/sign-macos-runtime-payload.sh`
- `APPLE_SIGNING_IDENTITY=- scripts/sign-macos-runtime-payload.sh` 在本地展开的 runtime payload 上完整通过，包含 Python.framework 内的 Python Mach-O。