### PR TITLE
batch-2: route ErrorBoundaries (#37), drop unused fs/shell caps (#44), safe runtime data dir (#53)

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -987,15 +987,6 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "4ef6b89e5b37196644d8796de5268852ff179b44e96276cf4290264843743bb7"
 
 [[package]]
-name = "encoding_rs"
-version = "0.8.35"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "75030f3c4f45dafd7586dd6780965a8c7e8e285a5ecb86713e63a79c5b2766f3"
-dependencies = [
- "cfg-if",
-]
-
-[[package]]
 name = "env_filter"
 version = "1.0.1"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -1650,8 +1641,6 @@ dependencies = [
  "tauri",
  "tauri-build",
  "tauri-plugin-dialog",
- "tauri-plugin-fs",
- "tauri-plugin-shell",
  "tempfile",
  "thiserror 2.0.18",
  "tokio",
@@ -2694,7 +2683,6 @@ version = "5.3.5"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "2fbaa89d2ddc8473c78a3adf69eea8cffa28c483b8e02a971ef31527cd0fc92c"
 dependencies = [
- "dunce",
  "is-wsl",
  "libc",
  "pathdiff",
@@ -2705,16 +2693,6 @@ name = "option-ext"
 version = "0.2.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "04744f49eae99ab78e0d5c0b603ab218f515ea8cfe5a456d7629ad883a3b6e7d"
-
-[[package]]
-name = "os_pipe"
-version = "1.2.3"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "7d8fae84b431384b68627d0f9b3b1245fcf9f46f6c0e3dc902e9dce64edd1967"
-dependencies = [
- "libc",
- "windows-sys 0.61.2",
-]
 
 [[package]]
 name = "pango"
@@ -3798,17 +3776,6 @@ dependencies = [
 ]
 
 [[package]]
-name = "shared_child"
-version = "1.1.1"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "1e362d9935bc50f019969e2f9ecd66786612daae13e8f277be7bfb66e8bed3f7"
-dependencies = [
- "libc",
- "sigchld",
- "windows-sys 0.60.2",
-]
-
-[[package]]
 name = "shared_library"
 version = "0.1.9"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -3829,27 +3796,6 @@ name = "shlex"
 version = "1.3.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "0fda2ff0d084019ba4d7c6f371c95d8fd75ce3524c3cb8fb653a3023f6323e64"
-
-[[package]]
-name = "sigchld"
-version = "0.2.4"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "47106eded3c154e70176fc83df9737335c94ce22f821c32d17ed1db1f83badb1"
-dependencies = [
- "libc",
- "os_pipe",
- "signal-hook",
-]
-
-[[package]]
-name = "signal-hook"
-version = "0.3.18"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "d881a16cf4426aa584979d30bd82cb33429027e42122b169753d6ef1085ed6e2"
-dependencies = [
- "libc",
- "signal-hook-registry",
-]
 
 [[package]]
 name = "signal-hook-registry"
@@ -4295,27 +4241,6 @@ dependencies = [
  "thiserror 2.0.18",
  "toml 1.1.2+spec-1.1.0",
  "url",
-]
-
-[[package]]
-name = "tauri-plugin-shell"
-version = "2.3.5"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "8457dbf9e2bab1edd8df22bb2c20857a59a9868e79cb3eac5ed639eec4d0c73b"
-dependencies = [
- "encoding_rs",
- "log",
- "open",
- "os_pipe",
- "regex",
- "schemars 0.8.22",
- "serde",
- "serde_json",
- "shared_child",
- "tauri",
- "tauri-plugin",
- "thiserror 2.0.18",
- "tokio",
 ]
 
 [[package]]

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -12,8 +12,6 @@ name = "hermes_agent_cn"
 [dependencies]
 tauri = { version = "2", features = [] }
 tauri-plugin-dialog = "2"
-tauri-plugin-shell = "2"
-tauri-plugin-fs = "2"
 serde = { version = "1", features = ["derive"] }
 serde_json = "1"
 tokio = { version = "1", features = ["full"] }

--- a/capabilities/default.json
+++ b/capabilities/default.json
@@ -7,9 +7,6 @@
     "core:default",
     "core:window:allow-start-dragging",
     "dialog:default",
-    "dialog:allow-open",
-    "shell:default",
-    "shell:allow-open",
-    "fs:default"
+    "dialog:allow-open"
   ]
 }

--- a/src/main.rs
+++ b/src/main.rs
@@ -262,8 +262,6 @@ fn main() {
 
     let app = tauri::Builder::default()
         .plugin(tauri_plugin_dialog::init())
-        .plugin(tauri_plugin_shell::init())
-        .plugin(tauri_plugin_fs::init())
         .manage(app_state)
         .setup(|app| {
             use tauri::Manager;

--- a/src/process/runtime.rs
+++ b/src/process/runtime.rs
@@ -271,8 +271,31 @@ pub fn runtime_root() -> PathBuf {
         }
     }
 
-    let data_dir = dirs::data_dir().unwrap_or_else(|| PathBuf::from("."));
-    data_dir.join("cn.org.hermesagent.desktop").join("runtime")
+    let base = resolve_runtime_data_base(dirs::data_dir(), dirs::home_dir()).expect(
+        "无法确定可写的数据目录：系统数据目录与用户主目录都不可用。\
+         请设置环境变量 HERMES_DESKTOP_RUNTIME_ROOT 指向一个可写目录后重试。",
+    );
+    base.join("cn.org.hermesagent.desktop").join("runtime")
+}
+
+/// Resolve the base directory under which the managed runtime tree lives,
+/// without ever silently falling back to the current working directory (which
+/// for a packaged app may be read-only, a network path, or otherwise
+/// unexpected — writing the runtime/downloads/HERMES_HOME there causes
+/// permission and data-isolation problems). Prefer the OS data dir, then a
+/// well-known location under the user's home, and otherwise return an
+/// actionable error. Pure/injectable so it can be unit tested. (#53)
+fn resolve_runtime_data_base(
+    data_dir: Option<PathBuf>,
+    home_dir: Option<PathBuf>,
+) -> Result<PathBuf, String> {
+    if let Some(dir) = data_dir {
+        return Ok(dir);
+    }
+    if let Some(home) = home_dir {
+        return Ok(home.join(".local").join("share"));
+    }
+    Err("system data dir and home dir are both unavailable".to_string())
 }
 
 pub fn hermes_home_dir() -> PathBuf {
@@ -1904,6 +1927,25 @@ mod tests {
         assert!(now.ends_with('Z'), "missing Z suffix: {now}");
         assert_eq!(&now[4..5], "-");
         assert_eq!(&now[10..11], "T");
+    }
+
+    #[test]
+    fn resolve_runtime_data_base_prefers_os_data_dir() {
+        let base =
+            resolve_runtime_data_base(Some(PathBuf::from("/data")), Some(PathBuf::from("/home/u")));
+        assert_eq!(base, Ok(PathBuf::from("/data")));
+    }
+
+    #[test]
+    fn resolve_runtime_data_base_falls_back_to_home_not_cwd() {
+        let base = resolve_runtime_data_base(None, Some(PathBuf::from("/home/u")));
+        // Must NOT be "." (the current working directory) — that is the bug (#53).
+        assert_eq!(base, Ok(PathBuf::from("/home/u/.local/share")));
+    }
+
+    #[test]
+    fn resolve_runtime_data_base_errors_when_nothing_available() {
+        assert!(resolve_runtime_data_base(None, None).is_err());
     }
 
     // -------- Fixtures --------

--- a/web/src/app.tsx
+++ b/web/src/app.tsx
@@ -1,6 +1,6 @@
 import { Routes, Route, Navigate, useLocation } from "react-router-dom";
 import { hydrateThemeAtom, usePlatform } from "@hermes/shared-ui";
-import { useEffect } from "react";
+import { useEffect, type ReactNode } from "react";
 import { useSetAtom } from "jotai";
 import { useBootstrapActiveProfile } from "@/hooks/use-profiles";
 import { readUiValue } from "@/lib/ui-store";
@@ -34,6 +34,14 @@ function NewTaskRedirect() {
   return <Navigate to={{ pathname: "/", search }} replace />;
 }
 
+// Wrap each route's content in a local ErrorBoundary so a single page crash
+// keeps AppShell (sidebar + nav) usable instead of blanking the whole app via
+// the root boundary. Each route element mounts its own boundary, which resets
+// naturally on navigation. (#37)
+function withBoundary(node: ReactNode) {
+  return <ErrorBoundary>{node}</ErrorBoundary>;
+}
+
 export function App() {
   const platform = usePlatform();
   const hydrateTheme = useSetAtom(hydrateThemeAtom);
@@ -48,27 +56,27 @@ export function App() {
     <div lang="zh-CN" data-hermes-platform={platform}>
       <AppShell>
         <Routes>
-          <Route path="/" element={<PanelRoute />} />
+          <Route path="/" element={withBoundary(<PanelRoute />)} />
           <Route path="/new" element={<NewTaskRedirect />} />
-          <Route path="/tasks/:taskId" element={<ErrorBoundary><DetailRoute /></ErrorBoundary>} />
-          <Route path="/history" element={<HistoryRoute />} />
-          <Route path="/projects" element={<ProjectsRoute />} />
-          <Route path="/projects/:workspacePath" element={<ProjectDetailRoute />} />
-          <Route path="/skills" element={<SkillsRoute />} />
-          <Route path="/models" element={<ModelsRoute />} />
-          <Route path="/config-migration" element={<ConfigMigrationRoute />} />
-          <Route path="/mcp" element={<McpRoute />} />
-          <Route path="/profiles" element={<ProfilesRoute />} />
-          <Route path="/memory" element={<MemoryRoute />} />
-          <Route path="/soul" element={<SoulRoute />} />
-          <Route path="/cron" element={<CronRoute />} />
-          <Route path="/im/*" element={<ErrorBoundary><ImOnboardingRoute /></ErrorBoundary>} />
-          <Route path="/console" element={<ConsoleRoute />} />
-          <Route path="/health" element={<HealthRoute />} />
-          <Route path="/analytics" element={<AnalyticsRoute />} />
-          <Route path="/logs" element={<LogsRoute />} />
-          <Route path="/debug" element={<DebugRoute />} />
-          <Route path="/advanced/*" element={<ErrorBoundary><AdvancedRoute /></ErrorBoundary>} />
+          <Route path="/tasks/:taskId" element={withBoundary(<DetailRoute />)} />
+          <Route path="/history" element={withBoundary(<HistoryRoute />)} />
+          <Route path="/projects" element={withBoundary(<ProjectsRoute />)} />
+          <Route path="/projects/:workspacePath" element={withBoundary(<ProjectDetailRoute />)} />
+          <Route path="/skills" element={withBoundary(<SkillsRoute />)} />
+          <Route path="/models" element={withBoundary(<ModelsRoute />)} />
+          <Route path="/config-migration" element={withBoundary(<ConfigMigrationRoute />)} />
+          <Route path="/mcp" element={withBoundary(<McpRoute />)} />
+          <Route path="/profiles" element={withBoundary(<ProfilesRoute />)} />
+          <Route path="/memory" element={withBoundary(<MemoryRoute />)} />
+          <Route path="/soul" element={withBoundary(<SoulRoute />)} />
+          <Route path="/cron" element={withBoundary(<CronRoute />)} />
+          <Route path="/im/*" element={withBoundary(<ImOnboardingRoute />)} />
+          <Route path="/console" element={withBoundary(<ConsoleRoute />)} />
+          <Route path="/health" element={withBoundary(<HealthRoute />)} />
+          <Route path="/analytics" element={withBoundary(<AnalyticsRoute />)} />
+          <Route path="/logs" element={withBoundary(<LogsRoute />)} />
+          <Route path="/debug" element={withBoundary(<DebugRoute />)} />
+          <Route path="/advanced/*" element={withBoundary(<AdvancedRoute />)} />
           <Route path="/settings" element={<Navigate to="/advanced" replace />} />
           <Route path="*" element={<Navigate to="/" replace />} />
         </Routes>


### PR DESCRIPTION
## 概述

第二批"好处理"的低风险 issue，每个一个独立 commit（均含 `Closes #N`），全部对当前 `main` 验证仍适用。一个分支、一个 PR、独立 worktree。

## 包含的修复

| Commit | Issue | 内容 | 栈 |
|---|---|---|---|
| `fix` | #37 | 所有内容路由统一包局部 `ErrorBoundary`（`withBoundary` helper）——单页崩溃时保留 AppShell / 侧边栏 / 导航，不再整壳白屏 | web |
| `chore` | #44 | 移除未使用的 Tauri `fs` / `shell` 插件与 capability（`shell:default`/`shell:allow-open`/`fs:default`）——P1 收窄授权面 | Rust/Tauri |
| `fix` | #53 | `runtime_root()` 不再在系统数据目录不可用时静默 fallback 到当前工作目录（cwd） | Rust |

## 细节

**#37** — `app.tsx` 之前只有 `/tasks/:taskId`、`/im/*`、`/advanced/*` 包了局部 boundary，其余路由渲染异常会落到根 boundary、整壳不可用。新增 `withBoundary()` 统一包裹全部内容路由（重定向路由除外）。每个路由 element 各自挂载 boundary，导航时自然重置；`ErrorBoundary` 仍把错误摘要写入 debugBus（不变）。

**#44** — 经核实前端 `web/src` **零**使用 `@tauri-apps/plugin-fs` / `plugin-shell`，文件选择/打开 workspace 走 Rust command + `tauri-plugin-dialog` + `open` crate；Rust 侧除 `::init()` 外也无任何 `tauri_plugin_shell` / `tauri_plugin_fs` 调用。因此移除这两个插件的 `.plugin()` 注册、`Cargo.toml` 依赖、以及 `capabilities/default.json` 中对应权限。保留仍在用的 `dialog`。

**#53** — `runtime_root()` 原为 `dirs::data_dir().unwrap_or_else(|| PathBuf::from("."))`，打包应用 cwd 可能只读/网络位置/意外目录，把 managed runtime、downloads、HERMES_HOME 写到 cwd 会造成权限与数据隔离问题。抽出可注入的纯函数 `resolve_runtime_data_base(data_dir, home_dir)`：优先系统数据目录 → 退到 `~/.local/share` → 都不可用时返回可操作的错误（`expect` 给出中文 actionable message，并提示设 `HERMES_DESKTOP_RUNTIME_ROOT`），**绝不**落到 cwd。新增 3 个单测覆盖三种分支。

## 验证

- ✅ `pnpm typecheck`（3 个 workspace）
- ✅ `pnpm test:unit`：367 passed
- ✅ `cargo fmt --check`
- ✅ `cargo check`（移除插件后仍编译通过）
- ✅ `cargo test --all-features`（含 3 个新 `resolve_runtime_data_base` 单测）
- ✅ `cargo clippy --all-targets --all-features -- -D warnings`

`Closes #37`, `Closes #44`, `Closes #53`.

🤖 Generated with [Claude Code](https://claude.com/claude-code)
