### PR TITLE
[codex] 修复模型首次设为当前配置顺序

### DIFF
--- a/src/process/dashboard.rs
+++ b/src/process/dashboard.rs
@@ -21,11 +21,12 @@ use serde::{Deserialize, Serialize};
 use crate::error::AppError;
 use crate::state::{DashboardHandle, DashboardJobHandle};
 
-// A freshly installed onefile runtime can spend ~20s on macOS unpacking its
-// embedded Python payload before the dashboard process begins serving HTTP.
-// Use a production-safe margin so first launch does not fail right after a
-// successful runtime install on slower machines.
-const DASHBOARD_READY_TIMEOUT: Duration = Duration::from_secs(60);
+// A freshly installed onefile runtime can spend tens of seconds on macOS
+// unpacking/importing its embedded Python payload before the dashboard process
+// begins serving HTTP. Local-source dev runtimes can also cross the old 60s
+// boundary on cold caches, leaving a dashboard that becomes ready just after
+// bootstrap has already failed. Keep a wider production-safe margin.
+const DASHBOARD_READY_TIMEOUT: Duration = Duration::from_secs(120);
 const PROBE_TIMEOUT: Duration = Duration::from_millis(900);
 const SESSION_TOKEN_TIMEOUT: Duration = Duration::from_millis(1200);
 const SHUTDOWN_HTTP_TIMEOUT: Duration = Duration::from_millis(800);

--- a/web/src/lib/provider-catalog.test.ts
+++ b/web/src/lib/provider-catalog.test.ts
@@ -82,6 +82,38 @@ describe("provider catalog config updates", () => {
     });
   });
 
+
+  it("writes Volcengine Coding Plan as a resolvable provider and current model", () => {
+    const preset = BUILTIN_PROVIDER_CATALOG.providers.find((provider) => provider.id === "volcengine-ark-coding");
+    expect(preset).toBeTruthy();
+
+    const config = buildProviderConfigUpdate(
+      {},
+      preset!,
+      {
+        apiKey: "ark-coding-key",
+        baseUrl: "https://ark.cn-beijing.volces.com/api/coding/v3",
+        model: "doubao-seed-2.0-code",
+      },
+    );
+
+    expect(config.providers["volcengine-ark-coding"]).toMatchObject({
+      name: "火山方舟 · Coding Plan",
+      api_key: "ark-coding-key",
+      base_url: "https://ark.cn-beijing.volces.com/api/coding/v3",
+      api_mode: "chat_completions",
+      transport: "openai_chat",
+      model: "doubao-seed-2.0-code",
+    });
+    expect(config.model).toMatchObject({
+      provider: "volcengine-ark-coding",
+      default: "doubao-seed-2.0-code",
+      base_url: "https://ark.cn-beijing.volces.com/api/coding/v3",
+      api_mode: "chat_completions",
+      api_key: "ark-coding-key",
+    });
+  });
+
   it("can set the current model without rewriting provider metadata", () => {
     const preset = BUILTIN_PROVIDER_CATALOG.providers.find((provider) => provider.id === "kimi-for-coding");
     expect(preset).toBeTruthy();

--- a/web/src/routes/settings-models-section.tsx
+++ b/web/src/routes/settings-models-section.tsx
@@ -8,7 +8,6 @@ import { useProviderModels } from "@/hooks/use-provider-models";
 import type { ModelInfo, ProviderProbeResult } from "@hermes/protocol";
 import {
   BUILTIN_PROVIDER_CATALOG,
-  buildCurrentModelConfigUpdate,
   buildProviderConfigUpdate,
   buildProviderSettingsUpdate,
   getProviderEntry,
@@ -900,18 +899,35 @@ export function ModelsSection() {
   const handleSetCurrentModel = async () => {
     if (!config || !selectedProvider) return;
     const pendingStartedAt = performance.now();
+    const newApiKey = providerForm.apiKey.trim();
+    const savedBaseUrl = providerForm.baseUrl.trim() || selectedProvider.baseUrl;
     const savedModel = providerForm.model.trim() || selectedProvider.defaultModel;
     const providerId = selectedProvider.id;
     const providerName = selectedProvider.name;
+    const isCustomProvider = providerId.startsWith("custom:");
     setProviderSetCurrentPending(true);
     setProviderSaveError("");
     try {
-      // Same hot-switch path as the composer model picker: update the live
-      // gateway runtime explicitly instead of only editing provider metadata.
-      await setRuntimeModel(savedModel, providerId);
+      if (newApiKey && !isCustomProvider && selectedProvider.apiKeyLabel) {
+        await setEnv.mutateAsync({ key: selectedProvider.apiKeyLabel, value: newApiKey });
+      }
+      // Persist both providers.<id> and model.* before asking the live gateway
+      // to hot-switch. First-run setups otherwise have no current provider for
+      // gateway _apply_model_switch() to resolve, so it can fail before it ever
+      // considers the explicit `--provider <id>` argument.
       await saveConfig.mutateAsync(
-        buildCurrentModelConfigUpdate(config, selectedProvider, providerForm),
+        buildProviderConfigUpdate(config, selectedProvider, providerForm),
       );
+      // Same hot-switch path as the composer model picker: update the live
+      // gateway runtime explicitly after disk config is already usable.
+      await setRuntimeModel(savedModel, providerId);
+      setProviderForm((prev) => ({ ...prev, apiKey: "" }));
+      setSavedSnapshot({
+        baseUrl: savedBaseUrl,
+        model: savedModel,
+        providerId,
+      });
+      setSavedFlashFor(providerId);
       // PanelComposer seeds its model picker from the UI store.
       // This mirrors picking a model from the workbench composer, so the next
       // new session carries this explicit choice even before /api/model/info


### PR DESCRIPTION
## 变更内容

本 PR 修复模型配置页首次保存并设为当前模型时的顺序问题，避免用户在第一次配置服务商时需要重复操作才能让当前模型生效。同时放宽桌面端托管 runtime 的 dashboard 启动就绪等待时间，减少本地 runtime 首次启动或环境较慢时误判失败的概率。

## 修复原因

首次配置模型时，当前模型写入依赖已保存的服务商配置。如果保存和设为当前模型的时序过紧，UI 可能在配置尚未稳定落盘时就继续执行后续动作，导致设置流程表现不稳定。dashboard 启动探测也在部分机器上偏短，容易在 runtime 实际仍在初始化时提前报错。

## 验证

- `pnpm typecheck`
- `pnpm test:unit`
- `cargo check`
