### PR TITLE
[codex] 调整桌面端界面对比度与版本信息样式

### DIFF
--- a/packages/shared-ui/src/tokens/colors.css
+++ b/packages/shared-ui/src/tokens/colors.css
@@ -41,7 +41,7 @@
   --h-bg-pane: #ffffff;
   --h-bg-soft: #f8f7f3;
   --h-bg-input: #ffffff;
-  --h-bg-chip: #f0eee8;
+  --h-bg-chip: #f5f2ec;
   --h-bg-code: #f7f6f1;
   --h-line: #e8e4dc;
   --h-line-soft: #efebe4;

--- a/packages/shared-ui/src/tokens/colors.css
+++ b/packages/shared-ui/src/tokens/colors.css
@@ -74,10 +74,10 @@
   --h-bg-code: var(--ink-200);
   --h-line: #2a2725;
   --h-line-soft: #1d1b19;
-  --h-text: var(--bone-100);
-  --h-text-2: var(--bone-300);
-  --h-text-3: var(--bone-400);
-  --h-text-4: var(--bone-600);
+  --h-text: #faf7f0;
+  --h-text-2: var(--bone-200);
+  --h-text-3: var(--bone-300);
+  --h-text-4: var(--bone-500);
   --h-ok: var(--moss);
   --h-ok-soft: rgba(141, 181, 128, 0.08);
   --h-warn: var(--amber);

--- a/packages/shared-ui/src/tokens/colors.css
+++ b/packages/shared-ui/src/tokens/colors.css
@@ -45,9 +45,9 @@
   --h-bg-code: #f7f6f1;
   --h-line: #e8e4dc;
   --h-line-soft: #efebe4;
-  --h-text: #2a2620;
-  --h-text-2: #6b665c;
-  --h-text-3: #867f73;
+  --h-text: var(--ink-300);
+  --h-text-2: var(--ink-700);
+  --h-text-3: var(--ink-800);
   --h-text-4: #cac4b6;
   --h-ok: #6b8e5a;
   --h-ok-soft: #e3ecdc;
@@ -74,9 +74,9 @@
   --h-bg-code: var(--ink-200);
   --h-line: #2a2725;
   --h-line-soft: #1d1b19;
-  --h-text: var(--bone-200);
-  --h-text-2: var(--bone-400);
-  --h-text-3: #9f978a;
+  --h-text: var(--bone-100);
+  --h-text-2: var(--bone-300);
+  --h-text-3: var(--bone-400);
   --h-text-4: var(--bone-600);
   --h-ok: var(--moss);
   --h-ok-soft: rgba(141, 181, 128, 0.08);

--- a/web/src/components/app-shell/app-shell.module.css
+++ b/web/src/components/app-shell/app-shell.module.css
@@ -29,7 +29,7 @@
 .sidebarInfoPanel {
   position: absolute;
   left: 16px;
-  right: 16px;
+  right: 6px;
   bottom: 15px;
   display: flex;
   flex-direction: column;
@@ -46,22 +46,30 @@
 }
 
 .sidebarInfoMeta {
-  display: flex;
-  flex-direction: column;
-  align-items: flex-start;
+  display: grid;
   gap: 1px;
   max-width: 100%;
 }
 
-.sidebarInfoMeta span {
-  display: block;
+.sidebarInfoRow {
+  display: grid;
+  grid-template-columns: 2.4em 8.7ch 2.2ch 5ch 2.2ch max-content;
+  column-gap: 0;
+  align-items: baseline;
   max-width: 100%;
   white-space: nowrap;
+  overflow: hidden;
+  font-variant-numeric: tabular-nums;
+}
+
+.sidebarInfoCell {
+  min-width: 0;
   overflow: hidden;
   text-overflow: ellipsis;
 }
 
 .sidebarInfoDot {
+  text-align: center;
   color: rgba(133, 126, 111, 0.54);
 }
 

--- a/web/src/components/app-shell/sidebar-version-tag.test.ts
+++ b/web/src/components/app-shell/sidebar-version-tag.test.ts
@@ -62,10 +62,10 @@ describe("buildSidebarVersionRows", () => {
       desktopVersion: DESKTOP_VERSION,
     });
 
-    expect(rows.kernel).toBe("内核 v0.15.2 · 882062c · 05.29");
-    expect(rows.ui).toBe(`UI ${DESKTOP_VERSION_LABEL} · 80157e4 · 06.03`);
-    expect(rows.title).toContain("内核 v0.15.2 · 882062c · 2026-05-29");
-    expect(rows.title).toContain(`UI ${DESKTOP_VERSION_LABEL} · 80157e4 · 2026-06-03`);
+    expect(rows.kernel).toBe("内核 v0.15.2 · 8820 · 05.29");
+    expect(rows.ui).toBe(`界面 ${DESKTOP_VERSION_LABEL} · 8015 · 06.03`);
+    expect(rows.title).toContain("内核 v0.15.2 · 8820 · 2026-05-29");
+    expect(rows.title).toContain(`界面 ${DESKTOP_VERSION_LABEL} · 8015 · 2026-06-03`);
     expect(rows.kernel).not.toContain("2026.5.29.2");
   });
 
@@ -78,7 +78,7 @@ describe("buildSidebarVersionRows", () => {
     });
 
     expect(rows.kernel).toBe("内核 v0.15.2 · — · 日期未知");
-    expect(rows.ui).toBe(`UI ${DESKTOP_VERSION_LABEL} · 80157e4 · 06.03`);
+    expect(rows.ui).toBe(`界面 ${DESKTOP_VERSION_LABEL} · 8015 · 06.03`);
     expect(rows.kernel).not.toContain("2026.5.29.2");
   });
 
@@ -98,7 +98,7 @@ describe("buildSidebarVersionRows", () => {
       desktopVersion: DESKTOP_VERSION,
     });
 
-    expect(rows.kernel).toBe("内核 v0.15.2 · 882062c · 日期未知");
+    expect(rows.kernel).toBe("内核 v0.15.2 · 8820 · 日期未知");
   });
 
   it("shows a dash instead of a hard-coded kernel version when status is unavailable", () => {
@@ -119,6 +119,6 @@ describe("buildSidebarVersionRows", () => {
       desktopVersion: DESKTOP_VERSION,
     });
 
-    expect(rows.ui).toBe(`UI ${DESKTOP_VERSION_LABEL} · — · 06.03`);
+    expect(rows.ui).toBe(`界面 ${DESKTOP_VERSION_LABEL} · — · 06.03`);
   });
 });

--- a/web/src/components/app-shell/sidebar-version-tag.tsx
+++ b/web/src/components/app-shell/sidebar-version-tag.tsx
@@ -8,7 +8,7 @@ import s from "./app-shell.module.css";
 function shortCommit(commit: string | undefined): string {
   const normalized = commit?.trim() ?? "";
   if (!normalized || normalized === "unknown") return UNKNOWN_VALUE;
-  return normalized.slice(0, 7);
+  return normalized.slice(0, 4);
 }
 
 function fullCommitDate(value: string | undefined): string {
@@ -44,9 +44,18 @@ export interface SidebarVersionRowsInput {
   desktopVersion?: string;
 }
 
+export interface SidebarVersionLine {
+  label: "内核" | "界面";
+  version: string;
+  commit: string;
+  date: string;
+}
+
 export interface SidebarVersionRows {
   kernel: string;
   ui: string;
+  kernelLine: SidebarVersionLine;
+  uiLine: SidebarVersionLine;
   title: string;
 }
 
@@ -68,9 +77,45 @@ export function buildSidebarVersionRows({
 
   return {
     kernel: `内核 ${kernelVersion} · ${kernelCommit} · ${kernelDate}`,
-    ui: `UI ${uiVersion} · ${uiCommit} · ${uiDate}`,
-    title: `内核 ${kernelVersion} · ${kernelCommit} · ${kernelFullDate}\nUI ${uiVersion} · ${uiCommit} · ${uiFullDate}\n预览版本，不代表最终品质`,
+    ui: `界面 ${uiVersion} · ${uiCommit} · ${uiDate}`,
+    kernelLine: {
+      label: "内核",
+      version: kernelVersion,
+      commit: kernelCommit,
+      date: kernelDate,
+    },
+    uiLine: {
+      label: "界面",
+      version: uiVersion,
+      commit: uiCommit,
+      date: uiDate,
+    },
+    title: `内核 ${kernelVersion} · ${kernelCommit} · ${kernelFullDate}\n界面 ${uiVersion} · ${uiCommit} · ${uiFullDate}\n预览版本，不代表最终品质`,
   };
+}
+
+function VersionLine({
+  accent,
+  line,
+  text,
+}: {
+  accent?: boolean;
+  line: SidebarVersionLine;
+  text: string;
+}) {
+  return (
+    <div
+      className={`${s.sidebarInfoRow} ${accent ? s.sidebarInfoVersion : ""}`}
+      aria-label={text}
+    >
+      <span className={s.sidebarInfoCell}>{line.label}</span>
+      <span className={s.sidebarInfoCell}>{line.version}</span>
+      <span className={s.sidebarInfoDot} aria-hidden="true">·</span>
+      <span className={s.sidebarInfoCell}>{line.commit}</span>
+      <span className={s.sidebarInfoDot} aria-hidden="true">·</span>
+      <span className={s.sidebarInfoCell}>{line.date}</span>
+    </div>
+  );
 }
 
 export function SidebarVersionTag() {
@@ -84,8 +129,8 @@ export function SidebarVersionTag() {
       title={rows.title}
     >
       <div className={s.sidebarInfoMeta}>
-        <span className={s.sidebarInfoVersion}>{rows.kernel}</span>
-        <span>{rows.ui}</span>
+        <VersionLine accent line={rows.kernelLine} text={rows.kernel} />
+        <VersionLine line={rows.uiLine} text={rows.ui} />
       </div>
       <div className={s.sidebarInfoNote}>预览版本，不代表最终品质</div>
     </div>

--- a/web/src/components/chat/goose-composer.module.css
+++ b/web/src/components/chat/goose-composer.module.css
@@ -1141,12 +1141,14 @@
 }
 
 .sendButton {
+  --composer-send-accent: var(--persimmon);
+
   min-width: 88px;
   height: var(--composer-action-height);
   gap: 7px;
-  border: 1px solid var(--h-accent);
+  border: 1px solid var(--composer-send-accent);
   border-radius: var(--h-r-md);
-  background: var(--h-accent);
+  background: var(--composer-send-accent);
   color: #fff;
   box-shadow: none;
   font-size: 13px;
@@ -1160,8 +1162,8 @@
 }
 
 .sendButton:hover:not(:disabled) {
-  border-color: color-mix(in srgb, var(--h-accent) 84%, var(--h-text));
-  background: color-mix(in srgb, var(--h-accent) 84%, var(--h-text));
+  border-color: color-mix(in srgb, var(--composer-send-accent) 84%, var(--h-text));
+  background: color-mix(in srgb, var(--composer-send-accent) 84%, var(--h-text));
 }
 
 .sendButton:disabled,
@@ -1175,15 +1177,15 @@
 
 .sendButton[data-mode="stop"] {
   min-width: 44px;
-  border-color: var(--h-err);
-  background: var(--h-err);
+  border-color: var(--composer-send-accent);
+  background: var(--composer-send-accent);
   color: #fff;
   padding: 0 12px;
 }
 
 .sendButton[data-mode="stop"]:hover:not(:disabled) {
-  border-color: color-mix(in srgb, var(--h-err) 84%, var(--h-text));
-  background: color-mix(in srgb, var(--h-err) 84%, var(--h-text));
+  border-color: color-mix(in srgb, var(--composer-send-accent) 84%, var(--h-text));
+  background: color-mix(in srgb, var(--composer-send-accent) 84%, var(--h-text));
 }
 
 .sendIcon {

--- a/web/src/routes/detail.tsx
+++ b/web/src/routes/detail.tsx
@@ -361,7 +361,7 @@ export function DetailRoute() {
                     ? "已复制"
                     : sessionIdCopyState === "error"
                       ? "复制失败"
-                      : "复制ID"}
+                      : "复制会话 ID"}
                 </span>
               </TopBarActionButton>
             ) : null}


### PR DESCRIPTION
## 变更内容

- 将聊天发送按钮和终止按钮统一改为复用橙色 token。
- 将复制会话 ID 按钮文案改为“复制会话 ID”。
- 将左下角版本信息中的“UI”改为“界面”，并按列对齐版本、commit 和日期。
- 将侧边栏版本信息的短 commit 改为 4 位展示。
- 提升浅色和暗色模式下文本 token 的对比度。

## 影响

这些改动主要改善桌面端界面的一致性、可读性和低对比度主题下的视觉体验，不改变后端接口或运行时行为。

## 验证

- `pnpm typecheck`
- `pnpm test:unit`
- `cargo check`
