### PR TITLE
feat: add desktop-faithful Profile redesign mock

### DIFF
--- a/web/design-preview/README.md
+++ b/web/design-preview/README.md
@@ -1,0 +1,57 @@
+# design-preview — Profile 改造 · 桌面保真静态稿
+
+桌面端 Profile 功能改造的**视觉稿**。目标:对齐 App 的真实设计语言,让稿子 1:1 映射 React,
+几乎零翻译成本。**这不是 App 的一部分**,不参与构建。
+
+## 怎么看
+
+浏览器直接打开 `profile/index.html`(支持 `file://`),从索引进入四屏。每页右上角可切换明/暗主题。
+
+```
+open web/design-preview/profile/index.html      # 或拖进浏览器
+```
+
+> 与运行中的 App 对照:在桌面 repo 起 `pnpm web:dev`(:9545,需先 `hermes dashboard --no-open`)。
+
+## 设计基准(为什么这样画)
+
+之前在 `hermes-cn-ui-prototypes-sans` 的稿子用了编辑/杂志风(Fraunces 大斜体、12 栏网格、页边码、
+sparkline),已偏离桌面端实现、移植成本高。本目录改为**桌面保真**:
+
+- **复用真实 token**:每个 HTML 直接 `<link>` 真实的 `packages/shared-ui/src/tokens/index.css`(零重复)。
+- **镜像真实组件样式**:`preview.css` 逐字镜像各 `*.module.css` 的规则(只用 `--h-*` 与真实 px),
+  因为 CSS Module 类名是 hash 的、无法直接引入,所以重声明并加前缀避免 `.row/.nav/.page` 冲突,
+  每块都注明对应的真实 `源文件 .类名`。
+- **保真红线**:纯无衬线(HarmonyOS Sans + Cascadia mono)、字号 ≤14px、圆角只用 `--h-r-*`、
+  小边框按钮、单一柿色 `--h-accent` 强调、状态用 `--h-ok/warn/err` + `Dot`;**无** Fraunces/斜体大标题、
+  **无** 12 栏网格/页边码/sparkline;弹窗是居中 560 `Dialog`。
+
+## 四屏 → React 映射(落地指引)
+
+| 稿 | 文件 | 落地到 |
+|---|---|---|
+| ① 档案列表 + 切换 | `profile/01-profiles-list.html` | `web/src/routes/profiles.tsx` + `components/sidebar/profile-selector.tsx`(补:头像、元数据/用量列、UI 内重命名入口) |
+| ② 档案详情与编辑 | `profile/02-profile-detail.html` | 新建 `web/src/routes/profile-detail.tsx` + shared-ui `Dialog`(头像生成/上传、就地重命名、危险区:克隆/导出/导入/删除) |
+| ③ 运行时健康 | `profile/03-runtime-health.html` | `web/src/routes/health.tsx` + 新建 `profile-runtime-grid.tsx`(克隆 `components/panel/health-grid.tsx`) |
+| ④ 个人中心 | `profile/04-personal-center.html` | `web/src/routes/settings.tsx` 新增 `PersonalCenterSection`(并入设置页,非新大页) |
+
+功能范围沿用 PRD:`../../..` 之外的 `hermes-cn-ui-prototypes-sans/docs/profile-overhaul/PRD.md`
+(头像、运行时健康、克隆/导入导出、重命名 + 元数据/用量)。本目录只换**视觉语言**。
+
+## 构建隔离
+
+`web/design-preview/` 在 `web/tsconfig.json` 的 `include` 与 Vite 入口之外,不进 App bundle、
+不影响 `pnpm typecheck` / `pnpm test:unit`。可安全保留在仓库里作为设计参考。
+
+## 文件
+
+```
+web/design-preview/
+  preview.css                  镜像真实 module.css 的样式(带源注释)
+  profile/
+    index.html                 索引 + 主题切换
+    01-profiles-list.html      档案列表 + 切换
+    02-profile-detail.html     档案详情与编辑(含 Dialog)
+    03-runtime-health.html     运行时健康
+    04-personal-center.html    个人中心(设置页内 section)
+```

--- a/web/design-preview/preview.css
+++ b/web/design-preview/preview.css
@@ -1,0 +1,330 @@
+/* ───────────────────────────────────────────────────────────────────────────
+   preview.css — 桌面保真静态稿样式
+
+   这是 hermes-agent-cn-desktop 的 Profile 改造**视觉稿**专用样式,不参与 App 构建。
+   每个块都逐字镜像真实 .module.css 的规则,只用 packages/shared-ui/src/tokens/*
+   里的 --h-* 变量与真实 px 值。类名加了前缀以避免 .row/.nav/.page/.content 等
+   在 profiles / settings / shell / dialog 之间的命名冲突;每块都注明对应的真实
+   `源文件 .类名`,落 React 时按注释 1:1 还原。
+
+   token 由每个 HTML 直接 <link> 真实的 shared-ui/src/tokens/index.css 提供。
+   ─────────────────────────────────────────────────────────────────────────── */
+
+/* ── reset / body  (web/src/styles/global.css) ───────────────────────────── */
+*, *::before, *::after { box-sizing: border-box; }
+html, body { margin: 0; padding: 0; height: 100%; }
+body {
+  font-family: var(--h-font-ui);
+  font-size: var(--h-fs);
+  line-height: var(--h-lh);
+  background: var(--h-bg-app);
+  color: var(--h-text);
+  -webkit-font-smoothing: antialiased;
+  -moz-osx-font-smoothing: grayscale;
+}
+::-webkit-scrollbar { width: 8px; height: 8px; }
+::-webkit-scrollbar-track { background: transparent; }
+::-webkit-scrollbar-thumb { background: var(--h-line); border-radius: 4px; }
+.lucide { width: 14px; height: 14px; vertical-align: middle; flex-shrink: 0; }
+
+/* ── app shell  (app-shell.module.css .shell / *Slot) ─────────────────────── */
+.shell {
+  width: 100vw; height: 100vh;
+  display: grid;
+  grid-template-rows: var(--h-topbar-h) 1fr var(--h-statusbar-h);
+  grid-template-columns: var(--h-sidebar-w) 1fr;
+  overflow: hidden;
+  background: var(--h-bg-app);
+  color: var(--h-text);
+  font-family: var(--h-font-ui);
+}
+.topbarSlot   { grid-column: 1 / -1; grid-row: 1; }
+.sidebarSlot  { grid-column: 1; grid-row: 2; min-height: 0; overflow: hidden; position: relative; }
+.mainSlot     { grid-column: 2; grid-row: 2; position: relative; min-height: 0; min-width: 0;
+                overflow: hidden; display: flex; flex-direction: column; background: var(--h-bg-app); }
+.statusbarSlot{ grid-column: 1 / -1; grid-row: 3; }
+
+/* ── top bar  (app-top-bar.module.css) ───────────────────────────────────── */
+.topbar {
+  height: var(--h-topbar-h);
+  display: flex; align-items: center;
+  padding: 0 14px; gap: 16px;
+  border-bottom: 1px solid var(--h-line);
+  background: linear-gradient(180deg, var(--h-bg-pane), var(--h-bg-app));
+  position: relative; z-index: 10;
+}
+.brand { display: flex; align-items: center; gap: 7px; width: calc(var(--h-sidebar-w) - 30px);
+  height: 44px; padding: 0 2px 0 4px; flex-shrink: 0; color: var(--h-text); border-radius: 8px; cursor: pointer; }
+.brandMark { display: block; flex-shrink: 0; border-radius: 8px; }
+.brandText { min-width: 0; flex: 1; display: grid; gap: 4px; }
+.wordmark { font-family: var(--h-font-ui); font-size: 13px; font-weight: 700; letter-spacing: -0.02em;
+  white-space: nowrap; line-height: 1.18; }
+.wordmark em { color: var(--h-accent); font-style: normal; }
+.brandMeta { display: flex; align-items: center; gap: 2px; line-height: 1.25; white-space: nowrap; }
+.edition { color: color-mix(in srgb, var(--h-text) 76%, var(--h-text-3)); font-family: var(--h-font-cn);
+  font-size: 9.5px; font-weight: 650; letter-spacing: 0.035em; }
+.metaDot { color: color-mix(in srgb, var(--h-accent) 58%, var(--h-text-3)); font-family: var(--h-font-mono); font-size: 10px; line-height: 1; }
+.topnav { display: flex; align-items: center; gap: 2px; }
+.topnavLink { padding: 6px 10px; font-size: 12px; color: var(--h-text-2); border-radius: 3px;
+  letter-spacing: 0.01em; font-family: var(--h-font-mono); text-transform: lowercase; cursor: pointer;
+  display: inline-flex; align-items: center; background: transparent; border: none; }
+.topnavLink:hover { color: var(--h-text); background: var(--h-bg-soft); }
+.topnavLink[data-active="true"] { color: var(--h-text); background: var(--h-bg-soft); }
+[data-theme="light"] .topnavLink[data-active="true"] {
+  background: color-mix(in srgb, var(--h-accent) 14%, var(--h-bg-chip));
+  box-shadow: inset 0 0 0 1px color-mix(in srgb, var(--h-accent) 28%, transparent); }
+.navNum { font-size: 9px; color: var(--h-text-3); margin-right: 6px; }
+.topnavLink[data-active="true"] .navNum { color: var(--h-accent); }
+.topsearch { flex: 0 1 clamp(220px, 28vw, 360px); width: clamp(220px, 28vw, 360px); max-width: 360px;
+  margin-left: auto; height: 28px; background: var(--h-bg-soft); border: 1px solid var(--h-line);
+  border-radius: 3px; display: flex; align-items: center; padding: 0 10px; gap: 8px; color: var(--h-text-2);
+  font-family: var(--h-font-mono); font-size: 11px; }
+.searchKbd { margin-left: auto; font-family: var(--h-font-mono); font-size: 9.5px; color: var(--h-text-3);
+  border: 1px solid var(--h-line); background: var(--h-bg-pane); padding: 1px 4px; border-radius: 2px; }
+.topactions { display: flex; align-items: center; gap: 6px; }
+.iconbtn { width: 28px; height: 28px; display: inline-flex; align-items: center; justify-content: center;
+  border-radius: 3px; color: var(--h-text-2); border: 1px solid transparent; background: transparent; cursor: pointer; }
+.iconbtn:hover { color: var(--h-text); background: var(--h-bg-soft); border-color: var(--h-line); }
+
+/* ── left sidebar  (equivalent of PlaceholderSidebar, real tokens) ────────── */
+.sidebar { height: 100%; background: var(--h-bg-app); border-right: 1px solid var(--h-line);
+  display: flex; flex-direction: column; overflow-y: auto; padding-bottom: 8px; }
+.sideNav { padding: 6px 8px; display: flex; flex-direction: column; gap: 1px; }
+.sideItem { display: flex; align-items: center; gap: 9px; padding: 8px 12px; border-radius: var(--h-r-md);
+  color: var(--h-text-2); font-size: 12.5px; font-family: var(--h-font-cn); cursor: pointer;
+  text-decoration: none; border: none; background: transparent; }
+.sideItem:hover { background: var(--h-line-soft); color: var(--h-text); }
+.sideItem[data-active="true"] { color: var(--h-text); font-weight: 600; background: var(--h-bg-chip); }
+.sideItem .lucide { width: 15px; height: 15px; color: var(--h-text-3); }
+.sideItem[data-active="true"] .lucide { color: var(--h-accent); }
+.sideLabel { padding: 14px 14px 6px; font-size: 9.5px; text-transform: uppercase; letter-spacing: 0.08em;
+  color: var(--h-text-3); font-family: var(--h-font-mono); font-weight: 600; }
+
+/* profile-selector  (sidebar/profile-selector.module.css) */
+.pstrigger { display: flex; align-items: center; gap: 8px; width: calc(100% - 12px); margin: 8px 6px 4px;
+  padding: 8px 10px; border-radius: 8px; border: 1px solid var(--h-line); background: var(--h-bg-pane);
+  color: var(--h-text); font-family: var(--h-font-cn); font-size: 12.5px; text-align: left; cursor: pointer; }
+.pstrigger:hover { background: var(--h-bg-soft); }
+.pstriggerLabel { font-size: 9.5px; text-transform: uppercase; letter-spacing: 0.06em; color: var(--h-text-3); font-weight: 500; }
+.pstriggerName { flex: 1; font-weight: 500; font-family: var(--h-font-mono); font-size: 12px; color: var(--h-text);
+  overflow: hidden; text-overflow: ellipsis; white-space: nowrap; }
+.pstriggerChevron { color: var(--h-text-3); flex-shrink: 0; }
+.psmenu { width: 230px; padding: 4px; background: var(--h-bg-pane); border-radius: 8px; border: 1px solid var(--h-line);
+  box-shadow: 0 8px 24px rgba(0, 0, 0, 0.08); font-family: var(--h-font-cn); }
+.psmenuTitle { padding: 6px 10px 4px; font-size: 9.5px; text-transform: uppercase; letter-spacing: 0.06em; color: var(--h-text-3); font-weight: 500; }
+.psmenuItem { display: flex; align-items: center; gap: 8px; width: 100%; padding: 7px 10px; border: none;
+  background: transparent; border-radius: 5px; text-align: left; font-family: var(--h-font-mono); font-size: 12px; color: var(--h-text); cursor: pointer; }
+.psmenuItem:hover { background: var(--h-line-soft); }
+.psmenuItem[data-active="true"] { background: var(--h-bg-chip); }
+.psmenuItemName { flex: 1; overflow: hidden; text-overflow: ellipsis; white-space: nowrap; }
+.psmenuItemBadge { font-family: var(--h-font-cn); font-size: 9.5px; letter-spacing: 0.04em; color: var(--h-text-3); text-transform: uppercase; }
+.psmenuCheck { color: var(--h-text); }
+.psmenuFoot { margin-top: 4px; padding: 6px 10px; border-top: 1px solid var(--h-line); font-size: 11px; color: var(--h-text-3); }
+.psmenuFootLink { background: transparent; border: none; color: var(--h-text-2); cursor: pointer; font-family: var(--h-font-cn); font-size: 11px; padding: 0; }
+
+/* ── status bar  (app-status-bar.module.css) ─────────────────────────────── */
+.statusbar { height: var(--h-statusbar-h); display: flex; align-items: center; padding: 0 12px; gap: 14px;
+  font-family: var(--h-font-mono); font-size: 10.5px; line-height: 1; color: var(--h-text-2);
+  border-top: 1px solid var(--h-line); background: var(--h-bg-pane); }
+.statusbar .stat { display: inline-flex; align-items: baseline; gap: 6px; }
+.statusbar .lbl { color: var(--h-text-3); text-transform: uppercase; letter-spacing: 0.08em; font-size: 9px; }
+.statusbar .val { color: var(--h-text); font-variant-numeric: tabular-nums; }
+.statusbar .sep { width: 1px; height: 10px; background: var(--h-line); }
+.statusbar .right { margin-left: auto; display: flex; align-items: center; gap: 14px; }
+.sbDot { width: 6px; height: 6px; border-radius: 50%; display: inline-block; align-self: center; background: var(--moss); box-shadow: 0 0 6px rgba(141,181,128,0.5); }
+
+/* ── page chrome: section-shell + page top-bar  (section-shell + top-bar) ── */
+.secpage { flex: 1; display: flex; flex-direction: column; min-width: 0; background: var(--h-bg-pane); overflow: hidden; }
+.pageTopBar { height: 44px; display: flex; align-items: center; padding: 0 16px; gap: 12px; background: var(--h-bg-pane);
+  border-bottom: 1px solid var(--h-line); font-family: var(--h-font-cn); flex-shrink: 0; }
+.pageTitleGroup { display: inline-flex; align-items: baseline; gap: 12px; min-width: 0; }
+.pageTitle { font-size: 13px; font-weight: 600; color: var(--h-text); line-height: 1; }
+.pageSub { font-size: 11px; color: var(--h-text-3); line-height: 1; }
+.pageSpacer { flex: 1; }
+.pageChip { font-size: 11px; color: var(--h-text-2); padding: 3px 10px; border: 1px solid var(--h-line);
+  border-radius: var(--h-r-sm); cursor: pointer; background: transparent; display: inline-flex; align-items: center; gap: 4px; }
+.pageChip:hover { background: var(--h-bg-soft); }
+.scroll { flex: 1; min-width: 0; overflow-y: auto; padding: 20px 24px 48px; }
+
+/* ── settings page chrome  (settings.module.css .page/.layout/.nav/.content) ── */
+.setpage { flex: 1; display: flex; flex-direction: column; min-width: 0; background: var(--h-bg-pane); overflow: hidden; }
+.setLayout { flex: 1; display: flex; min-width: 0; overflow: hidden; }
+.setNav { width: 220px; padding: 18px 12px; border-right: 1px solid var(--h-line); background: var(--h-bg-app); overflow-y: auto; flex-shrink: 0; }
+.setNavItem { display: block; width: 100%; padding: 10px 16px; margin: 2px 0; border: none; border-radius: var(--h-r-md);
+  background: transparent; color: var(--h-text-2); font-size: 12.5px; cursor: pointer; font-family: var(--h-font-cn); text-align: left; }
+.setNavItem:hover { background: var(--h-line-soft); }
+.setNavItem[data-active="true"] { color: var(--h-text); font-weight: 600; background: var(--h-bg-chip); }
+.setContent { flex: 1; min-width: 0; overflow-y: auto; padding: 28px 36px 40px; }
+
+/* ── common controls  (settings.module.css) ──────────────────────────────── */
+.heading { font-size: 17px; font-weight: 600; color: var(--h-text); margin: 0 0 6px; }
+.sdesc { font-size: 12px; color: var(--h-text-2); margin: 0 0 22px; line-height: 1.7; }
+.sectionTitleRow { display: flex; align-items: center; justify-content: space-between; gap: 12px; margin: 26px 0 6px; }
+.sectionTitleRow .heading { margin-bottom: 0; }
+.btn, .btnPrimary, .btnDanger { display: inline-flex; align-items: center; justify-content: center; gap: 6px;
+  padding: 6px 14px; border-radius: 6px; font-size: 12px; cursor: pointer; font-family: var(--h-font-cn); }
+.btn { border: 1px solid var(--h-line); background: transparent; color: var(--h-text); }
+.btn:hover { background: var(--h-bg-soft); border-color: var(--h-text-3); }
+.btnPrimary { border: 1px solid var(--h-accent); background: var(--h-accent); color: #fff; }
+.btnPrimary:hover { opacity: 0.9; }
+.btnDanger { border: 1px solid var(--h-err); background: transparent; color: var(--h-err); }
+.btnDanger:hover { background: color-mix(in srgb, var(--h-err) 8%, transparent); }
+.btnSm { padding: 4px 10px; font-size: 11.5px; }
+.toggle { width: 30px; height: 17px; border-radius: var(--h-r-pill); border: 1px solid var(--h-line);
+  background: var(--h-bg-chip); position: relative; cursor: pointer; flex-shrink: 0; padding: 0; display: inline-block; }
+.toggle[data-on="true"] { background: var(--h-text); border-color: var(--h-text); }
+.toggleThumb { position: absolute; top: 1px; left: 1px; width: 13px; height: 13px; border-radius: 50%;
+  background: #fff; box-shadow: 0 1px 2px rgba(0,0,0,0.2); transition: left 0.15s; }
+.toggle[data-on="true"] .toggleThumb { left: 14px; }
+.select { box-sizing: border-box; padding: 5px 10px; background: var(--h-bg-input); border: 1px solid var(--h-line);
+  border-radius: 6px; color: var(--h-text); font-size: 12px; outline: none; font-family: var(--h-font-cn); }
+.sinput { padding: 5px 10px; background: var(--h-bg-input); border: 1px solid var(--h-line); border-radius: 6px;
+  color: var(--h-text); font-size: 12px; outline: none; font-family: var(--h-font-cn); }
+.sinput[data-mono="true"] { font-family: var(--h-font-mono); }
+.srow { display: flex; align-items: center; gap: 16px; padding: 12px 0; border-bottom: 1px solid var(--h-line-soft); }
+.srowLeft { flex: 1; min-width: 0; }
+.srowLabel { font-size: 13px; color: var(--h-text); }
+.srowSub { font-size: 11px; color: var(--h-text-3); margin-top: 3px; line-height: 1.5; }
+.srowRight { flex-shrink: 0; min-width: 120px; display: flex; justify-content: flex-end; align-items: center; gap: 6px; }
+
+/* inline <code> chip  (recurring .metaCell code / .value code) */
+.codeChip { font-family: var(--h-font-mono); font-size: 11px; background: var(--h-bg-soft); padding: 1px 4px; border-radius: 3px; color: var(--h-text-2); }
+
+/* ── pill + dot  (ui/pill.module.css) ────────────────────────────────────── */
+.pill { display: inline-flex; align-items: center; gap: 6px; padding: 3px 9px; border-radius: 999px;
+  border: 1px solid var(--h-line); background: var(--h-bg-pane); color: var(--h-text-2); font-size: 11.5px; font-weight: 500; line-height: 1.4; white-space: nowrap; }
+.pill[data-tone="ok"] { background: var(--h-ok-soft); color: var(--h-ok); border-color: color-mix(in srgb, var(--h-ok) 25%, var(--h-line)); }
+.pill[data-tone="warn"] { background: var(--h-warn-soft); color: var(--h-warn); border-color: color-mix(in srgb, var(--h-warn) 25%, var(--h-line)); }
+.pill[data-tone="err"] { background: color-mix(in srgb, var(--h-err) 14%, var(--h-bg-pane)); color: var(--h-err); border-color: color-mix(in srgb, var(--h-err) 30%, var(--h-line)); }
+.pillSm { font-size: 10px; padding: 1px 7px; }
+.dot { display: inline-block; width: 7px; height: 7px; border-radius: 50%; background: var(--h-text-3); flex: 0 0 auto; }
+.dot[data-tone="ok"] { background: var(--h-ok); }
+.dot[data-tone="warn"] { background: var(--h-warn); }
+.dot[data-tone="err"] { background: var(--h-err); }
+
+/* ── profiles list  (routes/profiles.module.css) ─────────────────────────── */
+.pdesc { margin: 0 0 16px; font-size: 12.5px; color: var(--h-text-3); line-height: 1.6; max-width: 720px; }
+.pwarning { display: flex; flex-direction: column; gap: 4px; padding: 12px 14px;
+  border: 1px solid color-mix(in srgb, var(--h-warn) 40%, transparent); border-radius: 10px;
+  background: color-mix(in srgb, var(--h-warn) 6%, transparent); font-size: 12px; line-height: 1.6; color: var(--h-text-2); margin-bottom: 16px; max-width: 720px; }
+.pwarning strong { color: var(--h-text); }
+.prestartHint { display: flex; align-items: center; gap: 12px; padding: 10px 14px;
+  border: 1px solid color-mix(in srgb, var(--h-ok) 35%, transparent); border-radius: 10px;
+  background: color-mix(in srgb, var(--h-ok) 8%, transparent); font-size: 12px; color: var(--h-text-2); margin-bottom: 16px; max-width: 720px; }
+.prestartHint strong { color: var(--h-text); flex-shrink: 0; }
+.ptoolbar { display: flex; align-items: center; justify-content: space-between; gap: 12px; margin-bottom: 12px; }
+.pnewBtn { padding: 6px 14px; font-size: 12px; border-radius: 7px; border: 1px solid var(--h-line);
+  background: var(--h-bg-pane); color: var(--h-text); cursor: pointer; font-family: var(--h-font-cn); font-weight: 500; display: inline-flex; align-items: center; gap: 6px; }
+.pnewBtn:hover { border-color: var(--h-text-3); background: var(--h-bg-soft); }
+.plist { display: flex; flex-direction: column; gap: 8px; }
+.prow { display: flex; align-items: center; gap: 16px; padding: 14px 16px; border: 1px solid var(--h-line-soft); border-radius: 10px; background: var(--h-bg-pane); }
+.prow[data-active="true"] { border-color: color-mix(in srgb, var(--h-ok) 40%, var(--h-line-soft)); background: color-mix(in srgb, var(--h-ok) 4%, var(--h-bg-pane)); }
+.prow[data-clickable="true"] { cursor: pointer; }
+.prow[data-clickable="true"]:hover { border-color: var(--h-text-3); }
+.prowMain { flex: 1; min-width: 0; display: flex; flex-direction: column; gap: 6px; }
+.prowHead { display: flex; align-items: center; gap: 10px; }
+.prowName { font-family: var(--h-font-mono); font-size: 13px; color: var(--h-text); font-weight: 600; }
+.ptag { font-size: 10px; padding: 1px 6px; border-radius: 4px; background: var(--h-bg-soft); color: var(--h-text-3); text-transform: uppercase; letter-spacing: 0.04em; }
+.pactiveBadge { display: inline-flex; align-items: center; gap: 3px; font-size: 11px; padding: 2px 8px; border-radius: 12px; font-weight: 500;
+  color: var(--h-ok); background: color-mix(in srgb, var(--h-ok) 14%, transparent); }
+.prowMeta { display: flex; flex-wrap: wrap; gap: 12px; font-size: 11.5px; color: var(--h-text-3); }
+.pmetaCell { display: inline-flex; align-items: center; gap: 4px; }
+.prowActions { flex-shrink: 0; display: flex; align-items: center; gap: 6px; }
+.pactionBtn { font-size: 11.5px; padding: 6px 12px; border-radius: 6px; border: 1px solid var(--h-line); background: var(--h-bg-pane); color: var(--h-text); cursor: pointer; font-weight: 500; display: inline-flex; align-items: center; gap: 5px; }
+.pactionBtn:hover { border-color: var(--h-text-3); background: var(--h-bg-soft); }
+.pdeleteBtn { font-size: 11.5px; padding: 6px 10px; border-radius: 6px; border: 1px solid transparent; background: transparent; color: var(--h-text-3); cursor: pointer; font-family: var(--h-font-cn); }
+.pdeleteBtn:hover { color: var(--h-err); border-color: color-mix(in srgb, var(--h-err) 35%, transparent); }
+.pactionPlaceholder { color: var(--h-text-3); font-size: 12px; padding: 0 12px; }
+.pfootnote { margin-top: 24px; font-size: 11.5px; color: var(--h-text-3); line-height: 1.7; }
+/* create / clone inline card */
+.pcreateCard { padding: 14px 16px; border: 1px solid var(--h-line); border-radius: 10px; background: var(--h-bg-pane); margin-bottom: 12px; display: flex; flex-direction: column; gap: 12px; }
+.pcreateTitle { font-size: 12.5px; color: var(--h-text); font-weight: 600; }
+.pfieldRow { display: flex; flex-direction: column; gap: 4px; }
+.pfieldLabel { font-size: 11px; color: var(--h-text-3); font-family: var(--h-font-cn); }
+.pfieldInput { padding: 6px 10px; font-size: 12.5px; font-family: var(--h-font-mono); border: 1px solid var(--h-line); border-radius: 6px; background: var(--h-bg-input); color: var(--h-text); outline: none; }
+.pfieldInput:focus { border-color: var(--h-text-3); }
+.pfieldRadios { display: flex; gap: 14px; flex-wrap: wrap; font-size: 12px; color: var(--h-text-2); font-family: var(--h-font-cn); }
+.pfieldRadios label { display: inline-flex; align-items: center; gap: 5px; cursor: pointer; }
+.pformActions { display: flex; gap: 8px; justify-content: flex-end; }
+
+/* ── NEW mock-only: avatar / detail header / danger zone (real tokens only) ── */
+.pAvatar { width: 24px; height: 24px; border-radius: var(--h-r-sm); flex-shrink: 0; display: inline-flex;
+  align-items: center; justify-content: center; font-family: var(--h-font-mono); font-size: 11px; font-weight: 600;
+  color: #fff; overflow: hidden; }
+.pAvatar img { width: 100%; height: 100%; object-fit: cover; }
+.detailHeader { display: flex; align-items: center; gap: 14px; padding-bottom: 16px; margin-bottom: 4px; border-bottom: 1px solid var(--h-line-soft); }
+.detailAvatar { width: 48px; height: 48px; border-radius: var(--h-r-md); flex-shrink: 0; display: inline-flex;
+  align-items: center; justify-content: center; font-family: var(--h-font-mono); font-size: 20px; font-weight: 600; color: #fff; overflow: hidden; }
+.detailAvatar img { width: 100%; height: 100%; object-fit: cover; }
+/* deterministic avatar tints — palette tokens only, no hardcoded hex in markup */
+.pAvatar[data-tint="persimmon"], .detailAvatar[data-tint="persimmon"] { background: linear-gradient(135deg, var(--persimmon), var(--persimmon-dim)); }
+.pAvatar[data-tint="moss"], .detailAvatar[data-tint="moss"] { background: linear-gradient(135deg, var(--moss), var(--moss-deep)); }
+.pAvatar[data-tint="sky"], .detailAvatar[data-tint="sky"] { background: linear-gradient(135deg, var(--sky), color-mix(in srgb, var(--sky) 62%, #11100e)); }
+.detailName { font-family: var(--h-font-mono); font-size: 16px; font-weight: 600; color: var(--h-text); display: inline-flex; align-items: center; gap: 8px; }
+.detailNameEdit { background: transparent; border: none; color: var(--h-text-3); cursor: pointer; display: inline-flex; padding: 2px; }
+.detailNameEdit:hover { color: var(--h-accent); }
+.detailNameInput { font-family: var(--h-font-mono); font-size: 15px; font-weight: 600; color: var(--h-text);
+  background: var(--h-bg-input); border: 1px solid var(--h-text-3); border-radius: 6px; padding: 5px 10px; outline: none; }
+.detailSub { font-size: 11.5px; color: var(--h-text-3); margin-top: 4px; font-family: var(--h-font-mono); }
+.dangerZone { border: 1px solid color-mix(in srgb, var(--h-err) 30%, var(--h-line)); border-radius: 10px;
+  background: color-mix(in srgb, var(--h-err) 3%, var(--h-bg-pane)); overflow: hidden; }
+.dzRow { display: flex; align-items: center; gap: 16px; padding: 14px 16px; border-bottom: 1px solid var(--h-line-soft); }
+.dzRow:last-child { border-bottom: none; }
+.dzLeft { flex: 1; min-width: 0; }
+.dzLabel { font-size: 13px; color: var(--h-text); font-weight: 500; }
+.dzSub { font-size: 11px; color: var(--h-text-3); margin-top: 3px; line-height: 1.5; max-width: 520px; }
+.dzRight { flex-shrink: 0; }
+
+/* ── health grid  (panel/health-grid.module.css) ─────────────────────────── */
+.hbar { display: flex; align-items: center; gap: 12px; width: 100%; padding: 11px 16px; background: var(--h-bg-pane);
+  border: 1px solid var(--h-line); border-radius: var(--h-r-md); font-size: 12.5px; color: var(--h-text); text-align: left; }
+.hbar[data-tone="warn"] { background: color-mix(in srgb, var(--h-warn-soft) 35%, var(--h-bg-pane)); border-color: color-mix(in srgb, var(--h-warn) 25%, var(--h-line)); }
+.hbar[data-tone="err"] { background: color-mix(in srgb, var(--h-err) 8%, var(--h-bg-pane)); border-color: color-mix(in srgb, var(--h-err) 30%, var(--h-line)); }
+.hbarLabel { font-weight: 500; color: var(--h-text); }
+.hbarSummary { color: var(--h-text-3); font-size: 11.5px; }
+.hbarChev { margin-left: auto; color: var(--h-text-3); font-size: 11px; display: inline-flex; gap: 6px; align-items: center; }
+.hgrid { display: grid; grid-template-columns: repeat(12, minmax(0, 1fr)); gap: 8px; margin-top: 10px; }
+.hcell { grid-column: span 2; background: var(--h-bg-pane); border: 1px solid var(--h-line); border-radius: var(--h-r-md);
+  padding: 12px 14px; display: flex; flex-direction: column; gap: 6px; min-width: 0; }
+.hcell[data-size="wide"] { grid-column: span 4; }
+.hcell[data-size="full"] { grid-column: span 12; }
+.hcell[data-warn="true"] { background: color-mix(in srgb, var(--h-warn-soft) 35%, var(--h-bg-pane)); border-color: color-mix(in srgb, var(--h-warn) 25%, var(--h-line)); }
+.hcell[data-err="true"] { background: color-mix(in srgb, var(--h-err) 8%, var(--h-bg-pane)); border-color: color-mix(in srgb, var(--h-err) 30%, var(--h-line)); }
+.hlabel { display: flex; align-items: center; gap: 6px; font-size: 11px; color: var(--h-text-3); white-space: nowrap; overflow: hidden; text-overflow: ellipsis; }
+.hvalue { font-size: 14px; font-weight: 600; color: var(--h-text); overflow: hidden; text-overflow: ellipsis; white-space: nowrap; }
+.hvalue[data-mono="true"] { font-family: var(--h-font-mono); font-size: 12px; font-weight: 500; }
+.hsub { font-size: 10.5px; color: var(--h-text-3); font-family: var(--h-font-mono); overflow: hidden; text-overflow: ellipsis; white-space: nowrap; }
+
+/* ── dialog  (composites/dialog/dialog.module.css) ───────────────────────── */
+.overlay { position: fixed; inset: 0; background: rgba(0,0,0,0.36); z-index: 60; }
+.dialog { position: fixed; top: 50%; left: 50%; transform: translate(-50%, -50%); z-index: 61; background: var(--h-bg-pane);
+  color: var(--h-text); border: 1px solid var(--h-line); border-radius: var(--h-r-md); box-shadow: var(--h-shadow-l);
+  max-width: min(560px, calc(100vw - 32px)); width: 560px; max-height: 85vh; display: flex; flex-direction: column; overflow: hidden; }
+.dialogHead { padding: 16px 18px 12px; border-bottom: 1px solid var(--h-line-soft); display: flex; align-items: center; gap: 10px; }
+.dialogTitle { font-size: 14px; font-weight: 600; color: var(--h-text); }
+.dialogClose { margin-left: auto; width: 26px; height: 26px; border-radius: var(--h-r-sm); border: 1px solid transparent;
+  background: transparent; color: var(--h-text-3); cursor: pointer; display: inline-flex; align-items: center; justify-content: center; }
+.dialogClose:hover { background: var(--h-bg-soft); color: var(--h-text); }
+.dialogBody { padding: 16px 18px; display: flex; flex-direction: column; gap: 14px; overflow-y: auto; }
+.dialogText { font-size: 12.5px; color: var(--h-text-2); line-height: 1.7; }
+.dialogText strong { color: var(--h-text); }
+.dialogFoot { padding: 12px 18px; border-top: 1px solid var(--h-line-soft); display: flex; gap: 8px; justify-content: flex-end; }
+.dropzone { border: 1px dashed var(--h-line); border-radius: var(--h-r-md); padding: 24px; text-align: center;
+  font-size: 12.5px; color: var(--h-text-3); background: var(--h-bg-soft); display: flex; flex-direction: column; align-items: center; gap: 8px; }
+
+/* ── index landing page ──────────────────────────────────────────────────── */
+.idxWrap { max-width: 880px; margin: 0 auto; padding: 48px 32px 80px; height: 100vh; overflow-y: auto; }
+.idxHead { padding-bottom: 20px; border-bottom: 1px solid var(--h-line); margin-bottom: 24px; }
+.idxTitle { font-size: 22px; font-weight: 700; color: var(--h-text); margin: 0 0 6px; }
+.idxSub { font-size: 13px; color: var(--h-text-2); line-height: 1.7; margin: 0; max-width: 640px; }
+.idxNote { margin: 16px 0 0; padding: 10px 14px; border: 1px solid color-mix(in srgb, var(--h-warn) 40%, transparent);
+  background: color-mix(in srgb, var(--h-warn) 6%, transparent); border-radius: 8px; font-size: 12px; color: var(--h-text-2); line-height: 1.6; }
+.idxRow { display: flex; align-items: center; gap: 14px; padding: 14px 16px; border: 1px solid var(--h-line-soft);
+  border-radius: 10px; background: var(--h-bg-pane); text-decoration: none; color: var(--h-text); margin-bottom: 8px; }
+.idxRow:hover { border-color: var(--h-text-3); background: var(--h-bg-soft); }
+.idxRowNum { font-family: var(--h-font-mono); font-size: 12px; color: var(--h-accent); width: 28px; }
+.idxRowMain { flex: 1; min-width: 0; }
+.idxRowTitle { font-size: 13.5px; font-weight: 600; color: var(--h-text); }
+.idxRowSub { font-size: 11.5px; color: var(--h-text-3); margin-top: 2px; }
+.idxRowMap { font-family: var(--h-font-mono); font-size: 10.5px; color: var(--h-text-3); }
+.themeToggle { position: fixed; top: 16px; right: 20px; z-index: 90; }

--- a/web/design-preview/profile/01-profiles-list.html
+++ b/web/design-preview/profile/01-profiles-list.html
@@ -1,0 +1,210 @@
+<!doctype html>
+<html lang="zh-CN" data-theme="light" data-density="comfortable">
+<head>
+  <meta charset="utf-8" />
+  <title>档案列表 + 切换 · 桌面保真稿</title>
+  <meta name="viewport" content="width=device-width, initial-scale=1" />
+  <link rel="stylesheet" href="../../../packages/shared-ui/src/tokens/index.css" />
+  <link rel="stylesheet" href="../preview.css" />
+</head>
+<body>
+  <button class="btn themeToggle" onclick="hxTheme()"><i data-lucide="sun-moon"></i> 明/暗</button>
+
+  <div class="shell">
+    <!-- top bar -->
+    <div class="topbarSlot">
+      <header class="topbar">
+        <div class="brand">
+          <svg class="brandMark" width="22" height="22" viewBox="0 0 80 80"><rect width="80" height="80" rx="18" fill="#f6f1e3"/><g transform="translate(-2,2)"><polygon points="58,22 58,58 62,54 62,18" fill="#3a3633"/><path d="M22,22 H30 V36 H50 V22 H58 V58 H50 V44 H30 V58 H22 Z" fill="#0a0908"/><rect x="30" y="36" width="20" height="8" fill="#ff7a3d"/></g></svg>
+          <div class="brandText">
+            <div class="wordmark">Hermes<em>·</em>CN</div>
+            <div class="brandMeta"><span class="edition">桌面端</span><span class="metaDot">·</span><span class="edition">v2</span></div>
+          </div>
+        </div>
+        <nav class="topnav">
+          <a class="topnavLink" href="#"><span class="navNum">01</span>workbench</a>
+          <a class="topnavLink" href="#"><span class="navNum">02</span>skills</a>
+          <a class="topnavLink" href="#"><span class="navNum">03</span>advanced</a>
+          <a class="topnavLink" data-active="true" href="#"><span class="navNum">04</span>settings</a>
+        </nav>
+        <div class="topsearch"><i data-lucide="search"></i><span>搜索…</span><span class="searchKbd">⌘ K</span></div>
+        <div class="topactions">
+          <button class="iconbtn" onclick="hxTheme()" title="切换主题"><i data-lucide="sun-moon"></i></button>
+          <button class="iconbtn"><i data-lucide="settings"></i></button>
+        </div>
+      </header>
+    </div>
+
+    <!-- sidebar -->
+    <div class="sidebarSlot">
+      <aside class="sidebar">
+        <button class="pstrigger" onclick="hxToggleMenu()">
+          <span class="pstriggerLabel">档案</span>
+          <span class="pstriggerName">work</span>
+          <i data-lucide="chevrons-up-down" class="pstriggerChevron"></i>
+        </button>
+        <div class="sideLabel">我</div>
+        <div class="sideNav">
+          <a class="sideItem" data-active="true" href="01-profiles-list.html"><i data-lucide="folder"></i> 档案</a>
+          <a class="sideItem" href="03-runtime-health.html"><i data-lucide="activity"></i> 运行时健康</a>
+          <a class="sideItem" href="04-personal-center.html"><i data-lucide="user-round"></i> 个人中心</a>
+        </div>
+        <div class="sideLabel">会话</div>
+        <div class="sideNav">
+          <a class="sideItem" href="#"><i data-lucide="message-square"></i> 最近会话</a>
+          <a class="sideItem" href="#"><i data-lucide="history"></i> 历史</a>
+        </div>
+
+        <!-- switch popover (profile-selector menu) — shown open as demo -->
+        <div class="psmenu" id="switchMenu" style="position:absolute; top:46px; left:6px; z-index:40; display:none;">
+          <div class="psmenuTitle">切换档案</div>
+          <button class="psmenuItem" data-active="true"><span class="psmenuItemName">work</span><span class="psmenuItemBadge">default</span><i data-lucide="check" class="psmenuCheck"></i></button>
+          <button class="psmenuItem"><span class="psmenuItemName">client-atlas</span></button>
+          <button class="psmenuItem"><span class="psmenuItemName">demo</span></button>
+          <div class="psmenuFoot"><button class="psmenuFootLink">管理档案…</button></div>
+        </div>
+      </aside>
+    </div>
+
+    <!-- main -->
+    <div class="mainSlot">
+      <div class="secpage">
+        <div class="pageTopBar">
+          <div class="pageTitleGroup"><span class="pageTitle">档案</span><span class="pageSub">3 个档案 · 当前 work</span></div>
+          <div class="pageSpacer"></div>
+          <button class="pageChip"><i data-lucide="rotate-cw"></i> 刷新</button>
+        </div>
+
+        <div class="scroll">
+          <p class="pdesc">每个档案是一套隔离的 Agent 环境 —— 独立的 config / .env / SOUL.md / sessions / memory。切换即时、可逆,上下文不跨档案泄漏。</p>
+
+          <div class="pwarning">
+            <strong>切换档案会重启 dashboard 子进程</strong>
+            <span>桌面端为热切换(约 2–3 秒,自动重连并保留 5 分钟回滚指针);Web 模式仅写 sticky,需手动重启生效。</span>
+          </div>
+
+          <div class="ptoolbar">
+            <span class="pdesc" style="margin:0;">共 3 个档案 · 1 个使用中</span>
+            <button class="pnewBtn" onclick="hxToggleCreate()"><i data-lucide="plus"></i> 新建档案</button>
+          </div>
+
+          <!-- create / clone inline card -->
+          <div class="pcreateCard" id="createCard" style="display:none;">
+            <div class="pcreateTitle">新建档案</div>
+            <div class="pfieldRow">
+              <label class="pfieldLabel">档案名 <span style="color:var(--h-text-4)">允许 A–Z a–z 0–9 _ -</span></label>
+              <input class="pfieldInput" value="atlas-q3" spellcheck="false" />
+            </div>
+            <div class="pfieldRow">
+              <label class="pfieldLabel">初始化</label>
+              <div class="pfieldRadios">
+                <label><input type="radio" name="init" /> 空白</label>
+                <label><input type="radio" name="init" checked /> 从档案克隆</label>
+                <select class="select" style="margin-left:4px;"><option>work</option><option>client-atlas</option><option>demo</option></select>
+              </div>
+            </div>
+            <div class="pformActions">
+              <button class="btn" onclick="hxToggleCreate()">取消</button>
+              <button class="btnPrimary">创建</button>
+            </div>
+          </div>
+
+          <div class="plist">
+
+            <!-- active / default profile -->
+            <div class="prow" data-active="true">
+              <span class="pAvatar" data-tint="persimmon">w</span>
+              <div class="prowMain">
+                <div class="prowHead">
+                  <span class="prowName">work</span>
+                  <span class="ptag">default</span>
+                  <span class="pactiveBadge"><i data-lucide="check"></i> 当前默认</span>
+                </div>
+                <div class="prowMeta">
+                  <span class="pmetaCell">模型 <code class="codeChip">glm-4.6</code> · zhipu</span>
+                  <span class="pmetaCell">12 个技能</span>
+                  <span class="pmetaCell">会话 48</span>
+                  <span class="pmetaCell">7d $2.41</span>
+                  <span class="pmetaCell">磁盘 312 MB</span>
+                </div>
+              </div>
+              <div class="prowActions">
+                <a class="pactionBtn" href="02-profile-detail.html"><i data-lucide="pencil"></i> 编辑</a>
+                <span class="pactionPlaceholder">—</span>
+              </div>
+            </div>
+
+            <!-- client-atlas -->
+            <div class="prow">
+              <span class="pAvatar" data-tint="moss">c</span>
+              <div class="prowMain">
+                <div class="prowHead">
+                  <span class="prowName">client-atlas</span>
+                </div>
+                <div class="prowMeta">
+                  <span class="pmetaCell">模型 <code class="codeChip">glm-4.6</code> · zhipu</span>
+                  <span class="pmetaCell">6 个技能</span>
+                  <span class="pmetaCell">会话 38</span>
+                  <span class="pmetaCell">7d $4.80</span>
+                  <span class="pmetaCell">磁盘 88 MB</span>
+                </div>
+              </div>
+              <div class="prowActions">
+                <button class="pactionBtn"><i data-lucide="check-check"></i> 设为默认</button>
+                <a class="pactionBtn" href="02-profile-detail.html"><i data-lucide="pencil"></i> 编辑</a>
+                <button class="pdeleteBtn">删除</button>
+              </div>
+            </div>
+
+            <!-- demo (no .env) -->
+            <div class="prow">
+              <span class="pAvatar" data-tint="sky">d</span>
+              <div class="prowMain">
+                <div class="prowHead">
+                  <span class="prowName">demo</span>
+                  <span class="ptag">只读演示</span>
+                </div>
+                <div class="prowMeta">
+                  <span class="pmetaCell">模型 <code class="codeChip">glm-4.5-air</code> · zhipu</span>
+                  <span class="pmetaCell">3 个技能</span>
+                  <span class="pmetaCell">会话 2</span>
+                  <span class="pmetaCell" style="color:color-mix(in srgb,var(--h-text-3) 70%,transparent);">无 .env</span>
+                  <span class="pmetaCell">磁盘 24 MB</span>
+                </div>
+              </div>
+              <div class="prowActions">
+                <button class="pactionBtn"><i data-lucide="check-check"></i> 设为默认</button>
+                <a class="pactionBtn" href="02-profile-detail.html"><i data-lucide="pencil"></i> 编辑</a>
+                <button class="pdeleteBtn">删除</button>
+              </div>
+            </div>
+
+          </div>
+
+          <p class="pfootnote">重命名、克隆、导出/导入、头像设置在「编辑」里(档案详情)。曾经只能在 CLI 做的事,现在都搬进了 UI。</p>
+        </div>
+      </div>
+    </div>
+
+    <!-- status bar -->
+    <div class="statusbarSlot">
+      <footer class="statusbar">
+        <span class="stat"><span class="sbDot"></span><span class="lbl">网关</span><span class="val">9120</span></span>
+        <span class="sep"></span>
+        <span class="stat"><span class="lbl">档案</span><span class="val">work</span></span>
+        <span class="sep"></span>
+        <span class="stat"><span class="lbl">模型</span><span class="val">glm-4.6</span></span>
+        <span class="right"><span class="stat"><span class="lbl">运行时</span><span class="val">running</span></span></span>
+      </footer>
+    </div>
+  </div>
+
+  <script defer src="https://unpkg.com/lucide@0.460.0/dist/umd/lucide.min.js"></script>
+  <script>
+    function hxTheme(){var r=document.documentElement;r.dataset.theme=(r.dataset.theme==='dark'?'light':'dark');}
+    function hxToggleMenu(){var m=document.getElementById('switchMenu');m.style.display=(m.style.display==='none'?'block':'none');}
+    function hxToggleCreate(){var c=document.getElementById('createCard');c.style.display=(c.style.display==='none'?'flex':'none');}
+    document.addEventListener('DOMContentLoaded',function(){window.lucide&&window.lucide.createIcons();});
+  </script>
+</body>
+</html>

--- a/web/design-preview/profile/02-profile-detail.html
+++ b/web/design-preview/profile/02-profile-detail.html
@@ -1,0 +1,237 @@
+<!doctype html>
+<html lang="zh-CN" data-theme="light" data-density="comfortable">
+<head>
+  <meta charset="utf-8" />
+  <title>档案详情与编辑 · 桌面保真稿</title>
+  <meta name="viewport" content="width=device-width, initial-scale=1" />
+  <link rel="stylesheet" href="../../../packages/shared-ui/src/tokens/index.css" />
+  <link rel="stylesheet" href="../preview.css" />
+</head>
+<body>
+  <button class="btn themeToggle" onclick="hxTheme()"><i data-lucide="sun-moon"></i> 明/暗</button>
+
+  <div class="shell">
+    <div class="topbarSlot">
+      <header class="topbar">
+        <div class="brand">
+          <svg class="brandMark" width="22" height="22" viewBox="0 0 80 80"><rect width="80" height="80" rx="18" fill="#f6f1e3"/><g transform="translate(-2,2)"><polygon points="58,22 58,58 62,54 62,18" fill="#3a3633"/><path d="M22,22 H30 V36 H50 V22 H58 V58 H50 V44 H30 V58 H22 Z" fill="#0a0908"/><rect x="30" y="36" width="20" height="8" fill="#ff7a3d"/></g></svg>
+          <div class="brandText">
+            <div class="wordmark">Hermes<em>·</em>CN</div>
+            <div class="brandMeta"><span class="edition">桌面端</span><span class="metaDot">·</span><span class="edition">v2</span></div>
+          </div>
+        </div>
+        <nav class="topnav">
+          <a class="topnavLink" href="#"><span class="navNum">01</span>workbench</a>
+          <a class="topnavLink" href="#"><span class="navNum">02</span>skills</a>
+          <a class="topnavLink" href="#"><span class="navNum">03</span>advanced</a>
+          <a class="topnavLink" data-active="true" href="#"><span class="navNum">04</span>settings</a>
+        </nav>
+        <div class="topsearch"><i data-lucide="search"></i><span>搜索…</span><span class="searchKbd">⌘ K</span></div>
+        <div class="topactions">
+          <button class="iconbtn" onclick="hxTheme()" title="切换主题"><i data-lucide="sun-moon"></i></button>
+          <button class="iconbtn"><i data-lucide="settings"></i></button>
+        </div>
+      </header>
+    </div>
+
+    <div class="sidebarSlot">
+      <aside class="sidebar">
+        <button class="pstrigger">
+          <span class="pstriggerLabel">档案</span>
+          <span class="pstriggerName">work</span>
+          <i data-lucide="chevrons-up-down" class="pstriggerChevron"></i>
+        </button>
+        <div class="sideLabel">我</div>
+        <div class="sideNav">
+          <a class="sideItem" data-active="true" href="01-profiles-list.html"><i data-lucide="folder"></i> 档案</a>
+          <a class="sideItem" href="03-runtime-health.html"><i data-lucide="activity"></i> 运行时健康</a>
+          <a class="sideItem" href="04-personal-center.html"><i data-lucide="user-round"></i> 个人中心</a>
+        </div>
+        <div class="sideLabel">会话</div>
+        <div class="sideNav">
+          <a class="sideItem" href="#"><i data-lucide="message-square"></i> 最近会话</a>
+          <a class="sideItem" href="#"><i data-lucide="history"></i> 历史</a>
+        </div>
+      </aside>
+    </div>
+
+    <div class="mainSlot">
+      <div class="secpage">
+        <div class="pageTopBar">
+          <div class="pageTitleGroup">
+            <a class="pageChip" href="01-profiles-list.html" style="border:none;padding:0 4px 0 0;"><i data-lucide="chevron-left"></i></a>
+            <span class="pageTitle">档案详情</span><span class="pageSub">client-atlas</span>
+          </div>
+          <div class="pageSpacer"></div>
+          <button class="pageChip"><i data-lucide="check-check"></i> 设为默认</button>
+        </div>
+
+        <div class="scroll">
+
+          <!-- detail header: avatar + inline rename -->
+          <div class="detailHeader">
+            <span class="detailAvatar" data-tint="moss">c</span>
+            <div style="flex:1; min-width:0;">
+              <span class="detailName" id="nameView">
+                client-atlas
+                <button class="detailNameEdit" onclick="hxRename(true)" title="重命名"><i data-lucide="pencil"></i></button>
+              </span>
+              <span id="nameEdit" style="display:none; align-items:center; gap:8px;">
+                <input class="detailNameInput" value="client-atlas" spellcheck="false" />
+                <button class="btnPrimary btnSm" onclick="hxRename(false)">保存</button>
+                <button class="btn btnSm" onclick="hxRename(false)">取消</button>
+              </span>
+              <div class="detailSub">profile · ~/.hermes/profiles/client-atlas</div>
+            </div>
+          </div>
+
+          <!-- avatar controls -->
+          <div class="srow">
+            <div class="srowLeft">
+              <div class="srowLabel">头像</div>
+              <div class="srowSub">确定性生成(按档案名取种子)或上传图片。上传支持 PNG/JPEG/WebP,客户端自动压缩到 &lt; 500 KB。</div>
+            </div>
+            <div class="srowRight">
+              <button class="btn btnSm"><i data-lucide="dices"></i> 生成</button>
+              <button class="btn btnSm"><i data-lucide="upload"></i> 上传</button>
+              <button class="btnDanger btnSm"><i data-lucide="x"></i> 移除</button>
+            </div>
+          </div>
+
+          <!-- metadata / usage -->
+          <h2 class="heading" style="margin-top:26px;">元数据与用量</h2>
+          <div class="srow"><div class="srowLeft"><div class="srowLabel">创建时间</div></div><div class="srowRight"><span class="codeChip">2026-03-18</span></div></div>
+          <div class="srow"><div class="srowLeft"><div class="srowLabel">最近活跃</div></div><div class="srowRight">2 天前</div></div>
+          <div class="srow"><div class="srowLeft"><div class="srowLabel">会话数</div></div><div class="srowRight">38</div></div>
+          <div class="srow"><div class="srowLeft"><div class="srowLabel">7 天消费</div></div><div class="srowRight">$4.80</div></div>
+          <div class="srow"><div class="srowLeft"><div class="srowLabel">磁盘占用</div></div><div class="srowRight">88 MB · sessions 52 MB</div></div>
+          <div class="srow"><div class="srowLeft"><div class="srowLabel">HERMES_HOME</div></div><div class="srowRight"><span class="codeChip">~/.hermes/profiles/client-atlas</span></div></div>
+          <div class="srow"><div class="srowLeft"><div class="srowLabel">凭证 .env</div></div><div class="srowRight"><span class="pill" data-tone="ok"><span class="dot" data-tone="ok"></span> 已配置 · 2 键</span></div></div>
+          <div class="srow"><div class="srowLeft"><div class="srowLabel">SOUL.md</div></div><div class="srowRight"><span class="pill" data-tone="ok">存在 · 2.4 KB</span></div></div>
+
+          <!-- config summary -->
+          <div class="sectionTitleRow">
+            <h2 class="heading">配置</h2>
+            <button class="btn btnSm"><i data-lucide="settings-2"></i> 在设置中编辑</button>
+          </div>
+          <div class="srow"><div class="srowLeft"><div class="srowLabel">模型</div></div><div class="srowRight"><span class="codeChip">glm-4.6</span> · 1M 兜底</div></div>
+          <div class="srow"><div class="srowLeft"><div class="srowLabel">供应商</div></div><div class="srowRight">zhipu</div></div>
+          <div class="srow"><div class="srowLeft"><div class="srowLabel">技能</div></div><div class="srowRight">6 / 12 启用</div></div>
+
+          <!-- danger zone -->
+          <h2 class="heading" style="margin-top:26px;">危险操作</h2>
+          <div class="dangerZone">
+            <div class="dzRow">
+              <div class="dzLeft"><div class="dzLabel">克隆此档案</div><div class="dzSub">复制 config / .env / SOUL.md 到新档案。独占凭据(平台 token)会在克隆时被剥离。</div></div>
+              <div class="dzRight"><button class="btn btnSm" onclick="hxDialog('dlgClone')"><i data-lucide="copy"></i> 克隆…</button></div>
+            </div>
+            <div class="dzRow">
+              <div class="dzLeft"><div class="dzLabel">导出为 .tar.gz</div><div class="dzSub">打包整个档案目录用于备份或迁移到另一台机器。点击后直接下载。</div></div>
+              <div class="dzRight"><button class="btn btnSm"><i data-lucide="download"></i> 导出</button></div>
+            </div>
+            <div class="dzRow">
+              <div class="dzLeft"><div class="dzLabel">导入档案</div><div class="dzSub">从 .tar.gz 恢复一个档案。导入前会校验目录结构、防止路径穿越。</div></div>
+              <div class="dzRight"><button class="btn btnSm" onclick="hxDialog('dlgImport')"><i data-lucide="upload"></i> 导入…</button></div>
+            </div>
+            <div class="dzRow">
+              <div class="dzLeft"><div class="dzLabel" style="color:var(--h-err);">删除此档案</div><div class="dzSub">永久删除该档案的全部会话、记忆与配置。默认档案与使用中的档案不可删除。</div></div>
+              <div class="dzRight"><button class="btnDanger btnSm" onclick="hxDialog('dlgDelete')"><i data-lucide="trash-2"></i> 删除</button></div>
+            </div>
+          </div>
+
+          <div style="height:24px;"></div>
+        </div>
+      </div>
+    </div>
+
+    <div class="statusbarSlot">
+      <footer class="statusbar">
+        <span class="stat"><span class="sbDot"></span><span class="lbl">网关</span><span class="val">9120</span></span>
+        <span class="sep"></span>
+        <span class="stat"><span class="lbl">编辑中</span><span class="val">client-atlas</span></span>
+        <span class="right"><span class="stat"><span class="lbl">保存</span><span class="val">即时 · 防抖 300ms</span></span></span>
+      </footer>
+    </div>
+  </div>
+
+  <!-- ── Dialogs (shared-ui Dialog) ───────────────────────────────────────── -->
+  <!-- clone: shown open by default to demonstrate the modal style -->
+  <div class="hx-modal" id="dlgClone">
+    <div class="overlay" onclick="hxClose()"></div>
+    <div class="dialog" role="dialog">
+      <div class="dialogHead">
+        <span class="dialogTitle">克隆 client-atlas</span>
+        <button class="dialogClose" onclick="hxClose()"><i data-lucide="x"></i></button>
+      </div>
+      <div class="dialogBody">
+        <div class="pfieldRow">
+          <label class="pfieldLabel">新档案名</label>
+          <input class="pfieldInput" value="client-atlas-copy" spellcheck="false" />
+        </div>
+        <div class="dialogText">克隆会<strong>剥离</strong>以下独占凭据,避免身份串味 —— 创建后在新档案里重新授权即可:</div>
+        <div style="display:flex; flex-wrap:wrap; gap:6px;">
+          <span class="pill pillSm" data-tone="warn">strippedCredentials · 2</span>
+          <span class="pill pillSm" data-tone="warn">disabledPlatforms · 飞书/微信</span>
+          <span class="pill pillSm" data-tone="warn">configCredentials · 1</span>
+        </div>
+      </div>
+      <div class="dialogFoot">
+        <button class="btn" onclick="hxClose()">取消</button>
+        <button class="btnPrimary"><i data-lucide="copy"></i> 克隆创建</button>
+      </div>
+    </div>
+  </div>
+
+  <!-- import -->
+  <div class="hx-modal" id="dlgImport" style="display:none;">
+    <div class="overlay" onclick="hxClose()"></div>
+    <div class="dialog" role="dialog">
+      <div class="dialogHead">
+        <span class="dialogTitle">导入档案</span>
+        <button class="dialogClose" onclick="hxClose()"><i data-lucide="x"></i></button>
+      </div>
+      <div class="dialogBody">
+        <div class="dropzone">
+          <i data-lucide="upload-cloud" style="width:22px;height:22px;"></i>
+          <span>拖拽 <span class="codeChip">.tar.gz</span> 到这里,或点击选择文件</span>
+        </div>
+        <div class="dialogText">导入前会校验目录结构并防止路径穿越;同名档案会提示是否覆盖。</div>
+      </div>
+      <div class="dialogFoot">
+        <button class="btn" onclick="hxClose()">取消</button>
+        <button class="btnPrimary" disabled style="opacity:.55;cursor:not-allowed;">导入</button>
+      </div>
+    </div>
+  </div>
+
+  <!-- delete -->
+  <div class="hx-modal" id="dlgDelete" style="display:none;">
+    <div class="overlay" onclick="hxClose()"></div>
+    <div class="dialog" role="dialog">
+      <div class="dialogHead">
+        <span class="dialogTitle">删除 client-atlas?</span>
+        <button class="dialogClose" onclick="hxClose()"><i data-lucide="x"></i></button>
+      </div>
+      <div class="dialogBody">
+        <div class="dialogText">
+          这会<strong>永久删除</strong>该档案目录 <span class="codeChip">~/.hermes/profiles/client-atlas</span>
+          下的全部会话、记忆与配置,<strong>不可恢复</strong>。建议先导出备份。
+        </div>
+      </div>
+      <div class="dialogFoot">
+        <button class="btn" onclick="hxClose()">取消</button>
+        <button class="btnDanger"><i data-lucide="trash-2"></i> 确认删除</button>
+      </div>
+    </div>
+  </div>
+
+  <script defer src="https://unpkg.com/lucide@0.460.0/dist/umd/lucide.min.js"></script>
+  <script>
+    function hxTheme(){var r=document.documentElement;r.dataset.theme=(r.dataset.theme==='dark'?'light':'dark');}
+    function hxRename(on){document.getElementById('nameView').style.display=on?'none':'inline-flex';document.getElementById('nameEdit').style.display=on?'inline-flex':'none';}
+    function hxDialog(id){document.querySelectorAll('.hx-modal').forEach(function(m){m.style.display='none';});var el=document.getElementById(id);if(el)el.style.display='block';}
+    function hxClose(){document.querySelectorAll('.hx-modal').forEach(function(m){m.style.display='none';});}
+    document.addEventListener('DOMContentLoaded',function(){window.lucide&&window.lucide.createIcons();});
+  </script>
+</body>
+</html>

--- a/web/design-preview/profile/03-runtime-health.html
+++ b/web/design-preview/profile/03-runtime-health.html
@@ -1,0 +1,179 @@
+<!doctype html>
+<html lang="zh-CN" data-theme="light" data-density="comfortable">
+<head>
+  <meta charset="utf-8" />
+  <title>运行时健康 · 桌面保真稿</title>
+  <meta name="viewport" content="width=device-width, initial-scale=1" />
+  <link rel="stylesheet" href="../../../packages/shared-ui/src/tokens/index.css" />
+  <link rel="stylesheet" href="../preview.css" />
+</head>
+<body>
+  <button class="btn themeToggle" onclick="hxTheme()"><i data-lucide="sun-moon"></i> 明/暗</button>
+
+  <div class="shell">
+    <div class="topbarSlot">
+      <header class="topbar">
+        <div class="brand">
+          <svg class="brandMark" width="22" height="22" viewBox="0 0 80 80"><rect width="80" height="80" rx="18" fill="#f6f1e3"/><g transform="translate(-2,2)"><polygon points="58,22 58,58 62,54 62,18" fill="#3a3633"/><path d="M22,22 H30 V36 H50 V22 H58 V58 H50 V44 H30 V58 H22 Z" fill="#0a0908"/><rect x="30" y="36" width="20" height="8" fill="#ff7a3d"/></g></svg>
+          <div class="brandText">
+            <div class="wordmark">Hermes<em>·</em>CN</div>
+            <div class="brandMeta"><span class="edition">桌面端</span><span class="metaDot">·</span><span class="edition">v2</span></div>
+          </div>
+        </div>
+        <nav class="topnav">
+          <a class="topnavLink" href="#"><span class="navNum">01</span>workbench</a>
+          <a class="topnavLink" href="#"><span class="navNum">02</span>skills</a>
+          <a class="topnavLink" href="#"><span class="navNum">03</span>advanced</a>
+          <a class="topnavLink" data-active="true" href="#"><span class="navNum">04</span>settings</a>
+        </nav>
+        <div class="topsearch"><i data-lucide="search"></i><span>搜索…</span><span class="searchKbd">⌘ K</span></div>
+        <div class="topactions">
+          <button class="iconbtn" onclick="hxTheme()" title="切换主题"><i data-lucide="sun-moon"></i></button>
+          <button class="iconbtn"><i data-lucide="settings"></i></button>
+        </div>
+      </header>
+    </div>
+
+    <div class="sidebarSlot">
+      <aside class="sidebar">
+        <button class="pstrigger">
+          <span class="pstriggerLabel">档案</span>
+          <span class="pstriggerName">work</span>
+          <i data-lucide="chevrons-up-down" class="pstriggerChevron"></i>
+        </button>
+        <div class="sideLabel">我</div>
+        <div class="sideNav">
+          <a class="sideItem" href="01-profiles-list.html"><i data-lucide="folder"></i> 档案</a>
+          <a class="sideItem" data-active="true" href="03-runtime-health.html"><i data-lucide="activity"></i> 运行时健康</a>
+          <a class="sideItem" href="04-personal-center.html"><i data-lucide="user-round"></i> 个人中心</a>
+        </div>
+        <div class="sideLabel">会话</div>
+        <div class="sideNav">
+          <a class="sideItem" href="#"><i data-lucide="message-square"></i> 最近会话</a>
+          <a class="sideItem" href="#"><i data-lucide="history"></i> 历史</a>
+        </div>
+      </aside>
+    </div>
+
+    <div class="mainSlot">
+      <div class="secpage">
+        <div class="pageTopBar">
+          <div class="pageTitleGroup"><span class="pageTitle">运行时健康</span><span class="pageSub">work · gateway running</span></div>
+          <div class="pageSpacer"></div>
+          <button class="pageChip"><i data-lucide="rotate-cw"></i> 刷新</button>
+        </div>
+
+        <div class="scroll">
+
+          <!-- summary bar -->
+          <button class="hbar" data-tone="ok">
+            <span class="dot" data-tone="ok"></span>
+            <span class="hbarLabel">运行时正常</span>
+            <span class="hbarSummary">网关 + 桥接在线 · 探针 18ms · 24h 0 次失败</span>
+            <span class="hbarChev"><i data-lucide="chevron-down"></i></span>
+          </button>
+
+          <!-- restart / recover actions -->
+          <div class="sectionTitleRow">
+            <h2 class="heading">work · 当前运行时</h2>
+            <div style="display:flex; gap:8px;">
+              <button class="btn btnSm"><i data-lucide="rotate-cw"></i> 重启网关</button>
+              <button class="btn btnSm"><i data-lucide="refresh-cw"></i> 重启运行时</button>
+              <button class="btn btnSm"><i data-lucide="undo-2"></i> 恢复上一个</button>
+            </div>
+          </div>
+
+          <div class="prestartHint" style="margin-bottom:14px;">
+            <strong>已重启网关</strong>
+            <span>14:02 · 健康恢复 18ms · 自动重连成功。回滚指针保留 5 分钟。</span>
+          </div>
+
+          <!-- runtime grid (health-grid .grid/.cell) -->
+          <div class="hgrid">
+            <div class="hcell" data-size="wide">
+              <span class="hlabel"><span class="dot" data-tone="ok"></span> 网关 Gateway</span>
+              <span class="hvalue" data-mono="true">127.0.0.1:9120</span>
+              <span class="hsub">running · pid 48213 · 18ms</span>
+            </div>
+            <div class="hcell" data-size="wide">
+              <span class="hlabel"><span class="dot" data-tone="ok"></span> 桥接 Bridge</span>
+              <span class="hvalue">reachable</span>
+              <span class="hsub">electron · live · 0 err</span>
+            </div>
+            <div class="hcell" data-size="wide">
+              <span class="hlabel"><span class="dot" data-tone="ok"></span> 健康探针</span>
+              <span class="hvalue" data-mono="true">/health</span>
+              <span class="hsub">health_ok=true · 缓存 60s</span>
+            </div>
+
+            <div class="hcell">
+              <span class="hlabel">PID</span>
+              <span class="hvalue" data-mono="true">48213</span>
+            </div>
+            <div class="hcell">
+              <span class="hlabel">端口</span>
+              <span class="hvalue" data-mono="true">9120</span>
+            </div>
+            <div class="hcell">
+              <span class="hlabel">Host</span>
+              <span class="hvalue" data-mono="true">127.0.0.1</span>
+            </div>
+            <div class="hcell">
+              <span class="hlabel">模式</span>
+              <span class="hvalue">electron · live</span>
+            </div>
+            <div class="hcell">
+              <span class="hlabel">在线时长</span>
+              <span class="hvalue">12d 4h</span>
+            </div>
+            <div class="hcell">
+              <span class="hlabel">最近错误</span>
+              <span class="hvalue">—</span>
+            </div>
+          </div>
+
+          <!-- non-active profiles -->
+          <div class="sectionTitleRow">
+            <h2 class="heading">其他档案</h2>
+            <span class="pdesc" style="margin:0;">非活跃档案不运行网关 · 切换后启动</span>
+          </div>
+
+          <div class="hgrid">
+            <div class="hcell" data-size="wide">
+              <span class="hlabel"><span class="dot"></span> client-atlas</span>
+              <span class="hvalue" style="color:var(--h-text-3);">未运行</span>
+              <span class="hsub">上次在线 2 天前</span>
+            </div>
+            <div class="hcell" data-size="wide">
+              <span class="hlabel"><span class="dot"></span> demo</span>
+              <span class="hvalue" style="color:var(--h-text-3);">未运行</span>
+              <span class="hsub">上次在线 12 天前</span>
+            </div>
+            <div class="hcell" data-size="wide" style="justify-content:center;">
+              <span class="hsub" style="white-space:normal;">切到某档案后,Hermes 会启动它的网关与桥接;这里只显示活跃档案的实时运行时。</span>
+            </div>
+          </div>
+
+        </div>
+      </div>
+    </div>
+
+    <div class="statusbarSlot">
+      <footer class="statusbar">
+        <span class="stat"><span class="sbDot"></span><span class="lbl">网关</span><span class="val">9120 · 18ms</span></span>
+        <span class="sep"></span>
+        <span class="stat"><span class="lbl">桥接</span><span class="val">reachable</span></span>
+        <span class="sep"></span>
+        <span class="stat"><span class="lbl">档案</span><span class="val">work</span></span>
+        <span class="right"><span class="stat"><span class="lbl">下次探测</span><span class="val">in 26s</span></span></span>
+      </footer>
+    </div>
+  </div>
+
+  <script defer src="https://unpkg.com/lucide@0.460.0/dist/umd/lucide.min.js"></script>
+  <script>
+    function hxTheme(){var r=document.documentElement;r.dataset.theme=(r.dataset.theme==='dark'?'light':'dark');}
+    document.addEventListener('DOMContentLoaded',function(){window.lucide&&window.lucide.createIcons();});
+  </script>
+</body>
+</html>

--- a/web/design-preview/profile/04-personal-center.html
+++ b/web/design-preview/profile/04-personal-center.html
@@ -1,0 +1,131 @@
+<!doctype html>
+<html lang="zh-CN" data-theme="light" data-density="comfortable">
+<head>
+  <meta charset="utf-8" />
+  <title>个人中心 · 桌面保真稿</title>
+  <meta name="viewport" content="width=device-width, initial-scale=1" />
+  <link rel="stylesheet" href="../../../packages/shared-ui/src/tokens/index.css" />
+  <link rel="stylesheet" href="../preview.css" />
+</head>
+<body>
+  <button class="btn themeToggle" onclick="hxTheme()"><i data-lucide="sun-moon"></i> 明/暗</button>
+
+  <!-- 设置是全屏路由,自带顶栏(带返回),不套 app 外壳 -->
+  <div class="setpage" style="height:100vh;">
+    <div class="pageTopBar">
+      <a class="pageChip" href="01-profiles-list.html" style="border:none;padding:0 4px 0 0;"><i data-lucide="chevron-left"></i></a>
+      <span class="pageTitle">设置</span>
+    </div>
+
+    <div class="setLayout">
+      <!-- internal settings nav (settings.module.css .nav/.navItem) -->
+      <nav class="setNav">
+        <button class="setNavItem">通用</button>
+        <button class="setNavItem">模型</button>
+        <button class="setNavItem">技能</button>
+        <button class="setNavItem" data-active="true">个人中心</button>
+        <button class="setNavItem">隐私</button>
+        <button class="setNavItem">关于</button>
+      </nav>
+
+      <div class="setContent">
+        <h1 class="heading">个人中心</h1>
+        <p class="sdesc">你的本地身份、全局偏好,以及全部档案的总览。本机单用户、离线优先 —— 不涉及账户密码、多用户或登录设备。</p>
+
+        <!-- identity -->
+        <div class="detailHeader">
+          <span class="detailAvatar" data-tint="persimmon">e</span>
+          <div style="flex:1; min-width:0;">
+            <span class="detailName" id="nameView">
+              enzo
+              <button class="detailNameEdit" onclick="hxRename(true)" title="改名"><i data-lucide="pencil"></i></button>
+            </span>
+            <span id="nameEdit" style="display:none; align-items:center; gap:8px;">
+              <input class="detailNameInput" value="enzo" spellcheck="false" />
+              <button class="btnPrimary btnSm" onclick="hxRename(false)">保存</button>
+              <button class="btn btnSm" onclick="hxRename(false)">取消</button>
+            </span>
+            <div class="detailSub">本地账户 · 单用户</div>
+          </div>
+        </div>
+
+        <div class="srow"><div class="srowLeft"><div class="srowLabel">设备</div></div><div class="srowRight">studio · darwin 25.4.0</div></div>
+        <div class="srow"><div class="srowLeft"><div class="srowLabel">时区</div></div><div class="srowRight">Asia/Shanghai (UTC+8)</div></div>
+        <div class="srow"><div class="srowLeft"><div class="srowLabel">HERMES_HOME</div></div><div class="srowRight"><span class="codeChip">~/.hermes</span></div></div>
+        <div class="srow"><div class="srowLeft"><div class="srowLabel">首次使用</div></div><div class="srowRight">2026-01-04 · 152 天</div></div>
+
+        <!-- global preferences -->
+        <h2 class="heading" style="margin-top:28px;">全局偏好</h2>
+        <div class="srow">
+          <div class="srowLeft"><div class="srowLabel">审批模式</div><div class="srowSub">破坏性 shell 与网络写入前 Hermes 先询问</div></div>
+          <div class="srowRight"><button class="toggle" data-on="true"><span class="toggleThumb"></span></button></div>
+        </div>
+        <div class="srow">
+          <div class="srowLeft"><div class="srowLabel">记忆自动保存</div><div class="srowSub">自动保存用户 / 反馈 / 项目相关的记忆</div></div>
+          <div class="srowRight"><button class="toggle" data-on="true"><span class="toggleThumb"></span></button></div>
+        </div>
+        <div class="srow">
+          <div class="srowLeft"><div class="srowLabel">默认进入只读</div><div class="srowSub">已完成的会话首次打开时自动折叠工作区面板</div></div>
+          <div class="srowRight"><button class="toggle" data-on="true"><span class="toggleThumb"></span></button></div>
+        </div>
+        <div class="srow">
+          <div class="srowLeft"><div class="srowLabel">遥测</div><div class="srowSub">仅本地。绝不发到 Anthropic 或外部</div></div>
+          <div class="srowRight"><button class="toggle"><span class="toggleThumb"></span></button></div>
+        </div>
+        <div class="srow">
+          <div class="srowLeft"><div class="srowLabel">主题</div></div>
+          <div class="srowRight"><select class="select"><option>跟随系统</option><option>浅色</option><option>深色</option></select></div>
+        </div>
+        <div class="srow">
+          <div class="srowLeft"><div class="srowLabel">密度</div></div>
+          <div class="srowRight"><select class="select"><option>舒适</option><option>紧凑</option></select></div>
+        </div>
+
+        <!-- cross-profile overview -->
+        <h2 class="heading" style="margin-top:28px;">档案总览</h2>
+        <div class="hgrid" style="margin-bottom:14px;">
+          <div class="hcell" data-size="wide"><span class="hlabel">档案数</span><span class="hvalue">3 个 · 1 使用中</span></div>
+          <div class="hcell" data-size="wide"><span class="hlabel">7 天总消费</span><span class="hvalue">$7.21</span></div>
+          <div class="hcell" data-size="wide"><span class="hlabel">当前档案</span><span class="hvalue" data-mono="true">work</span></div>
+        </div>
+
+        <div class="plist">
+          <a class="prow" data-clickable="true" href="02-profile-detail.html" style="text-decoration:none;">
+            <span class="pAvatar" data-tint="persimmon">w</span>
+            <div class="prowMain">
+              <div class="prowHead"><span class="prowName">work</span><span class="ptag">default</span></div>
+              <div class="prowMeta"><span class="pmetaCell">会话 48</span><span class="pmetaCell">7d $2.41</span><span class="pmetaCell">磁盘 312 MB</span></div>
+            </div>
+            <div class="prowActions"><i data-lucide="chevron-right" style="color:var(--h-text-3);"></i></div>
+          </a>
+          <a class="prow" data-clickable="true" href="02-profile-detail.html" style="text-decoration:none;">
+            <span class="pAvatar" data-tint="moss">c</span>
+            <div class="prowMain">
+              <div class="prowHead"><span class="prowName">client-atlas</span></div>
+              <div class="prowMeta"><span class="pmetaCell">会话 38</span><span class="pmetaCell">7d $4.80</span><span class="pmetaCell">磁盘 88 MB</span></div>
+            </div>
+            <div class="prowActions"><i data-lucide="chevron-right" style="color:var(--h-text-3);"></i></div>
+          </a>
+          <a class="prow" data-clickable="true" href="02-profile-detail.html" style="text-decoration:none;">
+            <span class="pAvatar" data-tint="sky">d</span>
+            <div class="prowMain">
+              <div class="prowHead"><span class="prowName">demo</span><span class="ptag">只读演示</span></div>
+              <div class="prowMeta"><span class="pmetaCell">会话 2</span><span class="pmetaCell">7d $0.00</span><span class="pmetaCell">磁盘 24 MB</span></div>
+            </div>
+            <div class="prowActions"><i data-lucide="chevron-right" style="color:var(--h-text-3);"></i></div>
+          </a>
+        </div>
+
+        <div style="height:24px;"></div>
+      </div>
+    </div>
+  </div>
+
+  <script defer src="https://unpkg.com/lucide@0.460.0/dist/umd/lucide.min.js"></script>
+  <script>
+    function hxTheme(){var r=document.documentElement;r.dataset.theme=(r.dataset.theme==='dark'?'light':'dark');}
+    function hxRename(on){document.getElementById('nameView').style.display=on?'none':'inline-flex';document.getElementById('nameEdit').style.display=on?'inline-flex':'none';}
+    document.addEventListener('DOMContentLoaded',function(){window.lucide&&window.lucide.createIcons();});
+  </script>
+</body>
+</html>

--- a/web/design-preview/profile/index.html
+++ b/web/design-preview/profile/index.html
@@ -1,0 +1,76 @@
+<!doctype html>
+<html lang="zh-CN" data-theme="light" data-density="comfortable">
+<head>
+  <meta charset="utf-8" />
+  <title>Profile 改造 · 桌面保真稿 · 索引</title>
+  <meta name="viewport" content="width=device-width, initial-scale=1" />
+  <link rel="stylesheet" href="../../../packages/shared-ui/src/tokens/index.css" />
+  <link rel="stylesheet" href="../preview.css" />
+</head>
+<body>
+  <button class="btn themeToggle" onclick="hxTheme()"><i data-lucide="sun-moon"></i> 明/暗</button>
+
+  <div class="idxWrap">
+    <header class="idxHead">
+      <h1 class="idxTitle">Profile 改造 · 桌面保真稿</h1>
+      <p class="idxSub">
+        对齐 <strong>hermes-agent-cn-desktop</strong> 真实设计语言的高保真视觉稿:复用真实
+        <code class="codeChip">--h-*</code> token 与 <code class="codeChip">section-shell</code> /
+        <code class="codeChip">.row</code> / <code class="codeChip">health-grid</code> /
+        <code class="codeChip">Dialog</code> 组件样式。纯无衬线、紧凑密度、字号 ≤14px、单一柿色强调。
+        每屏标注其映射的 React 文件,1:1 可落地。
+      </p>
+      <p class="idxNote">
+        ⚠ 这是放在 <code class="codeChip">web/design-preview/</code> 的静态视觉稿,<strong>不参与 App 构建</strong>
+        (在 tsconfig include 与 vite input 之外)。浏览器直开即可;右上角可切换明/暗。
+      </p>
+    </header>
+
+    <a class="idxRow" href="01-profiles-list.html">
+      <span class="idxRowNum">01</span>
+      <span class="idxRowMain">
+        <span class="idxRowTitle">档案列表 + 切换</span>
+        <span class="idxRowSub">列表 · 头像 · 当前默认 · 元数据/用量 · 切换弹窗 · 新建/克隆</span>
+      </span>
+      <span class="idxRowMap">→ profiles.tsx</span>
+      <i data-lucide="chevron-right"></i>
+    </a>
+
+    <a class="idxRow" href="02-profile-detail.html">
+      <span class="idxRowNum">02</span>
+      <span class="idxRowMain">
+        <span class="idxRowTitle">档案详情与编辑</span>
+        <span class="idxRowSub">头像(生成/上传)· 就地重命名 · 元数据/用量 · 配置摘要 · 危险区(克隆/导出/导入/删除)</span>
+      </span>
+      <span class="idxRowMap">→ profile-detail.tsx</span>
+      <i data-lucide="chevron-right"></i>
+    </a>
+
+    <a class="idxRow" href="03-runtime-health.html">
+      <span class="idxRowNum">03</span>
+      <span class="idxRowMain">
+        <span class="idxRowTitle">运行时健康</span>
+        <span class="idxRowSub">网关 + 桥接状态卡 · 一键重启/恢复(health-grid 卡片范式,非 sparkline)</span>
+      </span>
+      <span class="idxRowMap">→ health.tsx · profile-runtime-grid.tsx</span>
+      <i data-lucide="chevron-right"></i>
+    </a>
+
+    <a class="idxRow" href="04-personal-center.html">
+      <span class="idxRowNum">04</span>
+      <span class="idxRowMain">
+        <span class="idxRowTitle">个人中心</span>
+        <span class="idxRowSub">身份 · 全局偏好 · 跨档案总览 —— 并入设置页作为一个 section</span>
+      </span>
+      <span class="idxRowMap">→ settings.tsx · PersonalCenterSection</span>
+      <i data-lucide="chevron-right"></i>
+    </a>
+  </div>
+
+  <script defer src="https://unpkg.com/lucide@0.460.0/dist/umd/lucide.min.js"></script>
+  <script>
+    function hxTheme(){var r=document.documentElement;r.dataset.theme=(r.dataset.theme==='dark'?'light':'dark');}
+    document.addEventListener('DOMContentLoaded',function(){window.lucide&&window.lucide.createIcons();});
+  </script>
+</body>
+</html>


### PR DESCRIPTION
## 背景 / Why

之前的 Profile 改造原型放在 `hermes-cn-ui-prototypes-sans`,走的是 sans **编辑/杂志风**(Fraunces
56–64px 大斜体、`.grid-12` 12 栏网格、§ 页边码、sparkline)。这套设计语言已经和桌面端真实实现脱节
—— 在其上继续画,既偏离桌面方向、移植成本又高(全盘照搬约 2–3 周 CSS 重构)。

本 PR 改为 **桌面保真静态稿**:对齐 App 的真实设计语言,让稿子 1:1 映射 React、近乎零翻译成本。

## 做法 / How

放在 `web/design-preview/`(**构建隔离**:在 `web/tsconfig.json` 的 `include` 与 Vite 入口之外,
不进 bundle、不影响 `pnpm typecheck` / `pnpm test:unit`):

- **复用真实 token**:每页直接 `<link>` 真实的 `packages/shared-ui/src/tokens/index.css`,零重复。
- **逐字镜像组件样式**:`preview.css` 把 `profiles.module.css` / `settings.module.css` /
  `panel/health-grid.module.css` / `ui/pill` / `composites/dialog` / 外壳(app-shell 48/248/26 网格、
  44px 顶栏、section-shell)的规则按真实 px 重声明(CSS Module 类名是 hash 的、无法直接引入,故加前缀
  避免冲突),每块注明对应的真实 `源文件 .类名`。
- **保真红线**:纯无衬线(HarmonyOS Sans + Cascadia)、字号 ≤14px、圆角只用 `--h-r-*`、小边框按钮、
  单一柿色 `--h-accent` + `--h-ok/warn/err`;**无** Fraunces/斜体大标题、12 栏网格、页边码、sparkline;
  弹窗是居中 560 `Dialog`。

## 四屏 → 落地映射

| 稿 | 文件 | 落地到 |
|---|---|---|
| ① 档案列表 + 切换 | `01-profiles-list.html` | `routes/profiles.tsx` + `sidebar/profile-selector.tsx` |
| ② 详情与编辑 | `02-profile-detail.html` | 新建 `routes/profile-detail.tsx` + shared-ui `Dialog` |
| ③ 运行时健康 | `03-runtime-health.html` | `routes/health.tsx` + 新建 `profile-runtime-grid.tsx` |
| ④ 个人中心 | `04-personal-center.html` | `routes/settings.tsx` 新 `PersonalCenterSection` |

功能范围沿用 PRD(头像、运行时健康、克隆/导入导出、就地重命名 + 元数据/用量),**只换视觉语言**。

## 验证

- 浏览器直开 `web/design-preview/profile/index.html`(右上角切明/暗),四屏点一遍。
- 与运行中的 App 对照:`pnpm web:dev`(:9545,需先 `hermes dashboard --no-open`)。
- 已确认:token 路径可达、构建隔离、无硬编码颜色、无衬线/大标题违规。

> 注:这是**设计稿**,非 App 代码;落地时按上表映射到真实 React 文件。
> 旧 sans 编辑风原型保留为「北极星」参考,不在本 PR 范围。

🤖 Generated with [Claude Code](https://claude.com/claude-code)