### PR TITLE
[codex] add IM onboarding under configuration

### DIFF
--- a/packages/protocol/src/channels.ts
+++ b/packages/protocol/src/channels.ts
@@ -172,6 +172,110 @@ export interface SwitchProfileInput {
   name: string;
 }
 
+// Desktop-only IM onboarding bridge types. Secrets are returned as
+// RedactedValue and must not be cached or rendered in plaintext.
+export type ImPlatform = "feishu" | "weixin";
+
+export interface ImOnboardingStateInput {
+  platform: ImPlatform;
+}
+
+export interface ImRedactedValue {
+  isSet: boolean;
+  redactedValue?: string | null;
+  fingerprint?: string | null;
+}
+
+export interface ImOnboardingStateResult {
+  platform: ImPlatform | string;
+  currentProfile: string;
+  hermesHome: string;
+  envPath: string;
+  configured: Record<string, ImRedactedValue>;
+}
+
+export interface ImOnboardingBeginInput {
+  platform: ImPlatform;
+  domain?: "feishu" | "lark" | string;
+  botType?: string;
+}
+
+export interface ImOnboardingBeginResult {
+  flowId: string;
+  platform: ImPlatform | string;
+  status: string;
+  qrUrl?: string | null;
+  qrScanData?: string | null;
+  userCode?: string | null;
+  intervalSeconds: number;
+  expiresAtMs: number;
+  message?: string | null;
+}
+
+export interface ImCredentialSummary {
+  appId?: ImRedactedValue | null;
+  appSecret?: ImRedactedValue | null;
+  accountId?: ImRedactedValue | null;
+  token?: ImRedactedValue | null;
+  baseUrl?: string | null;
+  domain?: string | null;
+  userId?: ImRedactedValue | null;
+  botName?: string | null;
+  botOpenId?: ImRedactedValue | null;
+  openId?: ImRedactedValue | null;
+}
+
+export interface ImOnboardingPollInput {
+  platform: ImPlatform;
+  flowId: string;
+}
+
+export interface ImOnboardingPollResult {
+  flowId: string;
+  platform: ImPlatform | string;
+  status: string;
+  qrUrl?: string | null;
+  qrScanData?: string | null;
+  intervalSeconds: number;
+  expiresAtMs: number;
+  credentialSummary?: ImCredentialSummary | null;
+  message?: string | null;
+}
+
+export interface ImManualCredentials {
+  appId?: string;
+  appSecret?: string;
+  accountId?: string;
+  token?: string;
+  baseUrl?: string;
+  userId?: string;
+}
+
+export interface ImOnboardingApplyInput {
+  platform: ImPlatform;
+  flowId?: string;
+  manualCredentials?: ImManualCredentials;
+  settings: Record<string, string>;
+  restartGateway?: boolean;
+}
+
+export interface ImRestartResult {
+  requested: boolean;
+  ok: boolean;
+  status?: number | null;
+  message?: string | null;
+}
+
+export interface ImOnboardingApplyResult {
+  ok: boolean;
+  platform: ImPlatform | string;
+  currentProfile: string;
+  envPath: string;
+  backupPath?: string | null;
+  written: Record<string, ImRedactedValue>;
+  restart: ImRestartResult;
+}
+
 // Result of asking the desktop main process to swap the dashboard subprocess
 // over to a different profile. On `ok: true`, the renderer must adopt the new
 // `apiBaseUrl / gatewayUrl / sessionToken / hermesHome` (token is fresh; URL
@@ -180,6 +284,7 @@ export interface SwitchProfileInput {
 // have rolled back to the previous profile (`recoveredPreviousProfile: true`)
 // or be down entirely (`recoveredPreviousProfile: false`); in the second case
 // the user has to fix config and restart the desktop.
+
 export interface SwitchProfileResult {
   ok: boolean;
   profileName?: string;

--- a/pnpm-lock.yaml
+++ b/pnpm-lock.yaml
@@ -23,7 +23,7 @@ importers:
         version: 5.9.3
       vitest:
         specifier: ^4.1.5
-        version: 4.1.6(vite@6.4.2)
+        version: 4.1.6(@types/node@25.9.1)(vite@6.4.2(@types/node@25.9.1))
 
   packages/shared-ui:
     dependencies:
@@ -63,7 +63,7 @@ importers:
         version: 5.9.3
       vite:
         specifier: ^6.3.0
-        version: 6.4.2
+        version: 6.4.2(@types/node@25.9.1)
 
   web:
     dependencies:
@@ -100,6 +100,9 @@ importers:
       lucide-react:
         specifier: ^1.11.0
         version: 1.16.0(react@19.2.6)
+      qrcode:
+        specifier: ^1.5.4
+        version: 1.5.4
       react:
         specifier: ^19.1.0
         version: 19.2.6
@@ -127,16 +130,16 @@ importers:
         version: 19.2.3(@types/react@19.2.14)
       '@vitejs/plugin-react':
         specifier: ^4.5.2
-        version: 4.7.0(vite@6.4.2)
+        version: 4.7.0(vite@6.4.2(@types/node@25.9.1))
       typescript:
         specifier: ^5.9.3
         version: 5.9.3
       vite:
         specifier: ^6.3.0
-        version: 6.4.2
+        version: 6.4.2(@types/node@25.9.1)
       vitest:
         specifier: ^4.1.5
-        version: 4.1.6(vite@6.4.2)
+        version: 4.1.6(@types/node@25.9.1)(vite@6.4.2(@types/node@25.9.1))
 
 packages:
 
@@ -1103,6 +1106,9 @@ packages:
   '@types/ms@2.1.0':
     resolution: {integrity: sha512-GsCCIZDE/p3i96vtEqx+7dBUGXrc7zeSK3wwPHIaRThS+9OhWIXRqzs4d6k1SVU8g91DrNRWxWUGhp5KXQb2VA==}
 
+  '@types/node@25.9.1':
+    resolution: {integrity: sha512-xfrlY7UD5rMJk3ZVJP8BNzS28J36YJg+xp+LPXV1TdWxr8uMH5A860QNxYDGQe/ylDSgjxE52Q9VnO7p75tJxg==}
+
   '@types/react-dom@19.2.3':
     resolution: {integrity: sha512-jp2L/eY6fn+KgVVQAOqYItbF0VY/YApe5Mz2F0aykSO8gx31bYCZyvSeYxCHKvzHG5eZjc+zyaS5BrBWya2+kQ==}
     peerDependencies:
@@ -1161,6 +1167,14 @@ packages:
   '@vitest/utils@4.1.6':
     resolution: {integrity: sha512-FxIY+U81R3LGKCxaHHFRQ5+g6/iRgGLmeHWdp2Amj4ljQRrEIWHmZyDfDYBRZlpyqA7qKxtS9DD1dhk8RnRIVQ==}
 
+  ansi-regex@5.0.1:
+    resolution: {integrity: sha512-quJQXlTSUGL2LH9SUXo8VwsY4soanhgo6LNSm84E1LBcE8s3O0wpdiRzyR9z/ZZJMlMWv37qOOb9pdJlMUEKFQ==}
+    engines: {node: '>=8'}
+
+  ansi-styles@4.3.0:
+    resolution: {integrity: sha512-zbB9rCJAT1rbjiVDb2hqKFHNYLxgtk8NURxZ3IZwD3F6NtxbXZQCnnSi1Lkx+IDohdPlFp222wVALIheZJQSEg==}
+    engines: {node: '>=8'}
+
   aria-hidden@1.2.6:
     resolution: {integrity: sha512-ik3ZgC9dY/lYVVM++OISsaYDeg1tb0VtP5uL3ouh1koGOaUMDPpbFIei4JkFimWUFPn90sbMNMXQAIVOlnYKJA==}
     engines: {node: '>=10'}
@@ -1181,6 +1195,10 @@ packages:
     resolution: {integrity: sha512-48xSriZYYg+8qXna9kwqjIVzuQxi+KYWp2+5nCYnYKPTr0LvD89Jqk2Or5ogxz0NUMfIjhh2lIUX/LyX9B4oIg==}
     engines: {node: ^6 || ^7 || ^8 || ^9 || ^10 || ^11 || ^12 || >=13.7}
     hasBin: true
+
+  camelcase@5.3.1:
+    resolution: {integrity: sha512-L28STB170nwWS63UjtlEOE3dldQApaJXZkOI1uMFfzf3rRuPegHaHesyee+YxQ+W6SvRDQV6UrdOdRiR153wJg==}
+    engines: {node: '>=6'}
 
   caniuse-lite@1.0.30001792:
     resolution: {integrity: sha512-hVLMUZFgR4JJ6ACt1uEESvQN1/dBVqPAKY0hgrV70eN3391K6juAfTjKZLKvOMsx8PxA7gsY1/tLMMTcfFLLpw==}
@@ -1207,6 +1225,9 @@ packages:
   class-variance-authority@0.7.1:
     resolution: {integrity: sha512-Ka+9Trutv7G8M6WT6SeiRWz792K5qEqIGEGzXKhAE6xOWAY6pPH8U+9IY3oCMv6kqTmLsv7Xh/2w2RigkePMsg==}
 
+  cliui@6.0.0:
+    resolution: {integrity: sha512-t6wbgtoCXvAzst7QgXxJYqPt0usEfbgQdftEPbLL/cvv6HPE5VgvqCuAIDR0NgU52ds6rFwqrgakNLrHEjCbrQ==}
+
   clsx@2.1.1:
     resolution: {integrity: sha512-eYm0QWBtUrBWZWG0d386OGAw16Z995PiOVo2B7bjWSbHedGl5e0ZWaq65kOGgUSNesEIDkB9ISbTg/JK9dhCZA==}
     engines: {node: '>=6'}
@@ -1216,6 +1237,13 @@ packages:
     peerDependencies:
       react: ^18 || ^19 || ^19.0.0-rc
       react-dom: ^18 || ^19 || ^19.0.0-rc
+
+  color-convert@2.0.1:
+    resolution: {integrity: sha512-RRECPsj7iu/xb5oKYcsFHSppFNnsj/52OVTRKb4zP5onXwVF3zVmmToNcOfGC+CRDpfK/U584fMg38ZHCaElKQ==}
+    engines: {node: '>=7.0.0'}
+
+  color-name@1.1.4:
+    resolution: {integrity: sha512-dOy+3AuW3a2wNbZHIuMZpTcgjGuLU/uBL/ubcZF9OXbDo8ff4O8yVp5Bf0efS8uEoYo5q4Fx7dY9OgQGXgAsQA==}
 
   comma-separated-tokens@2.0.3:
     resolution: {integrity: sha512-Fu4hJdvzeylCfQPp9SGWidpzrMs7tTrlu6Vb8XGaRGck8QSNZJJp538Wrb60Lax4fPwR64ViY468OIUTbRlGZg==}
@@ -1415,6 +1443,10 @@ packages:
       supports-color:
         optional: true
 
+  decamelize@1.2.0:
+    resolution: {integrity: sha512-z2S+W9X73hAUUki+N+9Za2lBlun89zigOyGrsax+KUQ6wKW4ZoWpEYBkGhQjwAjjDCkWxhY0VKEhk8wzY7F5cA==}
+    engines: {node: '>=0.10.0'}
+
   decode-named-character-reference@1.3.0:
     resolution: {integrity: sha512-GtpQYB283KrPp6nRw50q3U9/VfOutZOe103qlN7BPP6Ad27xYnOIWv4lPzo8HCAL+mMZofJ9KEy30fq6MfaK6Q==}
 
@@ -1431,11 +1463,17 @@ packages:
   devlop@1.1.0:
     resolution: {integrity: sha512-RWmIqhcFf1lRYBvNmr7qTNuyCt/7/ns2jbpp1+PalgE/rDQcBT0fioSMUpJ93irlUhC5hrg4cYqe6U+0ImW0rA==}
 
+  dijkstrajs@1.0.3:
+    resolution: {integrity: sha512-qiSlmBq9+BCdCA/L46dw8Uy93mloxsPSbwnm5yrKn2vMPiy8KyAskTF6zuV/j5BMsmOGZDPs7KjU+mjb670kfA==}
+
   dompurify@3.4.3:
     resolution: {integrity: sha512-VVwJidIJcp1hpg2OMXML3ZVRPYSZiq4aX7qBh83BSIpOaRDqI+qxhXjjIWnpzkOXhmp0L81lnoME1mnCc9H48A==}
 
   electron-to-chromium@1.5.356:
     resolution: {integrity: sha512-9NgFd7m5t5MCJ5rUSjJITUXAH9mEGlrlofnMf4YEr+pz6JlP7cWmTAH+JFmbPnaSW8koVTkuW7pacORWAnA5Yw==}
+
+  emoji-regex@8.0.0:
+    resolution: {integrity: sha512-MSjYzcWNOA0ewAHpz0MxpYFvwg6yjy1NG3xteoqz644VCo/RPgnr1/GGt+ic3iJTzQ8Eu3TdM14SawnVUmGE6A==}
 
   entities@6.0.1:
     resolution: {integrity: sha512-aN97NXWF6AWBTahfVOIrB/NShkzi5H7F9r1s9mD3cDj4Ko5f2qhhVoYMibXF7GlLveb/D2ioWay8lxI97Ven3g==}
@@ -1482,6 +1520,10 @@ packages:
       picomatch:
         optional: true
 
+  find-up@4.1.0:
+    resolution: {integrity: sha512-PpOwAdQ/YlXQ2vj8a3h8IipDuYRi3wceVQQGYWxNINccq40Anw7BlsEXCMbt1Zt+OLA6Fq9suIpIWD0OsnISlw==}
+    engines: {node: '>=8'}
+
   fsevents@2.3.3:
     resolution: {integrity: sha512-5xoDfX+fL7faATnagmWPpbFtwh/R77WmMMqqHGS65C3vvB0YHrgF+B1YmZ3441tMj5n63k0212XNoJwzlhffQw==}
     engines: {node: ^8.16.0 || ^10.6.0 || >=11.0.0}
@@ -1490,6 +1532,10 @@ packages:
   gensync@1.0.0-beta.2:
     resolution: {integrity: sha512-3hN7NaskYvMDLQY55gnW3NQ+mesEAepTqlg+VEbj7zzqEMBVNhzcGYYeqFo/TlYz6eQiFcp1HcsCZO+nGgS8zg==}
     engines: {node: '>=6.9.0'}
+
+  get-caller-file@2.0.5:
+    resolution: {integrity: sha512-DyFP3BM/3YHTQOCUL/w0OZHR0lpKeGrxotcHWcqNEdnltqFwXVfhEBQ94eIo34AfQpo0rGki4cyIiftY06h2Fg==}
+    engines: {node: 6.* || 8.* || >= 10.*}
 
   get-east-asian-width@1.6.0:
     resolution: {integrity: sha512-QRbvDIbx6YklUe6RxeTeleMR0yv3cYH6PsPZHcnVn7xv7zO1BHN8r0XETu8n6Ye3Q+ahtSarc3WgtNWmehIBfA==}
@@ -1573,6 +1619,10 @@ packages:
   is-decimal@2.0.1:
     resolution: {integrity: sha512-AAB9hiomQs5DXWcRB1rqsxGUstbRroFOPPVAomNk/3XHR5JyEZChOyTWe2oayKnsSsr/kcGqF+z6yuH6HHpN0A==}
 
+  is-fullwidth-code-point@3.0.0:
+    resolution: {integrity: sha512-zymm5+u+sCsSWyD9qNaejV3DFvhCKclKdizYaJUuHA83RLjb7nSuGnddCHGv0hk+KY7BMAlsWeK4Ueg6EV6XQg==}
+    engines: {node: '>=8'}
+
   is-hexadecimal@2.0.1:
     resolution: {integrity: sha512-DgZQp241c8oO6cA1SbTEWiXeoxV42vlcJxgH+B3hi1AiqqKruZR3ZGF8In3fj4+/y/7rHvlOZLZtgJ/4ttYGZg==}
 
@@ -1623,6 +1673,10 @@ packages:
 
   layout-base@2.0.1:
     resolution: {integrity: sha512-dp3s92+uNI1hWIpPGH3jK2kxE2lMjdXdr+DH8ynZHpd6PUlH6x6cbuXnoMmiNumznqaNO31xu9e79F0uuZ0JFg==}
+
+  locate-path@5.0.0:
+    resolution: {integrity: sha512-t7hw9pI+WvuwNJXwk5zVHpyhIqzg2qTlklJOf0mVxGSbe3Fp2VieZcduNYjaLDoy6p9uGpQEGWG87WpMKlNq8g==}
+    engines: {node: '>=8'}
 
   lodash-es@4.18.1:
     resolution: {integrity: sha512-J8xewKD/Gk22OZbhpOVSwcs60zhd95ESDwezOFuA3/099925PdHJ7OFHNTGtajL3AlZkykD32HykiMo+BIBI8A==}
@@ -1835,6 +1889,18 @@ packages:
   obug@2.1.1:
     resolution: {integrity: sha512-uTqF9MuPraAQ+IsnPf366RG4cP9RtUi7MLO1N3KEc+wb0a6yKpeL0lmk2IB1jY5KHPAlTc6T/JRdC/YqxHNwkQ==}
 
+  p-limit@2.3.0:
+    resolution: {integrity: sha512-//88mFWSJx8lxCzwdAABTJL2MyWB12+eIY7MDL2SqLmAkeKU9qxRvWuSyTjm3FUmpBEMuFfckAIqEaVGUDxb6w==}
+    engines: {node: '>=6'}
+
+  p-locate@4.1.0:
+    resolution: {integrity: sha512-R79ZZ/0wAxKGu3oYMlz8jy/kbhsNrS7SKZ7PxEHBgJ5+F2mtFW2fK2cOtBh1cHYkQsbzFV7I+EoRKe6Yt0oK7A==}
+    engines: {node: '>=8'}
+
+  p-try@2.2.0:
+    resolution: {integrity: sha512-R4nPAVTAU0B9D35/Gk3uJf/7XYbQcyohSKdvAxIRSNghFl4e71hVoGnBNQz9cWaXxO2I10KTC+3jMdvvoKw6dQ==}
+    engines: {node: '>=6'}
+
   package-manager-detector@1.6.0:
     resolution: {integrity: sha512-61A5ThoTiDG/C8s8UMZwSorAGwMJ0ERVGj2OjoW5pAalsNOg15+iQiPzrLJ4jhZ1HJzmC2PIHT2oEiH3R5fzNA==}
 
@@ -1847,6 +1913,10 @@ packages:
   path-data-parser@0.1.0:
     resolution: {integrity: sha512-NOnmBpt5Y2RWbuv0LMzsayp3lVylAHLPUTut412ZA3l+C4uw4ZVkQbjShYCQ8TCpUMdPapr4YjUqLYD6v68j+w==}
 
+  path-exists@4.0.0:
+    resolution: {integrity: sha512-ak9Qy5Q7jYb2Wwcey5Fpvg2KoAc/ZIhLSLOSBmRmygPsGwkVVt0fZa0qrtMz+m6tJTAHfZQ8FnmB4MG4LWy7/w==}
+    engines: {node: '>=8'}
+
   pathe@2.0.3:
     resolution: {integrity: sha512-WUjGcAqP1gQacoQe+OBJsFA7Ld4DyXuUIjZ5cc75cLHvJ7dtNsTugphxIADwspS+AraAUePCKrSVtPLFj/F88w==}
 
@@ -1856,6 +1926,10 @@ packages:
   picomatch@4.0.4:
     resolution: {integrity: sha512-QP88BAKvMam/3NxH6vj2o21R6MjxZUAd6nlwAS/pnGvN9IVLocLHxGYIzFhg6fUQ+5th6P4dv4eW9jX3DSIj7A==}
     engines: {node: '>=12'}
+
+  pngjs@5.0.0:
+    resolution: {integrity: sha512-40QW5YalBNfQo5yRYmiw7Yz6TKKVr3h6970B2YE+3fQpsWcrbj1PzJgxeJ19DRQjhMbKPIuMY8rFaXc8moolVw==}
+    engines: {node: '>=10.13.0'}
 
   points-on-curve@0.2.0:
     resolution: {integrity: sha512-0mYKnYYe9ZcqMCWhUjItv/oHjvgEsfKvnUTg8sAtnHr3GVy7rGkXCb6d5cSyqrWqL4k81b9CPg3urd+T7aop3A==}
@@ -1869,6 +1943,11 @@ packages:
 
   property-information@7.1.0:
     resolution: {integrity: sha512-TwEZ+X+yCJmYfL7TPUOcvBZ4QfoT5YenQiJuX//0th53DE6w0xxLEtfK3iyryQFddXuvkIk51EEgrJQ0WJkOmQ==}
+
+  qrcode@1.5.4:
+    resolution: {integrity: sha512-1ca71Zgiu6ORjHqFBDpnSMTR2ReToX4l1Au1VFLyVeBTFavzQnv5JxMFr3ukHVKpSrSA2MCk0lNJSykjUfz7Zg==}
+    engines: {node: '>=10.13.0'}
+    hasBin: true
 
   react-dom@19.2.6:
     resolution: {integrity: sha512-0prMI+hvBbPjsWnxDLxlCGyM8PN6UuWjEUCYmZhO67xIV9Xasa/r/vDnq+Xyq4Lo27g8QSbO5YzARu0D1Sps3g==}
@@ -1980,6 +2059,13 @@ packages:
   remend@1.3.0:
     resolution: {integrity: sha512-iIhggPkhW3hFImKtB10w0dz4EZbs28mV/dmbcYVonWEJ6UGHHpP+bFZnTh6GNWJONg5m+U56JrL+8IxZRdgWjw==}
 
+  require-directory@2.1.1:
+    resolution: {integrity: sha512-fGxEI7+wsG9xrvdjsrlmL22OMTTiHRwAMroiEeMgq8gzoLC/PQr7RsRDSTLUg/bZAZtF+TVIkHc6/4RIKrui+Q==}
+    engines: {node: '>=0.10.0'}
+
+  require-main-filename@2.0.0:
+    resolution: {integrity: sha512-NKN5kMDylKuldxYLSUfrbo5Tuzh4hd+2E8NPPX02mZtn1VuREQToYe/ZdlJy+J3uCpfaiGF05e7B8W0iXbQHmg==}
+
   robust-predicates@3.0.3:
     resolution: {integrity: sha512-NS3levdsRIUOmiJ8FZWCP7LG3QpJyrs/TE0Zpf1yvZu8cAJJ6QMW92H1c7kWpdIHo8RvmLxN/o2JXTKHp74lUA==}
 
@@ -2003,6 +2089,9 @@ packages:
   semver@6.3.1:
     resolution: {integrity: sha512-BR7VvDCVHO+q2xBEWskxS6DJE1qRnb7DxzUrogb71CWoSficBxYsiAGd+Kl0mmq/MprG9yArRkyrQxTO6XjMzA==}
     hasBin: true
+
+  set-blocking@2.0.0:
+    resolution: {integrity: sha512-KiKBS8AnWGEyLzofFfmvKwpdPzqiy16LvQfK3yv/fVH7Bj13/wl3JSR1J+rfgRE9q7xUJK4qvgS8raSOeLUehw==}
 
   set-cookie-parser@2.7.2:
     resolution: {integrity: sha512-oeM1lpU/UvhTxw+g3cIfxXHyJRc/uidd3yK1P242gzHds0udQBYzs3y8j4gCCW+ZJ7ad0yctld8RYO+bdurlvw==}
@@ -2029,8 +2118,16 @@ packages:
       react: ^18.0.0 || ^19.0.0
       react-dom: ^18.0.0 || ^19.0.0
 
+  string-width@4.2.3:
+    resolution: {integrity: sha512-wKyQRQpjJ0sIp62ErSZdGsjMJWsap5oRNihHhu6G7JVO/9jIB6UyevL+tXuOqrng8j/cxKTWyWUwvSTriiZz/g==}
+    engines: {node: '>=8'}
+
   stringify-entities@4.0.4:
     resolution: {integrity: sha512-IwfBptatlO+QCJUo19AqvrPNqlVMpW9YEL2LIVY+Rpv2qsjCGxaDLNRgeGsQWJhfItebuJhsGSLjaBbNSQ+ieg==}
+
+  strip-ansi@6.0.1:
+    resolution: {integrity: sha512-Y38VPSHcqkFrCpFnQ9vuSXmquuv5oXOKpGeT6aGrr3o3Gc9AlVa6JBfUSOCnbxGGZF+/0ooI7KrPuUSztUdU5A==}
+    engines: {node: '>=8'}
 
   style-to-js@1.1.21:
     resolution: {integrity: sha512-RjQetxJrrUJLQPHbLku6U/ocGtzyjbJMP9lCNK7Ag0CNh690nSH8woqWH9u16nMjYBAok+i7JO1NP2pOy8IsPQ==}
@@ -2076,6 +2173,9 @@ packages:
     resolution: {integrity: sha512-jl1vZzPDinLr9eUt3J/t7V6FgNEw9QjvBPdysz9KfQDD41fQrC2Y4vKQdiaUpFT4bXlb1RHhLpp8wtm6M5TgSw==}
     engines: {node: '>=14.17'}
     hasBin: true
+
+  undici-types@7.24.6:
+    resolution: {integrity: sha512-WRNW+sJgj5OBN4/0JpHFqtqzhpbnV0GuB+OozA9gCL7a993SmU+1JBZCzLNxYsbMfIeDL+lTsphD5jN5N+n0zg==}
 
   unified@11.0.5:
     resolution: {integrity: sha512-xKvGhPWw3k84Qjh8bI3ZeJjqnyadK+GEFtazSfZv/rKeTkTjOJho6mFqh2SM96iIcZokxiOpg78GazTSg8+KHA==}
@@ -2224,13 +2324,31 @@ packages:
   web-namespaces@2.0.1:
     resolution: {integrity: sha512-bKr1DkiNa2krS7qxNtdrtHAmzuYGFQLiQ13TsorsdT6ULTkPLKuu5+GsFpDlg6JFjUTwX2DyhMPG2be8uPrqsQ==}
 
+  which-module@2.0.1:
+    resolution: {integrity: sha512-iBdZ57RDvnOR9AGBhML2vFZf7h8vmBjhoaZqODJBFWHVtKkDmKuHai3cx5PgVMrX5YDNp27AofYbAwctSS+vhQ==}
+
   why-is-node-running@2.3.0:
     resolution: {integrity: sha512-hUrmaWBdVDcxvYqnyh09zunKzROWjbZTiNy8dBEjkS7ehEDQibXJ7XvlmtbwuTclUiIyN+CyXQD4Vmko8fNm8w==}
     engines: {node: '>=8'}
     hasBin: true
 
+  wrap-ansi@6.2.0:
+    resolution: {integrity: sha512-r6lPcBGxZXlIcymEu7InxDMhdW0KDxpLgoFLcguasxCaJ/SOIZwINatK9KY/tf+ZrlywOKU0UDj3ATXUBfxJXA==}
+    engines: {node: '>=8'}
+
+  y18n@4.0.3:
+    resolution: {integrity: sha512-JKhqTOwSrqNA1NY5lSztJ1GrBiUodLMmIZuLiDaMRJ+itFd+ABVE8XBjOvIWL+rSqNDC74LCSFmlb/U4UZ4hJQ==}
+
   yallist@3.1.1:
     resolution: {integrity: sha512-a4UGQaWPH59mOXUYnAG2ewncQS4i4F43Tv3JoAM+s2VDAmS9NsK8GpDMLrCHPksFT7h3K6TOoUNn2pb7RoXx4g==}
+
+  yargs-parser@18.1.3:
+    resolution: {integrity: sha512-o50j0JeToy/4K6OZcaQmW6lyXXKhq7csREXcDwk2omFPJEwUNOVtJKvmDr9EI1fAJZUyZcRF7kxGBWmRXudrCQ==}
+    engines: {node: '>=6'}
+
+  yargs@15.4.1:
+    resolution: {integrity: sha512-aePbxDmcYW++PaqBsJ+HYUFwCdv4LVvdnhBy78E57PIor8/OVvhMrADFFEDh8DHDFRv/O9i3lPhsENjO7QX0+A==}
+    engines: {node: '>=8'}
 
   zod@3.25.76:
     resolution: {integrity: sha512-gzUt/qt81nXsFGKIFcC3YnfEAx5NkunCfnDlvuBSSFS02bcXu4Lmea0AFIUwbLWxWPx3d9p8S5QoaujKcNQxcQ==}
@@ -3115,6 +3233,11 @@ snapshots:
 
   '@types/ms@2.1.0': {}
 
+  '@types/node@25.9.1':
+    dependencies:
+      undici-types: 7.24.6
+    optional: true
+
   '@types/react-dom@19.2.3(@types/react@19.2.14)':
     dependencies:
       '@types/react': 19.2.14
@@ -3137,7 +3260,7 @@ snapshots:
       d3-selection: 3.0.0
       d3-transition: 3.0.1(d3-selection@3.0.0)
 
-  '@vitejs/plugin-react@4.7.0(vite@6.4.2)':
+  '@vitejs/plugin-react@4.7.0(vite@6.4.2(@types/node@25.9.1))':
     dependencies:
       '@babel/core': 7.29.0
       '@babel/plugin-transform-react-jsx-self': 7.27.1(@babel/core@7.29.0)
@@ -3145,7 +3268,7 @@ snapshots:
       '@rolldown/pluginutils': 1.0.0-beta.27
       '@types/babel__core': 7.20.5
       react-refresh: 0.17.0
-      vite: 6.4.2
+      vite: 6.4.2(@types/node@25.9.1)
     transitivePeerDependencies:
       - supports-color
 
@@ -3158,13 +3281,13 @@ snapshots:
       chai: 6.2.2
       tinyrainbow: 3.1.0
 
-  '@vitest/mocker@4.1.6(vite@6.4.2)':
+  '@vitest/mocker@4.1.6(vite@6.4.2(@types/node@25.9.1))':
     dependencies:
       '@vitest/spy': 4.1.6
       estree-walker: 3.0.3
       magic-string: 0.30.21
     optionalDependencies:
-      vite: 6.4.2
+      vite: 6.4.2(@types/node@25.9.1)
 
   '@vitest/pretty-format@4.1.6':
     dependencies:
@@ -3190,6 +3313,12 @@ snapshots:
       convert-source-map: 2.0.0
       tinyrainbow: 3.1.0
 
+  ansi-regex@5.0.1: {}
+
+  ansi-styles@4.3.0:
+    dependencies:
+      color-convert: 2.0.1
+
   aria-hidden@1.2.6:
     dependencies:
       tslib: 2.8.1
@@ -3207,6 +3336,8 @@ snapshots:
       electron-to-chromium: 1.5.356
       node-releases: 2.0.44
       update-browserslist-db: 1.2.3(browserslist@4.28.2)
+
+  camelcase@5.3.1: {}
 
   caniuse-lite@1.0.30001792: {}
 
@@ -3226,6 +3357,12 @@ snapshots:
     dependencies:
       clsx: 2.1.1
 
+  cliui@6.0.0:
+    dependencies:
+      string-width: 4.2.3
+      strip-ansi: 6.0.1
+      wrap-ansi: 6.2.0
+
   clsx@2.1.1: {}
 
   cmdk@1.1.1(@types/react-dom@19.2.3(@types/react@19.2.14))(@types/react@19.2.14)(react-dom@19.2.6(react@19.2.6))(react@19.2.6):
@@ -3239,6 +3376,12 @@ snapshots:
     transitivePeerDependencies:
       - '@types/react'
       - '@types/react-dom'
+
+  color-convert@2.0.1:
+    dependencies:
+      color-name: 1.1.4
+
+  color-name@1.1.4: {}
 
   comma-separated-tokens@2.0.3: {}
 
@@ -3452,6 +3595,8 @@ snapshots:
     dependencies:
       ms: 2.1.3
 
+  decamelize@1.2.0: {}
+
   decode-named-character-reference@1.3.0:
     dependencies:
       character-entities: 2.0.2
@@ -3468,11 +3613,15 @@ snapshots:
     dependencies:
       dequal: 2.0.3
 
+  dijkstrajs@1.0.3: {}
+
   dompurify@3.4.3:
     optionalDependencies:
       '@types/trusted-types': 2.0.7
 
   electron-to-chromium@1.5.356: {}
+
+  emoji-regex@8.0.0: {}
 
   entities@6.0.1: {}
 
@@ -3527,10 +3676,17 @@ snapshots:
     optionalDependencies:
       picomatch: 4.0.4
 
+  find-up@4.1.0:
+    dependencies:
+      locate-path: 5.0.0
+      path-exists: 4.0.0
+
   fsevents@2.3.3:
     optional: true
 
   gensync@1.0.0-beta.2: {}
+
+  get-caller-file@2.0.5: {}
 
   get-east-asian-width@1.6.0: {}
 
@@ -3675,6 +3831,8 @@ snapshots:
 
   is-decimal@2.0.1: {}
 
+  is-fullwidth-code-point@3.0.0: {}
+
   is-hexadecimal@2.0.1: {}
 
   is-plain-obj@4.1.0: {}
@@ -3701,6 +3859,10 @@ snapshots:
   layout-base@1.0.2: {}
 
   layout-base@2.0.1: {}
+
+  locate-path@5.0.0:
+    dependencies:
+      p-locate: 4.1.0
 
   lodash-es@4.18.1: {}
 
@@ -4154,6 +4316,16 @@ snapshots:
 
   obug@2.1.1: {}
 
+  p-limit@2.3.0:
+    dependencies:
+      p-try: 2.2.0
+
+  p-locate@4.1.0:
+    dependencies:
+      p-limit: 2.3.0
+
+  p-try@2.2.0: {}
+
   package-manager-detector@1.6.0: {}
 
   parse-entities@4.0.2:
@@ -4172,11 +4344,15 @@ snapshots:
 
   path-data-parser@0.1.0: {}
 
+  path-exists@4.0.0: {}
+
   pathe@2.0.3: {}
 
   picocolors@1.1.1: {}
 
   picomatch@4.0.4: {}
+
+  pngjs@5.0.0: {}
 
   points-on-curve@0.2.0: {}
 
@@ -4192,6 +4368,12 @@ snapshots:
       source-map-js: 1.2.1
 
   property-information@7.1.0: {}
+
+  qrcode@1.5.4:
+    dependencies:
+      dijkstrajs: 1.0.3
+      pngjs: 5.0.0
+      yargs: 15.4.1
 
   react-dom@19.2.6(react@19.2.6):
     dependencies:
@@ -4333,6 +4515,10 @@ snapshots:
 
   remend@1.3.0: {}
 
+  require-directory@2.1.1: {}
+
+  require-main-filename@2.0.0: {}
+
   robust-predicates@3.0.3: {}
 
   rollup@4.60.4:
@@ -4381,6 +4567,8 @@ snapshots:
 
   semver@6.3.1: {}
 
+  set-blocking@2.0.0: {}
+
   set-cookie-parser@2.7.2: {}
 
   siginfo@2.0.0: {}
@@ -4416,10 +4604,20 @@ snapshots:
     transitivePeerDependencies:
       - supports-color
 
+  string-width@4.2.3:
+    dependencies:
+      emoji-regex: 8.0.0
+      is-fullwidth-code-point: 3.0.0
+      strip-ansi: 6.0.1
+
   stringify-entities@4.0.4:
     dependencies:
       character-entities-html4: 2.1.0
       character-entities-legacy: 3.0.0
+
+  strip-ansi@6.0.1:
+    dependencies:
+      ansi-regex: 5.0.1
 
   style-to-js@1.1.21:
     dependencies:
@@ -4453,6 +4651,9 @@ snapshots:
   tslib@2.8.1: {}
 
   typescript@5.9.3: {}
+
+  undici-types@7.24.6:
+    optional: true
 
   unified@11.0.5:
     dependencies:
@@ -4535,7 +4736,7 @@ snapshots:
       '@types/unist': 3.0.3
       vfile-message: 4.0.3
 
-  vite@6.4.2:
+  vite@6.4.2(@types/node@25.9.1):
     dependencies:
       esbuild: 0.25.12
       fdir: 6.5.0(picomatch@4.0.4)
@@ -4544,12 +4745,13 @@ snapshots:
       rollup: 4.60.4
       tinyglobby: 0.2.16
     optionalDependencies:
+      '@types/node': 25.9.1
       fsevents: 2.3.3
 
-  vitest@4.1.6(vite@6.4.2):
+  vitest@4.1.6(@types/node@25.9.1)(vite@6.4.2(@types/node@25.9.1)):
     dependencies:
       '@vitest/expect': 4.1.6
-      '@vitest/mocker': 4.1.6(vite@6.4.2)
+      '@vitest/mocker': 4.1.6(vite@6.4.2(@types/node@25.9.1))
       '@vitest/pretty-format': 4.1.6
       '@vitest/runner': 4.1.6
       '@vitest/snapshot': 4.1.6
@@ -4566,19 +4768,50 @@ snapshots:
       tinyexec: 1.1.2
       tinyglobby: 0.2.16
       tinyrainbow: 3.1.0
-      vite: 6.4.2
+      vite: 6.4.2(@types/node@25.9.1)
       why-is-node-running: 2.3.0
+    optionalDependencies:
+      '@types/node': 25.9.1
     transitivePeerDependencies:
       - msw
 
   web-namespaces@2.0.1: {}
+
+  which-module@2.0.1: {}
 
   why-is-node-running@2.3.0:
     dependencies:
       siginfo: 2.0.0
       stackback: 0.0.2
 
+  wrap-ansi@6.2.0:
+    dependencies:
+      ansi-styles: 4.3.0
+      string-width: 4.2.3
+      strip-ansi: 6.0.1
+
+  y18n@4.0.3: {}
+
   yallist@3.1.1: {}
+
+  yargs-parser@18.1.3:
+    dependencies:
+      camelcase: 5.3.1
+      decamelize: 1.2.0
+
+  yargs@15.4.1:
+    dependencies:
+      cliui: 6.0.0
+      decamelize: 1.2.0
+      find-up: 4.1.0
+      get-caller-file: 2.0.5
+      require-directory: 2.1.1
+      require-main-filename: 2.0.0
+      set-blocking: 2.0.0
+      string-width: 4.2.3
+      which-module: 2.0.1
+      y18n: 4.0.3
+      yargs-parser: 18.1.3
 
   zod@3.25.76: {}
 

--- a/src/commands/im_onboarding.rs
+++ b/src/commands/im_onboarding.rs
@@ -1,0 +1,1680 @@
+use once_cell::sync::Lazy;
+use reqwest::Client;
+use serde::{Deserialize, Serialize};
+use serde_json::Value;
+use sha2::{Digest, Sha256};
+use std::collections::{BTreeMap, HashMap};
+use std::fs;
+use std::path::{Path, PathBuf};
+use std::sync::Mutex;
+use std::time::{Duration, Instant, SystemTime, UNIX_EPOCH};
+use tauri::State;
+use url::Url;
+
+use crate::error::AppError;
+use crate::state::AppState;
+
+static HTTP: Lazy<Client> = Lazy::new(|| {
+    Client::builder()
+        .timeout(Duration::from_secs(15))
+        .build()
+        .expect("valid IM onboarding HTTP client")
+});
+
+static FLOWS: Lazy<Mutex<HashMap<String, FlowState>>> = Lazy::new(|| Mutex::new(HashMap::new()));
+
+const FEISHU_ACCOUNTS_BASE: &str = "https://accounts.feishu.cn";
+const FEISHU_OPEN_BASE: &str = "https://open.feishu.cn";
+const LARK_ACCOUNTS_BASE: &str = "https://accounts.larksuite.com";
+const LARK_OPEN_BASE: &str = "https://open.larksuite.com";
+const FEISHU_REGISTRATION_PATH: &str = "/oauth/v1/app/registration";
+const WEIXIN_BASE_URL: &str = "https://ilinkai.weixin.qq.com";
+const WEIXIN_CDN_BASE_URL: &str = "https://novac2c.cdn.weixin.qq.com/c2c";
+const WEIXIN_CLIENT_VERSION: &str = "131584";
+const WEIXIN_QR_REFRESH_LIMIT: u8 = 3;
+
+const FEISHU_SECRET_KEYS: &[&str] = &[
+    "FEISHU_APP_SECRET",
+    "FEISHU_ENCRYPT_KEY",
+    "FEISHU_VERIFICATION_TOKEN",
+];
+const WEIXIN_SECRET_KEYS: &[&str] = &["WEIXIN_TOKEN"];
+
+const FEISHU_ALLOWED_KEYS: &[&str] = &[
+    "FEISHU_DOMAIN",
+    "FEISHU_APP_ID",
+    "FEISHU_APP_SECRET",
+    "FEISHU_CONNECTION_MODE",
+    "FEISHU_WEBHOOK_HOST",
+    "FEISHU_WEBHOOK_PORT",
+    "FEISHU_WEBHOOK_PATH",
+    "FEISHU_ENCRYPT_KEY",
+    "FEISHU_VERIFICATION_TOKEN",
+    "FEISHU_ALLOW_ALL_USERS",
+    "FEISHU_ALLOWED_USERS",
+    "FEISHU_GROUP_POLICY",
+    "FEISHU_REQUIRE_MENTION",
+    "FEISHU_HOME_CHANNEL",
+];
+const WEIXIN_ALLOWED_KEYS: &[&str] = &[
+    "WEIXIN_ACCOUNT_ID",
+    "WEIXIN_TOKEN",
+    "WEIXIN_BASE_URL",
+    "WEIXIN_CDN_BASE_URL",
+    "WEIXIN_DM_POLICY",
+    "WEIXIN_ALLOW_ALL_USERS",
+    "WEIXIN_ALLOWED_USERS",
+    "WEIXIN_GROUP_POLICY",
+    "WEIXIN_GROUP_ALLOWED_USERS",
+    "WEIXIN_HOME_CHANNEL",
+];
+
+#[derive(Debug, Clone, Copy, PartialEq, Eq, Serialize, Deserialize)]
+#[serde(rename_all = "lowercase")]
+pub enum ImPlatform {
+    Feishu,
+    Weixin,
+}
+
+impl ImPlatform {
+    fn as_str(self) -> &'static str {
+        match self {
+            ImPlatform::Feishu => "feishu",
+            ImPlatform::Weixin => "weixin",
+        }
+    }
+
+    fn allowed_keys(self) -> &'static [&'static str] {
+        match self {
+            ImPlatform::Feishu => FEISHU_ALLOWED_KEYS,
+            ImPlatform::Weixin => WEIXIN_ALLOWED_KEYS,
+        }
+    }
+
+    fn secret_keys(self) -> &'static [&'static str] {
+        match self {
+            ImPlatform::Feishu => FEISHU_SECRET_KEYS,
+            ImPlatform::Weixin => WEIXIN_SECRET_KEYS,
+        }
+    }
+}
+
+#[derive(Debug, Deserialize)]
+#[serde(rename_all = "camelCase")]
+pub struct ImOnboardingStateInput {
+    pub platform: ImPlatform,
+}
+
+#[derive(Debug, Deserialize)]
+#[serde(rename_all = "camelCase")]
+pub struct ImOnboardingBeginInput {
+    pub platform: ImPlatform,
+    pub domain: Option<String>,
+    pub bot_type: Option<String>,
+}
+
+#[derive(Debug, Deserialize)]
+#[serde(rename_all = "camelCase")]
+pub struct ImOnboardingPollInput {
+    pub platform: ImPlatform,
+    pub flow_id: String,
+}
+
+#[derive(Debug, Deserialize)]
+#[serde(rename_all = "camelCase")]
+pub struct ImManualCredentials {
+    pub app_id: Option<String>,
+    pub app_secret: Option<String>,
+    pub account_id: Option<String>,
+    pub token: Option<String>,
+    pub base_url: Option<String>,
+    pub user_id: Option<String>,
+}
+
+#[derive(Debug, Deserialize)]
+#[serde(rename_all = "camelCase")]
+pub struct ImOnboardingApplyInput {
+    pub platform: ImPlatform,
+    pub flow_id: Option<String>,
+    pub manual_credentials: Option<ImManualCredentials>,
+    pub settings: BTreeMap<String, String>,
+    pub restart_gateway: Option<bool>,
+}
+
+#[derive(Debug, Serialize, Clone)]
+#[serde(rename_all = "camelCase")]
+pub struct RedactedValue {
+    pub is_set: bool,
+    pub redacted_value: Option<String>,
+    pub fingerprint: Option<String>,
+}
+
+#[derive(Debug, Serialize)]
+#[serde(rename_all = "camelCase")]
+pub struct ImOnboardingStateResult {
+    pub platform: String,
+    pub current_profile: String,
+    pub hermes_home: String,
+    pub env_path: String,
+    pub configured: BTreeMap<String, RedactedValue>,
+}
+
+#[derive(Debug, Serialize)]
+#[serde(rename_all = "camelCase")]
+pub struct ImOnboardingBeginResult {
+    pub flow_id: String,
+    pub platform: String,
+    pub status: String,
+    pub qr_url: Option<String>,
+    pub qr_scan_data: Option<String>,
+    pub user_code: Option<String>,
+    pub interval_seconds: u64,
+    pub expires_at_ms: u64,
+    pub message: Option<String>,
+}
+
+#[derive(Debug, Serialize)]
+#[serde(rename_all = "camelCase")]
+pub struct CredentialSummary {
+    pub app_id: Option<RedactedValue>,
+    pub app_secret: Option<RedactedValue>,
+    pub account_id: Option<RedactedValue>,
+    pub token: Option<RedactedValue>,
+    pub base_url: Option<String>,
+    pub domain: Option<String>,
+    pub user_id: Option<RedactedValue>,
+    pub bot_name: Option<String>,
+    pub bot_open_id: Option<RedactedValue>,
+    pub open_id: Option<RedactedValue>,
+}
+
+#[derive(Debug, Serialize)]
+#[serde(rename_all = "camelCase")]
+pub struct ImOnboardingPollResult {
+    pub flow_id: String,
+    pub platform: String,
+    pub status: String,
+    pub qr_url: Option<String>,
+    pub qr_scan_data: Option<String>,
+    pub interval_seconds: u64,
+    pub expires_at_ms: u64,
+    pub credential_summary: Option<CredentialSummary>,
+    pub message: Option<String>,
+}
+
+#[derive(Debug, Serialize)]
+#[serde(rename_all = "camelCase")]
+pub struct ImRestartResult {
+    pub requested: bool,
+    pub ok: bool,
+    pub status: Option<u16>,
+    pub message: Option<String>,
+}
+
+#[derive(Debug, Serialize)]
+#[serde(rename_all = "camelCase")]
+pub struct ImOnboardingApplyResult {
+    pub ok: bool,
+    pub platform: String,
+    pub current_profile: String,
+    pub env_path: String,
+    pub backup_path: Option<String>,
+    pub written: BTreeMap<String, RedactedValue>,
+    pub restart: ImRestartResult,
+}
+
+#[derive(Debug, Clone)]
+enum FlowState {
+    Feishu(FeishuFlow),
+    Weixin(WeixinFlow),
+}
+
+#[derive(Debug, Clone)]
+struct FeishuFlow {
+    device_code: String,
+    domain: String,
+    interval_seconds: u64,
+    expires_at: Instant,
+    expires_at_ms: u64,
+    credential: Option<FeishuCredential>,
+}
+
+#[derive(Debug, Clone)]
+struct FeishuCredential {
+    app_id: String,
+    app_secret: String,
+    domain: String,
+    open_id: Option<String>,
+    bot_name: Option<String>,
+    bot_open_id: Option<String>,
+}
+
+#[derive(Debug, Clone)]
+struct WeixinFlow {
+    qrcode_value: String,
+    qrcode_url: Option<String>,
+    current_base_url: String,
+    refresh_count: u8,
+    interval_seconds: u64,
+    expires_at: Instant,
+    expires_at_ms: u64,
+    credential: Option<WeixinCredential>,
+}
+
+#[derive(Debug, Clone)]
+struct WeixinCredential {
+    account_id: String,
+    token: String,
+    base_url: String,
+    user_id: Option<String>,
+}
+
+fn now_ms() -> u64 {
+    SystemTime::now()
+        .duration_since(UNIX_EPOCH)
+        .unwrap_or_default()
+        .as_millis() as u64
+}
+
+fn new_flow_id(platform: ImPlatform) -> String {
+    let seed = format!("{}:{}:{}", platform.as_str(), std::process::id(), now_ms());
+    let digest = Sha256::digest(seed.as_bytes());
+    format!("{}-{}", platform.as_str(), bytes_to_lower_hex(&digest[..8]))
+}
+
+fn bytes_to_lower_hex(bytes: &[u8]) -> String {
+    bytes.iter().map(|byte| format!("{byte:02x}")).collect()
+}
+
+fn same_path(left: &str, right: &str) -> bool {
+    let left = fs::canonicalize(left).unwrap_or_else(|_| PathBuf::from(left));
+    let right = fs::canonicalize(right).unwrap_or_else(|_| PathBuf::from(right));
+    left == right
+}
+
+fn expires_at_ms_from(timeout: Duration) -> u64 {
+    now_ms() + timeout.as_millis() as u64
+}
+
+fn normalized_domain(value: Option<String>) -> String {
+    match value
+        .unwrap_or_else(|| "feishu".to_string())
+        .trim()
+        .to_lowercase()
+        .as_str()
+    {
+        "lark" => "lark".to_string(),
+        _ => "feishu".to_string(),
+    }
+}
+
+fn feishu_accounts_base(domain: &str) -> String {
+    if let Ok(base) = std::env::var("HERMES_IM_ONBOARDING_FEISHU_ACCOUNTS_URL") {
+        return base.trim_end_matches('/').to_string();
+    }
+    match domain {
+        "lark" => LARK_ACCOUNTS_BASE.to_string(),
+        _ => FEISHU_ACCOUNTS_BASE.to_string(),
+    }
+}
+
+fn feishu_open_base(domain: &str) -> String {
+    if let Ok(base) = std::env::var("HERMES_IM_ONBOARDING_FEISHU_OPEN_URL") {
+        return base.trim_end_matches('/').to_string();
+    }
+    match domain {
+        "lark" => LARK_OPEN_BASE.to_string(),
+        _ => FEISHU_OPEN_BASE.to_string(),
+    }
+}
+
+fn weixin_base_url() -> String {
+    std::env::var("HERMES_IM_ONBOARDING_WEIXIN_BASE_URL")
+        .unwrap_or_else(|_| WEIXIN_BASE_URL.to_string())
+        .trim_end_matches('/')
+        .to_string()
+}
+
+fn redacted(value: Option<&str>, secret: bool) -> RedactedValue {
+    let value = value.unwrap_or("");
+    if value.is_empty() {
+        return RedactedValue {
+            is_set: false,
+            redacted_value: None,
+            fingerprint: None,
+        };
+    }
+    let digest = Sha256::digest(value.as_bytes());
+    let fingerprint = format!("sha256:{}", bytes_to_lower_hex(&digest[..4]));
+    let chars: Vec<char> = value.chars().collect();
+    let suffix_len = if secret { 4 } else { 6 }.min(chars.len());
+    let suffix: String = chars[chars.len() - suffix_len..].iter().collect();
+    let prefix: String = if !secret && chars.len() > suffix_len + 6 {
+        chars[..6].iter().collect::<String>()
+    } else {
+        String::new()
+    };
+    let redacted_value = if secret {
+        format!("••••{}", suffix)
+    } else if prefix.is_empty() {
+        format!("••{}", suffix)
+    } else {
+        format!("{}••••{}", prefix, suffix)
+    };
+    RedactedValue {
+        is_set: true,
+        redacted_value: Some(redacted_value),
+        fingerprint: Some(fingerprint),
+    }
+}
+
+fn credential_from_feishu(value: &FeishuCredential) -> CredentialSummary {
+    CredentialSummary {
+        app_id: Some(redacted(Some(&value.app_id), false)),
+        app_secret: Some(redacted(Some(&value.app_secret), true)),
+        account_id: None,
+        token: None,
+        base_url: None,
+        domain: Some(value.domain.clone()),
+        user_id: None,
+        bot_name: value.bot_name.clone(),
+        bot_open_id: value
+            .bot_open_id
+            .as_deref()
+            .map(|v| redacted(Some(v), false)),
+        open_id: value.open_id.as_deref().map(|v| redacted(Some(v), false)),
+    }
+}
+
+fn credential_from_weixin(value: &WeixinCredential) -> CredentialSummary {
+    CredentialSummary {
+        app_id: None,
+        app_secret: None,
+        account_id: Some(redacted(Some(&value.account_id), false)),
+        token: Some(redacted(Some(&value.token), true)),
+        base_url: Some(value.base_url.clone()),
+        domain: None,
+        user_id: value.user_id.as_deref().map(|v| redacted(Some(v), false)),
+        bot_name: None,
+        bot_open_id: None,
+        open_id: None,
+    }
+}
+
+fn env_path(hermes_home: &str) -> PathBuf {
+    Path::new(hermes_home).join(".env")
+}
+
+fn parse_env(path: &Path) -> Result<BTreeMap<String, String>, AppError> {
+    let mut result = BTreeMap::new();
+    if !path.exists() {
+        return Ok(result);
+    }
+    let raw = fs::read_to_string(path)?;
+    for line in raw.lines() {
+        let trimmed = line.trim_start();
+        if trimmed.is_empty() || trimmed.starts_with('#') || !line.contains('=') {
+            continue;
+        }
+        let Some((key, value)) = line.split_once('=') else {
+            continue;
+        };
+        let key = key.trim();
+        if is_valid_env_key(key) {
+            result.insert(key.to_string(), value.to_string());
+        }
+    }
+    Ok(result)
+}
+
+fn is_valid_env_key(key: &str) -> bool {
+    let mut chars = key.chars();
+    match chars.next() {
+        Some(c) if c.is_ascii_alphabetic() || c == '_' => {}
+        _ => return false,
+    }
+    chars.all(|c| c.is_ascii_alphanumeric() || c == '_')
+}
+
+fn validate_env_patch(
+    platform: ImPlatform,
+    patch: &BTreeMap<String, String>,
+) -> Result<(), AppError> {
+    for (key, value) in patch {
+        if !is_valid_env_key(key) {
+            return Err(AppError::InvalidRequest(format!("Invalid env key: {key}")));
+        }
+        if !platform.allowed_keys().contains(&key.as_str()) {
+            return Err(AppError::InvalidRequest(format!(
+                "{key} is not allowed for {} onboarding",
+                platform.as_str()
+            )));
+        }
+        if value.contains('\n') || value.contains('\r') || value.bytes().any(|b| b == 0) {
+            return Err(AppError::InvalidRequest(format!(
+                "Invalid value for {key}: newline and NUL are not allowed"
+            )));
+        }
+    }
+    Ok(())
+}
+
+fn backup_env(path: &Path) -> Result<Option<PathBuf>, AppError> {
+    if !path.exists() {
+        return Ok(None);
+    }
+    let Some(parent) = path.parent() else {
+        return Ok(None);
+    };
+    let backup_dir = parent.join(".env.backups");
+    fs::create_dir_all(&backup_dir)?;
+    let backup_path = backup_dir.join(format!("im-onboarding-{}.bak", now_ms()));
+    fs::copy(path, &backup_path)?;
+    Ok(Some(backup_path))
+}
+
+fn write_env_patch(
+    path: &Path,
+    platform: ImPlatform,
+    patch: &BTreeMap<String, String>,
+) -> Result<Option<PathBuf>, AppError> {
+    validate_env_patch(platform, patch)?;
+    if let Some(parent) = path.parent() {
+        fs::create_dir_all(parent)?;
+    }
+    let backup = backup_env(path)?;
+    let original = if path.exists() {
+        fs::read_to_string(path)?
+    } else {
+        String::new()
+    };
+
+    let mut seen = BTreeMap::<String, bool>::new();
+    let mut lines = Vec::new();
+    for line in original.lines() {
+        if let Some((raw_key, _)) = line.split_once('=') {
+            let key = raw_key.trim();
+            if patch.contains_key(key) {
+                lines.push(format!(
+                    "{}={}",
+                    key,
+                    patch.get(key).cloned().unwrap_or_default()
+                ));
+                seen.insert(key.to_string(), true);
+                continue;
+            }
+        }
+        lines.push(line.to_string());
+    }
+
+    if !patch.is_empty() && !original.is_empty() && !original.ends_with('\n') {
+        // `lines()` intentionally strips the trailing newline; this branch only
+        // keeps the append block readable for hand-edited files without one.
+    }
+    for (key, value) in patch {
+        if !seen.contains_key(key) {
+            lines.push(format!("{}={}", key, value));
+        }
+    }
+    let mut out = lines.join("\n");
+    if !out.is_empty() {
+        out.push('\n');
+    }
+    let tmp = path.with_extension(format!("env.tmp.{}", now_ms()));
+    fs::write(&tmp, out)?;
+    fs::rename(&tmp, path)?;
+    #[cfg(unix)]
+    {
+        use std::os::unix::fs::PermissionsExt;
+        let _ = fs::set_permissions(path, fs::Permissions::from_mode(0o600));
+    }
+    Ok(backup)
+}
+
+fn configured_for(
+    platform: ImPlatform,
+    env: &BTreeMap<String, String>,
+) -> BTreeMap<String, RedactedValue> {
+    let mut result = BTreeMap::new();
+    for key in platform.allowed_keys() {
+        if let Some(value) = env.get(*key) {
+            result.insert(
+                key.to_string(),
+                redacted(Some(value), platform.secret_keys().contains(key)),
+            );
+        }
+    }
+    result
+}
+
+async fn feishu_registration_post(domain: &str, body: &[(&str, &str)]) -> Result<Value, AppError> {
+    let url = format!(
+        "{}{}",
+        feishu_accounts_base(domain),
+        FEISHU_REGISTRATION_PATH
+    );
+    let res = HTTP
+        .post(url)
+        .header("Content-Type", "application/x-www-form-urlencoded")
+        .form(body)
+        .send()
+        .await?;
+    let text = res.text().await.unwrap_or_default();
+    serde_json::from_str(&text)
+        .map_err(|e| AppError::ProxyError(format!("Invalid Feishu registration JSON: {e}")))
+}
+
+async fn begin_feishu(input: &ImOnboardingBeginInput) -> Result<ImOnboardingBeginResult, AppError> {
+    let domain = normalized_domain(input.domain.clone());
+    let init = feishu_registration_post(&domain, &[("action", "init")]).await?;
+    let supported = init
+        .get("supported_auth_methods")
+        .and_then(Value::as_array)
+        .map(|items| {
+            items
+                .iter()
+                .any(|item| item.as_str() == Some("client_secret"))
+        })
+        .unwrap_or(false);
+    if !supported {
+        return Err(AppError::ProxyError(
+            "Feishu / Lark registration does not support client_secret auth".to_string(),
+        ));
+    }
+
+    let begin = feishu_registration_post(
+        &domain,
+        &[
+            ("action", "begin"),
+            ("archetype", "PersonalAgent"),
+            ("auth_method", "client_secret"),
+            ("request_user_info", "open_id"),
+        ],
+    )
+    .await?;
+    let device_code = begin
+        .get("device_code")
+        .and_then(Value::as_str)
+        .filter(|v| !v.is_empty())
+        .ok_or_else(|| {
+            AppError::ProxyError("Feishu registration did not return device_code".to_string())
+        })?
+        .to_string();
+    let mut qr_url = begin
+        .get("verification_uri_complete")
+        .and_then(Value::as_str)
+        .unwrap_or("")
+        .to_string();
+    if !qr_url.is_empty() {
+        if qr_url.contains('?') {
+            qr_url.push_str("&from=hermes&tp=hermes");
+        } else {
+            qr_url.push_str("?from=hermes&tp=hermes");
+        }
+    }
+    let interval_seconds = begin
+        .get("interval")
+        .and_then(Value::as_u64)
+        .unwrap_or(5)
+        .max(1);
+    let expire_in = begin
+        .get("expire_in")
+        .and_then(Value::as_u64)
+        .unwrap_or(600)
+        .min(600);
+    let timeout = Duration::from_secs(expire_in);
+    let expires_at_ms = expires_at_ms_from(timeout);
+    let flow_id = new_flow_id(ImPlatform::Feishu);
+    let flow = FeishuFlow {
+        device_code,
+        domain,
+        interval_seconds,
+        expires_at: Instant::now() + timeout,
+        expires_at_ms,
+        credential: None,
+    };
+    FLOWS
+        .lock()?
+        .insert(flow_id.clone(), FlowState::Feishu(flow));
+
+    Ok(ImOnboardingBeginResult {
+        flow_id,
+        platform: ImPlatform::Feishu.as_str().to_string(),
+        status: "pending".to_string(),
+        qr_url: Some(qr_url.clone()).filter(|v| !v.is_empty()),
+        qr_scan_data: Some(qr_url).filter(|v| !v.is_empty()),
+        user_code: begin
+            .get("user_code")
+            .and_then(Value::as_str)
+            .map(ToString::to_string),
+        interval_seconds,
+        expires_at_ms,
+        message: Some("请使用飞书或 Lark 手机端扫码并确认授权。".to_string()),
+    })
+}
+
+async fn probe_feishu_bot(credential: &FeishuCredential) -> (Option<String>, Option<String>) {
+    let token_url = format!(
+        "{}/open-apis/auth/v3/tenant_access_token/internal",
+        feishu_open_base(&credential.domain)
+    );
+    let Ok(resp) = HTTP
+        .post(token_url)
+        .json(&serde_json::json!({
+            "app_id": credential.app_id,
+            "app_secret": credential.app_secret,
+        }))
+        .send()
+        .await
+    else {
+        return (None, None);
+    };
+    let Ok(token_json) = resp.json::<Value>().await else {
+        return (None, None);
+    };
+    let Some(access_token) = token_json
+        .get("tenant_access_token")
+        .and_then(Value::as_str)
+    else {
+        return (None, None);
+    };
+    let bot_url = format!(
+        "{}/open-apis/bot/v3/info",
+        feishu_open_base(&credential.domain)
+    );
+    let Ok(resp) = HTTP.get(bot_url).bearer_auth(access_token).send().await else {
+        return (None, None);
+    };
+    let Ok(bot_json) = resp.json::<Value>().await else {
+        return (None, None);
+    };
+    if bot_json.get("code").and_then(Value::as_i64) != Some(0) {
+        return (None, None);
+    }
+    let bot = bot_json
+        .get("bot")
+        .or_else(|| bot_json.get("data").and_then(|v| v.get("bot")));
+    let name = bot
+        .and_then(|v| v.get("app_name").or_else(|| v.get("bot_name")))
+        .and_then(Value::as_str)
+        .map(ToString::to_string);
+    let open_id = bot
+        .and_then(|v| v.get("open_id"))
+        .and_then(Value::as_str)
+        .map(ToString::to_string);
+    (name, open_id)
+}
+
+async fn poll_feishu(flow_id: &str) -> Result<ImOnboardingPollResult, AppError> {
+    let mut flow = {
+        let flows = FLOWS.lock()?;
+        match flows.get(flow_id) {
+            Some(FlowState::Feishu(flow)) => flow.clone(),
+            _ => {
+                return Err(AppError::InvalidRequest(format!(
+                    "Unknown Feishu flow: {flow_id}"
+                )))
+            }
+        }
+    };
+    if Instant::now() > flow.expires_at {
+        return Ok(ImOnboardingPollResult {
+            flow_id: flow_id.to_string(),
+            platform: ImPlatform::Feishu.as_str().to_string(),
+            status: "expired".to_string(),
+            qr_url: None,
+            qr_scan_data: None,
+            interval_seconds: flow.interval_seconds,
+            expires_at_ms: flow.expires_at_ms,
+            credential_summary: flow.credential.as_ref().map(credential_from_feishu),
+            message: Some("飞书扫码授权已过期，请重新生成二维码。".to_string()),
+        });
+    }
+    if let Some(credential) = &flow.credential {
+        return Ok(ImOnboardingPollResult {
+            flow_id: flow_id.to_string(),
+            platform: ImPlatform::Feishu.as_str().to_string(),
+            status: "confirmed".to_string(),
+            qr_url: None,
+            qr_scan_data: None,
+            interval_seconds: flow.interval_seconds,
+            expires_at_ms: flow.expires_at_ms,
+            credential_summary: Some(credential_from_feishu(credential)),
+            message: Some("飞书机器人凭据已确认。".to_string()),
+        });
+    }
+
+    let res = feishu_registration_post(
+        &flow.domain,
+        &[
+            ("action", "poll"),
+            ("device_code", &flow.device_code),
+            ("tp", "ob_app"),
+        ],
+    )
+    .await?;
+    if let Some(tenant_brand) = res
+        .get("user_info")
+        .and_then(|v| v.get("tenant_brand"))
+        .and_then(Value::as_str)
+    {
+        if tenant_brand == "lark" {
+            flow.domain = "lark".to_string();
+        }
+    }
+    if let (Some(app_id), Some(app_secret)) = (
+        res.get("client_id").and_then(Value::as_str),
+        res.get("client_secret").and_then(Value::as_str),
+    ) {
+        let mut credential = FeishuCredential {
+            app_id: app_id.to_string(),
+            app_secret: app_secret.to_string(),
+            domain: flow.domain.clone(),
+            open_id: res
+                .get("user_info")
+                .and_then(|v| v.get("open_id"))
+                .and_then(Value::as_str)
+                .map(ToString::to_string),
+            bot_name: None,
+            bot_open_id: None,
+        };
+        let (bot_name, bot_open_id) = probe_feishu_bot(&credential).await;
+        credential.bot_name = bot_name;
+        credential.bot_open_id = bot_open_id;
+        flow.credential = Some(credential.clone());
+        FLOWS
+            .lock()?
+            .insert(flow_id.to_string(), FlowState::Feishu(flow.clone()));
+        return Ok(ImOnboardingPollResult {
+            flow_id: flow_id.to_string(),
+            platform: ImPlatform::Feishu.as_str().to_string(),
+            status: "confirmed".to_string(),
+            qr_url: None,
+            qr_scan_data: None,
+            interval_seconds: flow.interval_seconds,
+            expires_at_ms: flow.expires_at_ms,
+            credential_summary: Some(credential_from_feishu(&credential)),
+            message: Some("飞书机器人凭据已确认。".to_string()),
+        });
+    }
+    let error = res.get("error").and_then(Value::as_str).unwrap_or("");
+    let (status, message) = match error {
+        "access_denied" => ("denied", "用户取消或拒绝了飞书授权。"),
+        "expired_token" => ("expired", "飞书扫码授权已过期，请重新生成二维码。"),
+        _ => ("pending", "等待飞书扫码确认。"),
+    };
+    FLOWS
+        .lock()?
+        .insert(flow_id.to_string(), FlowState::Feishu(flow.clone()));
+    Ok(ImOnboardingPollResult {
+        flow_id: flow_id.to_string(),
+        platform: ImPlatform::Feishu.as_str().to_string(),
+        status: status.to_string(),
+        qr_url: None,
+        qr_scan_data: None,
+        interval_seconds: flow.interval_seconds,
+        expires_at_ms: flow.expires_at_ms,
+        credential_summary: None,
+        message: Some(message.to_string()),
+    })
+}
+
+async fn weixin_get(base_url: &str, endpoint: &str) -> Result<Value, AppError> {
+    let url = format!(
+        "{}/{}",
+        base_url.trim_end_matches('/'),
+        endpoint.trim_start_matches('/')
+    );
+    let res = HTTP
+        .get(url)
+        .header("iLink-App-Id", "bot")
+        .header("iLink-App-ClientVersion", WEIXIN_CLIENT_VERSION)
+        .send()
+        .await?;
+    let text = res.text().await.unwrap_or_default();
+    serde_json::from_str(&text)
+        .map_err(|e| AppError::ProxyError(format!("Invalid Weixin QR JSON: {e}")))
+}
+
+async fn refresh_weixin_qr(flow: &mut WeixinFlow) -> Result<(), AppError> {
+    let qr_resp = weixin_get(&weixin_base_url(), "ilink/bot/get_bot_qrcode?bot_type=3").await?;
+    let qrcode_value = qr_resp
+        .get("qrcode")
+        .and_then(Value::as_str)
+        .filter(|v| !v.is_empty())
+        .ok_or_else(|| AppError::ProxyError("Weixin QR response missing qrcode".to_string()))?
+        .to_string();
+    let qrcode_url = qr_resp
+        .get("qrcode_img_content")
+        .and_then(Value::as_str)
+        .filter(|v| !v.is_empty())
+        .map(ToString::to_string);
+    flow.qrcode_value = qrcode_value;
+    flow.qrcode_url = qrcode_url;
+    flow.current_base_url = weixin_base_url();
+    Ok(())
+}
+
+async fn begin_weixin(input: &ImOnboardingBeginInput) -> Result<ImOnboardingBeginResult, AppError> {
+    let bot_type = input.bot_type.clone().unwrap_or_else(|| "3".to_string());
+    let base_url = weixin_base_url();
+    let endpoint = format!(
+        "ilink/bot/get_bot_qrcode?bot_type={}",
+        urlencoding::encode(&bot_type)
+    );
+    let qr_resp = weixin_get(&base_url, &endpoint).await?;
+    let qrcode_value = qr_resp
+        .get("qrcode")
+        .and_then(Value::as_str)
+        .filter(|v| !v.is_empty())
+        .ok_or_else(|| AppError::ProxyError("Weixin QR response missing qrcode".to_string()))?
+        .to_string();
+    let qrcode_url = qr_resp
+        .get("qrcode_img_content")
+        .and_then(Value::as_str)
+        .filter(|v| !v.is_empty())
+        .map(ToString::to_string);
+    let timeout = Duration::from_secs(480);
+    let expires_at_ms = expires_at_ms_from(timeout);
+    let flow_id = new_flow_id(ImPlatform::Weixin);
+    let flow = WeixinFlow {
+        qrcode_value: qrcode_value.clone(),
+        qrcode_url: qrcode_url.clone(),
+        current_base_url: base_url,
+        refresh_count: 0,
+        interval_seconds: 1,
+        expires_at: Instant::now() + timeout,
+        expires_at_ms,
+        credential: None,
+    };
+    FLOWS
+        .lock()?
+        .insert(flow_id.clone(), FlowState::Weixin(flow));
+    let scan_data = qrcode_url.clone().unwrap_or(qrcode_value);
+    Ok(ImOnboardingBeginResult {
+        flow_id,
+        platform: ImPlatform::Weixin.as_str().to_string(),
+        status: "pending".to_string(),
+        qr_url: qrcode_url,
+        qr_scan_data: Some(scan_data),
+        user_code: None,
+        interval_seconds: 1,
+        expires_at_ms,
+        message: Some("请使用微信手机端扫码，并在手机端确认绑定 iLink bot。".to_string()),
+    })
+}
+
+async fn poll_weixin(flow_id: &str) -> Result<ImOnboardingPollResult, AppError> {
+    let mut flow = {
+        let flows = FLOWS.lock()?;
+        match flows.get(flow_id) {
+            Some(FlowState::Weixin(flow)) => flow.clone(),
+            _ => {
+                return Err(AppError::InvalidRequest(format!(
+                    "Unknown Weixin flow: {flow_id}"
+                )))
+            }
+        }
+    };
+    if Instant::now() > flow.expires_at {
+        return Ok(ImOnboardingPollResult {
+            flow_id: flow_id.to_string(),
+            platform: ImPlatform::Weixin.as_str().to_string(),
+            status: "expired".to_string(),
+            qr_url: flow.qrcode_url.clone(),
+            qr_scan_data: Some(
+                flow.qrcode_url
+                    .clone()
+                    .unwrap_or_else(|| flow.qrcode_value.clone()),
+            ),
+            interval_seconds: flow.interval_seconds,
+            expires_at_ms: flow.expires_at_ms,
+            credential_summary: flow.credential.as_ref().map(credential_from_weixin),
+            message: Some("微信二维码已过期，请重新开始扫码。".to_string()),
+        });
+    }
+    if let Some(credential) = &flow.credential {
+        return Ok(ImOnboardingPollResult {
+            flow_id: flow_id.to_string(),
+            platform: ImPlatform::Weixin.as_str().to_string(),
+            status: "confirmed".to_string(),
+            qr_url: None,
+            qr_scan_data: None,
+            interval_seconds: flow.interval_seconds,
+            expires_at_ms: flow.expires_at_ms,
+            credential_summary: Some(credential_from_weixin(credential)),
+            message: Some("微信 iLink bot 已确认绑定。".to_string()),
+        });
+    }
+    let endpoint = format!(
+        "ilink/bot/get_qrcode_status?qrcode={}",
+        urlencoding::encode(&flow.qrcode_value)
+    );
+    let status_resp = weixin_get(&flow.current_base_url, &endpoint).await?;
+    let status = status_resp
+        .get("status")
+        .and_then(Value::as_str)
+        .unwrap_or("wait");
+    match status {
+        "scaned_but_redirect" => {
+            if let Some(host) = status_resp.get("redirect_host").and_then(Value::as_str) {
+                if !host.is_empty() {
+                    flow.current_base_url = format!("https://{}", host.trim_end_matches('/'));
+                }
+            }
+        }
+        "expired" => {
+            flow.refresh_count += 1;
+            if flow.refresh_count <= WEIXIN_QR_REFRESH_LIMIT {
+                refresh_weixin_qr(&mut flow).await?;
+                FLOWS
+                    .lock()?
+                    .insert(flow_id.to_string(), FlowState::Weixin(flow.clone()));
+                return Ok(ImOnboardingPollResult {
+                    flow_id: flow_id.to_string(),
+                    platform: ImPlatform::Weixin.as_str().to_string(),
+                    status: "expired_refreshed".to_string(),
+                    qr_url: flow.qrcode_url.clone(),
+                    qr_scan_data: Some(
+                        flow.qrcode_url
+                            .clone()
+                            .unwrap_or_else(|| flow.qrcode_value.clone()),
+                    ),
+                    interval_seconds: flow.interval_seconds,
+                    expires_at_ms: flow.expires_at_ms,
+                    credential_summary: None,
+                    message: Some(format!(
+                        "微信二维码已过期，已自动刷新（{}/3）。",
+                        flow.refresh_count
+                    )),
+                });
+            }
+        }
+        "confirmed" => {
+            let account_id = status_resp
+                .get("ilink_bot_id")
+                .and_then(Value::as_str)
+                .unwrap_or("")
+                .to_string();
+            let token = status_resp
+                .get("bot_token")
+                .and_then(Value::as_str)
+                .unwrap_or("")
+                .to_string();
+            if account_id.is_empty() || token.is_empty() {
+                return Err(AppError::ProxyError(
+                    "Weixin QR confirmed but credential payload was incomplete".to_string(),
+                ));
+            }
+            let credential = WeixinCredential {
+                account_id,
+                token,
+                base_url: status_resp
+                    .get("baseurl")
+                    .and_then(Value::as_str)
+                    .unwrap_or(WEIXIN_BASE_URL)
+                    .to_string(),
+                user_id: status_resp
+                    .get("ilink_user_id")
+                    .and_then(Value::as_str)
+                    .filter(|v| !v.is_empty())
+                    .map(ToString::to_string),
+            };
+            flow.credential = Some(credential.clone());
+            FLOWS
+                .lock()?
+                .insert(flow_id.to_string(), FlowState::Weixin(flow.clone()));
+            return Ok(ImOnboardingPollResult {
+                flow_id: flow_id.to_string(),
+                platform: ImPlatform::Weixin.as_str().to_string(),
+                status: "confirmed".to_string(),
+                qr_url: None,
+                qr_scan_data: None,
+                interval_seconds: flow.interval_seconds,
+                expires_at_ms: flow.expires_at_ms,
+                credential_summary: Some(credential_from_weixin(&credential)),
+                message: Some("微信 iLink bot 已确认绑定。".to_string()),
+            });
+        }
+        _ => {}
+    }
+    FLOWS
+        .lock()?
+        .insert(flow_id.to_string(), FlowState::Weixin(flow.clone()));
+    let normalized = match status {
+        "scaned" => "scanned",
+        "expired" => "expired",
+        "wait" => "pending",
+        other => other,
+    };
+    let message = match status {
+        "scaned" => "已扫码，请在微信手机端确认。",
+        "expired" => "微信二维码多次过期，请重新开始扫码。",
+        "scaned_but_redirect" => "微信扫码已跳转，继续等待确认。",
+        _ => "等待微信扫码。",
+    };
+    Ok(ImOnboardingPollResult {
+        flow_id: flow_id.to_string(),
+        platform: ImPlatform::Weixin.as_str().to_string(),
+        status: normalized.to_string(),
+        qr_url: flow.qrcode_url.clone(),
+        qr_scan_data: Some(
+            flow.qrcode_url
+                .clone()
+                .unwrap_or_else(|| flow.qrcode_value.clone()),
+        ),
+        interval_seconds: flow.interval_seconds,
+        expires_at_ms: flow.expires_at_ms,
+        credential_summary: None,
+        message: Some(message.to_string()),
+    })
+}
+
+fn state_snapshot(
+    platform: ImPlatform,
+    hermes_home: &str,
+    current_profile: &str,
+) -> Result<ImOnboardingStateResult, AppError> {
+    let path = env_path(hermes_home);
+    let env = parse_env(&path)?;
+    Ok(ImOnboardingStateResult {
+        platform: platform.as_str().to_string(),
+        current_profile: current_profile.to_string(),
+        hermes_home: hermes_home.to_string(),
+        env_path: path.to_string_lossy().to_string(),
+        configured: configured_for(platform, &env),
+    })
+}
+
+fn apply_patch_from_input(
+    input: &ImOnboardingApplyInput,
+) -> Result<BTreeMap<String, String>, AppError> {
+    let mut patch = input.settings.clone();
+    match input.platform {
+        ImPlatform::Feishu => {
+            let credential = if let Some(flow_id) = &input.flow_id {
+                let flows = FLOWS.lock()?;
+                match flows.get(flow_id) {
+                    Some(FlowState::Feishu(flow)) => flow.credential.clone(),
+                    _ => None,
+                }
+            } else {
+                None
+            };
+            if let Some(credential) = credential {
+                patch.insert("FEISHU_APP_ID".to_string(), credential.app_id);
+                patch.insert("FEISHU_APP_SECRET".to_string(), credential.app_secret);
+                patch.insert("FEISHU_DOMAIN".to_string(), credential.domain);
+            } else if let Some(manual) = &input.manual_credentials {
+                if let Some(app_id) = manual.app_id.as_ref().filter(|v| !v.trim().is_empty()) {
+                    patch.insert("FEISHU_APP_ID".to_string(), app_id.trim().to_string());
+                }
+                if let Some(secret) = manual.app_secret.as_ref().filter(|v| !v.trim().is_empty()) {
+                    patch.insert("FEISHU_APP_SECRET".to_string(), secret.trim().to_string());
+                }
+            }
+            patch
+                .entry("FEISHU_DOMAIN".to_string())
+                .or_insert_with(|| "feishu".to_string());
+            patch
+                .entry("FEISHU_CONNECTION_MODE".to_string())
+                .or_insert_with(|| "websocket".to_string());
+        }
+        ImPlatform::Weixin => {
+            let credential = if let Some(flow_id) = &input.flow_id {
+                let flows = FLOWS.lock()?;
+                match flows.get(flow_id) {
+                    Some(FlowState::Weixin(flow)) => flow.credential.clone(),
+                    _ => None,
+                }
+            } else {
+                None
+            };
+            if let Some(credential) = credential {
+                patch.insert("WEIXIN_ACCOUNT_ID".to_string(), credential.account_id);
+                patch.insert("WEIXIN_TOKEN".to_string(), credential.token);
+                patch.insert("WEIXIN_BASE_URL".to_string(), credential.base_url);
+                if let Some(user_id) = credential.user_id {
+                    patch
+                        .entry("WEIXIN_HOME_CHANNEL".to_string())
+                        .or_insert(user_id);
+                }
+            } else if let Some(manual) = &input.manual_credentials {
+                if let Some(account_id) =
+                    manual.account_id.as_ref().filter(|v| !v.trim().is_empty())
+                {
+                    patch.insert(
+                        "WEIXIN_ACCOUNT_ID".to_string(),
+                        account_id.trim().to_string(),
+                    );
+                }
+                if let Some(token) = manual.token.as_ref().filter(|v| !v.trim().is_empty()) {
+                    patch.insert("WEIXIN_TOKEN".to_string(), token.trim().to_string());
+                }
+                if let Some(base_url) = manual.base_url.as_ref().filter(|v| !v.trim().is_empty()) {
+                    patch.insert(
+                        "WEIXIN_BASE_URL".to_string(),
+                        base_url.trim().trim_end_matches('/').to_string(),
+                    );
+                }
+                if let Some(user_id) = manual.user_id.as_ref().filter(|v| !v.trim().is_empty()) {
+                    patch
+                        .entry("WEIXIN_HOME_CHANNEL".to_string())
+                        .or_insert(user_id.trim().to_string());
+                }
+            }
+            patch
+                .entry("WEIXIN_BASE_URL".to_string())
+                .or_insert_with(|| WEIXIN_BASE_URL.to_string());
+            patch
+                .entry("WEIXIN_CDN_BASE_URL".to_string())
+                .or_insert_with(|| WEIXIN_CDN_BASE_URL.to_string());
+        }
+    }
+    validate_required(input.platform, &patch)?;
+    Ok(patch)
+}
+
+fn validate_required(
+    platform: ImPlatform,
+    patch: &BTreeMap<String, String>,
+) -> Result<(), AppError> {
+    match platform {
+        ImPlatform::Feishu => {
+            if patch
+                .get("FEISHU_APP_ID")
+                .map(|v| v.trim().is_empty())
+                .unwrap_or(true)
+                || patch
+                    .get("FEISHU_APP_SECRET")
+                    .map(|v| v.trim().is_empty())
+                    .unwrap_or(true)
+            {
+                return Err(AppError::InvalidRequest(
+                    "FEISHU_APP_ID and FEISHU_APP_SECRET are required".to_string(),
+                ));
+            }
+        }
+        ImPlatform::Weixin => {
+            if patch
+                .get("WEIXIN_ACCOUNT_ID")
+                .map(|v| v.trim().is_empty())
+                .unwrap_or(true)
+                || patch
+                    .get("WEIXIN_TOKEN")
+                    .map(|v| v.trim().is_empty())
+                    .unwrap_or(true)
+            {
+                return Err(AppError::InvalidRequest(
+                    "WEIXIN_ACCOUNT_ID and WEIXIN_TOKEN are required".to_string(),
+                ));
+            }
+        }
+    }
+    Ok(())
+}
+
+fn write_weixin_account_store(
+    hermes_home: &str,
+    patch: &BTreeMap<String, String>,
+) -> Result<(), AppError> {
+    let Some(account_id) = patch
+        .get("WEIXIN_ACCOUNT_ID")
+        .filter(|v| !v.trim().is_empty())
+    else {
+        return Ok(());
+    };
+    validate_path_segment(account_id, "WEIXIN_ACCOUNT_ID")?;
+    let Some(token) = patch.get("WEIXIN_TOKEN").filter(|v| !v.trim().is_empty()) else {
+        return Ok(());
+    };
+    let account_dir = Path::new(hermes_home).join("weixin").join("accounts");
+    fs::create_dir_all(&account_dir)?;
+    let account_path = account_dir.join(format!("{}.json", account_id));
+    let payload = serde_json::json!({
+        "token": token,
+        "base_url": patch.get("WEIXIN_BASE_URL").cloned().unwrap_or_else(|| WEIXIN_BASE_URL.to_string()),
+        "user_id": patch.get("WEIXIN_HOME_CHANNEL").cloned().unwrap_or_default(),
+        "saved_at": now_ms().to_string(),
+    });
+    let tmp = account_path.with_extension(format!("json.tmp.{}", now_ms()));
+    fs::write(
+        &tmp,
+        serde_json::to_vec_pretty(&payload).unwrap_or_default(),
+    )?;
+    fs::rename(&tmp, &account_path)?;
+    #[cfg(unix)]
+    {
+        use std::os::unix::fs::PermissionsExt;
+        let _ = fs::set_permissions(&account_path, fs::Permissions::from_mode(0o600));
+    }
+    Ok(())
+}
+
+fn validate_path_segment(value: &str, label: &str) -> Result<(), AppError> {
+    let trimmed = value.trim();
+    if trimmed.is_empty()
+        || trimmed == "."
+        || trimmed == ".."
+        || trimmed.contains('/')
+        || trimmed.contains('\\')
+        || trimmed.bytes().any(|b| b == 0)
+    {
+        return Err(AppError::InvalidRequest(format!(
+            "{label} cannot be used as a file name"
+        )));
+    }
+    Ok(())
+}
+
+async fn restart_gateway(state: &State<'_, AppState>, requested: bool) -> ImRestartResult {
+    if !requested {
+        return ImRestartResult {
+            requested: false,
+            ok: true,
+            status: None,
+            message: Some("未请求重启 Gateway。".to_string()),
+        };
+    }
+    let (api_base_url, session_token, hermes_home, dashboard_owned, dashboard_home) = match state.inner.lock() {
+        Ok(inner) => (
+            inner.api_base_url.clone(),
+            inner.session_token.clone(),
+            inner.hermes_home.clone(),
+            inner.dashboard_handle.as_ref().map(|handle| handle.owns_process).unwrap_or(false),
+            inner.dashboard_handle.as_ref().and_then(|handle| {
+                handle
+                    .ownership_marker_path
+                    .as_ref()
+                    .and_then(|path| fs::read_to_string(path).ok())
+                    .and_then(|content| serde_json::from_str::<crate::process::dashboard::DashboardOwnershipMarker>(&content).ok())
+                    .map(|marker| marker.hermes_home)
+            }),
+        ),
+        Err(_) => {
+            return ImRestartResult {
+                requested: true,
+                ok: false,
+                status: None,
+                message: Some("无法读取桌面端运行状态。".to_string()),
+            }
+        }
+    };
+    if api_base_url.is_empty() {
+        return ImRestartResult {
+            requested: true,
+            ok: false,
+            status: None,
+            message: Some("Dashboard 尚未就绪，无法重启 Gateway。".to_string()),
+        };
+    }
+    let parsed = Url::parse(&api_base_url);
+    let port = parsed.as_ref().ok().and_then(Url::port);
+    let host = parsed.as_ref().ok().and_then(Url::host_str).unwrap_or_default();
+    if host != "127.0.0.1" || port == Some(9119) {
+        return ImRestartResult {
+            requested: true,
+            ok: false,
+            status: None,
+            message: Some(format!(
+                "拒绝重启非桌面端 managed runtime Gateway：{}",
+                api_base_url
+            )),
+        };
+    }
+    if !dashboard_owned {
+        return ImRestartResult {
+            requested: true,
+            ok: false,
+            status: None,
+            message: Some("拒绝重启 Gateway：当前 dashboard 不是桌面端托管进程。".to_string()),
+        };
+    }
+    if let Some(marker_home) = dashboard_home {
+        if !same_path(&marker_home, &hermes_home) {
+            return ImRestartResult {
+                requested: true,
+                ok: false,
+                status: None,
+                message: Some("拒绝重启 Gateway：dashboard 所属 HERMES_HOME 与当前 profile 不一致。".to_string()),
+            };
+        }
+    }
+    let url = format!("{}/api/gateway/restart", api_base_url.trim_end_matches('/'));
+    let mut req = HTTP.post(url);
+    if let Some(token) = session_token.filter(|v| !v.is_empty()) {
+        req = req
+            .header("Authorization", format!("Bearer {token}"))
+            .header("X-Hermes-Session-Token", token);
+    }
+    match req.send().await {
+        Ok(resp) => {
+            let status = resp.status().as_u16();
+            let ok = resp.status().is_success();
+            let body = resp.text().await.unwrap_or_default();
+            ImRestartResult {
+                requested: true,
+                ok,
+                status: Some(status),
+                message: Some(if ok {
+                    "已请求 Gateway 重启。".to_string()
+                } else {
+                    format!(
+                        "Gateway 重启请求失败：HTTP {status} {}",
+                        body.chars().take(160).collect::<String>()
+                    )
+                }),
+            }
+        }
+        Err(err) => ImRestartResult {
+            requested: true,
+            ok: false,
+            status: None,
+            message: Some(format!("Gateway 重启请求失败：{err}")),
+        },
+    }
+}
+
+#[tauri::command]
+pub fn im_onboarding_state(
+    input: ImOnboardingStateInput,
+    state: State<'_, AppState>,
+) -> Result<ImOnboardingStateResult, AppError> {
+    let (hermes_home, current_profile) = {
+        let inner = state.inner.lock()?;
+        (inner.hermes_home.clone(), inner.current_profile.clone())
+    };
+    state_snapshot(input.platform, &hermes_home, &current_profile)
+}
+
+#[tauri::command]
+pub async fn im_onboarding_begin(
+    input: ImOnboardingBeginInput,
+) -> Result<ImOnboardingBeginResult, AppError> {
+    match input.platform {
+        ImPlatform::Feishu => begin_feishu(&input).await,
+        ImPlatform::Weixin => begin_weixin(&input).await,
+    }
+}
+
+#[tauri::command]
+pub async fn im_onboarding_poll(
+    input: ImOnboardingPollInput,
+) -> Result<ImOnboardingPollResult, AppError> {
+    match input.platform {
+        ImPlatform::Feishu => poll_feishu(&input.flow_id).await,
+        ImPlatform::Weixin => poll_weixin(&input.flow_id).await,
+    }
+}
+
+#[tauri::command]
+pub async fn im_onboarding_apply(
+    input: ImOnboardingApplyInput,
+    state: State<'_, AppState>,
+) -> Result<ImOnboardingApplyResult, AppError> {
+    let (hermes_home, current_profile) = {
+        let inner = state.inner.lock()?;
+        (inner.hermes_home.clone(), inner.current_profile.clone())
+    };
+    let patch = apply_patch_from_input(&input)?;
+    let path = env_path(&hermes_home);
+    let backup = write_env_patch(&path, input.platform, &patch)?;
+    if input.platform == ImPlatform::Weixin {
+        write_weixin_account_store(&hermes_home, &patch)?;
+    }
+    let restart = restart_gateway(&state, input.restart_gateway.unwrap_or(true)).await;
+    let mut written = BTreeMap::new();
+    for (key, value) in &patch {
+        written.insert(
+            key.clone(),
+            redacted(
+                Some(value),
+                input.platform.secret_keys().contains(&key.as_str()),
+            ),
+        );
+    }
+    Ok(ImOnboardingApplyResult {
+        ok: true,
+        platform: input.platform.as_str().to_string(),
+        current_profile,
+        env_path: path.to_string_lossy().to_string(),
+        backup_path: backup.map(|p| p.to_string_lossy().to_string()),
+        written,
+        restart,
+    })
+}
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+    use pretty_assertions::assert_eq;
+    use serial_test::serial;
+    use tempfile::TempDir;
+    use wiremock::matchers::{body_string_contains, method, path, query_param};
+    use wiremock::{Mock, MockServer, ResponseTemplate};
+
+    fn clear_im_env_overrides() {
+        for key in [
+            "HERMES_IM_ONBOARDING_FEISHU_ACCOUNTS_URL",
+            "HERMES_IM_ONBOARDING_FEISHU_OPEN_URL",
+            "HERMES_IM_ONBOARDING_WEIXIN_BASE_URL",
+        ] {
+            std::env::remove_var(key);
+        }
+    }
+
+    #[test]
+    fn redaction_does_not_expose_secret() {
+        let value = redacted(Some("secret-abcdef"), true);
+        assert!(value.is_set);
+        let shown = value.redacted_value.unwrap();
+        assert!(shown.ends_with("cdef"));
+        assert!(!shown.contains("secret-ab"));
+    }
+
+    #[test]
+    fn env_patch_preserves_comments_and_updates_keys() {
+        let dir = TempDir::new().unwrap();
+        let env_path = dir.path().join(".env");
+        fs::write(
+            &env_path,
+            "# hello\nFEISHU_APP_ID=old\nOTHER=value\nFEISHU_APP_SECRET=old-secret\n",
+        )
+        .unwrap();
+        let patch = BTreeMap::from([
+            ("FEISHU_APP_ID".to_string(), "cli_new".to_string()),
+            ("FEISHU_APP_SECRET".to_string(), "new-secret".to_string()),
+            (
+                "FEISHU_CONNECTION_MODE".to_string(),
+                "websocket".to_string(),
+            ),
+        ]);
+        let backup = write_env_patch(&env_path, ImPlatform::Feishu, &patch).unwrap();
+        assert!(backup.unwrap().exists());
+        let out = fs::read_to_string(&env_path).unwrap();
+        assert!(out.contains("# hello"));
+        assert!(out.contains("OTHER=value"));
+        assert!(out.contains("FEISHU_APP_ID=cli_new"));
+        assert!(out.contains("FEISHU_APP_SECRET=new-secret"));
+        assert!(out.contains("FEISHU_CONNECTION_MODE=websocket"));
+    }
+
+    #[test]
+    fn env_patch_rejects_cross_platform_keys() {
+        let dir = TempDir::new().unwrap();
+        let env_path = dir.path().join(".env");
+        let patch = BTreeMap::from([("WEIXIN_TOKEN".to_string(), "x".to_string())]);
+        let err = write_env_patch(&env_path, ImPlatform::Feishu, &patch).unwrap_err();
+        assert!(err.to_string().contains("not allowed"));
+    }
+
+    #[test]
+    fn env_state_returns_only_platform_keys() {
+        let dir = TempDir::new().unwrap();
+        fs::write(
+            dir.path().join(".env"),
+            "FEISHU_APP_ID=cli_abc123\nWEIXIN_TOKEN=wx-secret\n",
+        )
+        .unwrap();
+        let state =
+            state_snapshot(ImPlatform::Feishu, dir.path().to_str().unwrap(), "default").unwrap();
+        assert!(state.configured.contains_key("FEISHU_APP_ID"));
+        assert!(!state.configured.contains_key("WEIXIN_TOKEN"));
+    }
+
+    #[test]
+    fn apply_patch_requires_core_credentials() {
+        let input = ImOnboardingApplyInput {
+            platform: ImPlatform::Weixin,
+            flow_id: None,
+            manual_credentials: None,
+            settings: BTreeMap::new(),
+            restart_gateway: Some(false),
+        };
+        let err = apply_patch_from_input(&input).unwrap_err();
+        assert!(err.to_string().contains("WEIXIN_ACCOUNT_ID"));
+    }
+
+    #[test]
+    fn parse_env_ignores_comments() {
+        let dir = TempDir::new().unwrap();
+        let path = dir.path().join(".env");
+        fs::write(&path, "# A=B\nGOOD=value\nBAD LINE\n").unwrap();
+        let parsed = parse_env(&path).unwrap();
+        assert_eq!(parsed.get("GOOD").map(String::as_str), Some("value"));
+        assert!(!parsed.contains_key("A"));
+    }
+
+    #[test]
+    fn weixin_account_store_rejects_path_segments() {
+        let dir = TempDir::new().unwrap();
+        let patch = BTreeMap::from([
+            ("WEIXIN_ACCOUNT_ID".to_string(), "../escape".to_string()),
+            ("WEIXIN_TOKEN".to_string(), "secret".to_string()),
+        ]);
+        let err = write_weixin_account_store(dir.path().to_str().unwrap(), &patch).unwrap_err();
+        assert!(err.to_string().contains("WEIXIN_ACCOUNT_ID"));
+    }
+
+    #[tokio::test]
+    #[serial]
+    async fn feishu_qr_mock_state_machine_confirms_credentials() {
+        clear_im_env_overrides();
+        let server = MockServer::start().await;
+        Mock::given(method("POST"))
+            .and(path(FEISHU_REGISTRATION_PATH))
+            .and(body_string_contains("action=init"))
+            .respond_with(ResponseTemplate::new(200).set_body_json(serde_json::json!({
+                "supported_auth_methods": ["client_secret"]
+            })))
+            .mount(&server)
+            .await;
+        Mock::given(method("POST"))
+            .and(path(FEISHU_REGISTRATION_PATH))
+            .and(body_string_contains("action=begin"))
+            .respond_with(ResponseTemplate::new(200).set_body_json(serde_json::json!({
+                "device_code": "device-1",
+                "verification_uri_complete": "https://example.test/scan",
+                "interval": 1,
+                "expire_in": 600,
+                "user_code": "ABC123"
+            })))
+            .mount(&server)
+            .await;
+        Mock::given(method("POST"))
+            .and(path(FEISHU_REGISTRATION_PATH))
+            .and(body_string_contains("action=poll"))
+            .respond_with(ResponseTemplate::new(200).set_body_json(serde_json::json!({
+                "client_id": "cli_mock_123456",
+                "client_secret": "secret-feishu-123456",
+                "user_info": { "tenant_brand": "feishu", "open_id": "ou_mock_123456" }
+            })))
+            .mount(&server)
+            .await;
+        Mock::given(method("POST"))
+            .and(path("/open-apis/auth/v3/tenant_access_token/internal"))
+            .respond_with(ResponseTemplate::new(200).set_body_json(serde_json::json!({
+                "tenant_access_token": "tenant-token"
+            })))
+            .mount(&server)
+            .await;
+        Mock::given(method("GET"))
+            .and(path("/open-apis/bot/v3/info"))
+            .respond_with(ResponseTemplate::new(200).set_body_json(serde_json::json!({
+                "code": 0,
+                "bot": { "app_name": "Hermes Bot", "open_id": "ou_bot_123456" }
+            })))
+            .mount(&server)
+            .await;
+        std::env::set_var("HERMES_IM_ONBOARDING_FEISHU_ACCOUNTS_URL", server.uri());
+        std::env::set_var("HERMES_IM_ONBOARDING_FEISHU_OPEN_URL", server.uri());
+
+        let flow = begin_feishu(&ImOnboardingBeginInput {
+            platform: ImPlatform::Feishu,
+            domain: Some("feishu".to_string()),
+            bot_type: None,
+        })
+        .await
+        .unwrap();
+        let result = poll_feishu(&flow.flow_id).await.unwrap();
+
+        assert_eq!(result.status, "confirmed");
+        let credential = result.credential_summary.expect("credential summary");
+        assert_eq!(credential.bot_name.as_deref(), Some("Hermes Bot"));
+        let app_secret = credential.app_secret.expect("redacted app secret");
+        assert!(app_secret.is_set);
+        assert!(!app_secret.redacted_value.unwrap().contains("secret-feishu"));
+
+        clear_im_env_overrides();
+    }
+
+    #[tokio::test]
+    #[serial]
+    async fn weixin_qr_mock_state_machine_confirms_credentials() {
+        clear_im_env_overrides();
+        let server = MockServer::start().await;
+        Mock::given(method("GET"))
+            .and(path("/ilink/bot/get_bot_qrcode"))
+            .and(query_param("bot_type", "3"))
+            .respond_with(ResponseTemplate::new(200).set_body_json(serde_json::json!({
+                "qrcode": "qr-one",
+                "qrcode_img_content": "https://example.test/qr.png"
+            })))
+            .mount(&server)
+            .await;
+        Mock::given(method("GET"))
+            .and(path("/ilink/bot/get_qrcode_status"))
+            .and(query_param("qrcode", "qr-one"))
+            .respond_with(ResponseTemplate::new(200).set_body_json(serde_json::json!({
+                "status": "confirmed",
+                "ilink_bot_id": "bot_123456",
+                "bot_token": "token-weixin-123456",
+                "baseurl": "https://mock.weixin.test",
+                "ilink_user_id": "wxid_mock"
+            })))
+            .mount(&server)
+            .await;
+        std::env::set_var("HERMES_IM_ONBOARDING_WEIXIN_BASE_URL", server.uri());
+
+        let flow = begin_weixin(&ImOnboardingBeginInput {
+            platform: ImPlatform::Weixin,
+            domain: None,
+            bot_type: None,
+        })
+        .await
+        .unwrap();
+        let result = poll_weixin(&flow.flow_id).await.unwrap();
+
+        assert_eq!(result.status, "confirmed");
+        let credential = result.credential_summary.expect("credential summary");
+        assert_eq!(
+            credential.base_url.as_deref(),
+            Some("https://mock.weixin.test")
+        );
+        let token = credential.token.expect("redacted token");
+        assert!(token.is_set);
+        assert!(!token.redacted_value.unwrap().contains("token-weixin"));
+
+        clear_im_env_overrides();
+    }
+}

--- a/src/commands/im_onboarding.rs
+++ b/src/commands/im_onboarding.rs
@@ -1296,8 +1296,7 @@ fn validate_managed_gateway_target(
     if let Some(marker_home) = dashboard_home {
         if !same_path(marker_home, hermes_home) {
             return Err(
-                "拒绝重启 Gateway：dashboard 所属 HERMES_HOME 与当前 profile 不一致。"
-                    .to_string(),
+                "拒绝重启 Gateway：dashboard 所属 HERMES_HOME 与当前 profile 不一致。".to_string(),
             );
         }
     }
@@ -1409,13 +1408,22 @@ async fn restart_gateway(state: &State<'_, AppState>, requested: bool) -> ImRest
         Ok(inner) => (
             inner.api_base_url.clone(),
             inner.hermes_home.clone(),
-            inner.dashboard_handle.as_ref().map(|handle| handle.owns_process).unwrap_or(false),
+            inner
+                .dashboard_handle
+                .as_ref()
+                .map(|handle| handle.owns_process)
+                .unwrap_or(false),
             inner.dashboard_handle.as_ref().and_then(|handle| {
                 handle
                     .ownership_marker_path
                     .as_ref()
                     .and_then(|path| fs::read_to_string(path).ok())
-                    .and_then(|content| serde_json::from_str::<crate::process::dashboard::DashboardOwnershipMarker>(&content).ok())
+                    .and_then(|content| {
+                        serde_json::from_str::<crate::process::dashboard::DashboardOwnershipMarker>(
+                            &content,
+                        )
+                        .ok()
+                    })
                     .map(|marker| marker.hermes_home)
             }),
         ),
@@ -1647,13 +1655,8 @@ mod tests {
     fn managed_gateway_target_rejects_global_9119() {
         let dir = TempDir::new().unwrap();
         let home = dir.path().to_str().unwrap();
-        let err = validate_managed_gateway_target(
-            "http://127.0.0.1:9119",
-            true,
-            Some(home),
-            home,
-        )
-        .unwrap_err();
+        let err = validate_managed_gateway_target("http://127.0.0.1:9119", true, Some(home), home)
+            .unwrap_err();
         assert!(err.contains("非桌面端 managed runtime"));
     }
 
@@ -1661,13 +1664,8 @@ mod tests {
     fn managed_gateway_target_rejects_unowned_dashboard() {
         let dir = TempDir::new().unwrap();
         let home = dir.path().to_str().unwrap();
-        let err = validate_managed_gateway_target(
-            "http://127.0.0.1:9120",
-            false,
-            Some(home),
-            home,
-        )
-        .unwrap_err();
+        let err = validate_managed_gateway_target("http://127.0.0.1:9120", false, Some(home), home)
+            .unwrap_err();
         assert!(err.contains("不是桌面端托管进程"));
     }
 
@@ -1689,8 +1687,7 @@ mod tests {
     fn managed_gateway_target_accepts_owned_runtime_dashboard() {
         let dir = TempDir::new().unwrap();
         let home = dir.path().to_str().unwrap();
-        validate_managed_gateway_target("http://127.0.0.1:9120", true, Some(home), home)
-            .unwrap();
+        validate_managed_gateway_target("http://127.0.0.1:9120", true, Some(home), home).unwrap();
     }
 
     #[tokio::test]

--- a/src/commands/im_onboarding.rs
+++ b/src/commands/im_onboarding.rs
@@ -4,9 +4,12 @@ use serde::{Deserialize, Serialize};
 use serde_json::Value;
 use sha2::{Digest, Sha256};
 use std::collections::{BTreeMap, HashMap};
-use std::fs;
+use std::fs::{self, OpenOptions};
+use std::io::Write;
 use std::path::{Path, PathBuf};
+use std::process::{Command, Stdio};
 use std::sync::Mutex;
+use std::thread;
 use std::time::{Duration, Instant, SystemTime, UNIX_EPOCH};
 use tauri::State;
 use url::Url;
@@ -1267,6 +1270,132 @@ fn validate_path_segment(value: &str, label: &str) -> Result<(), AppError> {
     Ok(())
 }
 
+fn validate_managed_gateway_target(
+    api_base_url: &str,
+    dashboard_owned: bool,
+    dashboard_home: Option<&str>,
+    hermes_home: &str,
+) -> Result<(), String> {
+    if api_base_url.is_empty() {
+        return Err("Dashboard 尚未就绪，无法重启 Gateway。".to_string());
+    }
+
+    let parsed = Url::parse(api_base_url)
+        .map_err(|_| format!("Dashboard API 地址无效，无法重启 Gateway：{api_base_url}"))?;
+    let port = parsed.port();
+    let host = parsed.host_str().unwrap_or_default();
+    if host != "127.0.0.1" || port == Some(9119) {
+        return Err(format!(
+            "拒绝重启非桌面端 managed runtime Gateway：{}",
+            api_base_url
+        ));
+    }
+    if !dashboard_owned {
+        return Err("拒绝重启 Gateway：当前 dashboard 不是桌面端托管进程。".to_string());
+    }
+    if let Some(marker_home) = dashboard_home {
+        if !same_path(marker_home, hermes_home) {
+            return Err(
+                "拒绝重启 Gateway：dashboard 所属 HERMES_HOME 与当前 profile 不一致。"
+                    .to_string(),
+            );
+        }
+    }
+
+    Ok(())
+}
+
+fn spawn_managed_gateway_process(hermes_home: &str) -> Result<(u32, PathBuf), String> {
+    let record = crate::process::runtime::read_current_record().ok_or_else(|| {
+        format!(
+            "Managed runtime 未安装或 current.json 无效，无法启动 Gateway。请先在运行时管理里安装 runtime：{}",
+            crate::process::runtime::current_record_path_display()
+        )
+    })?;
+
+    let gateway_runtime_dir = crate::process::runtime::gateway_runtime_dir();
+    let gateway_lock_dir = gateway_runtime_dir.join("token-locks");
+    fs::create_dir_all(&gateway_runtime_dir)
+        .map_err(|err| format!("无法创建 Gateway runtime 目录：{err}"))?;
+    fs::create_dir_all(&gateway_lock_dir)
+        .map_err(|err| format!("无法创建 Gateway lock 目录：{err}"))?;
+
+    let log_dir = Path::new(hermes_home).join("logs");
+    fs::create_dir_all(&log_dir).map_err(|err| format!("无法创建 Gateway 日志目录：{err}"))?;
+    let log_path = log_dir.join("desktop-gateway-restart.log");
+    let mut log = OpenOptions::new()
+        .create(true)
+        .append(true)
+        .open(&log_path)
+        .map_err(|err| format!("无法打开 Gateway 重启日志：{err}"))?;
+    let _ = writeln!(
+        log,
+        "\n=== desktop managed gateway restart {} ===\nexecutable={}\nHERMES_HOME={}\nHERMES_GATEWAY_RUNTIME_DIR={}\n",
+        now_ms(),
+        record.executable_path,
+        hermes_home,
+        gateway_runtime_dir.to_string_lossy(),
+    );
+
+    let stdout = log
+        .try_clone()
+        .map(Stdio::from)
+        .unwrap_or_else(|_| Stdio::null());
+    let stderr = Stdio::from(log);
+
+    let mut cmd = Command::new(&record.executable_path);
+    cmd.args(["gateway", "run", "--replace"])
+        .current_dir(&record.path)
+        .env("HERMES_HOME", hermes_home)
+        .env("HERMES_GATEWAY_RUNTIME_DIR", &gateway_runtime_dir)
+        .env("HERMES_GATEWAY_LOCK_DIR", &gateway_lock_dir)
+        .env("HERMES_GATEWAY_DETACHED", "1")
+        .env("HERMES_NONINTERACTIVE", "1")
+        .env("PYTHONUNBUFFERED", "1")
+        .stdout(stdout)
+        .stderr(stderr)
+        .stdin(Stdio::null());
+    if let Some(skills_dir) = crate::process::runtime::current_bundled_skills_dir() {
+        cmd.env("HERMES_BUNDLED_SKILLS", skills_dir);
+    }
+    if let Some(web_dist) = crate::process::runtime::current_dashboard_web_dist_dir() {
+        cmd.env("HERMES_WEB_DIST", web_dist);
+    }
+
+    #[cfg(unix)]
+    {
+        use std::os::unix::process::CommandExt;
+        cmd.process_group(0);
+    }
+    #[cfg(target_os = "windows")]
+    {
+        use std::os::windows::process::CommandExt;
+        const CREATE_NO_WINDOW: u32 = 0x08000000;
+        const CREATE_NEW_PROCESS_GROUP: u32 = 0x00000200;
+        const DETACHED_PROCESS: u32 = 0x00000008;
+        cmd.creation_flags(CREATE_NO_WINDOW | CREATE_NEW_PROCESS_GROUP | DETACHED_PROCESS);
+    }
+
+    let mut child = cmd
+        .spawn()
+        .map_err(|err| format!("无法启动桌面端 managed Gateway：{err}"))?;
+    let pid = child.id();
+    thread::sleep(Duration::from_millis(350));
+    match child.try_wait() {
+        Ok(Some(status)) => Err(format!(
+            "Gateway 启动进程过早退出：{status}。请查看日志：{}",
+            log_path.to_string_lossy()
+        )),
+        Ok(None) => {
+            thread::spawn(move || {
+                let _ = child.wait();
+            });
+            Ok((pid, log_path))
+        }
+        Err(err) => Err(format!("无法确认 Gateway 启动状态：{err}")),
+    }
+}
+
 async fn restart_gateway(state: &State<'_, AppState>, requested: bool) -> ImRestartResult {
     if !requested {
         return ImRestartResult {
@@ -1276,10 +1405,9 @@ async fn restart_gateway(state: &State<'_, AppState>, requested: bool) -> ImRest
             message: Some("未请求重启 Gateway。".to_string()),
         };
     }
-    let (api_base_url, session_token, hermes_home, dashboard_owned, dashboard_home) = match state.inner.lock() {
+    let (api_base_url, hermes_home, dashboard_owned, dashboard_home) = match state.inner.lock() {
         Ok(inner) => (
             inner.api_base_url.clone(),
-            inner.session_token.clone(),
             inner.hermes_home.clone(),
             inner.dashboard_handle.as_ref().map(|handle| handle.owns_process).unwrap_or(false),
             inner.dashboard_handle.as_ref().and_then(|handle| {
@@ -1300,77 +1428,36 @@ async fn restart_gateway(state: &State<'_, AppState>, requested: bool) -> ImRest
             }
         }
     };
-    if api_base_url.is_empty() {
+
+    if let Err(message) = validate_managed_gateway_target(
+        &api_base_url,
+        dashboard_owned,
+        dashboard_home.as_deref(),
+        &hermes_home,
+    ) {
         return ImRestartResult {
             requested: true,
             ok: false,
             status: None,
-            message: Some("Dashboard 尚未就绪，无法重启 Gateway。".to_string()),
+            message: Some(message),
         };
     }
-    let parsed = Url::parse(&api_base_url);
-    let port = parsed.as_ref().ok().and_then(Url::port);
-    let host = parsed.as_ref().ok().and_then(Url::host_str).unwrap_or_default();
-    if host != "127.0.0.1" || port == Some(9119) {
-        return ImRestartResult {
+
+    match spawn_managed_gateway_process(&hermes_home) {
+        Ok((pid, log_path)) => ImRestartResult {
             requested: true,
-            ok: false,
+            ok: true,
             status: None,
             message: Some(format!(
-                "拒绝重启非桌面端 managed runtime Gateway：{}",
-                api_base_url
+                "已在桌面端 managed runtime 中启动 Gateway（PID {pid}）。本次没有调用 dashboard /api/gateway/restart，因此不会重启 9119 上的用户全局 Hermes Agent。日志：{}",
+                log_path.to_string_lossy()
             )),
-        };
-    }
-    if !dashboard_owned {
-        return ImRestartResult {
-            requested: true,
-            ok: false,
-            status: None,
-            message: Some("拒绝重启 Gateway：当前 dashboard 不是桌面端托管进程。".to_string()),
-        };
-    }
-    if let Some(marker_home) = dashboard_home {
-        if !same_path(&marker_home, &hermes_home) {
-            return ImRestartResult {
-                requested: true,
-                ok: false,
-                status: None,
-                message: Some("拒绝重启 Gateway：dashboard 所属 HERMES_HOME 与当前 profile 不一致。".to_string()),
-            };
-        }
-    }
-    let url = format!("{}/api/gateway/restart", api_base_url.trim_end_matches('/'));
-    let mut req = HTTP.post(url);
-    if let Some(token) = session_token.filter(|v| !v.is_empty()) {
-        req = req
-            .header("Authorization", format!("Bearer {token}"))
-            .header("X-Hermes-Session-Token", token);
-    }
-    match req.send().await {
-        Ok(resp) => {
-            let status = resp.status().as_u16();
-            let ok = resp.status().is_success();
-            let body = resp.text().await.unwrap_or_default();
-            ImRestartResult {
-                requested: true,
-                ok,
-                status: Some(status),
-                message: Some(if ok {
-                    "已请求 Gateway 重启。".to_string()
-                } else {
-                    format!(
-                        "Gateway 重启请求失败：HTTP {status} {}",
-                        body.chars().take(160).collect::<String>()
-                    )
-                }),
-            }
-        }
+        },
         Err(err) => ImRestartResult {
             requested: true,
             ok: false,
             status: None,
-            message: Some(format!("Gateway 重启请求失败：{err}")),
+            message: Some(err),
         },
     }
 }
@@ -1554,6 +1641,56 @@ mod tests {
         ]);
         let err = write_weixin_account_store(dir.path().to_str().unwrap(), &patch).unwrap_err();
         assert!(err.to_string().contains("WEIXIN_ACCOUNT_ID"));
+    }
+
+    #[test]
+    fn managed_gateway_target_rejects_global_9119() {
+        let dir = TempDir::new().unwrap();
+        let home = dir.path().to_str().unwrap();
+        let err = validate_managed_gateway_target(
+            "http://127.0.0.1:9119",
+            true,
+            Some(home),
+            home,
+        )
+        .unwrap_err();
+        assert!(err.contains("非桌面端 managed runtime"));
+    }
+
+    #[test]
+    fn managed_gateway_target_rejects_unowned_dashboard() {
+        let dir = TempDir::new().unwrap();
+        let home = dir.path().to_str().unwrap();
+        let err = validate_managed_gateway_target(
+            "http://127.0.0.1:9120",
+            false,
+            Some(home),
+            home,
+        )
+        .unwrap_err();
+        assert!(err.contains("不是桌面端托管进程"));
+    }
+
+    #[test]
+    fn managed_gateway_target_rejects_marker_home_mismatch() {
+        let current = TempDir::new().unwrap();
+        let other = TempDir::new().unwrap();
+        let err = validate_managed_gateway_target(
+            "http://127.0.0.1:9120",
+            true,
+            Some(other.path().to_str().unwrap()),
+            current.path().to_str().unwrap(),
+        )
+        .unwrap_err();
+        assert!(err.contains("HERMES_HOME 与当前 profile 不一致"));
+    }
+
+    #[test]
+    fn managed_gateway_target_accepts_owned_runtime_dashboard() {
+        let dir = TempDir::new().unwrap();
+        let home = dir.path().to_str().unwrap();
+        validate_managed_gateway_target("http://127.0.0.1:9120", true, Some(home), home)
+            .unwrap();
     }
 
     #[tokio::test]

--- a/src/commands/mod.rs
+++ b/src/commands/mod.rs
@@ -1,6 +1,7 @@
 pub mod api_proxy;
 pub mod file_dialogs;
 pub mod gateway;
+pub mod im_onboarding;
 pub mod memory;
 pub mod profiles;
 pub mod runtime_manager;

--- a/src/main.rs
+++ b/src/main.rs
@@ -621,6 +621,10 @@ fn main() {
         .invoke_handler(tauri::generate_handler![
             commands::gateway::get_runtime_config,
             commands::gateway::refresh_gateway_url,
+            commands::im_onboarding::im_onboarding_state,
+            commands::im_onboarding::im_onboarding_begin,
+            commands::im_onboarding::im_onboarding_poll,
+            commands::im_onboarding::im_onboarding_apply,
             commands::file_dialogs::pick_files,
             commands::file_dialogs::pick_directory,
             commands::file_dialogs::create_workspace_project,

--- a/web/package.json
+++ b/web/package.json
@@ -24,6 +24,7 @@
     "jotai": "^2.12.0",
     "katex": "^0.16.45",
     "lucide-react": "^1.11.0",
+    "qrcode": "^1.5.4",
     "react": "^19.1.0",
     "react-dom": "^19.1.0",
     "react-router": "^7.6.0",

--- a/web/src/app.tsx
+++ b/web/src/app.tsx
@@ -23,6 +23,7 @@ import { LogsRoute } from "@/routes/logs";
 import { DebugRoute } from "@/routes/debug";
 import { AnalyticsRoute } from "@/routes/analytics";
 import { AdvancedRoute } from "@/routes/advanced";
+import { ImOnboardingRoute } from "@/routes/im-onboarding";
 
 function NewTaskRedirect() {
   const { search } = useLocation();
@@ -55,6 +56,7 @@ export function App() {
           <Route path="/profiles" element={<ProfilesRoute />} />
           <Route path="/memory" element={<MemoryRoute />} />
           <Route path="/cron" element={<CronRoute />} />
+          <Route path="/im/*" element={<ErrorBoundary><ImOnboardingRoute /></ErrorBoundary>} />
           <Route path="/health" element={<HealthRoute />} />
           <Route path="/analytics" element={<AnalyticsRoute />} />
           <Route path="/logs" element={<LogsRoute />} />

--- a/web/src/components/app-shell/capability-sidebar.test.ts
+++ b/web/src/components/app-shell/capability-sidebar.test.ts
@@ -1,0 +1,20 @@
+import { describe, expect, it } from "vitest";
+import { CAPABILITY_SECTIONS } from "./capability-sidebar";
+import { TOP_TABS } from "./use-active-top-tab";
+
+describe("configuration navigation", () => {
+  it("places IM onboarding under §023 in the 02 configuration sidebar", () => {
+    const im = CAPABILITY_SECTIONS.find((section) => section.label === "§023 · 消息平台接入");
+    expect(im?.items.map((item) => [item.label, item.path])).toEqual([
+      ["飞书接入", "/im/feishu"],
+      ["微信接入", "/im/weixin"],
+    ]);
+  });
+
+  it("keeps IM routes inside the 02 configuration top tab", () => {
+    const configTab = TOP_TABS.find((tab) => tab.num === "02");
+    expect(configTab?.label).toBe("配置");
+    expect(configTab?.matches("/im/feishu")).toBe(true);
+    expect(configTab?.matches("/im/weixin")).toBe(true);
+  });
+});

--- a/web/src/components/app-shell/capability-sidebar.tsx
+++ b/web/src/components/app-shell/capability-sidebar.tsx
@@ -1,8 +1,10 @@
-import { useLocation, useNavigate } from "react-router-dom";
+import { Link, useLocation } from "react-router-dom";
 import {
   Boxes,
   Brain,
   Clock,
+  MessageCircle,
+  MessageSquareText,
   Cpu,
   Puzzle,
   Sparkles,
@@ -34,16 +36,21 @@ const AUTOMATION_ITEMS: readonly CapabilityItem[] = [
   { label: "定时任务", path: "/cron", icon: Clock },
 ];
 
-const SECTIONS: readonly {
+const IM_ITEMS: readonly CapabilityItem[] = [
+  { label: "飞书接入", path: "/im/feishu", icon: MessageCircle, title: "飞书 / Lark 开放平台机器人接入" },
+  { label: "微信接入", path: "/im/weixin", icon: MessageSquareText, title: "个人微信 iLink bot 接入" },
+];
+
+export const CAPABILITY_SECTIONS: readonly {
   label: string;
   items: readonly CapabilityItem[];
 }[] = [
   { label: "§021 · 配置", items: CONFIG_ITEMS },
   { label: "§022 · 自动化", items: AUTOMATION_ITEMS },
+  { label: "§023 · 消息平台接入", items: IM_ITEMS },
 ];
 
 export function CapabilitySidebar() {
-  const navigate = useNavigate();
   const location = useLocation();
 
   const isActive = (path: string) =>
@@ -52,7 +59,7 @@ export function CapabilitySidebar() {
   return (
     <aside className={s.sidebar} aria-label="配置侧栏">
       <div className={s.scrollY}>
-        {SECTIONS.map((section) => (
+        {CAPABILITY_SECTIONS.map((section) => (
           <section key={section.label} className={s.section}>
             <div className={s.label}>
               <span>{section.label}</span>
@@ -61,12 +68,11 @@ export function CapabilitySidebar() {
             {section.items.map((item) => {
               const Icon = item.icon;
               return (
-                <button
+                <Link
                   key={item.path}
-                  type="button"
+                  to={item.path}
                   className={s.item}
                   data-active={isActive(item.path) ? "true" : undefined}
-                  onClick={() => navigate(item.path)}
                   title={item.title ?? item.path}
                 >
                   <span className={s.itemIcon}>
@@ -74,7 +80,7 @@ export function CapabilitySidebar() {
                   </span>
                   <span className={s.itemLabel}>{item.label}</span>
                   <span className={s.itemPath}>{item.path}</span>
-                </button>
+                </Link>
               );
             })}
           </section>

--- a/web/src/components/app-shell/debug-sidebar.module.css
+++ b/web/src/components/app-shell/debug-sidebar.module.css
@@ -77,11 +77,17 @@
   width: 100%;
   text-align: left;
   font-family: var(--h-font-cn);
+  text-decoration: none;
 }
 
 .item:hover {
   color: var(--h-text);
   background: var(--h-bg-soft);
+}
+
+.item:focus-visible {
+  outline: 2px solid color-mix(in srgb, var(--h-accent) 45%, transparent);
+  outline-offset: -2px;
 }
 
 .item[data-active="true"] {

--- a/web/src/components/app-shell/use-active-top-tab.ts
+++ b/web/src/components/app-shell/use-active-top-tab.ts
@@ -37,7 +37,8 @@ export const TOP_TABS: readonly TopTabDef[] = [
       path.startsWith("/profiles") ||
       path.startsWith("/models") ||
       path.startsWith("/memory") ||
-      path.startsWith("/cron"),
+      path.startsWith("/cron") ||
+      path.startsWith("/im"),
   },
   {
     id: "advanced",

--- a/web/src/hooks/use-im-onboarding.ts
+++ b/web/src/hooks/use-im-onboarding.ts
@@ -1,0 +1,54 @@
+import { useMutation, useQuery, useQueryClient } from "@tanstack/react-query";
+import { useActiveProfileName } from "@/hooks/use-profiles";
+import type {
+  ImOnboardingApplyInput,
+  ImOnboardingApplyResult,
+  ImOnboardingBeginInput,
+  ImOnboardingBeginResult,
+  ImOnboardingPollInput,
+  ImOnboardingPollResult,
+  ImOnboardingStateResult,
+  ImPlatform,
+} from "@hermes/protocol";
+
+function requireDesktop() {
+  const api = window.hermesDesktop;
+  if (!api?.imOnboardingState || !api.imOnboardingBegin || !api.imOnboardingPoll || !api.imOnboardingApply) {
+    throw new Error("当前运行环境不支持桌面端 IM 接入命令，请在 Tauri 桌面端中使用。");
+  }
+  return api;
+}
+
+export function useImOnboardingState(platform: ImPlatform) {
+  const profile = useActiveProfileName();
+  return useQuery<ImOnboardingStateResult>({
+    queryKey: ["im-onboarding", platform, profile],
+    queryFn: () => requireDesktop().imOnboardingState!({ platform }),
+    enabled: typeof window !== "undefined" && Boolean(window.hermesDesktop?.imOnboardingState),
+    staleTime: 10_000,
+  });
+}
+
+export function useBeginImOnboarding() {
+  return useMutation<ImOnboardingBeginResult, Error, ImOnboardingBeginInput>({
+    mutationFn: (input) => requireDesktop().imOnboardingBegin!(input),
+  });
+}
+
+export function usePollImOnboarding() {
+  return useMutation<ImOnboardingPollResult, Error, ImOnboardingPollInput>({
+    mutationFn: (input) => requireDesktop().imOnboardingPoll!(input),
+  });
+}
+
+export function useApplyImOnboarding(platform: ImPlatform) {
+  const qc = useQueryClient();
+  return useMutation<ImOnboardingApplyResult, Error, ImOnboardingApplyInput>({
+    mutationFn: (input) => requireDesktop().imOnboardingApply!(input),
+    onSuccess: () => {
+      qc.invalidateQueries({ queryKey: ["im-onboarding", platform] });
+      qc.invalidateQueries({ queryKey: ["env"] });
+      qc.invalidateQueries({ queryKey: ["status"] });
+    },
+  });
+}

--- a/web/src/hooks/use-profiles.ts
+++ b/web/src/hooks/use-profiles.ts
@@ -86,6 +86,7 @@ const PROFILE_AWARE_QUERY_KEYS = [
   "sessions-search",
   "cron-jobs",
   "analytics",
+  "im-onboarding",
 ] as const;
 
 // Mutation result distinguishes the two switching strategies for callers

--- a/web/src/lib/gateway-sse-client.ts
+++ b/web/src/lib/gateway-sse-client.ts
@@ -67,7 +67,7 @@ interface RpcAsyncAck {
 interface PendingRpcResponse {
   resolve: (value: unknown) => void;
   reject: (error: Error) => void;
-  timer: ReturnType<typeof setTimeout>;
+  timer: number;
 }
 
 function isAsyncAck(result: unknown): result is RpcAsyncAck {

--- a/web/src/lib/runtime.ts
+++ b/web/src/lib/runtime.ts
@@ -1,6 +1,14 @@
 import type {
   FileUploadInput,
   HermesMessageMetadata,
+  ImOnboardingApplyInput,
+  ImOnboardingApplyResult,
+  ImOnboardingBeginInput,
+  ImOnboardingBeginResult,
+  ImOnboardingPollInput,
+  ImOnboardingPollResult,
+  ImOnboardingStateInput,
+  ImOnboardingStateResult,
   RuntimeInfo,
   RuntimeInstallUpdateResult,
   RuntimeUpdateCheckResult,
@@ -141,6 +149,10 @@ declare global {
       installRuntimeUpdate?(): Promise<RuntimeInstallUpdateResult>;
       rollbackRuntime?(): Promise<RuntimeInstallUpdateResult>;
       switchProfile?(input: SwitchProfileInput): Promise<SwitchProfileResult>;
+      imOnboardingState?(input: ImOnboardingStateInput): Promise<ImOnboardingStateResult>;
+      imOnboardingBegin?(input: ImOnboardingBeginInput): Promise<ImOnboardingBeginResult>;
+      imOnboardingPoll?(input: ImOnboardingPollInput): Promise<ImOnboardingPollResult>;
+      imOnboardingApply?(input: ImOnboardingApplyInput): Promise<ImOnboardingApplyResult>;
       readSkillMarkdown?(input: { name: string }): Promise<SkillMarkdownResult>;
       readMemory?(): Promise<MemoryInfo>;
       addMemoryEntry?(content: string): Promise<MemoryMutationResult>;

--- a/web/src/lib/tauri-bridge.ts
+++ b/web/src/lib/tauri-bridge.ts
@@ -10,6 +10,14 @@ import type {
   ApiRequestResult,
   FilePickerResult,
   FileUploadInput,
+  ImOnboardingApplyInput,
+  ImOnboardingApplyResult,
+  ImOnboardingBeginInput,
+  ImOnboardingBeginResult,
+  ImOnboardingPollInput,
+  ImOnboardingPollResult,
+  ImOnboardingStateInput,
+  ImOnboardingStateResult,
   RuntimeInfo,
   RuntimeInstallUpdateResult,
   RuntimeUpdateCheckResult,
@@ -123,6 +131,26 @@ const tauriBridge = {
   async switchProfile(input: SwitchProfileInput): Promise<SwitchProfileResult> {
     const inv = await ensureInvoke();
     return inv("switch_profile", { input });
+  },
+
+  async imOnboardingState(input: ImOnboardingStateInput): Promise<ImOnboardingStateResult> {
+    const inv = await ensureInvoke();
+    return inv("im_onboarding_state", { input });
+  },
+
+  async imOnboardingBegin(input: ImOnboardingBeginInput): Promise<ImOnboardingBeginResult> {
+    const inv = await ensureInvoke();
+    return inv("im_onboarding_begin", { input });
+  },
+
+  async imOnboardingPoll(input: ImOnboardingPollInput): Promise<ImOnboardingPollResult> {
+    const inv = await ensureInvoke();
+    return inv("im_onboarding_poll", { input });
+  },
+
+  async imOnboardingApply(input: ImOnboardingApplyInput): Promise<ImOnboardingApplyResult> {
+    const inv = await ensureInvoke();
+    return inv("im_onboarding_apply", { input });
   },
 
   async readSkillMarkdown(input: { name: string }): Promise<SkillMarkdownResult> {

--- a/web/src/routes/im-onboarding.module.css
+++ b/web/src/routes/im-onboarding.module.css
@@ -15,10 +15,15 @@
 .sub { max-width: 720px; margin: 0; color: var(--h-text-2); line-height: 1.8; font-size: 13px; }
 .heroActions { display: flex; flex-direction: column; align-items: flex-end; justify-content: space-between; gap: 12px; flex-shrink: 0; }
 .heroState { color: var(--h-text-3); font-family: var(--h-font-mono); font-size: 11px; }
-.btn { height: 32px; display: inline-flex; align-items: center; justify-content: center; gap: 7px; border: 1px solid var(--h-line); color: var(--h-text); background: var(--h-bg-pane); border-radius: var(--h-r-sm); padding: 0 12px; font-family: var(--h-font-ui); font-size: 12px; white-space: nowrap; cursor: pointer; }
+.btn { height: 32px; display: inline-flex; align-items: center; justify-content: center; gap: 7px; border: 1px solid var(--h-line); color: var(--h-text); background: var(--h-bg-pane); border-radius: var(--h-r-sm); padding: 0 12px; font-family: var(--h-font-ui); font-size: 12px; white-space: nowrap; transition: background-color .14s ease, border-color .14s ease, color .14s ease, box-shadow .14s ease, transform .14s ease; cursor: pointer; }
 .btn:hover:not(:disabled) { border-color: color-mix(in srgb, var(--h-accent) 40%, var(--h-line)); background: var(--h-bg-soft); }
+.btn:active:not(:disabled) { transform: translateY(1px); }
+.btn:focus-visible { outline: 2px solid color-mix(in srgb, var(--h-accent) 45%, transparent); outline-offset: 2px; }
 .btn:disabled { opacity: .45; cursor: not-allowed; }
-.primary { color: var(--ink-050); background: var(--h-accent); border-color: var(--h-accent); font-weight: 700; }
+.primary { color: var(--ink-050); background: var(--h-accent); border-color: var(--h-accent); font-weight: 700; box-shadow: 0 0 0 1px color-mix(in srgb, var(--h-accent) 20%, transparent); }
+.primary:hover:not(:disabled) { color: var(--ink-050); background: color-mix(in srgb, var(--h-accent) 86%, var(--bone-100)); border-color: color-mix(in srgb, var(--h-accent) 92%, var(--bone-100)); box-shadow: 0 0 0 1px color-mix(in srgb, var(--h-accent) 42%, transparent), 0 6px 18px color-mix(in srgb, var(--h-accent) 22%, transparent); }
+.primary:active:not(:disabled) { color: var(--ink-050); background: color-mix(in srgb, var(--h-accent) 78%, var(--ink-000)); border-color: var(--h-accent); box-shadow: 0 0 0 1px color-mix(in srgb, var(--h-accent) 34%, transparent); }
+.primary:disabled { color: color-mix(in srgb, var(--ink-050) 78%, transparent); background: color-mix(in srgb, var(--h-accent) 58%, var(--h-bg-soft)); border-color: color-mix(in srgb, var(--h-accent) 46%, var(--h-line)); opacity: .72; }
 .actionFeedback { display: flex; align-items: center; justify-content: space-between; gap: 12px; border: 1px solid var(--h-line); border-radius: var(--h-r-md); background: var(--h-bg-pane); padding: 10px 12px; color: var(--h-text-2); }
 .actionFeedback b { display: block; color: var(--h-text); font-size: 13px; }
 .actionFeedback span { display: block; margin-top: 3px; font-size: 12px; line-height: 1.55; }
@@ -72,7 +77,9 @@
 .qrSection { grid-template-columns: 256px 1fr; align-items: center; }
 .qrBox { width: 240px; height: 240px; display: grid; place-items: center; border-radius: var(--h-r-lg); border: 1px solid var(--h-line); background: var(--bone-100); overflow: hidden; }
 .qrBox img { width: 232px; height: 232px; display: block; }
-.qrPlaceholder { color: var(--ink-700); font-family: var(--h-font-mono); letter-spacing: .2em; }
+.qrPlaceholder { display: grid; place-items: center; gap: 14px; color: var(--ink-700); font-family: var(--h-font-mono); letter-spacing: .2em; }
+.qrPlaceholder span { opacity: .55; }
+.qrStartBtn { font-family: var(--h-font-ui); letter-spacing: 0; }
 .qrCopy h3 { margin: 6px 0; font-size: 18px; color: var(--h-text); }
 .qrCopy p { margin: 0 0 12px; color: var(--h-text-2); line-height: 1.7; }
 .miniEyebrow { color: var(--h-accent); font-family: var(--h-font-mono); font-size: 10px; letter-spacing: .12em; }

--- a/web/src/routes/im-onboarding.module.css
+++ b/web/src/routes/im-onboarding.module.css
@@ -1,0 +1,375 @@
+.wrap {
+  min-height: 100%;
+  background:
+    radial-gradient(circle at 78% 4%, color-mix(in srgb, var(--h-accent) 10%, transparent), transparent 26%),
+    linear-gradient(180deg, var(--h-bg-app), var(--h-bg-app));
+}
+.mainCol { min-width: 0; display: grid; gap: 14px; align-content: start; }
+.headBand { display: flex; justify-content: space-between; gap: 18px; padding: 24px; border: 1px solid var(--h-line); background: linear-gradient(135deg, var(--h-bg-pane), var(--h-bg-soft)); border-radius: var(--h-r-lg); box-shadow: var(--h-shadow); }
+.heroCopy { min-width: 0; }
+.heroKicker { display: flex; align-items: center; flex-wrap: wrap; gap: 8px; color: var(--h-text-3); font-family: var(--h-font-mono); font-size: 10px; letter-spacing: .08em; text-transform: uppercase; }
+.heroKicker span { color: var(--h-accent); border: 1px solid color-mix(in srgb, var(--h-accent) 30%, transparent); padding: 2px 6px; border-radius: var(--h-r-sm); background: color-mix(in srgb, var(--h-accent) 8%, transparent); }
+.heroKicker em { font-style: normal; text-transform: none; letter-spacing: 0; color: var(--h-text-2); }
+.headBand h1 { margin: 14px 0 10px; color: var(--h-text); font-size: clamp(34px, 5vw, 58px); line-height: .96; letter-spacing: -.055em; }
+.headBand h1 em { color: var(--h-accent); font-style: normal; }
+.sub { max-width: 720px; margin: 0; color: var(--h-text-2); line-height: 1.8; font-size: 13px; }
+.heroActions { display: flex; flex-direction: column; align-items: flex-end; justify-content: space-between; gap: 12px; flex-shrink: 0; }
+.heroState { color: var(--h-text-3); font-family: var(--h-font-mono); font-size: 11px; }
+.btn { height: 32px; display: inline-flex; align-items: center; justify-content: center; gap: 7px; border: 1px solid var(--h-line); color: var(--h-text); background: var(--h-bg-pane); border-radius: var(--h-r-sm); padding: 0 12px; font-family: var(--h-font-ui); font-size: 12px; white-space: nowrap; cursor: pointer; }
+.btn:hover:not(:disabled) { border-color: color-mix(in srgb, var(--h-accent) 40%, var(--h-line)); background: var(--h-bg-soft); }
+.btn:disabled { opacity: .45; cursor: not-allowed; }
+.primary { color: var(--ink-050); background: var(--h-accent); border-color: var(--h-accent); font-weight: 700; }
+.actionFeedback { display: flex; align-items: center; justify-content: space-between; gap: 12px; border: 1px solid var(--h-line); border-radius: var(--h-r-md); background: var(--h-bg-pane); padding: 10px 12px; color: var(--h-text-2); }
+.actionFeedback b { display: block; color: var(--h-text); font-size: 13px; }
+.actionFeedback span { display: block; margin-top: 3px; font-size: 12px; line-height: 1.55; }
+.actionFeedback[data-tone="info"] { border-color: color-mix(in srgb, var(--h-accent) 35%, var(--h-line)); background: color-mix(in srgb, var(--h-accent) 7%, var(--h-bg-pane)); }
+.actionFeedback[data-tone="ok"] { border-color: color-mix(in srgb, var(--h-ok) 34%, var(--h-line)); background: color-mix(in srgb, var(--h-ok) 7%, var(--h-bg-pane)); }
+.actionFeedback[data-tone="error"] { border-color: color-mix(in srgb, var(--h-err) 45%, var(--h-line)); background: color-mix(in srgb, var(--h-err) 7%, var(--h-bg-pane)); }
+.actionFeedback[data-tone="error"] b, .actionFeedback[data-tone="error"] span { color: var(--h-err); }
+.inlineBtn { height: 26px; flex: none; border: 1px solid var(--h-line); border-radius: var(--h-r-pill); color: var(--h-text); background: var(--h-bg-soft); padding: 0 10px; font-size: 11px; cursor: pointer; }
+.inlineBtn:hover { border-color: color-mix(in srgb, var(--h-accent) 40%, var(--h-line)); }
+.externalBtn { flex: 0 0 auto; min-width: max-content; }
+.externalBtn svg { flex: 0 0 auto; }
+.metaStrip { display: grid; grid-template-columns: repeat(5, minmax(0, 1fr)); border: 1px solid var(--h-line); background: var(--h-bg-pane); border-radius: var(--h-r-md); overflow: hidden; }
+.metaStrip div { padding: 12px; border-right: 1px solid var(--h-line-soft); }
+.metaStrip div:last-child { border-right: 0; }
+.metaStrip span { display: block; color: var(--h-text-3); font-family: var(--h-font-mono); font-size: 10px; text-transform: uppercase; margin-bottom: 5px; }
+.metaStrip b { color: var(--h-text); font-size: 13px; overflow: hidden; text-overflow: ellipsis; white-space: nowrap; display: block; }
+.metaStrip b[data-tone="ok"] { color: var(--h-ok); }
+.metaStrip b[data-tone="warn"] { color: var(--h-warn); }
+.flowSteps { display: grid; grid-template-columns: repeat(auto-fit, minmax(150px, 1fr)); gap: 8px; }
+.step { display: grid; grid-template-columns: auto 1fr; gap: 2px 9px; align-items: center; padding: 11px; border: 1px solid var(--h-line); border-radius: var(--h-r-md); background: var(--h-bg-pane); }
+.step span { grid-row: span 2; width: 24px; height: 24px; border-radius: var(--h-r-pill); display: grid; place-items: center; color: var(--h-text-2); background: var(--h-bg-soft); font-family: var(--h-font-mono); font-size: 11px; }
+.step b { color: var(--h-text); font-size: 12px; }
+.step em { color: var(--h-text-3); font-size: 11px; font-style: normal; overflow: hidden; text-overflow: ellipsis; white-space: nowrap; }
+.step[data-done="true"] span { background: var(--h-ok-soft); color: var(--h-ok); }
+.step[data-active="true"] { border-color: color-mix(in srgb, var(--h-accent) 35%, var(--h-line)); }
+.sectionTitle { display: flex; align-items: baseline; gap: 10px; margin-top: 4px; }
+.sectionTitle span { color: var(--h-accent); font-family: var(--h-font-mono); font-size: 10px; }
+.sectionTitle h2 { margin: 0; color: var(--h-text); font-size: 16px; }
+.sectionTitle em { color: var(--h-text-3); font-size: 12px; font-style: normal; }
+.section { border: 1px solid var(--h-line); background: color-mix(in srgb, var(--h-bg-pane) 92%, transparent); border-radius: var(--h-r-lg); padding: 14px; display: grid; gap: 12px; }
+.anchorBlock { scroll-margin-top: 16px; display: grid; gap: 12px; }
+.choiceGrid, .policyGrid { display: grid; grid-template-columns: repeat(3, minmax(0, 1fr)); gap: 10px; }
+.choiceGrid { grid-template-columns: repeat(2, minmax(0, 1fr)); }
+.choiceCard, .policyCard { text-align: left; border: 1px solid var(--h-line); background: var(--h-bg-soft); border-radius: var(--h-r-md); padding: 14px; color: var(--h-text); cursor: pointer; }
+.choiceCard[data-active="true"], .policyCard[data-active="true"] { border-color: color-mix(in srgb, var(--h-accent) 55%, var(--h-line)); box-shadow: inset 0 0 0 1px color-mix(in srgb, var(--h-accent) 16%, transparent); }
+.choiceTop { display: flex; justify-content: space-between; align-items: center; margin-bottom: 12px; }
+.choiceIcon { color: var(--h-accent); }
+.pill { display: inline-flex; align-items: center; border: 1px solid var(--h-line); border-radius: var(--h-r-pill); padding: 2px 8px; color: var(--h-text-2); font-size: 10px; background: var(--h-bg-pane); }
+.choiceCard h3, .policyCard h3 { margin: 0 0 7px; font-size: 14px; }
+.choiceCard p, .policyCard p { margin: 0; color: var(--h-text-2); line-height: 1.65; font-size: 12px; }
+.choiceCard small { display: block; margin-top: 12px; color: var(--h-accent); font-size: 11px; }
+.policyCard span { color: var(--h-accent); font-family: var(--h-font-mono); }
+.policyCard[data-warning="true"] span { color: var(--h-warn); }
+.field { display: grid; grid-template-columns: minmax(180px, .9fr) minmax(240px, 1.2fr) 160px; align-items: center; gap: 12px; padding: 10px 0; border-bottom: 1px solid var(--h-line-soft); }
+.field:last-child { border-bottom: 0; }
+.fieldLabel b { display: block; color: var(--h-text); font-size: 13px; }
+.fieldLabel small { display: block; color: var(--h-text-3); line-height: 1.5; margin-top: 3px; }
+.fieldControl input, .fieldControl select { width: 100%; height: 32px; border: 1px solid var(--h-line); background: var(--h-bg-input); color: var(--h-text); border-radius: var(--h-r-sm); padding: 0 10px; font-family: var(--h-font-ui); }
+.fieldControl input[type="password"], .field code, .urlPreview, .reviewTable code { font-family: var(--h-font-mono); }
+.field code { color: var(--h-text-3); font-size: 10px; overflow: hidden; text-overflow: ellipsis; }
+.qrSection { grid-template-columns: 256px 1fr; align-items: center; }
+.qrBox { width: 240px; height: 240px; display: grid; place-items: center; border-radius: var(--h-r-lg); border: 1px solid var(--h-line); background: var(--bone-100); overflow: hidden; }
+.qrBox img { width: 232px; height: 232px; display: block; }
+.qrPlaceholder { color: var(--ink-700); font-family: var(--h-font-mono); letter-spacing: .2em; }
+.qrCopy h3 { margin: 6px 0; font-size: 18px; color: var(--h-text); }
+.qrCopy p { margin: 0 0 12px; color: var(--h-text-2); line-height: 1.7; }
+.miniEyebrow { color: var(--h-accent); font-family: var(--h-font-mono); font-size: 10px; letter-spacing: .12em; }
+.traceRow { display: grid; grid-template-columns: 60px minmax(0, 1fr); gap: 2px 10px; align-items: center; padding: 10px; border-radius: var(--h-r-md); background: var(--h-bg-soft); }
+.traceRow span { color: var(--h-text-3); font-size: 11px; }
+.traceRow b { color: var(--h-text); }
+.traceRow em { grid-column: 2; color: var(--h-text-3); font-style: normal; font-size: 11px; }
+.urlPreview { display: block; color: var(--h-text-2); background: var(--h-bg-code); border: 1px solid var(--h-line); border-radius: var(--h-r-sm); padding: 8px; word-break: break-all; }
+.buttonRow, .sectionActions { display: flex; flex-wrap: wrap; gap: 8px; }
+.verifyGrid { display: grid; gap: 8px; }
+.verifyRow { display: flex; gap: 10px; align-items: flex-start; padding: 10px; border: 1px solid var(--h-line-soft); background: var(--h-bg-soft); border-radius: var(--h-r-md); }
+.verifyRow svg { color: var(--h-accent); flex-shrink: 0; margin-top: 2px; }
+.verifyRow b, .verifyRow small { display: block; }
+.verifyRow small { color: var(--h-text-3); margin-top: 3px; }
+.backendChecklist { gap: 14px; }
+.checkIntro { display: flex; align-items: flex-start; justify-content: space-between; gap: 16px; }
+.checkIntro h3, .testGuide h3 { margin: 5px 0 6px; color: var(--h-text); font-size: 16px; }
+.checkIntro p, .testGuide p { margin: 0; color: var(--h-text-2); line-height: 1.7; font-size: 12px; }
+.consoleSteps { display: grid; grid-template-columns: repeat(3, minmax(0, 1fr)); gap: 10px; }
+.consoleStep { display: grid; gap: 7px; align-content: start; border: 1px solid var(--h-line-soft); border-radius: var(--h-r-md); background: var(--h-bg-soft); padding: 12px; }
+.consoleStep span { width: 24px; height: 24px; display: grid; place-items: center; border-radius: var(--h-r-pill); color: var(--h-accent); background: color-mix(in srgb, var(--h-accent) 10%, transparent); font-family: var(--h-font-mono); font-size: 11px; }
+.consoleStep b { color: var(--h-text); font-size: 13px; }
+.consoleStep p { margin: 0; color: var(--h-text-2); line-height: 1.6; font-size: 12px; }
+.consoleStep code { color: var(--h-accent); font-family: var(--h-font-mono); font-size: 11px; word-break: break-all; }
+.scopeGrid { display: grid; grid-template-columns: repeat(2, minmax(0, 1fr)); gap: 10px; }
+.scopeBox, .importBox { display: grid; gap: 8px; border: 1px solid var(--h-line-soft); border-radius: var(--h-r-md); background: var(--h-bg-pane); padding: 12px; }
+.scopeHead { display: flex; align-items: center; justify-content: space-between; gap: 10px; }
+.scopeHead b { color: var(--h-text); font-size: 12px; }
+.scopeHead button { height: 24px; border: 1px solid var(--h-line); border-radius: var(--h-r-pill); color: var(--h-text-2); background: var(--h-bg-soft); padding: 0 9px; font-size: 11px; cursor: pointer; }
+.scopeHead button:hover { color: var(--h-text); border-color: color-mix(in srgb, var(--h-accent) 40%, var(--h-line)); }
+.scopeBox code { display: block; color: var(--h-text-2); font-family: var(--h-font-mono); font-size: 11px; word-break: break-all; }
+.importBox pre { max-height: 220px; overflow: auto; margin: 0; border: 1px solid var(--h-line-soft); border-radius: var(--h-r-sm); background: var(--h-bg-code); color: var(--h-text-2); padding: 10px; font-family: var(--h-font-mono); font-size: 10.5px; line-height: 1.55; }
+.testGuide { display: flex; align-items: flex-start; justify-content: space-between; gap: 16px; }
+.testGuide[data-ready="true"] { border-color: color-mix(in srgb, var(--h-ok) 34%, var(--h-line)); }
+.testCards { display: grid; grid-template-columns: repeat(2, minmax(150px, 1fr)); gap: 10px; min-width: min(420px, 48%); }
+.testCards div { display: grid; gap: 6px; border: 1px solid var(--h-line-soft); border-radius: var(--h-r-md); background: var(--h-bg-soft); padding: 12px; }
+.testCards svg { color: var(--h-accent); }
+.testCards b { color: var(--h-text); font-size: 13px; }
+.testCards span { color: var(--h-text-2); line-height: 1.6; font-size: 12px; }
+.testCards code { color: var(--h-accent); font-family: var(--h-font-mono); }
+.summaryLine { color: var(--h-text-2); background: var(--h-bg-soft); border: 1px solid var(--h-line); border-radius: var(--h-r-md); padding: 10px 12px; font-size: 12px; }
+.reviewTable { width: 100%; border-collapse: collapse; font-size: 12px; }
+.reviewTable th, .reviewTable td { text-align: left; border-bottom: 1px solid var(--h-line-soft); padding: 9px; color: var(--h-text-2); }
+.reviewTable th { color: var(--h-text); font-family: var(--h-font-mono); font-size: 10px; text-transform: uppercase; }
+.resultBox, .errorBox { display: flex; gap: 10px; align-items: flex-start; padding: 12px; border-radius: var(--h-r-md); border: 1px solid var(--h-line); background: var(--h-bg-pane); color: var(--h-text-2); }
+.resultBox svg { color: var(--h-ok); }
+.errorBox { border-color: color-mix(in srgb, var(--h-err) 45%, var(--h-line)); color: var(--h-err); }
+.resultBox b, .resultBox span { display: block; }
+.resultBox span { margin-top: 4px; }
+.contextRail {
+  position: relative;
+  width: 56px;
+  height: 100%;
+  min-height: 0;
+}
+
+.railTrack {
+  width: 56px;
+  height: 100%;
+  display: flex;
+  flex-direction: column;
+  align-items: center;
+  gap: 8px;
+  padding: 18px 8px;
+}
+
+.railTrigger {
+  position: relative;
+  width: 40px;
+  min-height: 66px;
+  display: flex;
+  flex-direction: column;
+  align-items: center;
+  justify-content: center;
+  gap: 6px;
+  border: 1px solid transparent;
+  border-radius: var(--h-r-md);
+  color: var(--h-text-3);
+  background: transparent;
+  cursor: pointer;
+}
+
+.railTrigger:hover,
+.railTrigger[data-active="true"] {
+  color: var(--h-text);
+  border-color: var(--h-line);
+  background: color-mix(in srgb, var(--h-bg-soft) 86%, transparent);
+}
+
+.railTrigger[data-active="true"] {
+  box-shadow: inset 0 0 0 1px color-mix(in srgb, var(--h-accent) 12%, transparent);
+}
+
+.railTrigger svg {
+  flex: none;
+}
+
+.railLabel {
+  writing-mode: vertical-rl;
+  letter-spacing: .08em;
+  font-size: 11px;
+  line-height: 1;
+}
+
+.railDot {
+  position: absolute;
+  top: 8px;
+  right: 8px;
+  width: 6px;
+  height: 6px;
+  border-radius: var(--h-r-pill);
+  background: var(--h-text-3);
+  opacity: .72;
+}
+
+.railTrigger[data-tone="ok"] .railDot { background: var(--h-ok); }
+.railTrigger[data-tone="accent"] .railDot { background: var(--h-accent); }
+.railTrigger[data-tone="warn"] .railDot { background: var(--h-warn); }
+
+.contextPopover {
+  position: absolute;
+  z-index: 30;
+  top: 16px;
+  bottom: 16px;
+  left: calc(-280px - 10px);
+  width: 280px;
+  overflow-y: auto;
+  overscroll-behavior: contain;
+  border: 1px solid var(--h-line);
+  border-radius: var(--h-r-lg);
+  background:
+    linear-gradient(180deg, color-mix(in srgb, var(--h-bg-pane) 98%, transparent), var(--h-bg-pane)),
+    var(--h-bg-pane);
+  box-shadow: var(--h-shadow);
+  padding: 12px;
+}
+
+.railClose {
+  position: sticky;
+  top: 0;
+  margin-left: auto;
+  margin-bottom: 6px;
+  display: flex;
+  align-items: center;
+  gap: 4px;
+  height: 24px;
+  border: 1px solid var(--h-line-soft);
+  border-radius: var(--h-r-pill);
+  color: var(--h-text-3);
+  background: color-mix(in srgb, var(--h-bg-pane) 92%, transparent);
+  font-size: 11px;
+  cursor: pointer;
+}
+
+.railClose:hover {
+  color: var(--h-text);
+  border-color: var(--h-line);
+}
+
+.railPanel {
+  display: grid;
+  gap: 10px;
+}
+
+.railPanelEyebrow {
+  color: var(--h-accent);
+  font-family: var(--h-font-mono);
+  font-size: 10px;
+  letter-spacing: .14em;
+}
+
+.railPanel h3 {
+  margin: 0;
+  color: var(--h-text);
+  font-size: 15px;
+  letter-spacing: -.02em;
+}
+
+.railPanel p {
+  margin: 0;
+  color: var(--h-text-2);
+  line-height: 1.7;
+  font-size: 12px;
+}
+
+.railPanelSection {
+  display: grid;
+  gap: 7px;
+  padding: 10px 0;
+  border-top: 1px solid var(--h-line-soft);
+}
+
+.railPanelSection b {
+  color: var(--h-text);
+  font-size: 12px;
+}
+
+.railPanelSection span {
+  color: var(--h-text-2);
+  line-height: 1.65;
+  font-size: 12px;
+}
+
+.compactList {
+  display: grid;
+  gap: 6px;
+  margin: 0;
+  padding: 0;
+  list-style: none;
+}
+
+.compactList li {
+  position: relative;
+  padding-left: 12px;
+  color: var(--h-text-2);
+  line-height: 1.55;
+  font-size: 12px;
+}
+
+.compactList li::before {
+  content: "";
+  position: absolute;
+  left: 0;
+  top: .68em;
+  width: 4px;
+  height: 4px;
+  border-radius: var(--h-r-pill);
+  background: var(--h-accent);
+}
+
+.railChips {
+  display: flex;
+  flex-wrap: wrap;
+  gap: 6px;
+}
+
+.railChips em {
+  display: inline-flex;
+  align-items: center;
+  min-height: 22px;
+  border: 1px solid var(--h-line-soft);
+  border-radius: var(--h-r-pill);
+  padding: 0 8px;
+  color: var(--h-text-2);
+  background: var(--h-bg-soft);
+  font-style: normal;
+  font-family: var(--h-font-mono);
+  font-size: 10px;
+}
+
+@media (max-width: 920px) {
+  .contextRail {
+    width: 100%;
+    height: 56px;
+  }
+
+  .railTrack {
+    width: 100%;
+    height: 56px;
+    flex-direction: row;
+    justify-content: center;
+    padding: 8px 12px;
+  }
+
+  .railTrigger {
+    width: min(31vw, 118px);
+    min-height: 40px;
+    flex-direction: row;
+    gap: 7px;
+  }
+
+  .railLabel {
+    writing-mode: initial;
+    letter-spacing: 0;
+  }
+
+  .railDot {
+    top: 8px;
+    right: 8px;
+  }
+
+  .contextPopover {
+    position: fixed;
+    left: 16px;
+    right: 16px;
+    bottom: 68px;
+    top: auto;
+    width: auto;
+    height: min(360px, calc(100vh - 180px));
+  }
+}
+
+@media (max-width: 760px) {
+  .headBand, .qrSection { grid-template-columns: 1fr; display: grid; }
+  .metaStrip, .flowSteps, .choiceGrid, .policyGrid, .consoleSteps, .scopeGrid, .testCards { grid-template-columns: 1fr; }
+  .actionFeedback, .checkIntro, .testGuide { align-items: flex-start; flex-direction: column; }
+  .testCards { min-width: 0; width: 100%; }
+  .field { grid-template-columns: 1fr; }
+  .heroActions { align-items: flex-start; }
+}

--- a/web/src/routes/im-onboarding.test.ts
+++ b/web/src/routes/im-onboarding.test.ts
@@ -1,0 +1,50 @@
+import { describe, expect, it } from "vitest";
+import {
+  FEISHU_RECOMMENDED_SCOPES,
+  FEISHU_REQUIRED_SCOPES,
+  railPanels,
+  sectionFromPath,
+  statusText,
+} from "./im-onboarding";
+
+describe("im onboarding routing helpers", () => {
+  it("maps /im to the Feishu page by default", () => {
+    expect(sectionFromPath("/im")).toBe("feishu");
+    expect(sectionFromPath("/im/")).toBe("feishu");
+  });
+
+  it("maps platform subroutes and rejects unrelated paths", () => {
+    expect(sectionFromPath("/im/feishu")).toBe("feishu");
+    expect(sectionFromPath("/im/weixin")).toBe("weixin");
+    expect(sectionFromPath("/models")).toBeNull();
+  });
+
+  it("renders stable Chinese labels for QR states", () => {
+    expect(statusText("confirmed")).toBe("已确认");
+    expect(statusText("scanned")).toBe("已扫码");
+    expect(statusText("expired")).toBe("已过期");
+    expect(statusText(undefined)).toBe("待开始");
+  });
+
+  it("keeps context rail entries compact and secret-safe", () => {
+    expect(railPanels("feishu").map((panel) => panel.label)).toEqual(["检查", "推荐", "诊断"]);
+    expect(railPanels("weixin").map((panel) => panel.label)).toEqual(["iLink", "群聊", "诊断"]);
+
+    const visibleCopy = JSON.stringify([railPanels("feishu"), railPanels("weixin")]).toLowerCase();
+    expect(visibleCopy).not.toContain("app_secret=");
+    expect(visibleCopy).not.toContain("weixin_token=");
+  });
+
+  it("documents Feishu chat readiness scopes in the onboarding flow", () => {
+    expect(FEISHU_REQUIRED_SCOPES).toEqual([
+      "im:message.p2p_msg:readonly",
+      "im:message.group_at_msg:readonly",
+      "im:message:send_as_bot",
+    ]);
+    expect(FEISHU_RECOMMENDED_SCOPES).toContain("im:resource");
+
+    const feishuRailCopy = JSON.stringify(railPanels("feishu"));
+    expect(feishuRailCopy).toContain("im.message.receive_v1");
+    expect(feishuRailCopy).toContain("创建版本并发布");
+  });
+});

--- a/web/src/routes/im-onboarding.tsx
+++ b/web/src/routes/im-onboarding.tsx
@@ -369,7 +369,7 @@ function FeishuTestGuide({ result }: { result: ImOnboardingApplyResult | null })
         <div className={s.miniEyebrow}>LIVE TEST</div>
         <h3>最后用真实消息验证闭环</h3>
         <p>{result?.ok
-          ? "Gateway 已尝试重启。现在请在飞书里用两条消息验证：私聊机器人发送 hi；在群聊里 @机器人 hi。"
+          ? "桌面端 managed runtime Gateway 已启动。现在请在飞书里用两条消息验证：私聊机器人发送 hi；在群聊里 @机器人 hi。"
           : "保存并重启 Gateway、完成飞书后台权限/事件/发布之后，再回来做真实消息验证。"}</p>
       </div>
       <div className={s.testCards}>
@@ -605,9 +605,10 @@ function ReviewTable({ rows }: { rows: Array<[string, string, string]> }) {
 
 function ApplyResult({ result }: { result: ImOnboardingApplyResult | null }) {
   if (!result) return null;
+  const Icon = result.restart.ok ? CheckCircle2 : XCircle;
   return (
     <div className={s.resultBox} data-ok={result.restart.ok ? "true" : undefined}>
-      <CheckCircle2 size={16} />
+      <Icon size={16} />
       <div>
         <b>配置已写入当前 profile：{result.currentProfile}</b>
         <span>env: <code>{result.envPath}</code>{result.backupPath ? <> · backup: <code>{result.backupPath}</code></> : null}</span>

--- a/web/src/routes/im-onboarding.tsx
+++ b/web/src/routes/im-onboarding.tsx
@@ -1,0 +1,892 @@
+import { useEffect, useRef, useState, type ReactNode } from "react";
+import { Navigate, useLocation } from "react-router-dom";
+import QRCode from "qrcode";
+import {
+  BadgeInfo,
+  CheckCircle2,
+  ClipboardList,
+  ExternalLink,
+  KeyRound,
+  ListChecks,
+  MessageSquareText,
+  RefreshCw,
+  RotateCw,
+  Save,
+  ScanLine,
+  Send,
+  ShieldCheck,
+  Stethoscope,
+  UsersRound,
+  X,
+  XCircle,
+  Zap,
+  type LucideIcon,
+} from "lucide-react";
+import type {
+  ImCredentialSummary,
+  ImOnboardingApplyResult,
+  ImOnboardingBeginResult,
+  ImOnboardingPollResult,
+  ImPlatform,
+  ImRedactedValue,
+} from "@hermes/protocol";
+import { useStatus } from "@/hooks/use-status";
+import {
+  useApplyImOnboarding,
+  useBeginImOnboarding,
+  useImOnboardingState,
+  usePollImOnboarding,
+} from "@/hooks/use-im-onboarding";
+import { SectionShell } from "./section-shell";
+import s from "./im-onboarding.module.css";
+
+type ImSection = "feishu" | "weixin";
+type FeishuMethod = "qr" | "manual";
+type DmPolicy = "pairing" | "allowlist" | "open" | "disabled";
+type FeishuGroupPolicy = "mention" | "disabled";
+type WeixinGroupPolicy = "disabled" | "open" | "allowlist";
+
+const FEISHU_DEVELOPER_URL = "https://open.feishu.cn/app";
+export const FEISHU_REQUIRED_SCOPES = [
+  "im:message.p2p_msg:readonly",
+  "im:message.group_at_msg:readonly",
+  "im:message:send_as_bot",
+] as const;
+export const FEISHU_RECOMMENDED_SCOPES = [
+  "im:resource",
+  "cardkit:card:write",
+  "cardkit:card:read",
+] as const;
+const FEISHU_RECEIVE_EVENT = "im.message.receive_v1";
+
+export function sectionFromPath(pathname: string): ImSection | null {
+  if (pathname === "/im" || pathname === "/im/") return "feishu";
+  if (pathname === "/im/feishu") return "feishu";
+  if (pathname === "/im/weixin") return "weixin";
+  return null;
+}
+
+function last(value?: ImRedactedValue | null): string {
+  return value?.redactedValue ?? "未设置";
+}
+
+export function statusText(status?: string): string {
+  switch (status) {
+    case "confirmed": return "已确认";
+    case "scanned": return "已扫码";
+    case "expired_refreshed": return "已刷新";
+    case "expired": return "已过期";
+    case "denied": return "已拒绝";
+    case "pending": return "等待中";
+    default: return status || "待开始";
+  }
+}
+
+function platformState(statusData: ReturnType<typeof useStatus>["data"], platform: ImPlatform) {
+  return statusData?.gateway_platforms?.[platform];
+}
+
+function textFromError(error: unknown): string | null {
+  if (!error) return null;
+  return error instanceof Error ? error.message : String(error);
+}
+
+function openExternal(url: string) {
+  const trimmed = url.trim();
+  if (!trimmed) return;
+
+  if (window.hermesDesktop?.openWorkspacePath) {
+    void window.hermesDesktop.openWorkspacePath({ path: trimmed }).catch(() => {
+      window.open(trimmed, "_blank", "noopener,noreferrer");
+    });
+    return;
+  }
+
+  window.open(trimmed, "_blank", "noopener,noreferrer");
+}
+
+function QrPanel({ data, url, status, message }: {
+  data?: string | null;
+  url?: string | null;
+  status?: string;
+  message?: string | null;
+}) {
+  const [src, setSrc] = useState<string | null>(null);
+  useEffect(() => {
+    let cancelled = false;
+    setSrc(null);
+    if (!data) return;
+    QRCode.toDataURL(data, {
+      width: 232,
+      margin: 1,
+      errorCorrectionLevel: "M",
+    }).then((next) => {
+      if (!cancelled) setSrc(next);
+    }).catch(() => {
+      if (!cancelled) setSrc(null);
+    });
+    return () => { cancelled = true; };
+  }, [data]);
+
+  const copy = () => {
+    if (data) void navigator.clipboard?.writeText(data);
+  };
+
+  return (
+    <section className={`${s.section} ${s.qrSection}`}>
+      <div className={s.qrBox} aria-label="二维码区域">
+        {src ? <img src={src} alt="扫码接入二维码" /> : <div className={s.qrPlaceholder}>QR</div>}
+      </div>
+      <div className={s.qrCopy}>
+        <div className={s.miniEyebrow}>QR ONBOARDING</div>
+        <h3>使用手机扫码确认</h3>
+        <p>{message || "生成二维码后，使用对应移动端扫码并在手机端确认。"}</p>
+        <div className={s.traceRow}><span>状态</span><b>{statusText(status)}</b><em>{data ? "二维码数据只保存在当前页面" : "尚未生成二维码"}</em></div>
+        {url && <code className={s.urlPreview}>{url}</code>}
+        <div className={s.buttonRow}>
+          <button className={s.btn} type="button" onClick={copy} disabled={!data}><ClipboardList size={14} />复制二维码数据</button>
+          {url && <button className={s.btn} type="button" onClick={() => openExternal(url)}><ExternalLink size={14} />打开备用链接</button>}
+        </div>
+      </div>
+    </section>
+  );
+}
+
+function Hero({ platform, stateSub, onPrimary, primaryBusy }: {
+  platform: ImPlatform;
+  stateSub: string;
+  onPrimary: () => void;
+  primaryBusy?: boolean;
+}) {
+  const isFeishu = platform === "feishu";
+  return (
+    <div className={s.headBand}>
+      <div className={s.heroCopy}>
+        <div className={s.heroKicker}><span>{isFeishu ? "№ 023A" : "№ 023B"}</span><span>IM ONBOARDING</span><em>配置 / 消息平台接入 / {isFeishu ? "飞书 · Lark" : "微信 · Weixin"}</em></div>
+        <h1>把<em>{isFeishu ? "飞书" : "微信"}</em>接到<br />Hermes。</h1>
+        <p className={s.sub}>{isFeishu
+          ? "将命令行里的 hermes gateway setup 拆成桌面端向导：获取应用凭据、写入当前 profile、启动长连接，再完成飞书后台权限、事件订阅、发版与真实消息验证。"
+          : "微信接入不是企业微信或公众号回调。这里绑定 Tencent iLink bot 身份，并用 getupdates 长轮询接收消息。"}</p>
+      </div>
+      <div className={s.heroActions}>
+        <span className={s.heroState}>{stateSub}</span>
+        <button className={`${s.btn} ${s.primary}`} type="button" onClick={onPrimary} disabled={primaryBusy}>
+          {isFeishu ? <ScanLine size={14} /> : <MessageSquareText size={14} />}
+          {primaryBusy ? "处理中…" : isFeishu ? "获取凭据" : "开始扫码"}
+        </button>
+      </div>
+    </div>
+  );
+}
+
+function ActionFeedback({ busy, error, flow, status, onJump }: {
+  busy: boolean;
+  error: unknown;
+  flow: ImOnboardingBeginResult | null;
+  status?: string;
+  onJump?: () => void;
+}) {
+  const message = textFromError(error);
+  if (!busy && !message && !flow) return null;
+  const tone = message ? "error" : flow ? "ok" : "info";
+  return (
+    <div className={s.actionFeedback} data-tone={tone} role={message ? "alert" : "status"}>
+      <div>
+        <b>{message ? "开始接入失败" : busy ? "正在生成扫码接入二维码" : "二维码已生成"}</b>
+        <span>{message || (busy ? "正在调用桌面端接入命令，请稍候。" : `状态：${statusText(status ?? flow?.status)}。请到扫码区域继续操作。`)}</span>
+      </div>
+      {flow && !message ? <button className={s.inlineBtn} type="button" onClick={onJump}>查看二维码</button> : null}
+    </div>
+  );
+}
+
+function MetaStrip({ platform, profile, statusData, configured }: {
+  platform: ImPlatform;
+  profile: string;
+  statusData: ReturnType<typeof useStatus>["data"];
+  configured: Record<string, ImRedactedValue>;
+}) {
+  const runtime = platformState(statusData, platform);
+  const credentialSet = platform === "feishu"
+    ? Boolean(configured.FEISHU_APP_ID?.isSet && configured.FEISHU_APP_SECRET?.isSet)
+    : Boolean(configured.WEIXIN_ACCOUNT_ID?.isSet && configured.WEIXIN_TOKEN?.isSet);
+  return (
+    <div className={s.metaStrip}>
+      <div><span>传输</span><b>{platform === "feishu" ? (configured.FEISHU_CONNECTION_MODE?.redactedValue ?? "WebSocket") : "Long-poll"}</b></div>
+      <div><span>档案</span><b>{profile || "default"}</b></div>
+      <div><span>Gateway</span><b data-tone={statusData?.gateway_running ? "ok" : "warn"}>{statusData?.gateway_running ? "running" : "stopped"}</b></div>
+      <div><span>凭据</span><b data-tone={credentialSet ? "ok" : "warn"}>{credentialSet ? "已保存" : "未保存"}</b></div>
+      <div><span>平台</span><b data-tone={runtime?.state === "connected" ? "ok" : undefined}>{runtime?.state || "pending"}</b></div>
+    </div>
+  );
+}
+
+function FlowSteps({ platform, status, saved }: { platform: ImPlatform; status?: string; saved: boolean }) {
+  const scanned = status === "scanned" || status === "confirmed";
+  const confirmed = status === "confirmed";
+  const labels = platform === "feishu"
+    ? [["选择方式", "扫码或手动"], ["获取凭据", "扫码或手动填写"], ["保存启动", "写入 profile 并重启"], ["后台配置", "权限、事件与发布"], ["测试消息", "私聊和群聊 @ 验证"]]
+    : [["环境检查", "依赖与 Gateway"], ["扫码绑定", "微信确认 iLink bot"], ["访问策略", "私聊、群聊与 home"], ["保存验证", "重启并检查 long-poll"]];
+  const states = platform === "feishu"
+    ? [true, scanned || confirmed, saved, false, false]
+    : [true, scanned || confirmed, confirmed, saved];
+  return (
+    <div className={s.flowSteps} aria-label="消息平台接入步骤">
+      {labels.map(([label, sub], index) => (
+        <div key={label} className={s.step} data-done={states[index] ? "true" : undefined} data-active={!states[index] ? "true" : undefined}>
+          <span>{states[index] ? "✓" : index + 1}</span><b>{label}</b><em>{sub}</em>
+        </div>
+      ))}
+    </div>
+  );
+}
+
+function SectionTitle({ num, title, meta }: { num: string; title: string; meta: string }) {
+  return <div className={s.sectionTitle}><span>{num}</span><h2>{title}</h2><em>{meta}</em></div>;
+}
+
+function ChoiceCard({ active, icon, badge, title, desc, foot, onClick }: {
+  active?: boolean;
+  icon: "scan" | "key";
+  badge: string;
+  title: string;
+  desc: string;
+  foot: string;
+  onClick: () => void;
+}) {
+  return (
+    <button type="button" className={s.choiceCard} data-active={active ? "true" : undefined} onClick={onClick}>
+      <div className={s.choiceTop}><span className={s.choiceIcon}>{icon === "scan" ? <ScanLine size={20} /> : <KeyRound size={20} />}</span><span className={s.pill}>{badge}</span></div>
+      <h3>{title}</h3>
+      <p>{desc}</p>
+      <small>{foot}</small>
+    </button>
+  );
+}
+
+function PolicyCard({ active, warning, title, desc, onClick }: { active?: boolean; warning?: boolean; title: string; desc: string; onClick: () => void }) {
+  return (
+    <button type="button" className={s.policyCard} data-active={active ? "true" : undefined} data-warning={warning ? "true" : undefined} onClick={onClick}>
+      <span>{active ? "✓" : warning ? "!" : "○"}</span>
+      <h3>{title}</h3>
+      <p>{desc}</p>
+    </button>
+  );
+}
+
+function Field({ label, desc, meta, children }: { label: string; desc: string; meta: string; children: ReactNode }) {
+  return (
+    <label className={s.field}>
+      <span className={s.fieldLabel}><b>{label}</b><small>{desc}</small></span>
+      <span className={s.fieldControl}>{children}</span>
+      <code>{meta}</code>
+    </label>
+  );
+}
+
+function copyText(value: string) {
+  void navigator.clipboard?.writeText(value);
+}
+
+function FeishuBackendChecklist() {
+  const requiredScopes = FEISHU_REQUIRED_SCOPES.join("\n");
+  const recommendedScopes = FEISHU_RECOMMENDED_SCOPES.join("\n");
+  const importJson = JSON.stringify({
+    scopes: {
+      tenant: [...FEISHU_REQUIRED_SCOPES, ...FEISHU_RECOMMENDED_SCOPES],
+    },
+  }, null, 2);
+
+  return (
+    <section className={`${s.section} ${s.backendChecklist}`}>
+      <div className={s.checkIntro}>
+        <div>
+          <div className={s.miniEyebrow}>FEISHU CONSOLE</div>
+          <h3>扫码成功后，还要完成飞书后台配置</h3>
+          <p>App ID / Secret 只是凭据。要让 Hermes 真正收到私聊、群聊 @ 并发出回复，需要在飞书开放平台确认机器人能力、长连接事件、权限和版本发布。</p>
+        </div>
+        <button className={`${s.btn} ${s.externalBtn}`} type="button" onClick={() => openExternal(FEISHU_DEVELOPER_URL)}>
+          <ExternalLink size={14} />打开飞书开发者后台
+        </button>
+      </div>
+
+      <div className={s.consoleSteps}>
+        <div className={s.consoleStep}>
+          <span>1</span>
+          <b>先保存并启动 Gateway</b>
+          <p>长连接订阅保存时可能要求应用已经建立连接，所以先把凭据写入当前 profile 并重启 Gateway。</p>
+        </div>
+        <div className={s.consoleStep}>
+          <span>2</span>
+          <b>事件订阅选择长连接</b>
+          <p>在「事件与回调」里选择使用长连接接收事件，然后添加应用身份事件「接收消息 v2.0」。</p>
+          <code>{FEISHU_RECEIVE_EVENT}</code>
+        </div>
+        <div className={s.consoleStep}>
+          <span>3</span>
+          <b>开通并发布权限</b>
+          <p>权限开通后仍需创建版本并发布，未发布时飞书客户端里通常表现为机器人不回复。</p>
+        </div>
+      </div>
+
+      <div className={s.scopeGrid}>
+        <div className={s.scopeBox}>
+          <div className={s.scopeHead}><b>必须权限</b><button type="button" onClick={() => copyText(requiredScopes)}>复制</button></div>
+          {FEISHU_REQUIRED_SCOPES.map((scope) => <code key={scope}>{scope}</code>)}
+        </div>
+        <div className={s.scopeBox}>
+          <div className={s.scopeHead}><b>按需推荐</b><button type="button" onClick={() => copyText(recommendedScopes)}>复制</button></div>
+          {FEISHU_RECOMMENDED_SCOPES.map((scope) => <code key={scope}>{scope}</code>)}
+        </div>
+      </div>
+
+      <div className={s.importBox}>
+        <div className={s.scopeHead}><b>权限导入 JSON</b><button type="button" onClick={() => copyText(importJson)}>复制 JSON</button></div>
+        <pre>{importJson}</pre>
+      </div>
+    </section>
+  );
+}
+
+function FeishuTestGuide({ result }: { result: ImOnboardingApplyResult | null }) {
+  return (
+    <section className={`${s.section} ${s.testGuide}`} data-ready={result?.ok ? "true" : undefined}>
+      <div>
+        <div className={s.miniEyebrow}>LIVE TEST</div>
+        <h3>最后用真实消息验证闭环</h3>
+        <p>{result?.ok
+          ? "Gateway 已尝试重启。现在请在飞书里用两条消息验证：私聊机器人发送 hi；在群聊里 @机器人 hi。"
+          : "保存并重启 Gateway、完成飞书后台权限/事件/发布之后，再回来做真实消息验证。"}</p>
+      </div>
+      <div className={s.testCards}>
+        <div><MessageSquareText size={15} /><b>私聊测试</b><span>给机器人发送 <code>hi</code>，应收到 Hermes 回复或配对提示。</span></div>
+        <div><Send size={15} /><b>群聊 @ 测试</b><span>把机器人拉入群并发送 <code>@机器人 hi</code>，默认只响应 @ 消息。</span></div>
+      </div>
+    </section>
+  );
+}
+
+type RailPanelId = "check" | "why" | "diagnosis";
+
+interface RailPanelSection {
+  title: string;
+  body?: string;
+  items?: string[];
+  chips?: string[];
+  tone?: "ok" | "warn";
+}
+
+interface RailPanelConfig {
+  id: RailPanelId;
+  icon: LucideIcon;
+  label: string;
+  tone: "ok" | "accent" | "warn";
+  eyebrow: string;
+  title: string;
+  summary: string;
+  sections: RailPanelSection[];
+}
+
+export function railPanels(platform: ImPlatform): RailPanelConfig[] {
+  if (platform === "feishu") {
+    return [
+      {
+        id: "check",
+        icon: ListChecks,
+        label: "检查",
+        tone: "ok",
+        eyebrow: "CHECKLIST",
+        title: "飞书后台检查清单",
+        summary: "扫码拿到凭据不等于能聊天；需要保存启动 Gateway 后，再确认飞书后台权限、事件订阅和发版状态。",
+        sections: [
+          {
+            title: "最小闭环",
+            items: ["机器人能力已启用", `长连接订阅方式已保存`, `事件订阅包含 ${FEISHU_RECEIVE_EVENT}`, "应用已创建版本并发布"],
+          },
+          {
+            title: "必须权限",
+            items: Array.from(FEISHU_REQUIRED_SCOPES),
+            chips: ["单聊可收", "群聊 @ 可收", "机器人可发"],
+          },
+        ],
+      },
+      {
+        id: "why",
+        icon: Zap,
+        label: "推荐",
+        tone: "accent",
+        eyebrow: "WHY WS",
+        title: "为什么默认 WebSocket",
+        summary: "桌面端运行在用户本机，WebSocket 能避开公网回调地址、域名和内网穿透要求。",
+        sections: [
+          {
+            title: "产品默认",
+            body: "长连接由官方 SDK 与开放平台建立，但飞书后台仍要添加接收消息事件并发布应用，事件才会真正投递到本地 Gateway。",
+            chips: ["无需公网 IP", "适合桌面端", "链路更稳定"],
+          },
+          {
+            title: "何时用 Webhook",
+            items: ["已有企业统一回调网关", "需要集中审计所有开放平台事件", "明确有可访问公网域名"],
+          },
+        ],
+      },
+      {
+        id: "diagnosis",
+        icon: Stethoscope,
+        label: "诊断",
+        tone: "warn",
+        eyebrow: "DIAGNOSIS",
+        title: "常见失败诊断",
+        summary: "这里仅展示可复现故障线索，不输出 app secret、token 或扫码凭据。",
+        sections: [
+          {
+            title: "快速排查",
+            items: ["私聊无响应：确认已开通 im:message.p2p_msg:readonly 并发布", "群聊无响应：确认已开通 im:message.group_at_msg:readonly 且消息里 @ 机器人", "能收不能发：确认已开通 im:message:send_as_bot", "事件日志为空：确认已订阅接收消息 v2.0 并创建版本发布"],
+          },
+          {
+            title: "日志关键词",
+            chips: ["gateway_platforms.feishu", "event subscription", "bot disabled"],
+          },
+        ],
+      },
+    ];
+  }
+
+  return [
+    {
+      id: "check",
+      icon: BadgeInfo,
+      label: "iLink",
+      tone: "accent",
+      eyebrow: "ILINK BOT",
+      title: "这是个人微信 iLink 接入",
+      summary: "该页面不是企业微信、公众号或普通微信群稳定回调配置，只绑定 iLink bot 身份。",
+      sections: [
+        {
+          title: "接入边界",
+          items: ["扫码得到 iLink bot account_id 与 token", "消息通过 getupdates 长轮询进入 Gateway", "媒体走独立 CDN base url"],
+        },
+        {
+          title: "安全默认",
+          body: "account_id、token 和 base_url 在摘要中脱敏展示，保存时只写入当前 profile。",
+          chips: ["非企微", "非公众号", "非微信群回调"],
+        },
+      ],
+    },
+    {
+      id: "why",
+      icon: UsersRound,
+      label: "群聊",
+      tone: "warn",
+      eyebrow: "GROUP LIMIT",
+      title: "微信群聊默认关闭",
+      summary: "iLink bot 身份通常不能像普通联系人一样加入微信群，也不保证投递普通微信群事件。",
+      sections: [
+        {
+          title: "默认策略",
+          body: "先保证私聊扫码、配对审批和 Gateway 长轮询闭环，群聊能力只在真实投递可验证时开启。",
+          chips: ["默认 disabled", "私聊优先", "可白名单试验"],
+        },
+        {
+          title: "开启前确认",
+          items: ["确认 iLink 实际投递 group id", "限制允许群聊列表", "避免把个人号群消息误当稳定 API"],
+        },
+      ],
+    },
+    {
+      id: "diagnosis",
+      icon: Stethoscope,
+      label: "诊断",
+      tone: "warn",
+      eyebrow: "DIAGNOSIS",
+      title: "常见失败诊断",
+      summary: "诊断只展示依赖、轮询状态和配置缺口，不展示 token 原文。",
+      sections: [
+        {
+          title: "快速排查",
+          items: ["missing dependency：修复 aiohttp / cryptography", "WEIXIN_TOKEN missing：重新扫码或手动恢复", "token already locked：停止另一 Gateway"],
+        },
+        {
+          title: "日志关键词",
+          chips: ["gateway_platforms.weixin", "getupdates", "poller locked"],
+        },
+      ],
+    },
+  ];
+}
+
+function Rail({ platform }: { platform: ImPlatform }) {
+  const [active, setActive] = useState<RailPanelId | null>(null);
+  const panels = railPanels(platform);
+  const activePanel = panels.find((panel) => panel.id === active) ?? null;
+
+  return (
+    <div className={s.contextRail} data-open={activePanel ? "true" : undefined}>
+      <div className={s.railTrack} aria-label={`${platform === "feishu" ? "飞书" : "微信"}接入上下文`}>
+        {panels.map((panel) => {
+          const Icon = panel.icon;
+          const isActive = active === panel.id;
+          return (
+            <button
+              key={panel.id}
+              type="button"
+              className={s.railTrigger}
+              data-active={isActive ? "true" : undefined}
+              data-tone={panel.tone}
+              aria-expanded={isActive}
+              aria-controls={`${platform}-${panel.id}-panel`}
+              onClick={() => setActive(isActive ? null : panel.id)}
+            >
+              <Icon size={17} aria-hidden="true" />
+              <span className={s.railLabel}>{panel.label}</span>
+              <span className={s.railDot} aria-hidden="true" />
+            </button>
+          );
+        })}
+      </div>
+
+      {activePanel ? (
+        <div className={s.contextPopover} role="dialog" aria-label={activePanel.title}>
+          <button className={s.railClose} type="button" onClick={() => setActive(null)}>
+            <X size={14} aria-hidden="true" />
+            收起
+          </button>
+          <section id={`${platform}-${activePanel.id}-panel`} className={s.railPanel}>
+            <div className={s.railPanelEyebrow}>{activePanel.eyebrow}</div>
+            <h3>{activePanel.title}</h3>
+            <p>{activePanel.summary}</p>
+            {activePanel.sections.map((section) => (
+              <div className={s.railPanelSection} data-tone={section.tone} key={section.title}>
+                <b>{section.title}</b>
+                {section.body ? <span>{section.body}</span> : null}
+                {section.items ? (
+                  <ul className={s.compactList}>
+                    {section.items.map((item) => <li key={item}>{item}</li>)}
+                  </ul>
+                ) : null}
+                {section.chips ? (
+                  <div className={s.railChips}>
+                    {section.chips.map((chip) => <em key={chip}>{chip}</em>)}
+                  </div>
+                ) : null}
+              </div>
+            ))}
+          </section>
+        </div>
+      ) : null}
+    </div>
+  );
+}
+
+function ReviewTable({ rows }: { rows: Array<[string, string, string]> }) {
+  return (
+    <section className={`${s.section} ${s.reviewSection}`}>
+      <table className={s.reviewTable}>
+        <thead><tr><th>产品项</th><th>将写入的配置</th><th>状态</th></tr></thead>
+        <tbody>{rows.map(([a, b, c]) => <tr key={a}><td>{a}</td><td><code>{b}</code></td><td>{c}</td></tr>)}</tbody>
+      </table>
+    </section>
+  );
+}
+
+function ApplyResult({ result }: { result: ImOnboardingApplyResult | null }) {
+  if (!result) return null;
+  return (
+    <div className={s.resultBox} data-ok={result.restart.ok ? "true" : undefined}>
+      <CheckCircle2 size={16} />
+      <div>
+        <b>配置已写入当前 profile：{result.currentProfile}</b>
+        <span>env: <code>{result.envPath}</code>{result.backupPath ? <> · backup: <code>{result.backupPath}</code></> : null}</span>
+        <span>{result.restart.message}</span>
+      </div>
+    </div>
+  );
+}
+
+function FeishuRoute() {
+  const stateQuery = useImOnboardingState("feishu");
+  const statusQuery = useStatus();
+  const begin = useBeginImOnboarding();
+  const poll = usePollImOnboarding();
+  const apply = useApplyImOnboarding("feishu");
+  const [method, setMethod] = useState<FeishuMethod>("qr");
+  const [domain, setDomain] = useState("feishu");
+  const [connectionMode, setConnectionMode] = useState("websocket");
+  const [dmPolicy, setDmPolicy] = useState<DmPolicy>("pairing");
+  const [groupPolicy, setGroupPolicy] = useState<FeishuGroupPolicy>("mention");
+  const [appId, setAppId] = useState("");
+  const [appSecret, setAppSecret] = useState("");
+  const [allowedUsers, setAllowedUsers] = useState("");
+  const [homeChannel, setHomeChannel] = useState("");
+  const [webhookHost, setWebhookHost] = useState("127.0.0.1");
+  const [webhookPort, setWebhookPort] = useState("8765");
+  const [webhookPath, setWebhookPath] = useState("/feishu/webhook");
+  const [encryptKey, setEncryptKey] = useState("");
+  const [verificationToken, setVerificationToken] = useState("");
+  const [flow, setFlow] = useState<ImOnboardingBeginResult | null>(null);
+  const [pollResult, setPollResult] = useState<ImOnboardingPollResult | null>(null);
+  const [result, setResult] = useState<ImOnboardingApplyResult | null>(null);
+  const qrAnchorRef = useRef<HTMLDivElement>(null);
+
+  const configured = stateQuery.data?.configured ?? {};
+  const status = pollResult?.status ?? flow?.status;
+  const credential = pollResult?.credentialSummary;
+  const canApplyQr = method === "qr" && credential && pollResult?.status === "confirmed";
+  const canApplyManual = method === "manual" && appId.trim() && appSecret.trim();
+  const busy = begin.isPending || poll.isPending || apply.isPending;
+  const jumpToQr = () => qrAnchorRef.current?.scrollIntoView({ behavior: "smooth", block: "start" });
+
+  const start = () => {
+    begin.reset();
+    poll.reset();
+    setResult(null);
+    begin.mutate({ platform: "feishu", domain }, {
+      onSuccess: (next) => {
+        setFlow(next);
+        setPollResult(null);
+        window.requestAnimationFrame(jumpToQr);
+      },
+    });
+  };
+  const pollOnce = () => {
+    const flowId = flow?.flowId;
+    if (!flowId) return;
+    poll.mutate({ platform: "feishu", flowId }, { onSuccess: setPollResult });
+  };
+  useEffect(() => {
+    if (!flow?.flowId || pollResult?.status === "confirmed" || pollResult?.status === "expired" || pollResult?.status === "denied") return;
+    const delay = Math.max(2, flow.intervalSeconds || 5) * 1000;
+    const id = window.setInterval(pollOnce, delay);
+    return () => window.clearInterval(id);
+  }, [flow?.flowId, flow?.intervalSeconds, pollResult?.status]);
+
+  const settings = () => {
+    const allowAll = dmPolicy === "open" ? "true" : "false";
+    return {
+      FEISHU_DOMAIN: domain,
+      FEISHU_CONNECTION_MODE: connectionMode,
+      FEISHU_ALLOW_ALL_USERS: allowAll,
+      FEISHU_ALLOWED_USERS: dmPolicy === "allowlist" ? allowedUsers.replaceAll(" ", "") : "",
+      FEISHU_GROUP_POLICY: groupPolicy === "disabled" ? "disabled" : "open",
+      FEISHU_REQUIRE_MENTION: groupPolicy === "mention" ? "true" : "false",
+      FEISHU_HOME_CHANNEL: homeChannel.trim(),
+      ...(connectionMode === "webhook" ? {
+        FEISHU_WEBHOOK_HOST: webhookHost.trim(),
+        FEISHU_WEBHOOK_PORT: webhookPort.trim(),
+        FEISHU_WEBHOOK_PATH: webhookPath.trim(),
+        FEISHU_ENCRYPT_KEY: encryptKey.trim(),
+        FEISHU_VERIFICATION_TOKEN: verificationToken.trim(),
+      } : {}),
+    };
+  };
+  const save = () => {
+    apply.mutate({
+      platform: "feishu",
+      flowId: method === "qr" ? flow?.flowId : undefined,
+      manualCredentials: method === "manual" ? { appId, appSecret } : undefined,
+      settings: settings(),
+      restartGateway: true,
+    }, { onSuccess: setResult });
+  };
+  const rows: Array<[string, string, string]> = [
+    ["连接模式", `FEISHU_CONNECTION_MODE=${connectionMode}`, connectionMode === "websocket" ? "推荐" : "高级"],
+    ["区域", `FEISHU_DOMAIN=${domain}`, "已选择"],
+    ["私聊策略", `FEISHU_ALLOW_ALL_USERS=${dmPolicy === "open" ? "true" : "false"}`, dmPolicy],
+    ["群聊策略", `FEISHU_GROUP_POLICY=${groupPolicy === "disabled" ? "disabled" : "open"}`, groupPolicy === "mention" ? "仅 @ 响应" : "关闭"],
+    ["首页频道", `FEISHU_HOME_CHANNEL=${homeChannel || ""}`, homeChannel ? "已填写" : "稍后设置"],
+  ];
+
+  return (
+    <SectionShell title="消息平台接入 · 飞书" sub="02 配置 / 023 消息平台接入" rail={<Rail platform="feishu" />} railLabel="飞书接入诊断边栏">
+      <div className={s.wrap}>
+        <main className={s.mainCol}>
+          <Hero platform="feishu" stateSub={`当前 profile：${stateQuery.data?.currentProfile ?? "default"}`} onPrimary={method === "qr" ? start : save} primaryBusy={busy} />
+          <ActionFeedback busy={begin.isPending} error={begin.error} flow={flow} status={status} onJump={jumpToQr} />
+          <MetaStrip platform="feishu" profile={stateQuery.data?.currentProfile ?? "default"} statusData={statusQuery.data} configured={configured} />
+          <FlowSteps platform="feishu" status={status} saved={Boolean(result?.ok)} />
+          <SectionTitle num="[ STEP 01 ]" title="选择接入方式" meta="普通用户走扫码，企业已有应用走手动凭据" />
+          <section className={s.section}><div className={s.choiceGrid}>
+            <ChoiceCard active={method === "qr"} icon="scan" badge="推荐" title="扫码获取应用凭据" desc="用飞书手机端扫码授权，自动获取 App ID、App Secret 与机器人信息；后续仍需确认后台权限、事件与发布。" foot="无需公网回调地址" onClick={() => setMethod("qr")} />
+            <ChoiceCard active={method === "manual"} icon="key" badge="高级" title="手动输入已有应用" desc="适合企业已有自建应用，需启用机器人能力并订阅消息事件。" foot="可切换 Webhook 模式" onClick={() => setMethod("manual")} />
+          </div></section>
+
+          {method === "qr" ? <>
+            <div ref={qrAnchorRef} className={s.anchorBlock}>
+              <SectionTitle num="[ STEP 02A ]" title="扫码授权并获取凭据" meta={flow ? `轮询间隔 ${flow.intervalSeconds}s；凭据获取后还要配置后台` : "device_code 只保存在桌面端内存"} />
+              <QrPanel data={pollResult?.qrScanData ?? flow?.qrScanData} url={pollResult?.qrUrl ?? flow?.qrUrl} status={status} message={pollResult?.message ?? flow?.message} />
+            </div>
+            <div className={s.sectionActions}><button className={`${s.btn} ${s.primary}`} onClick={start} disabled={busy}><ScanLine size={14} />生成二维码</button><button className={s.btn} onClick={pollOnce} disabled={!flow || busy}><RefreshCw size={14} />立即检查</button></div>
+          </> : <>
+            <SectionTitle num="[ STEP 02B ]" title="手动输入已有飞书应用" meta="App Secret 不会进入诊断输出" />
+            <section className={s.section}>
+              <Field label="区域" desc="选择飞书中国或 Lark 国际。" meta="FEISHU_DOMAIN"><select value={domain} onChange={(e) => setDomain(e.target.value)}><option value="feishu">飞书中国 · feishu</option><option value="lark">Lark 国际 · lark</option></select></Field>
+              <Field label="连接模式" desc="桌面端默认 WebSocket，无需公网地址。" meta="FEISHU_CONNECTION_MODE"><select value={connectionMode} onChange={(e) => setConnectionMode(e.target.value)}><option value="websocket">WebSocket（推荐）</option><option value="webhook">Webhook（高级）</option></select></Field>
+              <Field label="App ID" desc="来自飞书开放平台的应用凭证。" meta="FEISHU_APP_ID"><input value={appId} onChange={(e) => setAppId(e.target.value)} placeholder="cli_xxx" /></Field>
+              <Field label="App Secret" desc="敏感凭据，仅用于保存到当前 profile。" meta="FEISHU_APP_SECRET"><input type="password" value={appSecret} onChange={(e) => setAppSecret(e.target.value)} placeholder="••••••••" /></Field>
+              {connectionMode === "webhook" && <>
+                <Field label="Webhook Host" desc="仅 Webhook 模式需要。" meta="FEISHU_WEBHOOK_HOST"><input value={webhookHost} onChange={(e) => setWebhookHost(e.target.value)} /></Field>
+                <Field label="Webhook Port" desc="本地 handler 端口。" meta="FEISHU_WEBHOOK_PORT"><input value={webhookPort} onChange={(e) => setWebhookPort(e.target.value)} /></Field>
+                <Field label="Webhook Path" desc="开放平台回调路径。" meta="FEISHU_WEBHOOK_PATH"><input value={webhookPath} onChange={(e) => setWebhookPath(e.target.value)} /></Field>
+                <Field label="Webhook 安全" desc="Encrypt Key，可留空后续补充。" meta="FEISHU_ENCRYPT_KEY"><input type="password" value={encryptKey} onChange={(e) => setEncryptKey(e.target.value)} /></Field>
+                <Field label="Verification Token" desc="签名校验 token。" meta="FEISHU_VERIFICATION_TOKEN"><input type="password" value={verificationToken} onChange={(e) => setVerificationToken(e.target.value)} /></Field>
+              </>}
+              <div className={s.sectionActions}><button className={`${s.btn} ${s.externalBtn}`} onClick={() => openExternal(FEISHU_DEVELOPER_URL)}><ExternalLink size={14} />打开飞书开发者后台</button></div>
+            </section>
+          </>}
+
+          <SectionTitle num="[ STEP 03 ]" title="保存本地策略并启动 Gateway" meta="这一步只写入当前 profile，不代表飞书后台已经可聊天" />
+          <section className={s.section}>
+            <div className={s.policyGrid}>
+              <PolicyCard active={dmPolicy === "pairing"} title="私聊配对审批" desc="未知用户可发起请求，由管理员批准。" onClick={() => setDmPolicy("pairing")} />
+              <PolicyCard active={dmPolicy === "allowlist"} title="指定 open_id 白名单" desc="只允许列表中的成员触发。" onClick={() => setDmPolicy("allowlist")} />
+              <PolicyCard active={dmPolicy === "open"} warning title="允许所有私聊" desc="最快试用，但风险更高。" onClick={() => setDmPolicy("open")} />
+            </div>
+            {dmPolicy === "allowlist" && <Field label="允许用户" desc="多个 open_id 用英文逗号分隔。" meta="FEISHU_ALLOWED_USERS"><input value={allowedUsers} onChange={(e) => setAllowedUsers(e.target.value)} /></Field>}
+            <Field label="群聊策略" desc="减少噪声，默认仅 @Hermes 时响应。" meta="FEISHU_GROUP_POLICY"><select value={groupPolicy} onChange={(e) => setGroupPolicy(e.target.value as FeishuGroupPolicy)}><option value="mention">启用群聊，仅 @Hermes 时响应</option><option value="disabled">禁用群聊</option></select></Field>
+            <Field label="通知 Home Channel" desc="用于 cron 和跨平台通知，可稍后设置。" meta="FEISHU_HOME_CHANNEL"><input value={homeChannel} onChange={(e) => setHomeChannel(e.target.value)} placeholder="oc_xxx 或留空" /></Field>
+          </section>
+
+          <SectionTitle num="[ REVIEW ]" title="保存前配置摘要" meta="secret 只显示脱敏摘要；保存后继续配置飞书后台" />
+          {credential && <div className={s.summaryLine}>扫码结果：App ID {last(credential.appId)} · App Secret {last(credential.appSecret)} · Bot {credential.botName ?? "未探测"}</div>}
+          <ReviewTable rows={rows} />
+          <div className={s.sectionActions}><button className={`${s.btn} ${s.primary}`} onClick={save} disabled={busy || !(canApplyQr || canApplyManual)}><Save size={14} />保存并重启 Gateway</button></div>
+          <ApplyResult result={result} />
+          <SectionTitle num="[ STEP 04 ]" title="配置飞书后台权限与事件" meta="必须完成接收消息 v2.0、权限开通和版本发布" />
+          <FeishuBackendChecklist />
+          <SectionTitle num="[ STEP 05 ]" title="发送测试消息" meta="用私聊和群聊 @ 验证真正可聊天" />
+          <FeishuTestGuide result={result} />
+          {(begin.error || poll.error || apply.error || stateQuery.error) && <div className={s.errorBox}><XCircle size={16} />{textFromError(begin.error || poll.error || apply.error || stateQuery.error)}</div>}
+        </main>
+      </div>
+    </SectionShell>
+  );
+}
+
+function WeixinRoute() {
+  const stateQuery = useImOnboardingState("weixin");
+  const statusQuery = useStatus();
+  const begin = useBeginImOnboarding();
+  const poll = usePollImOnboarding();
+  const apply = useApplyImOnboarding("weixin");
+  const [dmPolicy, setDmPolicy] = useState<DmPolicy>("pairing");
+  const [groupPolicy, setGroupPolicy] = useState<WeixinGroupPolicy>("disabled");
+  const [allowedUsers, setAllowedUsers] = useState("");
+  const [groupAllowed, setGroupAllowed] = useState("");
+  const [homeChannel, setHomeChannel] = useState("");
+  const [accountId, setAccountId] = useState("");
+  const [token, setToken] = useState("");
+  const [baseUrl, setBaseUrl] = useState("https://ilinkai.weixin.qq.com");
+  const [cdnBaseUrl, setCdnBaseUrl] = useState("https://novac2c.cdn.weixin.qq.com/c2c");
+  const [flow, setFlow] = useState<ImOnboardingBeginResult | null>(null);
+  const [pollResult, setPollResult] = useState<ImOnboardingPollResult | null>(null);
+  const [result, setResult] = useState<ImOnboardingApplyResult | null>(null);
+  const qrAnchorRef = useRef<HTMLDivElement>(null);
+  const configured = stateQuery.data?.configured ?? {};
+  const status = pollResult?.status ?? flow?.status;
+  const credential = pollResult?.credentialSummary;
+  const busy = begin.isPending || poll.isPending || apply.isPending;
+  const canApplyQr = credential && pollResult?.status === "confirmed";
+  const canApplyManual = accountId.trim() && token.trim();
+  const jumpToQr = () => qrAnchorRef.current?.scrollIntoView({ behavior: "smooth", block: "start" });
+
+  const start = () => {
+    begin.reset();
+    poll.reset();
+    begin.mutate({ platform: "weixin" }, {
+      onSuccess: (next) => {
+        setFlow(next);
+        setPollResult(null);
+        setResult(null);
+        window.requestAnimationFrame(jumpToQr);
+      },
+    });
+  };
+  const pollOnce = () => {
+    if (!flow?.flowId) return;
+    poll.mutate({ platform: "weixin", flowId: flow.flowId }, { onSuccess: setPollResult });
+  };
+  useEffect(() => {
+    if (!flow?.flowId || pollResult?.status === "confirmed" || pollResult?.status === "expired") return;
+    const id = window.setInterval(pollOnce, 1500);
+    return () => window.clearInterval(id);
+  }, [flow?.flowId, pollResult?.status]);
+
+  const settings = () => ({
+    WEIXIN_BASE_URL: baseUrl.trim().replace(/\/$/, ""),
+    WEIXIN_CDN_BASE_URL: cdnBaseUrl.trim().replace(/\/$/, ""),
+    WEIXIN_DM_POLICY: dmPolicy,
+    WEIXIN_ALLOW_ALL_USERS: dmPolicy === "open" ? "true" : "false",
+    WEIXIN_ALLOWED_USERS: dmPolicy === "allowlist" ? allowedUsers.replaceAll(" ", "") : "",
+    WEIXIN_GROUP_POLICY: groupPolicy,
+    WEIXIN_GROUP_ALLOWED_USERS: groupPolicy === "allowlist" ? groupAllowed.replaceAll(" ", "") : "",
+    WEIXIN_HOME_CHANNEL: homeChannel.trim(),
+  });
+  const save = () => apply.mutate({
+    platform: "weixin",
+    flowId: flow?.flowId,
+    manualCredentials: canApplyQr ? undefined : { accountId, token, baseUrl },
+    settings: settings(),
+    restartGateway: true,
+  }, { onSuccess: setResult });
+  const rows: Array<[string, string, string]> = [
+    ["账号 ID", `WEIXIN_ACCOUNT_ID=${credential?.accountId?.redactedValue ?? accountId}`, credential ? "扫码返回" : "手动"],
+    ["认证 Token", `WEIXIN_TOKEN=${credential?.token?.redactedValue ?? (token ? "••••" : "")}`, "敏感"],
+    ["私聊策略", `WEIXIN_DM_POLICY=${dmPolicy}`, "推荐 pairing"],
+    ["允许所有用户", `WEIXIN_ALLOW_ALL_USERS=${dmPolicy === "open" ? "true" : "false"}`, "安全默认"],
+    ["群聊策略", `WEIXIN_GROUP_POLICY=${groupPolicy}`, groupPolicy === "disabled" ? "推荐" : "高级"],
+  ];
+
+  return (
+    <SectionShell title="消息平台接入 · 微信" sub="02 配置 / 023 消息平台接入" rail={<Rail platform="weixin" />} railLabel="微信接入诊断边栏">
+      <div className={s.wrap}>
+        <main className={s.mainCol}>
+          <Hero platform="weixin" stateSub={`当前 profile：${stateQuery.data?.currentProfile ?? "default"}`} onPrimary={start} primaryBusy={busy} />
+          <ActionFeedback busy={begin.isPending} error={begin.error} flow={flow} status={status} onJump={jumpToQr} />
+          <MetaStrip platform="weixin" profile={stateQuery.data?.currentProfile ?? "default"} statusData={statusQuery.data} configured={configured} />
+          <FlowSteps platform="weixin" status={status} saved={Boolean(result?.ok)} />
+          <SectionTitle num="[ STEP 01 ]" title="运行环境检查" meta="微信需要 aiohttp、cryptography 与唯一 token poller" />
+          <section className={s.section}><div className={s.verifyGrid}>
+            <div className={s.verifyRow}><ShieldCheck size={16} /><div><b>Gateway 状态</b><small>{statusQuery.data?.gateway_running ? "当前 Gateway 可重启。" : "Gateway 未运行，保存后会尝试重启。"}</small></div></div>
+            <div className={s.verifyRow}><KeyRound size={16} /><div><b>账号配置</b><small>{configured.WEIXIN_ACCOUNT_ID?.isSet ? `已保存 ${last(configured.WEIXIN_ACCOUNT_ID)}` : "尚未绑定 iLink bot。"}</small></div></div>
+          </div></section>
+          <div ref={qrAnchorRef} className={s.anchorBlock}>
+            <SectionTitle num="[ STEP 02 ]" title="微信扫码绑定 iLink bot" meta="默认 8 分钟超时，二维码过期后最多自动刷新 3 次" />
+            <QrPanel data={pollResult?.qrScanData ?? flow?.qrScanData} url={pollResult?.qrUrl ?? flow?.qrUrl} status={status} message={pollResult?.message ?? flow?.message} />
+          </div>
+          <div className={s.sectionActions}><button className={`${s.btn} ${s.primary}`} onClick={start} disabled={busy}><ScanLine size={14} />生成二维码</button><button className={s.btn} onClick={pollOnce} disabled={!flow || busy}><RotateCw size={14} />立即检查</button></div>
+          <SectionTitle num="[ STEP 03 ]" title="凭据与高级连接配置" meta="普通用户无需手填 token，扫码成功后自动写入" />
+          <section className={s.section}>
+            <Field label="Account ID" desc="扫码成功后自动得到，也可用于恢复已有配置。" meta="WEIXIN_ACCOUNT_ID"><input value={accountId} onChange={(e) => setAccountId(e.target.value)} placeholder={last(credential?.accountId)} /></Field>
+            <Field label="Bot Token" desc="敏感凭据，仅保存到当前 profile。" meta="WEIXIN_TOKEN"><input type="password" value={token} onChange={(e) => setToken(e.target.value)} placeholder={last(credential?.token)} /></Field>
+            <Field label="iLink API" desc="默认不需要修改。" meta="WEIXIN_BASE_URL"><input value={credential?.baseUrl ?? baseUrl} onChange={(e) => setBaseUrl(e.target.value)} /></Field>
+            <Field label="CDN Base" desc="媒体加密上传与下载使用。" meta="WEIXIN_CDN_BASE_URL"><input value={cdnBaseUrl} onChange={(e) => setCdnBaseUrl(e.target.value)} /></Field>
+          </section>
+          <SectionTitle num="[ STEP 04 ]" title="访问策略" meta="默认私聊配对审批，群聊保持关闭" />
+          <section className={s.section}>
+            <div className={s.policyGrid}>
+              <PolicyCard active={dmPolicy === "pairing"} title="私聊配对审批" desc="未知用户私聊时生成 pairing code。" onClick={() => setDmPolicy("pairing")} />
+              <PolicyCard active={dmPolicy === "allowlist"} title="指定用户 ID" desc="只允许 WEIXIN_ALLOWED_USERS 中的用户。" onClick={() => setDmPolicy("allowlist")} />
+              <PolicyCard active={dmPolicy === "open"} warning title="允许所有私聊" desc="试用最快，但访问面最大。" onClick={() => setDmPolicy("open")} />
+            </div>
+            {dmPolicy === "allowlist" && <Field label="允许用户" desc="多个用户 ID 用英文逗号分隔。" meta="WEIXIN_ALLOWED_USERS"><input value={allowedUsers} onChange={(e) => setAllowedUsers(e.target.value)} /></Field>}
+            <Field label="群聊策略" desc="iLink bot 身份通常收不到普通微信群事件。" meta="WEIXIN_GROUP_POLICY"><select value={groupPolicy} onChange={(e) => setGroupPolicy(e.target.value as WeixinGroupPolicy)}><option value="disabled">禁用群聊（推荐）</option><option value="open">允许所有群聊（仅 iLink 实际投递时有效）</option><option value="allowlist">仅允许指定群聊 ID</option></select></Field>
+            {groupPolicy === "allowlist" && <Field label="允许群聊" desc="填写群聊 ID，不是成员用户 ID。" meta="WEIXIN_GROUP_ALLOWED_USERS"><input value={groupAllowed} onChange={(e) => setGroupAllowed(e.target.value)} /></Field>}
+            <Field label="Home Channel" desc="用于 cron 和通知，可先用扫码返回 user_id。" meta="WEIXIN_HOME_CHANNEL"><input value={homeChannel} onChange={(e) => setHomeChannel(e.target.value)} placeholder="wxid_xxx / filehelper / user_id" /></Field>
+          </section>
+          <SectionTitle num="[ REVIEW ]" title="将写入的配置摘要" meta="token 永远只显示脱敏摘要" />
+          <ReviewTable rows={rows} />
+          <div className={s.sectionActions}><button className={`${s.btn} ${s.primary}`} onClick={save} disabled={busy || !(canApplyQr || canApplyManual)}><Save size={14} />保存并重启 Gateway</button></div>
+          <ApplyResult result={result} />
+          {(begin.error || poll.error || apply.error || stateQuery.error) && <div className={s.errorBox}><XCircle size={16} />{textFromError(begin.error || poll.error || apply.error || stateQuery.error)}</div>}
+        </main>
+      </div>
+    </SectionShell>
+  );
+}
+
+export function ImOnboardingRoute() {
+  const { pathname } = useLocation();
+  const section = sectionFromPath(pathname);
+  if (!section) return <Navigate to="/im/feishu" replace />;
+  return section === "feishu" ? <FeishuRoute /> : <WeixinRoute />;
+}

--- a/web/src/routes/im-onboarding.tsx
+++ b/web/src/routes/im-onboarding.tsx
@@ -105,11 +105,14 @@ function openExternal(url: string) {
   window.open(trimmed, "_blank", "noopener,noreferrer");
 }
 
-function QrPanel({ data, url, status, message }: {
+function QrPanel({ data, url, status, message, onStart, startLabel, startBusy }: {
   data?: string | null;
   url?: string | null;
   status?: string;
   message?: string | null;
+  onStart?: () => void;
+  startLabel?: string;
+  startBusy?: boolean;
 }) {
   const [src, setSrc] = useState<string | null>(null);
   useEffect(() => {
@@ -135,7 +138,18 @@ function QrPanel({ data, url, status, message }: {
   return (
     <section className={`${s.section} ${s.qrSection}`}>
       <div className={s.qrBox} aria-label="二维码区域">
-        {src ? <img src={src} alt="扫码接入二维码" /> : <div className={s.qrPlaceholder}>QR</div>}
+        {src ? (
+          <img src={src} alt="扫码接入二维码" />
+        ) : (
+          <div className={s.qrPlaceholder}>
+            <span>QR</span>
+            {onStart ? (
+              <button className={`${s.btn} ${s.primary} ${s.qrStartBtn}`} type="button" onClick={onStart} disabled={startBusy}>
+                <ScanLine size={14} />{startBusy ? "生成中…" : startLabel ?? "开始扫码"}
+              </button>
+            ) : null}
+          </div>
+        )}
       </div>
       <div className={s.qrCopy}>
         <div className={s.miniEyebrow}>QR ONBOARDING</div>
@@ -713,7 +727,15 @@ function FeishuRoute() {
           {method === "qr" ? <>
             <div ref={qrAnchorRef} className={s.anchorBlock}>
               <SectionTitle num="[ STEP 02A ]" title="扫码授权并获取凭据" meta={flow ? `轮询间隔 ${flow.intervalSeconds}s；凭据获取后还要配置后台` : "device_code 只保存在桌面端内存"} />
-              <QrPanel data={pollResult?.qrScanData ?? flow?.qrScanData} url={pollResult?.qrUrl ?? flow?.qrUrl} status={status} message={pollResult?.message ?? flow?.message} />
+              <QrPanel
+                data={pollResult?.qrScanData ?? flow?.qrScanData}
+                url={pollResult?.qrUrl ?? flow?.qrUrl}
+                status={status}
+                message={pollResult?.message ?? flow?.message}
+                onStart={start}
+                startLabel="开始扫码"
+                startBusy={begin.isPending}
+              />
             </div>
             <div className={s.sectionActions}><button className={`${s.btn} ${s.primary}`} onClick={start} disabled={busy}><ScanLine size={14} />生成二维码</button><button className={s.btn} onClick={pollOnce} disabled={!flow || busy}><RefreshCw size={14} />立即检查</button></div>
           </> : <>
@@ -851,7 +873,15 @@ function WeixinRoute() {
           </div></section>
           <div ref={qrAnchorRef} className={s.anchorBlock}>
             <SectionTitle num="[ STEP 02 ]" title="微信扫码绑定 iLink bot" meta="默认 8 分钟超时，二维码过期后最多自动刷新 3 次" />
-            <QrPanel data={pollResult?.qrScanData ?? flow?.qrScanData} url={pollResult?.qrUrl ?? flow?.qrUrl} status={status} message={pollResult?.message ?? flow?.message} />
+            <QrPanel
+              data={pollResult?.qrScanData ?? flow?.qrScanData}
+              url={pollResult?.qrUrl ?? flow?.qrUrl}
+              status={status}
+              message={pollResult?.message ?? flow?.message}
+              onStart={start}
+              startLabel="开始扫码"
+              startBusy={begin.isPending}
+            />
           </div>
           <div className={s.sectionActions}><button className={`${s.btn} ${s.primary}`} onClick={start} disabled={busy}><ScanLine size={14} />生成二维码</button><button className={s.btn} onClick={pollOnce} disabled={!flow || busy}><RotateCw size={14} />立即检查</button></div>
           <SectionTitle num="[ STEP 03 ]" title="凭据与高级连接配置" meta="普通用户无需手填 token，扫码成功后自动写入" />

--- a/web/src/routes/section-shell.module.css
+++ b/web/src/routes/section-shell.module.css
@@ -7,8 +7,65 @@
   overflow: hidden;
 }
 
+.body {
+  flex: 1;
+  min-height: 0;
+  min-width: 0;
+  display: flex;
+  overflow: hidden;
+}
+
 .scroll {
   flex: 1;
+  min-width: 0;
   overflow-y: auto;
   padding: 20px 24px 48px;
+}
+
+.body[data-with-rail="true"] .scroll {
+  padding-right: 20px;
+}
+
+.rail {
+  position: relative;
+  z-index: 12;
+  flex: 0 0 56px;
+  width: 56px;
+  min-height: 0;
+  overflow: visible;
+  padding: 0;
+  border-left: 1px solid var(--h-line-soft);
+  background:
+    radial-gradient(circle at 50% 0%, color-mix(in srgb, var(--h-accent) 8%, transparent), transparent 42%),
+    linear-gradient(180deg, color-mix(in srgb, var(--h-bg-pane) 98%, transparent), var(--h-bg-pane));
+}
+
+@media (max-width: 1120px) {
+  .body[data-with-rail="true"] .scroll {
+    padding-right: 16px;
+  }
+}
+
+@media (max-width: 920px) {
+  .body[data-with-rail="true"] {
+    flex-direction: column;
+    overflow: hidden;
+  }
+
+  .body[data-with-rail="true"] .scroll {
+    flex: 1;
+    min-height: 0;
+    overflow-y: auto;
+    padding-right: 24px;
+    padding-bottom: 88px;
+  }
+
+  .rail {
+    flex: 0 0 56px;
+    width: 100%;
+    overflow: visible;
+    border-left: 0;
+    border-top: 1px solid var(--h-line-soft);
+    background: color-mix(in srgb, var(--h-bg-pane) 96%, transparent);
+  }
 }

--- a/web/src/routes/section-shell.tsx
+++ b/web/src/routes/section-shell.tsx
@@ -6,14 +6,30 @@ interface SectionShellProps {
   title: ReactNode;
   sub?: ReactNode;
   right?: ReactNode;
+  rail?: ReactNode;
+  railLabel?: string;
   children: ReactNode;
 }
 
-export function SectionShell({ title, sub, right, children }: SectionShellProps) {
+export function SectionShell({
+  title,
+  sub,
+  right,
+  rail,
+  railLabel = "页面右侧边栏",
+  children,
+}: SectionShellProps) {
   return (
     <main className={s.page}>
       <TopBar title={title} sub={sub} right={right} />
-      <div className={s.scroll}>{children}</div>
+      <div className={s.body} data-with-rail={rail ? "true" : undefined}>
+        <div className={s.scroll}>{children}</div>
+        {rail ? (
+          <aside className={s.rail} aria-label={railLabel}>
+            {rail}
+          </aside>
+        ) : null}
+      </div>
     </main>
   );
 }

--- a/web/src/styles/global.css
+++ b/web/src/styles/global.css
@@ -43,16 +43,6 @@ body {
   -moz-osx-font-smoothing: grayscale;
 }
 
-body[data-hermes-window-type="tauri"][data-hermes-host-os="macos"] {
-  /*
-   * macOS transparent title bars place the WebView under the native window
-   * control area. AppShell and AppTopBar already consume this variable; keep
-   * the offset here so browser previews and non-macOS desktop builds stay
-   * unchanged.
-   */
-  --h-window-control-safe-top: 28px;
-}
-
 :where(p, li, blockquote, dd, dt) {
   text-spacing-trim: trim-start;
   text-autospace: ideograph-alpha ideograph-numeric;

--- a/web/src/styles/global.css
+++ b/web/src/styles/global.css
@@ -43,6 +43,16 @@ body {
   -moz-osx-font-smoothing: grayscale;
 }
 
+body[data-hermes-window-type="tauri"][data-hermes-host-os="macos"] {
+  /*
+   * macOS transparent title bars place the WebView under the native window
+   * control area. AppShell and AppTopBar already consume this variable; keep
+   * the offset here so browser previews and non-macOS desktop builds stay
+   * unchanged.
+   */
+  --h-window-control-safe-top: 28px;
+}
+
 :where(p, li, blockquote, dd, dt) {
   text-spacing-trim: trim-start;
   text-autospace: ideograph-alpha ideograph-numeric;

--- a/web/src/types/qrcode.d.ts
+++ b/web/src/types/qrcode.d.ts
@@ -1,0 +1,13 @@
+declare module "qrcode" {
+  export interface QRCodeToDataURLOptions {
+    margin?: number;
+    width?: number;
+    errorCorrectionLevel?: "L" | "M" | "Q" | "H";
+    color?: {
+      dark?: string;
+      light?: string;
+    };
+  }
+
+  export function toDataURL(text: string, options?: QRCodeToDataURLOptions): Promise<string>;
+}


### PR DESCRIPTION
## Summary

Closes #9.

This PR adds the `§023 · 消息平台接入` entry under `02 配置`, with Feishu/Lark and Weixin onboarding pages implemented in the desktop app. It ports the prototype direction into React/CSS Modules, adds the reusable lightweight context rail, and wires the onboarding flow through Tauri commands instead of direct file writes from the renderer.

The backend command layer now handles QR/session mock state, current-profile `.env` patching with backups, key whitelist validation, secret redaction, and managed runtime Gateway restart. The Gateway restart path is intentionally scoped to the desktop managed runtime on port `9120` and no longer calls the dashboard restart endpoint that could affect a separate user Hermes Agent on `9119`.

## Validation

- `pnpm typecheck`
- `pnpm test:unit`
- `cargo check`
- `cargo test --all-features`

## Notes

The macOS titlebar safe-area experiment was reverted because it made the current desktop layout look wrong. The final branch keeps the original global shell offset behavior.
