### PR TITLE
[codex] 修复历史会话工作区显示

### DIFF
--- a/web/src/hooks/use-gateway.ts
+++ b/web/src/hooks/use-gateway.ts
@@ -22,6 +22,7 @@ import {
 } from "@/lib/model-options-cache";
 import { buildGatewayModelConfigValue } from "@/lib/provider-id";
 import { rememberSessionMapping, resolveGatewaySessionId } from "@/lib/session-map";
+import { mirrorSessionWorkspaceMapping } from "@/lib/workspaces";
 import {
   applyGatewayEventAtom,
   chatRuntimeBySessionAtom,
@@ -134,6 +135,7 @@ async function rememberPersistentSessionKey(gatewaySessionId: string) {
     );
     if (result.session_key) {
       rememberSessionMapping(gatewaySessionId, result.session_key);
+      mirrorSessionWorkspaceMapping(gatewaySessionId, result.session_key);
     }
   } catch {}
 }
@@ -219,6 +221,7 @@ export function useGateway() {
     setGwSessionId(result.session_id);
     resetChatSession(result.session_id);
     rememberSessionMapping(result.session_id, result.resumed ?? persistentSessionId);
+    mirrorSessionWorkspaceMapping(result.session_id, result.resumed ?? persistentSessionId);
     return result.session_id;
   }, [ensureSubscribed, resetChatSession, setGwSessionId]);
 
@@ -418,6 +421,7 @@ export function useGateway() {
       );
       if (result.session_key) {
         rememberSessionMapping(sessionId, result.session_key);
+        mirrorSessionWorkspaceMapping(sessionId, result.session_key);
       }
       await Promise.all([
         queryClient.invalidateQueries({ queryKey: ["sessions"] }),

--- a/web/src/lib/session-map.test.ts
+++ b/web/src/lib/session-map.test.ts
@@ -4,6 +4,7 @@ import {
   rememberSessionMapping,
   resolveGatewaySessionId,
   resolvePersistentSessionId,
+  resolveSessionIdAliases,
 } from "./session-map";
 
 describe("session-map", () => {
@@ -28,6 +29,15 @@ describe("session-map", () => {
     expect(resolveGatewaySessionId("unknown")).toBeUndefined();
   });
 
+  it("returns both gateway and persistent aliases", () => {
+    rememberSessionMapping("gw-1", "20260426_000000_abcd");
+    expect(resolveSessionIdAliases("gw-1")).toEqual(["gw-1", "20260426_000000_abcd"]);
+    expect(resolveSessionIdAliases("20260426_000000_abcd")).toEqual([
+      "20260426_000000_abcd",
+      "gw-1",
+    ]);
+  });
+
   it("expires entries older than 24 hours", () => {
     rememberSessionMapping("gw-old", "sess-old");
     const raw = readUiValue<Record<string, { persistentId: string; ts: number }>>(
@@ -39,6 +49,11 @@ describe("session-map", () => {
 
     expect(resolvePersistentSessionId("gw-old")).toBe("gw-old");
     expect(resolveGatewaySessionId("sess-old")).toBeUndefined();
+    expect(resolveSessionIdAliases("gw-old")).toEqual(["gw-old"]);
+    expect(resolveSessionIdAliases("gw-old", { includeExpired: true })).toEqual([
+      "gw-old",
+      "sess-old",
+    ]);
   });
 
   it("migrates legacy string-value format", () => {

--- a/web/src/lib/session-map.ts
+++ b/web/src/lib/session-map.ts
@@ -84,3 +84,37 @@ export function resolveGatewaySessionId(sessionId: string | undefined): string |
   }
   return undefined;
 }
+
+interface ResolveSessionIdAliasOptions {
+  includeExpired?: boolean;
+}
+
+export function resolveSessionIdAliases(
+  sessionId: string | undefined,
+  options: ResolveSessionIdAliasOptions = {},
+): string[] {
+  if (!sessionId) return [];
+  const normalized = sessionId.trim();
+  if (!normalized) return [];
+
+  const aliases = new Set<string>([normalized]);
+  const map = readMap();
+  const now = Date.now();
+  const isFresh = (entry: SessionEntry) => now - entry.ts <= MAX_AGE_MS;
+  const isUsable = (entry: SessionEntry) => options.includeExpired || isFresh(entry);
+
+  const direct = map[normalized];
+  if (direct && isUsable(direct)) {
+    aliases.add(direct.persistentId);
+  }
+
+  for (const [gatewayId, entry] of Object.entries(map)) {
+    if (!isUsable(entry)) continue;
+    if (gatewayId === normalized || entry.persistentId === normalized) {
+      aliases.add(gatewayId);
+      aliases.add(entry.persistentId);
+    }
+  }
+
+  return Array.from(aliases);
+}

--- a/web/src/lib/workspaces.test.ts
+++ b/web/src/lib/workspaces.test.ts
@@ -1,6 +1,7 @@
 import { beforeEach, describe, expect, it, vi } from "vitest";
 import {
   normalizeWorkspacePath,
+  mirrorSessionWorkspaceMapping,
   readSessionWorkspaceMap,
   readWorkspaceProjects,
   rememberSessionWorkspace,
@@ -8,7 +9,8 @@ import {
   removeWorkspaceProject,
   workspaceNameFromPath,
 } from "./workspaces";
-import { __resetUiStoreForTests } from "./ui-store";
+import { rememberSessionMapping } from "./session-map";
+import { __resetUiStoreForTests, writeUiValue } from "./ui-store";
 
 describe("workspace persistence helpers", () => {
   beforeEach(() => {
@@ -71,6 +73,41 @@ describe("workspace persistence helpers", () => {
     expect(readWorkspaceProjects()[0]).toMatchObject({
       path: "/Users/claw/Project",
       name: "Project",
+    });
+  });
+
+  it("resolves workspace links across gateway and persistent session ids", () => {
+    rememberSessionMapping("gw-1", "20260426_000000_abcd");
+    rememberSessionWorkspace("gw-1", "/Users/claw/Project");
+
+    expect(readSessionWorkspaceMap()).toEqual({
+      "gw-1": "/Users/claw/Project",
+      "20260426_000000_abcd": "/Users/claw/Project",
+    });
+  });
+
+  it("keeps historical workspace links after session id mappings become stale", () => {
+    writeUiValue("hermes:gateway-session-map", {
+      "gw-old": {
+        persistentId: "20260426_000000_abcd",
+        ts: Date.now() - 25 * 60 * 60 * 1000,
+      },
+    });
+    rememberSessionWorkspace("gw-old", "/Users/claw/Project");
+
+    expect(readSessionWorkspaceMap()).toEqual({
+      "gw-old": "/Users/claw/Project",
+      "20260426_000000_abcd": "/Users/claw/Project",
+    });
+  });
+
+  it("mirrors an existing gateway workspace when the persistent id becomes known", () => {
+    rememberSessionWorkspace("gw-1", "/Users/claw/Project");
+    mirrorSessionWorkspaceMapping("gw-1", "20260426_000000_abcd");
+
+    expect(readSessionWorkspaceMap()).toEqual({
+      "gw-1": "/Users/claw/Project",
+      "20260426_000000_abcd": "/Users/claw/Project",
     });
   });
 

--- a/web/src/lib/workspaces.ts
+++ b/web/src/lib/workspaces.ts
@@ -1,4 +1,5 @@
 import { readUiValue, removeUiValue, subscribeUiStore, writeUiValue } from "@/lib/ui-store";
+import { resolveSessionIdAliases } from "@/lib/session-map";
 export interface WorkspaceProject {
   path: string;
   name: string;
@@ -104,12 +105,36 @@ export function rememberWorkspaceProject(path: string, name?: string): Workspace
   return nextProject;
 }
 
+function readRawSessionWorkspaceMap(): Record<string, string> {
+  const raw = readJSON<unknown>(SESSION_WORKSPACE_STORAGE_KEY, {});
+  if (!isRecord(raw)) return {};
+  return Object.fromEntries(
+    Object.entries(raw).flatMap(([sessionId, path]) => {
+      const normalizedSessionId = sessionId.trim();
+      const normalized = normalizeWorkspacePath(path);
+      return normalizedSessionId && normalized ? [[normalizedSessionId, normalized]] : [];
+    }),
+  );
+}
+
+function withSessionIdAliases(map: Record<string, string>): Record<string, string> {
+  const expanded = { ...map };
+  for (const [sessionId, workspacePath] of Object.entries(map)) {
+    for (const alias of resolveSessionIdAliases(sessionId, { includeExpired: true })) {
+      if (!expanded[alias]) {
+        expanded[alias] = workspacePath;
+      }
+    }
+  }
+  return expanded;
+}
+
 export function removeWorkspaceProject(path: string): void {
   const normalized = normalizeWorkspacePath(path);
   if (!normalized) return;
 
   const projects = readWorkspaceProjects().filter((item) => item.path !== normalized);
-  const sessionMap = readSessionWorkspaceMap();
+  const sessionMap = readRawSessionWorkspaceMap();
   const nextSessionMap = Object.fromEntries(
     Object.entries(sessionMap).filter(([, workspacePath]) => workspacePath !== normalized),
   );
@@ -123,14 +148,7 @@ export function removeWorkspaceProject(path: string): void {
 }
 
 export function readSessionWorkspaceMap(): Record<string, string> {
-  const raw = readJSON<unknown>(SESSION_WORKSPACE_STORAGE_KEY, {});
-  if (!isRecord(raw)) return {};
-  return Object.fromEntries(
-    Object.entries(raw).flatMap(([sessionId, path]) => {
-      const normalized = normalizeWorkspacePath(path);
-      return sessionId && normalized ? [[sessionId, normalized]] : [];
-    }),
-  );
+  return withSessionIdAliases(readRawSessionWorkspaceMap());
 }
 
 export function rememberSessionWorkspace(sessionId: string | null | undefined, path: string): void {
@@ -138,10 +156,34 @@ export function rememberSessionWorkspace(sessionId: string | null | undefined, p
   const normalizedPath = normalizeWorkspacePath(path);
   if (!normalizedSessionId || !normalizedPath) return;
 
-  const map = readSessionWorkspaceMap();
-  map[normalizedSessionId] = normalizedPath;
+  const map = readRawSessionWorkspaceMap();
+  const aliases = resolveSessionIdAliases(normalizedSessionId, { includeExpired: true });
+  for (const alias of aliases.length > 0 ? aliases : [normalizedSessionId]) {
+    map[alias] = normalizedPath;
+  }
   writeJSON(SESSION_WORKSPACE_STORAGE_KEY, map);
   rememberWorkspaceProject(normalizedPath);
+}
+
+export function mirrorSessionWorkspaceMapping(
+  gatewaySessionId: string | null | undefined,
+  persistentSessionId: string | null | undefined,
+): void {
+  const gatewayId = gatewaySessionId?.trim();
+  const persistentId = persistentSessionId?.trim();
+  if (!gatewayId || !persistentId || gatewayId === persistentId) return;
+
+  const map = readRawSessionWorkspaceMap();
+  const workspacePath = normalizeWorkspacePath(map[gatewayId] ?? map[persistentId]);
+  if (!workspacePath) return;
+
+  if (map[gatewayId] === workspacePath && map[persistentId] === workspacePath) {
+    return;
+  }
+  map[gatewayId] = workspacePath;
+  map[persistentId] = workspacePath;
+  writeJSON(SESSION_WORKSPACE_STORAGE_KEY, map);
+  rememberWorkspaceProject(workspacePath);
 }
 
 export function subscribeWorkspaceChanges(listener: () => void): () => void {


### PR DESCRIPTION
## 变更内容

修复对话历史和项目视图中工作区列显示为 `—` 的问题。

## 根因

桌面端在新建会话时先拿到的是 Gateway 临时会话 ID，而 `/api/sessions` 返回的是后端持久化会话 ID。工作区关联此前只按单个会话 ID 保存和读取，所以历史页用持久化 ID 查不到已保存的工作区。

## 处理方式

新增会话 ID alias 解析，把 Gateway 临时 ID 和持久化 ID 视为同一会话；在持久化 ID 变得可用后，将已有工作区关联同步镜像到两个 ID 上。这样已有本地映射和新建会话都能正常显示工作区。

## 验证

- `pnpm --filter @hermes/web test:unit src/lib/session-map.test.ts src/lib/workspaces.test.ts`
- `pnpm typecheck`
- `cargo check`

备注：全量 `pnpm test:unit` 当前仍被既有的 `web/src/components/app-shell/use-active-top-tab.test.ts` 失败拦住，该失败来自本 PR 范围外的未提交改动。
