### PR TITLE
[codex] ignore codex tmp directory

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -30,6 +30,7 @@ static/bundled-skills/*
 
 # Local logs
 .codex-logs/
+.codex-tmp/
 
 # Runtime release signing private key (gh secret RUNTIME_SIGN_PRIVATE_KEY_PEM)
 .runtime-keys/


### PR DESCRIPTION
## Summary

This PR updates the repository ignore rules to exclude the local `.codex-tmp/` working directory.

## Why

Codex temporary artifacts should stay local and should not appear as untracked files during normal development.

## Validation

- `git check-ignore -v .codex-tmp`
