### PR TITLE
fix: relocate macOS framework bundle layout

### DIFF
--- a/docs/macos-signing-and-notarization.md
+++ b/docs/macos-signing-and-notarization.md
@@ -64,7 +64,7 @@ APPLE_API_PRIVATE_KEY       AuthKey_<KEY_ID>.p8 的完整文本内容
 
 发版入口是 `.github/workflows/release-desktop.yml`。它在推送 `v*` tag 时运行，也支持手动 `workflow_dispatch` 指定 tag。macOS job 运行在 `macos-14`，目标架构是 `aarch64-apple-darwin`。
 
-流程大致是：先安装 Node、pnpm、Rust 和 Tauri 依赖，再拉取 `hermes-agent-cn` 对应 runtime manifest 的 Dashboard 前端、内置技能以及 macOS arm64 runtime manifest，并把 runtime zip 展开成 `Contents/Resources/bundled-runtime/hermes-agent-cn-runtime-darwin-arm64/`。macOS 不能把原始 runtime zip 直接塞进 app 资源里，因为 notary 会递归扫描 zip 内的 `.so`、`Python.framework` 等 Mach-O 文件；展开后的 runtime payload 还要在进入 Tauri 打包前用 Developer ID 重新签名，把上游 PyInstaller 产物里的 ad-hoc 签名替换成带 timestamp 的 Developer ID 签名。PyInstaller 的 `Python.framework` 不是标准 framework 布局，打包资源中会临时改名为 `Python__hermes_framework_payload` 来避免 notary 按 framework bundle 规则误判，桌面端首次安装 runtime 时再恢复成原始 `Python.framework` 目录，然后再对最终 `.dmg` 做公证。
+流程大致是：先安装 Node、pnpm、Rust 和 Tauri 依赖，再拉取 `hermes-agent-cn` 对应 runtime manifest 的 Dashboard 前端、内置技能以及 macOS arm64 runtime manifest，并把 runtime zip 展开成 `Contents/Resources/bundled-runtime/hermes-agent-cn-runtime-darwin-arm64/`。macOS 不能把原始 runtime zip 直接塞进 app 资源里，因为 notary 会递归扫描 zip 内的 `.so`、`Python.framework` 等 Mach-O 文件；展开后的 runtime payload 还要在进入 Tauri 打包前用 Developer ID 重新签名，把上游 PyInstaller 产物里的 ad-hoc 签名替换成带 timestamp 的 Developer ID 签名。PyInstaller 的 `Python.framework` 不是标准 framework 布局，打包资源中会临时改名为 `Python__hermes_framework_payload`，并把内部 `Versions` / `Resources` 目录改成 `*__hermes_bundle_payload` 来打散 framework bundle 形状，避免 notary 按 framework bundle 规则误判；桌面端首次安装 runtime 时再恢复成原始 `Python.framework` 目录，然后再对最终 `.dmg` 做公证。
 
 Tauri 构建结束后，workflow 会对最终 `.dmg` 做一次显式公证、staple 和验证：
 

--- a/docs/managed-runtime.md
+++ b/docs/managed-runtime.md
@@ -36,7 +36,8 @@ hermes-agent），调用 `subprocess.spawn("hermes", "dashboard")`
 Windows 直接预置 runtime zip；macOS 预置展开后的 runtime 目录，并在打包
 前对里面的 Mach-O 文件重新做 Developer ID 签名。PyInstaller 的
 `Python.framework` 不是标准 framework 布局，macOS 安装包资源里会临时写成
-`Python__hermes_framework_payload`，首次安装 runtime 时再恢复原名，否则 Apple
+`Python__hermes_framework_payload`，内部 `Versions` / `Resources` 也会临时改成
+`*__hermes_bundle_payload`，首次安装 runtime 时再恢复原名，否则 Apple
 notary 会按 framework bundle 规则误判这个目录。
 整套机制叫 **managed runtime**。
 

--- a/scripts/stage-bundled-runtime.mjs
+++ b/scripts/stage-bundled-runtime.mjs
@@ -59,6 +59,7 @@ const outDir = resolve(repoRoot, argValue("--out", "static/bundled-runtime"));
 const expandArtifact = hasFlag("--expand-artifact");
 const keepExisting = hasFlag("--keep-existing");
 const macosFrameworkPayloadSuffix = "__hermes_framework_payload";
+const macosBundleDirPayloadSuffix = "__hermes_bundle_payload";
 
 const runtimeName = `hermes-agent-cn-runtime-${platform}-${arch}`;
 const manifestName = `${channel}-${platform}-${arch}.json`;
@@ -119,9 +120,29 @@ function relocateMacosFrameworksForNotary(dir) {
       rmSync(target, { recursive: true, force: true });
       renameSync(source, target);
       relocated += 1;
+      relocated += relocateMacosBundleLayoutForNotary(target);
       relocated += relocateMacosFrameworksForNotary(target);
     } else {
       relocated += relocateMacosFrameworksForNotary(source);
+    }
+  }
+  return relocated;
+}
+
+function relocateMacosBundleLayoutForNotary(dir) {
+  let relocated = 0;
+  for (const entry of readdirSync(dir, { withFileTypes: true })) {
+    if (!entry.isDirectory()) continue;
+    const source = join(dir, entry.name);
+    const shouldRelocateBundleDir = entry.name === "Versions" || entry.name === "Resources";
+    if (shouldRelocateBundleDir) {
+      const target = join(dir, `${entry.name}${macosBundleDirPayloadSuffix}`);
+      rmSync(target, { recursive: true, force: true });
+      renameSync(source, target);
+      relocated += 1;
+      relocated += relocateMacosBundleLayoutForNotary(target);
+    } else {
+      relocated += relocateMacosBundleLayoutForNotary(source);
     }
   }
   return relocated;

--- a/src/process/runtime.rs
+++ b/src/process/runtime.rs
@@ -26,6 +26,7 @@ const DASHBOARD_WEB_DIST_DIR: &str = "web_dist";
 const BUNDLED_SKILLS_RESOURCE_DIR: &str = "bundled-skills";
 const BUNDLED_SKILLS_DIR: &str = "skills";
 const MACOS_FRAMEWORK_PAYLOAD_SUFFIX: &str = "__hermes_framework_payload";
+const MACOS_BUNDLE_DIR_PAYLOAD_SUFFIX: &str = "__hermes_bundle_payload";
 const RUNTIME_HTTP_CONNECT_TIMEOUT: Duration = Duration::from_secs(15);
 const RUNTIME_MANIFEST_HTTP_TIMEOUT: Duration = Duration::from_secs(30);
 const RUNTIME_ARTIFACT_HTTP_TIMEOUT: Duration = Duration::from_secs(15 * 60);
@@ -767,6 +768,20 @@ fn restore_macos_runtime_framework_payloads(dir: &Path) -> Result<usize, String>
         let name = name.to_string_lossy();
         if let Some(framework_stem) = name.strip_suffix(MACOS_FRAMEWORK_PAYLOAD_SUFFIX) {
             let restored_path = path.with_file_name(format!("{}.framework", framework_stem));
+            if restored_path.exists() {
+                return Err(format!(
+                    "Cannot restore macOS framework payload because target exists: {}",
+                    restored_path.display()
+                ));
+            }
+            fs::rename(&path, &restored_path).map_err(|e| e.to_string())?;
+            restored += 1;
+            restored += restore_macos_runtime_framework_payloads(&restored_path)?;
+            continue;
+        }
+
+        if let Some(restored_name) = name.strip_suffix(MACOS_BUNDLE_DIR_PAYLOAD_SUFFIX) {
+            let restored_path = path.with_file_name(restored_name);
             if restored_path.exists() {
                 return Err(format!(
                     "Cannot restore macOS framework payload because target exists: {}",
@@ -2374,17 +2389,30 @@ mod tests {
         let payload = root
             .join("_internal")
             .join("Python__hermes_framework_payload")
-            .join("Versions")
+            .join("Versions__hermes_bundle_payload")
             .join("3.11");
         std::fs::create_dir_all(&payload).unwrap();
         std::fs::write(payload.join("Python"), b"python").unwrap();
+        std::fs::create_dir_all(payload.join("Resources__hermes_bundle_payload")).unwrap();
+        std::fs::write(
+            payload
+                .join("Resources__hermes_bundle_payload")
+                .join("Info.plist"),
+            b"plist",
+        )
+        .unwrap();
 
         let restored = restore_macos_runtime_framework_payloads(&root).unwrap();
 
-        assert_eq!(restored, 1);
+        assert_eq!(restored, 3);
         assert!(!root
             .join("_internal")
             .join("Python__hermes_framework_payload")
+            .exists());
+        assert!(!root
+            .join("_internal")
+            .join("Python.framework")
+            .join("Versions__hermes_bundle_payload")
             .exists());
         assert_eq!(
             std::fs::read(
@@ -2396,6 +2424,18 @@ mod tests {
             )
             .unwrap(),
             b"python"
+        );
+        assert_eq!(
+            std::fs::read(
+                root.join("_internal")
+                    .join("Python.framework")
+                    .join("Versions")
+                    .join("3.11")
+                    .join("Resources")
+                    .join("Info.plist")
+            )
+            .unwrap(),
+            b"plist"
         );
     }
 


### PR DESCRIPTION
## Summary
- relocate `Versions` and `Resources` inside staged PyInstaller framework payloads so the bundled runtime no longer keeps a framework-shaped directory tree in the signed app resources
- restore those bundle directory names during managed runtime installation before the runtime smoke check
- document the additional layout relocation

## Verification
- `node --check scripts/stage-bundled-runtime.mjs`
- `bash -n scripts/sign-macos-runtime-payload.sh`
- real Python framework payload from the failed DMG was renamed to the staged layout, signed with `APPLE_SIGNING_IDENTITY=-`, and verified with `codesign --verify --strict` at the original staged paths
- `cargo test --all-features restore_macos_runtime_framework_payloads -- --nocapture`
- `cargo check`
- `pnpm typecheck`
- `pnpm test:unit`
- `cargo test --all-features`