### PR TITLE
fix: harden SSE transport — token leak (#46) + friendly gateway errors (#58)

### DIFF
--- a/src/commands/sse_proxy.rs
+++ b/src/commands/sse_proxy.rs
@@ -19,20 +19,19 @@ pub struct ConnectGatewayInput {
     pub client_id: Option<String>,
 }
 
-/// Build the SSE endpoint URL with token/client_id query params.
-/// Pure function so it can be unit tested without spinning up reqwest.
-pub fn build_sse_url(api_base_url: &str, token: Option<&str>, client_id: Option<&str>) -> String {
+/// Build the SSE endpoint URL with the `client_id` query param only.
+///
+/// The session token is intentionally NOT placed in the query string for the
+/// Tauri proxy path: `open_sse_response` authenticates via the `Authorization`
+/// header instead, so a token in the URL would be redundant and only risk
+/// leaking into logs. (The browser-native EventSource path in
+/// `web/src/lib/gateway-sse-client.ts` still passes the token via query because
+/// EventSource cannot set request headers — that is a separate, documented
+/// case.) Pure function so it can be unit tested without spinning up reqwest.
+pub fn build_sse_url(api_base_url: &str, client_id: Option<&str>) -> String {
     let mut url = format!("{}/api/v2/events", api_base_url.trim_end_matches('/'));
-    let mut params: Vec<String> = vec![];
-    if let Some(token) = token {
-        params.push(format!("token={}", urlencoding::encode(token)));
-    }
     if let Some(cid) = client_id {
-        params.push(format!("client_id={}", urlencoding::encode(cid)));
-    }
-    if !params.is_empty() {
-        url.push('?');
-        url.push_str(&params.join("&"));
+        url.push_str(&format!("?client_id={}", urlencoding::encode(cid)));
     }
     url
 }
@@ -69,7 +68,7 @@ async fn open_sse_response(
     session_token: Option<&str>,
     client_id: Option<&str>,
 ) -> Result<reqwest::Response, AppError> {
-    let url = build_sse_url(api_base_url, session_token, client_id);
+    let url = build_sse_url(api_base_url, client_id);
     let mut req = SSE_HTTP_CLIENT
         .get(&url)
         .header("Accept", "text/event-stream");
@@ -172,42 +171,35 @@ mod tests {
     // --- build_sse_url ----------------------------------------------------
 
     #[test]
-    fn build_sse_url_without_token_or_client_id() {
-        let url = build_sse_url("http://127.0.0.1:9119", None, None);
+    fn build_sse_url_without_client_id() {
+        let url = build_sse_url("http://127.0.0.1:9119", None);
         assert_eq!(url, "http://127.0.0.1:9119/api/v2/events");
     }
 
     #[test]
     fn build_sse_url_strips_trailing_slash_from_base() {
-        let url = build_sse_url("http://127.0.0.1:9119/", None, None);
+        let url = build_sse_url("http://127.0.0.1:9119/", None);
         assert_eq!(url, "http://127.0.0.1:9119/api/v2/events");
     }
 
     #[test]
-    fn build_sse_url_with_token_only() {
-        let url = build_sse_url("http://x", Some("tok"), None);
-        assert_eq!(url, "http://x/api/v2/events?token=tok");
-    }
-
-    #[test]
     fn build_sse_url_with_client_id_only() {
-        let url = build_sse_url("http://x", None, Some("cid-1"));
+        let url = build_sse_url("http://x", Some("cid-1"));
         assert_eq!(url, "http://x/api/v2/events?client_id=cid-1");
     }
 
     #[test]
-    fn build_sse_url_with_both_params() {
-        let url = build_sse_url("http://x", Some("tok"), Some("cid-1"));
-        assert_eq!(url, "http://x/api/v2/events?token=tok&client_id=cid-1");
+    fn build_sse_url_never_includes_token_query() {
+        // #46: the Tauri proxy authenticates via the Authorization header, so the
+        // session token must never appear in the URL (it would leak into logs).
+        let url = build_sse_url("http://x", Some("cid-1"));
+        assert!(!url.contains("token"), "token must not be in URL: {url}");
     }
 
     #[test]
-    fn build_sse_url_encodes_query_params() {
-        let url = build_sse_url("http://x", Some("tok+with space&x=y"), Some("cid/1?x=2"));
-        assert_eq!(
-            url,
-            "http://x/api/v2/events?token=tok%2Bwith%20space%26x%3Dy&client_id=cid%2F1%3Fx%3D2"
-        );
+    fn build_sse_url_encodes_client_id() {
+        let url = build_sse_url("http://x", Some("cid/1?x=2"));
+        assert_eq!(url, "http://x/api/v2/events?client_id=cid%2F1%3Fx%3D2");
     }
 
     // --- parse_sse_chunk --------------------------------------------------

--- a/web/src/hooks/use-gateway.ts
+++ b/web/src/hooks/use-gateway.ts
@@ -23,6 +23,7 @@ import {
 import { buildGatewayModelConfigValue } from "@/lib/provider-id";
 import { rememberSessionMapping, resolveGatewaySessionId } from "@/lib/session-map";
 import { mirrorSessionWorkspaceMapping } from "@/lib/workspaces";
+import { humanizeGatewayError, parseGatewayResult } from "@/lib/gateway-result";
 import {
   applyGatewayEventAtom,
   chatRuntimeBySessionAtom,
@@ -115,7 +116,7 @@ function subscribeGateway(
 }
 
 function errorMessage(error: unknown): string {
-  return error instanceof Error ? error.message : String(error || "发生错误");
+  return humanizeGatewayError(error);
 }
 
 function isSessionBusyError(error: unknown): boolean {
@@ -123,15 +124,17 @@ function isSessionBusyError(error: unknown): boolean {
 }
 
 function errorMessageFromUnknown(error: unknown): string {
-  return error instanceof Error ? error.message : String(error || "发生错误");
+  return humanizeGatewayError(error);
 }
 
 async function rememberPersistentSessionKey(gatewaySessionId: string) {
   try {
-    const result = SessionTitleResult.parse(
+    const result = parseGatewayResult(
+      SessionTitleResult,
       await getGatewayClient().request("session.title", {
         session_id: gatewaySessionId,
       }),
+      "session.title",
     );
     if (result.session_key) {
       rememberSessionMapping(gatewaySessionId, result.session_key);
@@ -177,8 +180,10 @@ export function useGateway() {
 
   const createSession = useCallback(async (options?: CreateSessionOptions): Promise<string> => {
     ensureSubscribed();
-    const result = SessionCreateResult.parse(
+    const result = parseGatewayResult(
+      SessionCreateResult,
       await getGatewayClient().request("session.create", {}),
+      "session.create",
     );
     if (options?.activate !== false) {
       setGwSessionId(result.session_id);
@@ -213,10 +218,12 @@ export function useGateway() {
 
   const resumeSession = useCallback(async (persistentSessionId: string): Promise<string> => {
     ensureSubscribed();
-    const result = SessionResumeResult.parse(
+    const result = parseGatewayResult(
+      SessionResumeResult,
       await getGatewayClient().request("session.resume", {
         session_id: persistentSessionId,
       }),
+      "session.resume",
     );
     setGwSessionId(result.session_id);
     resetChatSession(result.session_id);
@@ -272,8 +279,10 @@ export function useGateway() {
   const getSessionUsage = useCallback(
     async (sessionId: string): Promise<SessionUsageResult> => {
       ensureSubscribed();
-      return SessionUsageResult.parse(
+      return parseGatewayResult(
+        SessionUsageResult,
         await getGatewayClient().request("session.usage", { session_id: sessionId }),
+        "session.usage",
       );
     },
     [ensureSubscribed],
@@ -284,7 +293,8 @@ export function useGateway() {
       ensureSubscribed();
       return getCachedModelOptions(
         sessionId,
-        async () => ModelOptionsResult.parse(
+        async () => parseGatewayResult(
+          ModelOptionsResult,
           await getGatewayClient().request(
             "model.options",
             {
@@ -292,6 +302,7 @@ export function useGateway() {
               ...(sessionId ? { session_id: sessionId } : {}),
             },
           ),
+          "model.options",
         ),
       );
     },
@@ -306,8 +317,10 @@ export function useGateway() {
       timeout_ms?: number;
     }): Promise<ProviderProbeResult> => {
       ensureSubscribed();
-      return ProviderProbeResult.parse(
+      return parseGatewayResult(
+        ProviderProbeResult,
         await getGatewayClient().request("provider.probe", params),
+        "provider.probe",
       );
     },
     [ensureSubscribed],
@@ -321,12 +334,14 @@ export function useGateway() {
     ): Promise<ConfigSetResult> => {
       ensureSubscribed();
       const value = buildGatewayModelConfigValue(model, provider);
-      const result = ConfigSetResult.parse(
+      const result = parseGatewayResult(
+        ConfigSetResult,
         await getGatewayClient().request("config.set", {
           session_id: sessionId,
           key: "model",
           value,
         }),
+        "config.set",
       );
       invalidateModelOptionsCache(sessionId);
       await Promise.all([
@@ -345,11 +360,13 @@ export function useGateway() {
       provider?: string,
     ): Promise<ConfigSetResult> => {
       ensureSubscribed();
-      const result = ConfigSetResult.parse(
+      const result = parseGatewayResult(
+        ConfigSetResult,
         await getGatewayClient().request("config.set", {
           key: "model",
           value: buildGatewayModelConfigValue(model, provider),
         }),
+        "config.set",
       );
       invalidateModelOptionsCache();
       await Promise.all([
@@ -365,11 +382,13 @@ export function useGateway() {
   const attachImage = useCallback(
     async (sessionId: string, path: string): Promise<ImageAttachResult> => {
       ensureSubscribed();
-      return ImageAttachResult.parse(
+      return parseGatewayResult(
+        ImageAttachResult,
         await getGatewayClient().request("image.attach", {
           session_id: sessionId,
           path,
         }),
+        "image.attach",
       );
     },
     [ensureSubscribed],
@@ -378,11 +397,13 @@ export function useGateway() {
   const detectDroppedPath = useCallback(
     async (sessionId: string, path: string): Promise<InputDetectDropResult> => {
       ensureSubscribed();
-      return InputDetectDropResult.parse(
+      return parseGatewayResult(
+        InputDetectDropResult,
         await getGatewayClient().request("input.detect_drop", {
           session_id: sessionId,
           text: path,
         }),
+        "input.detect_drop",
       );
     },
     [ensureSubscribed],
@@ -413,11 +434,13 @@ export function useGateway() {
       const cleanTitle = title.trim();
       if (!sessionId || !cleanTitle) return;
       ensureSubscribed();
-      const result = SessionTitleResult.parse(
+      const result = parseGatewayResult(
+        SessionTitleResult,
         await getGatewayClient().request("session.title", {
           session_id: sessionId,
           title: cleanTitle,
         }),
+        "session.title",
       );
       if (result.session_key) {
         rememberSessionMapping(sessionId, result.session_key);

--- a/web/src/lib/gateway-result.test.ts
+++ b/web/src/lib/gateway-result.test.ts
@@ -1,0 +1,88 @@
+import { beforeEach, describe, expect, it } from "vitest";
+import { debugBus } from "./debug-bus";
+import {
+  GatewayResultError,
+  humanizeGatewayError,
+  parseGatewayResult,
+} from "./gateway-result";
+
+const passSchema = { parse: (v: unknown) => v as { ok: boolean } };
+
+function zodErrorDouble(): Error {
+  const err = Object.assign(new Error('[{"path":["session_id"],"message":"Required"}]'), {
+    issues: [{ path: ["session_id"], message: "Required" }],
+  });
+  err.name = "ZodError";
+  return err;
+}
+
+// A schema double that throws a ZodError-shaped error, like the real
+// `SessionResumeResult.parse` does when `session_id` is missing (#58).
+const failSchema = {
+  parse: (_v: unknown): { session_id: string } => {
+    throw zodErrorDouble();
+  },
+};
+
+describe("parseGatewayResult", () => {
+  beforeEach(() => debugBus.clear());
+
+  it("returns the parsed value on success", () => {
+    expect(parseGatewayResult(passSchema, { ok: true }, "session.create")).toEqual({
+      ok: true,
+    });
+  });
+
+  it("throws a friendly GatewayResultError instead of the raw ZodError blob", () => {
+    let thrown: unknown;
+    try {
+      parseGatewayResult(failSchema, { accepted: true, async: true }, "session.resume");
+    } catch (e) {
+      thrown = e;
+    }
+    expect(thrown).toBeInstanceOf(GatewayResultError);
+    const err = thrown as GatewayResultError;
+    expect(err.method).toBe("session.resume");
+    expect(err.message).toContain("session.resume");
+    // The infamous raw Zod blob must not reach the user.
+    expect(err.message).not.toContain("session_id");
+    expect(err.message).not.toContain("Required");
+  });
+
+  it("records a redacted gateway debug entry on parse failure", () => {
+    expect(() =>
+      parseGatewayResult(failSchema, { accepted: true, async: true }, "session.resume"),
+    ).toThrow(GatewayResultError);
+    const entries = debugBus.snapshot();
+    const last = entries[entries.length - 1];
+    expect(last?.type).toBe("gateway");
+    expect(last?.level).toBe("error");
+    expect(last?.summary).toContain("session.resume");
+  });
+});
+
+describe("humanizeGatewayError", () => {
+  it("passes through an already-friendly GatewayResultError message", () => {
+    expect(humanizeGatewayError(new GatewayResultError("自定义友好消息", "session.create"))).toBe(
+      "自定义友好消息",
+    );
+  });
+
+  it("converts a raw ZodError into a friendly message without leaking fields", () => {
+    const msg = humanizeGatewayError(zodErrorDouble());
+    expect(msg).not.toContain("session_id");
+    expect(msg).toContain("无法识别");
+  });
+
+  it("localizes timeout errors", () => {
+    expect(humanizeGatewayError(new Error("RPC timeout: session.resume"))).toContain("超时");
+  });
+
+  it("localizes connection-closed errors", () => {
+    expect(humanizeGatewayError(new Error("SSE connection closed"))).toContain("连接已断开");
+  });
+
+  it("passes through meaningful backend error messages unchanged", () => {
+    expect(humanizeGatewayError(new Error("unknown method: foo"))).toBe("unknown method: foo");
+  });
+});

--- a/web/src/lib/gateway-result.ts
+++ b/web/src/lib/gateway-result.ts
@@ -1,0 +1,116 @@
+/**
+ * Friendly parsing for gateway RPC results.
+ *
+ * Background (#58): the SSE+POST transport returns an async ack
+ * (`{accepted:true,async:true}`) and the real result arrives later over the
+ * SSE stream. `gateway-sse-client` already waits for that final frame, but if
+ * the final result is shaped unexpectedly (runtime version skew, error frame,
+ * missing field) the call sites in `use-gateway.ts` used to do a bare
+ * `Schema.parse(...)` and the raw `ZodError` — e.g. the infamous
+ * `[{"path":["session_id"],"message":"Required"}]` — leaked straight into the
+ * chat UI.
+ *
+ * `parseGatewayResult` keeps the strong typing but converts a parse failure
+ * into a user-readable Chinese message while recording a redacted debug summary
+ * (method + raw result + zod issues) for diagnostics. `humanizeGatewayError`
+ * is the display-boundary fallback so no raw ZodError / English transport error
+ * ever reaches the user.
+ */
+import { debugBus } from "./debug-bus";
+
+/** Error carrying a user-facing (Chinese) message; raw cause is in debugBus. */
+export class GatewayResultError extends Error {
+  readonly method: string;
+
+  constructor(message: string, method: string, options?: { cause?: unknown }) {
+    super(message);
+    this.name = "GatewayResultError";
+    this.method = method;
+    if (options?.cause !== undefined) {
+      (this as { cause?: unknown }).cause = options.cause;
+    }
+  }
+}
+
+interface ZodLikeError {
+  name: string;
+  issues: unknown[];
+  message: string;
+}
+
+function isZodError(error: unknown): error is ZodLikeError {
+  return (
+    !!error &&
+    typeof error === "object" &&
+    (error as { name?: unknown }).name === "ZodError" &&
+    Array.isArray((error as { issues?: unknown }).issues)
+  );
+}
+
+function genericResultMessage(method: string): string {
+  return `服务返回了无法识别的响应（${method}）。可能是运行时版本不匹配或连接异常，请重试，或重启 Hermes 后再试。`;
+}
+
+/**
+ * Validate a gateway RPC result against `schema`. On success returns the parsed
+ * value (same type as `schema.parse`). On failure, records a redacted debug
+ * summary and throws a friendly {@link GatewayResultError} instead of leaking
+ * the raw ZodError to the UI.
+ */
+export function parseGatewayResult<T>(
+  schema: { parse: (value: unknown) => T },
+  raw: unknown,
+  method: string,
+): T {
+  try {
+    return schema.parse(raw);
+  } catch (error) {
+    debugBus.push({
+      type: "gateway",
+      level: "error",
+      summary: `RPC ${method} 响应解析失败`,
+      payload: {
+        method,
+        raw,
+        issues: isZodError(error) ? error.issues : undefined,
+      },
+    });
+    throw new GatewayResultError(genericResultMessage(method), method, { cause: error });
+  }
+}
+
+/**
+ * Convert any gateway/transport error into a user-facing Chinese string. Used by
+ * the chat error display so users never see a raw Zod validation blob or an
+ * untranslated transport error. Raw ZodError details are logged to debugBus.
+ */
+export function humanizeGatewayError(error: unknown): string {
+  if (error instanceof GatewayResultError) return error.message;
+
+  if (isZodError(error)) {
+    debugBus.push({
+      type: "gateway",
+      level: "error",
+      summary: "Gateway 响应解析失败（ZodError）",
+      payload: { issues: error.issues },
+    });
+    return "服务返回了无法识别的响应，请重试，或重启 Hermes 后再试。";
+  }
+
+  const message = error instanceof Error ? error.message : String(error ?? "");
+  if (!message) return "发生错误，请重试。";
+
+  const lower = message.toLowerCase();
+  if (lower.includes("timeout") || message.includes("超时")) {
+    return "请求超时，请检查网络或重启 Hermes 后重试。";
+  }
+  if (
+    lower.includes("connection closed") ||
+    lower.includes("connection lost") ||
+    lower.includes("sse closed") ||
+    lower.includes("disconnect")
+  ) {
+    return "与运行时的连接已断开，请重试。";
+  }
+  return message;
+}


### PR DESCRIPTION
## 概述

SSE 传输是聊天流的命脉。本 PR 修两个 SSE 相关 issue，各一个独立 commit。

## #46 — Rust SSE proxy 不再把 session token 放进 URL（安全）

`src/commands/sse_proxy.rs::build_sse_url` 之前同时把 `?token=...` 写进 URL **并且** `open_sse_response` 又设了 `Authorization: Bearer` header——query token 纯冗余且会泄露进日志。

- `build_sse_url` 改为只拼 `client_id`，认证仅靠 Authorization header。
- **明确区分**：`web/src/lib/gateway-sse-client.ts::buildEventsUrl()`（浏览器原生 EventSource 分支）仍用 query token——EventSource 无法设请求头，这是服务端有意支持的 public-path + HMAC 场景，不在本次修改范围（已在代码注释里写明）。
- 替换固化旧行为的单测（`build_sse_url_with_token_only` / `with_both_params`），新增 `build_sse_url_never_includes_token_query` 断言 token 不出现在 URL。

`Closes #46`

## #58 — async ack / 畸形响应不再把原始 ZodError 抛给用户

用户反馈发消息/恢复会话时聊天区直接显示一段原始 Zod 校验错误（`[{"path":["session_id"],"message":"Required"}]`）。

**传输层早已修好**：`gateway-sse-client.ts::request()` 识别 `{accepted:true,async:true}` async ack 后会等同 id 的 SSE 最终响应（含 early-response / 超时 / 断开处理）。

**本 PR 补的是产品层**：`use-gateway.ts` 里每个 RPC 都 `Schema.parse(await request(...))` 直接解析，一旦最终响应形状异常就抛**原始 ZodError**，其 `.message` 正是那串 blob，`errorMessage()` 又原样塞进聊天区。

- 新增 `web/src/lib/gateway-result.ts`：
  - `parseGatewayResult(schema, raw, method)`：解析失败时把 `{method, raw, issues}` 写入 `debugBus`（自动脱敏），并抛**友好中文** `GatewayResultError`，而非泄露原始 ZodError。
  - `humanizeGatewayError(error)`：显示边界兜底——`GatewayResultError` 透传友好消息；裸 ZodError → 通用中文提示（原始 issues 进 debugBus）；`timeout` / `connection closed` → 中文超时/断连提示；其余后端业务错误原样透传。
- `use-gateway.ts`：全部 ~10 个 parse 站点改用 `parseGatewayResult`；`errorMessage` / `errorMessageFromUnknown` 经 `humanizeGatewayError`。
- 新增 `gateway-result.test.ts`（8 例）覆盖成功解析、失败抛 `GatewayResultError`（不泄露 `session_id`/`Required`）、debugBus 记录、以及 humanize 的 ZodError/超时/断连/透传分支。

> 选择在**显示边界**本地化 transport 文案（而非改 `gateway-sse-client.ts` 抛出的字符串），避免破坏其 14 个传输层单测（如 `connect() rejects ... /timeout/i`）。

`Closes #58`

## 验证

- ✅ `pnpm typecheck`（3 个 workspace）
- ✅ `pnpm test:unit`：367 passed（含 8 个新 `gateway-result` 用例）
- ✅ `cargo fmt --check`
- ✅ `cargo test --all-features`（`sse_proxy` 单测，含新增 token 不泄露断言）
- ✅ `cargo clippy --all-targets --all-features -- -D warnings`

🤖 Generated with [Claude Code](https://claude.com/claude-code)
