### PR TITLE
[codex] 修复灵魂页配置侧边栏归属

### DIFF
--- a/web/src/components/app-shell/use-active-top-tab.test.ts
+++ b/web/src/components/app-shell/use-active-top-tab.test.ts
@@ -15,4 +15,10 @@ describe("TOP_TABS", () => {
   it("shows config migration in the 021 config sidebar section", () => {
     expect(CONFIG_ITEMS.some((item) => item.label === "配置迁移" && item.path === "/config-migration")).toBe(true);
   });
+
+  it("keeps soul under the 02 config tab and sidebar section", () => {
+    expect(tabFor("/soul")).toBe("skills");
+    expect(tabFor("/soul/edit")).toBe("skills");
+    expect(CONFIG_ITEMS.some((item) => item.label === "灵魂" && item.path === "/soul")).toBe(true);
+  });
 });

--- a/web/src/components/app-shell/use-active-top-tab.ts
+++ b/web/src/components/app-shell/use-active-top-tab.ts
@@ -37,6 +37,7 @@ export const TOP_TABS: readonly TopTabDef[] = [
       path.startsWith("/profiles") ||
       path.startsWith("/models") ||
       path.startsWith("/config-migration") ||
+      path.startsWith("/soul") ||
       path.startsWith("/memory") ||
       path.startsWith("/cron") ||
       path.startsWith("/im") ||


### PR DESCRIPTION
## 变更内容

修复「灵魂」页面 `/soul` 没有归属到 02「配置」顶导的问题。此前配置侧边栏已经包含「灵魂」入口，但顶部 Tab 的路由匹配漏掉了 `/soul`，导致 `AppSidebar` 渲染占位侧栏。

本 PR 将 `/soul` 纳入 02「配置」Tab matcher，并补充回归测试，确保 `/soul` 与 `/soul/edit` 都显示配置侧边栏且保留「灵魂」入口。

## 验证

已运行：

```bash
pnpm typecheck
pnpm test:unit
cargo check
```
