### PR TITLE
fix(runtime-update): block UI during dashboard restart to avoid 401s

### DIFF
--- a/src/commands/gateway.rs
+++ b/src/commands/gateway.rs
@@ -39,15 +39,21 @@ pub struct RefreshGatewayResult {
 pub async fn refresh_gateway_url(
     state: State<'_, AppState>,
 ) -> Result<RefreshGatewayResult, AppError> {
-    let api_base_url = {
+    let (api_base_url, current_token) = {
         let inner = state.inner.lock()?;
-        inner.api_base_url.clone()
+        (inner.api_base_url.clone(), inner.session_token.clone())
     };
 
     let env_token = std::env::var("HERMES_DESKTOP_SESSION_TOKEN").ok();
+    // Dashboard session tokens are process-local and rotate on every restart.
+    // A refresh that races the dashboard coming back up (e.g. right after a
+    // runtime update) sees `fetch_session_token` fail and return None. Treat
+    // that as "token unchanged" and keep the token we already have rather than
+    // clobbering a valid token with None — otherwise every subsequent proxied
+    // request drops its Authorization header and 401s until the next restart.
     let fresh_token = match env_token {
         Some(t) => Some(t),
-        None => fetch_session_token(&api_base_url).await,
+        None => fetch_session_token(&api_base_url).await.or(current_token),
     };
 
     let fresh_url = build_gateway_url(&api_base_url, fresh_token.as_deref());

--- a/web/src/app.tsx
+++ b/web/src/app.tsx
@@ -6,6 +6,7 @@ import { useBootstrapActiveProfile } from "@/hooks/use-profiles";
 import { readUiValue } from "@/lib/ui-store";
 import { ErrorBoundary } from "@/components/error-boundary";
 import { ProfileSwitchOverlay } from "@/components/profile-switch-overlay";
+import { RuntimeUpdateOverlay } from "@/components/runtime-update-overlay";
 import { AppShell } from "@/components/app-shell/app-shell";
 import { PanelRoute } from "@/routes/panel";
 import { DetailRoute } from "@/routes/detail";
@@ -69,6 +70,7 @@ export function App() {
         </Routes>
       </AppShell>
       <ProfileSwitchOverlay />
+      <RuntimeUpdateOverlay />
     </div>
   );
 }

--- a/web/src/components/runtime-update-overlay.tsx
+++ b/web/src/components/runtime-update-overlay.tsx
@@ -1,0 +1,28 @@
+import { useAtomValue } from "jotai";
+import { runtimeUpdatingAtom } from "@/stores/ui";
+import s from "./profile-switch-overlay.module.css";
+
+// 仅在桌面端安装 runtime 更新 / 回滚期间显示。和切 profile 一样，主进程会
+// stop + 重新 spawn dashboard 子进程，而 dashboard 的 session token 每次启动
+// 都会重新随机生成（web_server.py: secrets.token_urlsafe(32)）。重启窗口里
+// 前端缓存的旧 token 打到新进程会 401。挡住 UI 直到 onSettled 刷新完 token，
+// 顺带让用户知道正在发生什么，而不是看到一堆 401 / network error。
+export function RuntimeUpdateOverlay() {
+  const state = useAtomValue(runtimeUpdatingAtom);
+  if (!state.active) return null;
+  const isRollback = state.mode === "rollback";
+  return (
+    <div className={s.backdrop} role="alert" aria-live="assertive">
+      <div className={s.card}>
+        <div className={s.title}>
+          <span className={s.spinner} aria-hidden="true" />
+          {isRollback ? "正在回滚 Runtime…" : "正在安装 Runtime 更新…"}
+        </div>
+        <div className={s.body}>
+          桌面端正在重启 dashboard 子进程并刷新会话凭证。这会重置内核连接，
+          通常需要几秒，请勿关闭应用。
+        </div>
+      </div>
+    </div>
+  );
+}

--- a/web/src/hooks/use-runtime-update.ts
+++ b/web/src/hooks/use-runtime-update.ts
@@ -1,10 +1,12 @@
 import { useMutation, useQuery, useQueryClient } from "@tanstack/react-query";
+import { useSetAtom } from "jotai";
 import type {
   RuntimeInfo,
   RuntimeInstallUpdateResult,
   RuntimeUpdateCheckResult,
 } from "@hermes/protocol";
 import { runtime } from "@/lib/runtime";
+import { runtimeUpdatingAtom } from "@/stores/ui";
 
 const RUNTIME_INFO_KEY = ["desktop-runtime-info"] as const;
 
@@ -38,22 +40,37 @@ export function useCheckRuntimeUpdate() {
 
 export function useInstallRuntimeUpdate() {
   const qc = useQueryClient();
+  const setUpdating = useSetAtom(runtimeUpdatingAtom);
   return useMutation<RuntimeInstallUpdateResult>({
     mutationFn: () => window.hermesDesktop!.installRuntimeUpdate!(),
-    onSuccess: async () => {
+    // Raise the blocking overlay before the IPC call so the dashboard restart
+    // window (stale token → 401) never surfaces to the user. Keep it up through
+    // onSettled until the token has been refreshed.
+    onMutate: () => {
+      setUpdating({ active: true, mode: "install" });
+    },
+    onSettled: async () => {
+      // Runs on success AND failure — a partial install can still have
+      // restarted the dashboard, so always resync the rotated session token.
       await refreshDesktopGateway();
       await qc.invalidateQueries({ queryKey: RUNTIME_INFO_KEY });
+      setUpdating({ active: false });
     },
   });
 }
 
 export function useRollbackRuntime() {
   const qc = useQueryClient();
+  const setUpdating = useSetAtom(runtimeUpdatingAtom);
   return useMutation<RuntimeInstallUpdateResult>({
     mutationFn: () => window.hermesDesktop!.rollbackRuntime!(),
-    onSuccess: async () => {
+    onMutate: () => {
+      setUpdating({ active: true, mode: "rollback" });
+    },
+    onSettled: async () => {
       await refreshDesktopGateway();
       await qc.invalidateQueries({ queryKey: RUNTIME_INFO_KEY });
+      setUpdating({ active: false });
     },
   });
 }

--- a/web/src/stores/ui.test.ts
+++ b/web/src/stores/ui.test.ts
@@ -101,3 +101,20 @@ describe("profileSwitchingAtom", () => {
     expect(calls).toBe(2);
   });
 });
+
+describe("runtimeUpdatingAtom", () => {
+  it("defaults to { active: false }", async () => {
+    const { runtimeUpdatingAtom } = await loadUi();
+    const store = createStore();
+    expect(store.get(runtimeUpdatingAtom)).toEqual({ active: false });
+  });
+
+  it("carries the mode when activating", async () => {
+    const { runtimeUpdatingAtom } = await loadUi();
+    const store = createStore();
+    store.set(runtimeUpdatingAtom, { active: true, mode: "install" });
+    expect(store.get(runtimeUpdatingAtom)).toEqual({ active: true, mode: "install" });
+    store.set(runtimeUpdatingAtom, { active: true, mode: "rollback" });
+    expect(store.get(runtimeUpdatingAtom)).toEqual({ active: true, mode: "rollback" });
+  });
+});

--- a/web/src/stores/ui.ts
+++ b/web/src/stores/ui.ts
@@ -39,3 +39,13 @@ export const showReasoningAtom = atom(
 export const profileSwitchingAtom = atom<{ active: boolean; targetName?: string }>({
   active: false,
 });
+
+// Set to true while the desktop main process is installing a runtime update or
+// rolling back. Like a profile switch, this stops + respawns the dashboard
+// subprocess, during which every REST/SSE/WS call would otherwise hit a stale
+// session token and surface a 401. The window-level RuntimeUpdateOverlay reads
+// this and blocks UI interaction (and the polling queries behind it) until the
+// new dashboard is ready and the token has been refreshed.
+export const runtimeUpdatingAtom = atom<{ active: boolean; mode?: "install" | "rollback" }>({
+  active: false,
+});


### PR DESCRIPTION
## 问题

用户在桌面端点击"安装更新"后,`/api/profiles/active` 等接口返回 **401 Unauthorized**。

## 根因

dashboard 的 session token 是进程级全局变量,每次进程启动都会重新随机生成:

```python
# hermes_cli/web_server.py
_SESSION_TOKEN = secrets.token_urlsafe(32)
```

"安装更新 / 回滚"会 stop + 重新 spawn dashboard 子进程,旧 token 立即失效。而前端在这段重启窗口里**没有**像"切换 profile"那样冻住 UI,导致:

- 在途 / 轮询(`useRuntimeInfo` 等) / SSE-WS 自动重连请求,带着缓存的旧 token 打到刚起来的新 dashboard → 401。
- 后端 `refresh_gateway_url` 在 dashboard 尚未 ready 时 `fetch_session_token` 拿到 `None`,直接把 `AppState` 里刚写对的新 token **覆盖成 None**,后续请求丢掉 `Authorization` 头继续 401,401-retry 兜底也失效。

## 修复

对齐已有的 profile-switch 流程:

**前端 — 重启窗口加全屏遮罩**
- 新增 `runtimeUpdatingAtom` + `RuntimeUpdateOverlay`(复用 profile-switch 的 overlay CSS)。
- install / rollback mutation 在 `onMutate` 拉起遮罩,`onSettled` 落下。
- token 刷新 + 缓存失效从 `onSuccess` 移到 `onSettled`——失败 / 部分安装同样可能已重启 dashboard,必须无条件重新同步轮换后的 token。

**后端 — 防止用 None 覆盖好 token**
- `refresh_gateway_url`:`fetch_session_token` 返回 `None`(常因 race 到 dashboard 还没 ready)时,`.or(current_token)` 保留已有 token,而不是清空。

## 测试

- `cargo test` — 200 passed
- `pnpm test:unit` — 327 passed(+2,覆盖 `runtimeUpdatingAtom` 默认值与 mode 切换)
- `pnpm typecheck` / `cargo check` — clean

🤖 Generated with [Claude Code](https://claude.com/claude-code)