### PR TITLE
fix: avoid framework token in macOS runtime payload

### DIFF
--- a/docs/macos-signing-and-notarization.md
+++ b/docs/macos-signing-and-notarization.md
@@ -64,7 +64,7 @@ APPLE_API_PRIVATE_KEY       AuthKey_<KEY_ID>.p8 的完整文本内容
 
 发版入口是 `.github/workflows/release-desktop.yml`。它在推送 `v*` tag 时运行，也支持手动 `workflow_dispatch` 指定 tag。macOS job 运行在 `macos-14`，目标架构是 `aarch64-apple-darwin`。
 
-流程大致是：先安装 Node、pnpm、Rust 和 Tauri 依赖，再拉取 `hermes-agent-cn` 对应 runtime manifest 的 Dashboard 前端、内置技能以及 macOS arm64 runtime manifest，并把 runtime zip 展开成 `Contents/Resources/bundled-runtime/hermes-agent-cn-runtime-darwin-arm64/`。macOS 不能把原始 runtime zip 直接塞进 app 资源里，因为 notary 会递归扫描 zip 内的 `.so`、`Python.framework` 等 Mach-O 文件；展开后的 runtime payload 还要在进入 Tauri 打包前用 Developer ID 重新签名，把上游 PyInstaller 产物里的 ad-hoc 签名替换成带 timestamp 的 Developer ID 签名。PyInstaller 的 `Python.framework` 不是标准 framework 布局，打包资源中会临时改名为 `Python.framework.payload` 来避免 notary 按 framework bundle 规则误判，桌面端首次安装 runtime 时再恢复成原始 `Python.framework` 目录，然后再对最终 `.dmg` 做公证。
+流程大致是：先安装 Node、pnpm、Rust 和 Tauri 依赖，再拉取 `hermes-agent-cn` 对应 runtime manifest 的 Dashboard 前端、内置技能以及 macOS arm64 runtime manifest，并把 runtime zip 展开成 `Contents/Resources/bundled-runtime/hermes-agent-cn-runtime-darwin-arm64/`。macOS 不能把原始 runtime zip 直接塞进 app 资源里，因为 notary 会递归扫描 zip 内的 `.so`、`Python.framework` 等 Mach-O 文件；展开后的 runtime payload 还要在进入 Tauri 打包前用 Developer ID 重新签名，把上游 PyInstaller 产物里的 ad-hoc 签名替换成带 timestamp 的 Developer ID 签名。PyInstaller 的 `Python.framework` 不是标准 framework 布局，打包资源中会临时改名为 `Python__hermes_framework_payload` 来避免 notary 按 framework bundle 规则误判，桌面端首次安装 runtime 时再恢复成原始 `Python.framework` 目录，然后再对最终 `.dmg` 做公证。
 
 Tauri 构建结束后，workflow 会对最终 `.dmg` 做一次显式公证、staple 和验证：
 

--- a/docs/managed-runtime.md
+++ b/docs/managed-runtime.md
@@ -36,7 +36,7 @@ hermes-agent），调用 `subprocess.spawn("hermes", "dashboard")`
 Windows 直接预置 runtime zip；macOS 预置展开后的 runtime 目录，并在打包
 前对里面的 Mach-O 文件重新做 Developer ID 签名。PyInstaller 的
 `Python.framework` 不是标准 framework 布局，macOS 安装包资源里会临时写成
-`Python.framework.payload`，首次安装 runtime 时再恢复原名，否则 Apple
+`Python__hermes_framework_payload`，首次安装 runtime 时再恢复原名，否则 Apple
 notary 会按 framework bundle 规则误判这个目录。
 整套机制叫 **managed runtime**。
 

--- a/scripts/sign-macos-runtime-payload.sh
+++ b/scripts/sign-macos-runtime-payload.sh
@@ -31,61 +31,14 @@ is_macho() {
   file "$1" | grep -q 'Mach-O'
 }
 
-is_relocated_framework_payload_path() {
-  [[ "$1" == *".framework.payload/"* ]]
-}
-
-with_plain_macho_path() {
-  local source_path="$1"
-  local action="$2"
-  local temp_dir
-  local temp_path
-  local rc=0
-
-  temp_dir="$(mktemp -d)"
-  temp_path="$temp_dir/macho"
-  cp -p "$source_path" "$temp_path"
-
-  case "$action" in
-    sign)
-      codesign "${sign_args[@]}" "$temp_path" || rc=$?
-      if [[ "$rc" -eq 0 ]]; then
-        cp -p "$temp_path" "$source_path" || rc=$?
-      fi
-      ;;
-    verify)
-      codesign --verify --strict --verbose=2 "$temp_path" || rc=$?
-      ;;
-    *)
-      echo "unknown Mach-O action: $action" >&2
-      rc=1
-      ;;
-  esac
-
-  rm -rf "$temp_dir"
-  return "$rc"
-}
-
 sign_macho() {
   local path="$1"
-  if is_relocated_framework_payload_path "$path"; then
-    # codesign still applies framework bundle heuristics to paths containing
-    # ".framework.", even after staging renamed PyInstaller's nonstandard
-    # Python.framework to Python.framework.payload. Sign the raw Mach-O bytes
-    # from a neutral temporary path, then copy the signed binary back.
-    with_plain_macho_path "$path" sign
-  else
-    codesign "${sign_args[@]}" "$path"
-  fi
+  codesign "${sign_args[@]}" "$path"
 }
 
 verify_macho() {
   local path="$1"
-  if is_relocated_framework_payload_path "$path"; then
-    with_plain_macho_path "$path" verify
-  else
-    codesign --verify --strict --verbose=2 "$path"
-  fi
+  codesign --verify --strict --verbose=2 "$path"
 }
 
 echo "Signing bundled macOS runtime payload with identity: $identity"

--- a/scripts/stage-bundled-runtime.mjs
+++ b/scripts/stage-bundled-runtime.mjs
@@ -58,6 +58,7 @@ const arch = argValue("--arch", process.env.HERMES_RUNTIME_ARCH ?? "x64");
 const outDir = resolve(repoRoot, argValue("--out", "static/bundled-runtime"));
 const expandArtifact = hasFlag("--expand-artifact");
 const keepExisting = hasFlag("--keep-existing");
+const macosFrameworkPayloadSuffix = "__hermes_framework_payload";
 
 const runtimeName = `hermes-agent-cn-runtime-${platform}-${arch}`;
 const manifestName = `${channel}-${platform}-${arch}.json`;
@@ -111,7 +112,10 @@ function relocateMacosFrameworksForNotary(dir) {
     if (!entry.isDirectory()) continue;
     const source = join(dir, entry.name);
     if (entry.name.endsWith(".framework")) {
-      const target = `${source}.payload`;
+      const target = join(
+        dir,
+        `${entry.name.slice(0, -".framework".length)}${macosFrameworkPayloadSuffix}`,
+      );
       rmSync(target, { recursive: true, force: true });
       renameSync(source, target);
       relocated += 1;

--- a/src/process/runtime.rs
+++ b/src/process/runtime.rs
@@ -25,7 +25,7 @@ const DASHBOARD_RESOURCE_DIR: &str = "dashboard";
 const DASHBOARD_WEB_DIST_DIR: &str = "web_dist";
 const BUNDLED_SKILLS_RESOURCE_DIR: &str = "bundled-skills";
 const BUNDLED_SKILLS_DIR: &str = "skills";
-const MACOS_FRAMEWORK_PAYLOAD_SUFFIX: &str = ".framework.payload";
+const MACOS_FRAMEWORK_PAYLOAD_SUFFIX: &str = "__hermes_framework_payload";
 const RUNTIME_HTTP_CONNECT_TIMEOUT: Duration = Duration::from_secs(15);
 const RUNTIME_MANIFEST_HTTP_TIMEOUT: Duration = Duration::from_secs(30);
 const RUNTIME_ARTIFACT_HTTP_TIMEOUT: Duration = Duration::from_secs(15 * 60);
@@ -765,20 +765,18 @@ fn restore_macos_runtime_framework_payloads(dir: &Path) -> Result<usize, String>
 
         let name = entry.file_name();
         let name = name.to_string_lossy();
-        if let Some(restored_name) = name.strip_suffix(".payload") {
-            if name.ends_with(MACOS_FRAMEWORK_PAYLOAD_SUFFIX) {
-                let restored_path = path.with_file_name(restored_name);
-                if restored_path.exists() {
-                    return Err(format!(
-                        "Cannot restore macOS framework payload because target exists: {}",
-                        restored_path.display()
-                    ));
-                }
-                fs::rename(&path, &restored_path).map_err(|e| e.to_string())?;
-                restored += 1;
-                restored += restore_macos_runtime_framework_payloads(&restored_path)?;
-                continue;
+        if let Some(framework_stem) = name.strip_suffix(MACOS_FRAMEWORK_PAYLOAD_SUFFIX) {
+            let restored_path = path.with_file_name(format!("{}.framework", framework_stem));
+            if restored_path.exists() {
+                return Err(format!(
+                    "Cannot restore macOS framework payload because target exists: {}",
+                    restored_path.display()
+                ));
             }
+            fs::rename(&path, &restored_path).map_err(|e| e.to_string())?;
+            restored += 1;
+            restored += restore_macos_runtime_framework_payloads(&restored_path)?;
+            continue;
         }
 
         restored += restore_macos_runtime_framework_payloads(&path)?;
@@ -2375,7 +2373,7 @@ mod tests {
         let root = dir.path().join("runtime");
         let payload = root
             .join("_internal")
-            .join("Python.framework.payload")
+            .join("Python__hermes_framework_payload")
             .join("Versions")
             .join("3.11");
         std::fs::create_dir_all(&payload).unwrap();
@@ -2386,7 +2384,7 @@ mod tests {
         assert_eq!(restored, 1);
         assert!(!root
             .join("_internal")
-            .join("Python.framework.payload")
+            .join("Python__hermes_framework_payload")
             .exists());
         assert_eq!(
             std::fs::read(


### PR DESCRIPTION
## Summary
- rename staged PyInstaller framework payloads from `*.framework.payload` to `*__hermes_framework_payload` so codesign/notary no longer apply framework bundle validation to the staged resource path
- restore the payload back to `*.framework` during managed runtime installation
- simplify runtime payload signing now that relocated paths no longer contain `.framework`

## Verification
- `node --check scripts/stage-bundled-runtime.mjs`
- `bash -n scripts/sign-macos-runtime-payload.sh`
- synthetic `Python__hermes_framework_payload/Python` Mach-O signing smoke test with `APPLE_SIGNING_IDENTITY=-`
- `cargo test --all-features restore_macos_runtime_framework_payloads -- --nocapture`
- `cargo check`
- `pnpm typecheck`
- `pnpm test:unit`
- `cargo test --all-features`