### PR TITLE
fix: 修复回复完成后用户消息排到 Hermes 回复下方的问题

### DIFF
--- a/web/src/components/chat/message-adapter.test.ts
+++ b/web/src/components/chat/message-adapter.test.ts
@@ -409,6 +409,73 @@ describe("message adapter", () => {
     });
   });
 
+  // Regression for issue #98: once a reply completes the stored refetch carries
+  // the persisted assistant turn, but the live user prompt can fail to match a
+  // stored row (its canonical text diverged), so it was appended *after* the
+  // assistant and rendered below the reply. The merge now re-orders by createdAt.
+  it("keeps the user prompt above the assistant reply after a completed turn", () => {
+    const stored = [
+      uiMessage({
+        id: "stored-assistant",
+        role: "assistant",
+        createdAt: 5_001,
+        parts: [{ type: "text", text: "这是回复。" }],
+      }),
+    ];
+    const live = [
+      uiMessage({
+        id: "live-user",
+        role: "user",
+        createdAt: 5_000,
+        parts: [{ type: "text", text: "帮我开发一个项目" }],
+      }),
+      uiMessage({
+        id: "live-assistant",
+        role: "assistant",
+        status: "streaming",
+        createdAt: 5_001,
+        parts: [{ type: "text", text: "这是回复。" }],
+      }),
+    ];
+
+    const merged = mergeHermesUIMessages(stored, live);
+
+    expect(merged.map((message) => message.role)).toEqual(["user", "assistant"]);
+    expect(merged[0]?.id).toBe("live-user");
+  });
+
+  // The optimistic user + assistant get the same `now` from startPromptAtom, so
+  // the createdAt sort relies on a user-before-assistant tiebreak on exact ties.
+  it("orders the user before the assistant when their createdAt ties", () => {
+    const stored = [
+      uiMessage({
+        id: "stored-assistant",
+        role: "assistant",
+        createdAt: 7_000,
+        parts: [{ type: "text", text: "答复" }],
+      }),
+    ];
+    const live = [
+      uiMessage({
+        id: "live-user",
+        role: "user",
+        createdAt: 7_000,
+        parts: [{ type: "text", text: "问题" }],
+      }),
+      uiMessage({
+        id: "live-assistant",
+        role: "assistant",
+        status: "streaming",
+        createdAt: 7_000,
+        parts: [{ type: "text", text: "答复" }],
+      }),
+    ];
+
+    const merged = mergeHermesUIMessages(stored, live);
+
+    expect(merged.map((message) => message.role)).toEqual(["user", "assistant"]);
+  });
+
   it("does not duplicate a stored refetch that matches a live assistant response", () => {
     const stored = legacySessionMessagesToHermesUIMessages([
       sessionMessage({ id: 1, role: "assistant", content: "完成", timestamp: 100 }),

--- a/web/src/components/chat/message-adapter.ts
+++ b/web/src/components/chat/message-adapter.ts
@@ -730,7 +730,26 @@ export function mergeHermesUIMessages(
     if (!usedLiveIndexes.has(index)) merged.push(liveMessage);
   });
 
-  return merged;
+  // Issue #98: a live message that fails to match any stored row — typically
+  // the current turn's user prompt whose canonical text diverged from the
+  // persisted copy — is pushed onto the end above, which lands it *below* the
+  // assistant reply once that reply is refetched into `stored`. Re-order the
+  // merged turn by createdAt so it keeps its chronological shape after the
+  // reply completes. The sort is stable: on an exact createdAt tie (startPrompt
+  // stamps the optimistic user + assistant with the same `now`) the user is
+  // floated before the assistant, otherwise the original order is preserved.
+  return merged
+    .map((message, index) => ({ message, index }))
+    .sort((a, b) => {
+      if (a.message.createdAt !== b.message.createdAt) {
+        return a.message.createdAt - b.message.createdAt;
+      }
+      const rank = (role: HermesUIMessage["role"]) => (role === "user" ? 0 : 1);
+      const rankDelta = rank(a.message.role) - rank(b.message.role);
+      if (rankDelta !== 0) return rankDelta;
+      return a.index - b.index;
+    })
+    .map((entry) => entry.message);
 }
 
 export function storedMessageToChatMessage(msg: SessionMessage): ChatMessage | null {


### PR DESCRIPTION
## 背景 (closes #98)

用户反馈：每次 Hermes 回复**完成**后，本应在回复上方的「我的消息」会自动排到 Hermes 回复下方，导致对话顺序看起来反转。

## 根因

`mergeHermesUIMessages`（`web/src/components/chat/message-adapter.ts`）合并「已落库 stored + 实时流 live」时，先按 stored 顺序输出，再把**未匹配的 live 消息一律追加到末尾**，全程不按时间重排。

一轮回复完成后，REST 刷新把已持久化的 assistant 回复带入 `stored`；而该轮的 live 用户消息因 canonical 文本与持久化副本有差异未能匹配 stored 行，于是被追加到**末尾**——排到了 assistant 回复下方。

## 改动

合并结束后按 `createdAt` 做**稳定排序**：
- `startPromptAtom` 给乐观的 user 与 assistant 打的是同一个 `now`，因此在 `createdAt` 相等时以「user 先于 assistant」兜底；
- 其余按原插入顺序保持稳定（stored 的服务端时间戳为 `timestamp*1000`，亚毫秒精度，跨轮不会碰撞）。

不触碰已有的去重/匹配逻辑。

## 验收

- 一轮回复完成后，用户消息仍在该回复上方 ✓
- 流式中 / 完成后排序不跳变 ✓

## 测试

- `pnpm typecheck` 通过
- `pnpm test:unit` 全绿（web 379 + protocol 15），新增 2 条回归用例：
  - keeps the user prompt above the assistant reply after a completed turn
  - orders the user before the assistant when their createdAt ties

🤖 Generated with [Claude Code](https://claude.com/claude-code)