### PR TITLE
[codex] Relocate macOS Python framework payload

### DIFF
--- a/docs/macos-signing-and-notarization.md
+++ b/docs/macos-signing-and-notarization.md
@@ -64,7 +64,7 @@ APPLE_API_PRIVATE_KEY       AuthKey_<KEY_ID>.p8 的完整文本内容
 
 发版入口是 `.github/workflows/release-desktop.yml`。它在推送 `v*` tag 时运行，也支持手动 `workflow_dispatch` 指定 tag。macOS job 运行在 `macos-14`，目标架构是 `aarch64-apple-darwin`。
 
-流程大致是：先安装 Node、pnpm、Rust 和 Tauri 依赖，再拉取 `hermes-agent-cn` 对应 runtime manifest 的 Dashboard 前端、内置技能以及 macOS arm64 runtime manifest，并把 runtime zip 展开成 `Contents/Resources/bundled-runtime/hermes-agent-cn-runtime-darwin-arm64/`。macOS 不能把原始 runtime zip 直接塞进 app 资源里，因为 notary 会递归扫描 zip 内的 `.so`、`Python.framework` 等 Mach-O 文件；展开后的 runtime payload 还要在进入 Tauri 打包前用 Developer ID 重新签名，把上游 PyInstaller 产物里的 ad-hoc 签名替换成带 timestamp 的 Developer ID 签名，然后再对最终 `.dmg` 做公证。
+流程大致是：先安装 Node、pnpm、Rust 和 Tauri 依赖，再拉取 `hermes-agent-cn` 对应 runtime manifest 的 Dashboard 前端、内置技能以及 macOS arm64 runtime manifest，并把 runtime zip 展开成 `Contents/Resources/bundled-runtime/hermes-agent-cn-runtime-darwin-arm64/`。macOS 不能把原始 runtime zip 直接塞进 app 资源里，因为 notary 会递归扫描 zip 内的 `.so`、`Python.framework` 等 Mach-O 文件；展开后的 runtime payload 还要在进入 Tauri 打包前用 Developer ID 重新签名，把上游 PyInstaller 产物里的 ad-hoc 签名替换成带 timestamp 的 Developer ID 签名。PyInstaller 的 `Python.framework` 不是标准 framework 布局，打包资源中会临时改名为 `Python.framework.payload` 来避免 notary 按 framework bundle 规则误判，桌面端首次安装 runtime 时再恢复成原始 `Python.framework` 目录，然后再对最终 `.dmg` 做公证。
 
 Tauri 构建结束后，workflow 会对最终 `.dmg` 做一次显式公证、staple 和验证：
 

--- a/docs/managed-runtime.md
+++ b/docs/managed-runtime.md
@@ -33,9 +33,11 @@ hermes-agent），调用 `subprocess.spawn("hermes", "dashboard")`
 解决方向：**桌面端自带 runtime**。Windows 与 macOS 的正式安装包都应
 预置目标平台的 `hermes-agent-cn` runtime payload + manifest，首次启动优先从
 包内资源安装；云端下载只作为包内 runtime 缺失、运行时升级或兜底修复路径。
-Windows 直接预置 runtime zip；macOS 预置展开后的 runtime 目录，让 Tauri
-的应用签名流程能够覆盖里面的 `.so`、framework 等 Mach-O 文件，否则 Apple
-notary 会把嵌在 zip 内部的未签名二进制也当作拒绝项。
+Windows 直接预置 runtime zip；macOS 预置展开后的 runtime 目录，并在打包
+前对里面的 Mach-O 文件重新做 Developer ID 签名。PyInstaller 的
+`Python.framework` 不是标准 framework 布局，macOS 安装包资源里会临时写成
+`Python.framework.payload`，首次安装 runtime 时再恢复原名，否则 Apple
+notary 会按 framework bundle 规则误判这个目录。
 整套机制叫 **managed runtime**。
 
 ## 二、组件 + 文件分布
@@ -287,7 +289,7 @@ desktop CI release-desktop.yml 触发：
     2. pnpm install
     3. 解析 runtime manifest 的 sourceCommit，checkout 对应 hermes-agent-cn
     4. stage Dashboard web_dist、bundled skills、目标平台 runtime payload + manifest
-       Windows 使用 zip；macOS 使用已展开目录，避免 notarization 扫到 zip 内未签名 Mach-O
+       Windows 使用 zip；macOS 使用已展开目录、Developer ID 重签名，并把非标准 Python.framework 临时改成 .payload
     5. tauri-apps/tauri-action@v0 → 打 .msi / .dmg
        runtime URL + 公钥仍是 baked-in 兜底，不需要 env wire 进 CI
   ↓

--- a/scripts/sign-macos-runtime-payload.sh
+++ b/scripts/sign-macos-runtime-payload.sh
@@ -33,43 +33,12 @@ is_macho() {
 
 sign_macho() {
   local path="$1"
-  case "$path" in
-    *.framework/*)
-      # PyInstaller's Python.framework is not laid out like a normal Apple
-      # framework: it has real Mach-O copies directly under the framework root
-      # instead of the usual symlink structure. Running codesign on those paths
-      # makes codesign try to treat the parent directory as a framework bundle
-      # and fail with "bundle format is ambiguous". Sign a temporary bare
-      # Mach-O copy, then copy the signed bytes back.
-      local tmp_dir tmp_file
-      tmp_dir="$(mktemp -d)"
-      tmp_file="$tmp_dir/$(basename "$path")"
-      cp -p "$path" "$tmp_file"
-      codesign "${sign_args[@]}" "$tmp_file"
-      cp -p "$tmp_file" "$path"
-      rm -rf "$tmp_dir"
-      ;;
-    *)
-      codesign "${sign_args[@]}" "$path"
-      ;;
-  esac
+  codesign "${sign_args[@]}" "$path"
 }
 
 verify_macho() {
   local path="$1"
-  case "$path" in
-    *.framework/*)
-      local tmp_dir tmp_file
-      tmp_dir="$(mktemp -d)"
-      tmp_file="$tmp_dir/$(basename "$path")"
-      cp -p "$path" "$tmp_file"
-      codesign --verify --strict --verbose=2 "$tmp_file"
-      rm -rf "$tmp_dir"
-      ;;
-    *)
-      codesign --verify --strict --verbose=2 "$path"
-      ;;
-  esac
+  codesign --verify --strict --verbose=2 "$path"
 }
 
 echo "Signing bundled macOS runtime payload with identity: $identity"

--- a/scripts/stage-bundled-runtime.mjs
+++ b/scripts/stage-bundled-runtime.mjs
@@ -5,6 +5,7 @@ import {
   existsSync,
   mkdirSync,
   readdirSync,
+  renameSync,
   rmSync,
   writeFileSync,
 } from "node:fs";
@@ -104,6 +105,24 @@ function cleanOutputDir() {
   }
 }
 
+function relocateMacosFrameworksForNotary(dir) {
+  let relocated = 0;
+  for (const entry of readdirSync(dir, { withFileTypes: true })) {
+    if (!entry.isDirectory()) continue;
+    const source = join(dir, entry.name);
+    if (entry.name.endsWith(".framework")) {
+      const target = `${source}.payload`;
+      rmSync(target, { recursive: true, force: true });
+      renameSync(source, target);
+      relocated += 1;
+      relocated += relocateMacosFrameworksForNotary(target);
+    } else {
+      relocated += relocateMacosFrameworksForNotary(source);
+    }
+  }
+  return relocated;
+}
+
 function expandRuntimeZip(zipBytes) {
   const tmpZipPath = join(outDir, `.${zipName}.download`);
   const expandedRuntimeDir = join(outDir, runtimeName);
@@ -124,6 +143,10 @@ function expandRuntimeZip(zipBytes) {
   }
   if (!existsSync(expandedRuntimeDir)) {
     throw new Error(`expanded runtime root was not created: ${expandedRuntimeDir}`);
+  }
+  if (platform === "darwin") {
+    const relocated = relocateMacosFrameworksForNotary(expandedRuntimeDir);
+    console.log(`relocated ${relocated} macOS framework directories for notarization`);
   }
   return expandedRuntimeDir;
 }
@@ -160,6 +183,7 @@ writeFileSync(join(outDir, "README.generated.txt"), [
   `repo=${repo}`,
   `tag=${tag}`,
   `stagingMode=${expandArtifact ? "expanded" : "zip"}`,
+  `macosFrameworkLayout=${expandArtifact && platform === "darwin" ? "relocated" : "native"}`,
   `runtimeVersion=${manifest.runtimeVersion}`,
   `kernelVersion=${manifest.kernelVersion}`,
   `runtimeFlavor=${manifest.runtimeFlavor}`,

--- a/src/process/runtime.rs
+++ b/src/process/runtime.rs
@@ -25,6 +25,7 @@ const DASHBOARD_RESOURCE_DIR: &str = "dashboard";
 const DASHBOARD_WEB_DIST_DIR: &str = "web_dist";
 const BUNDLED_SKILLS_RESOURCE_DIR: &str = "bundled-skills";
 const BUNDLED_SKILLS_DIR: &str = "skills";
+const MACOS_FRAMEWORK_PAYLOAD_SUFFIX: &str = ".framework.payload";
 const RUNTIME_HTTP_CONNECT_TIMEOUT: Duration = Duration::from_secs(15);
 const RUNTIME_MANIFEST_HTTP_TIMEOUT: Duration = Duration::from_secs(30);
 const RUNTIME_ARTIFACT_HTTP_TIMEOUT: Duration = Duration::from_secs(15 * 60);
@@ -748,6 +749,44 @@ fn sync_available_runtime_resources_from_resource(
     Ok(result)
 }
 
+fn restore_macos_runtime_framework_payloads(dir: &Path) -> Result<usize, String> {
+    if !dir.is_dir() {
+        return Ok(0);
+    }
+
+    let mut restored = 0;
+    let entries = fs::read_dir(dir).map_err(|e| e.to_string())?;
+    for entry in entries {
+        let entry = entry.map_err(|e| e.to_string())?;
+        let path = entry.path();
+        if !entry.file_type().map_err(|e| e.to_string())?.is_dir() {
+            continue;
+        }
+
+        let name = entry.file_name();
+        let name = name.to_string_lossy();
+        if let Some(restored_name) = name.strip_suffix(".payload") {
+            if name.ends_with(MACOS_FRAMEWORK_PAYLOAD_SUFFIX) {
+                let restored_path = path.with_file_name(restored_name);
+                if restored_path.exists() {
+                    return Err(format!(
+                        "Cannot restore macOS framework payload because target exists: {}",
+                        restored_path.display()
+                    ));
+                }
+                fs::rename(&path, &restored_path).map_err(|e| e.to_string())?;
+                restored += 1;
+                restored += restore_macos_runtime_framework_payloads(&restored_path)?;
+                continue;
+            }
+        }
+
+        restored += restore_macos_runtime_framework_payloads(&path)?;
+    }
+
+    Ok(restored)
+}
+
 fn bundled_manifest_path(runtime_dir: &Path) -> PathBuf {
     runtime_dir.join(format!(
         "{}-{}-{}.json",
@@ -1299,6 +1338,14 @@ async fn install_runtime_tree(
             installed: None,
             previous: None,
             error: Some(format!("Failed to stage runtime tree: {}", e)),
+        };
+    }
+    if let Err(e) = restore_macos_runtime_framework_payloads(&staged_runtime_tree) {
+        return RuntimeInstallUpdateResult {
+            ok: false,
+            installed: None,
+            previous: None,
+            error: Some(format!("Failed to restore macOS framework payloads: {}", e)),
         };
     }
 
@@ -2320,6 +2367,38 @@ mod tests {
         assert!(synced.dashboard_web_dist.is_none());
         assert!(synced.bundled_skills.is_none());
         assert!(!runtime.join("_internal").exists());
+    }
+
+    #[test]
+    fn restore_macos_runtime_framework_payloads_restores_relocated_frameworks() {
+        let dir = TempDir::new().unwrap();
+        let root = dir.path().join("runtime");
+        let payload = root
+            .join("_internal")
+            .join("Python.framework.payload")
+            .join("Versions")
+            .join("3.11");
+        std::fs::create_dir_all(&payload).unwrap();
+        std::fs::write(payload.join("Python"), b"python").unwrap();
+
+        let restored = restore_macos_runtime_framework_payloads(&root).unwrap();
+
+        assert_eq!(restored, 1);
+        assert!(!root
+            .join("_internal")
+            .join("Python.framework.payload")
+            .exists());
+        assert_eq!(
+            std::fs::read(
+                root.join("_internal")
+                    .join("Python.framework")
+                    .join("Versions")
+                    .join("3.11")
+                    .join("Python")
+            )
+            .unwrap(),
+            b"python"
+        );
     }
 
     #[test]


### PR DESCRIPTION
v0.1.5 已经进入 notarization，notary log 现在明确只剩三个错误：`_internal/Python.framework/Python`、`Versions/3.11/Python`、`Versions/Current/Python` 的签名无效。

原因是 PyInstaller 产物里的 `Python.framework` 不是标准 Apple framework 布局，即使把内部 Mach-O 重签，Apple notary 仍会按 framework bundle 规则校验这些路径并判 invalid。

本 PR 的处理方式：
- macOS runtime staging 时把 `*.framework` 目录临时重命名为 `*.framework.payload`，避免安装包内出现非标准 framework bundle 路径。
- Developer ID 签名脚本继续签所有 Mach-O；此时路径已经不再命中 `.framework`，codesign 和 notary 都按普通 Mach-O 处理。
- 桌面端首次安装 bundled runtime 时，把 `*.framework.payload` 恢复回原始 `*.framework` 后再 smoke check 和写入 runtime 目录，不影响运行时布局。

本地验证：
- `node --check scripts/stage-bundled-runtime.mjs`
- `bash -n scripts/sign-macos-runtime-payload.sh`
- `cargo fmt --check`
- `cargo test --all-features restore_macos_runtime_framework_payloads -- --nocapture`
- `cargo test --all-features install_bundled_runtime_from_expanded_tree -- --nocapture`
- `cargo check`
- `pnpm typecheck`