### PR TITLE
[codex] 隐藏底部主目录路径

### DIFF
--- a/web/src/components/app-shell/app-status-bar.tsx
+++ b/web/src/components/app-shell/app-status-bar.tsx
@@ -23,13 +23,6 @@ function formatContext(ctx: number | null | undefined): string {
   return `${ctx}`;
 }
 
-function tilde(path: string | undefined): string {
-  if (!path) return "—";
-  const home = path.match(/[A-Z]:[\\/]Users[\\/][^\\/]+/i)?.[0];
-  if (home && path.startsWith(home)) return path.replace(home, "~").replace(/\\/g, "/");
-  return path.replace(/\\/g, "/");
-}
-
 function portFromUrl(url: string | null | undefined): string | null {
   if (!url) return null;
   try {
@@ -65,7 +58,6 @@ export function AppStatusBar() {
   const contextLabel = formatContext(
     modelInfo?.effective_context_length ?? modelInfo?.auto_context_length,
   );
-  const homeLabel = tilde(status?.hermes_home);
 
   const runningCount = useMemo(() => {
     if (!sessions?.sessions) return status?.active_sessions ?? 0;
@@ -102,11 +94,6 @@ export function AppStatusBar() {
       <span className={s.stat}>
         <span className={s.lbl}>上下文</span>
         <span className={s.val}>{contextLabel}</span>
-      </span>
-      <span className={s.sep} />
-      <span className={s.stat} title={status?.hermes_home}>
-        <span className={s.lbl}>主目录</span>
-        <span className={s.val}>{homeLabel}</span>
       </span>
 
       <div className={s.right}>


### PR DESCRIPTION
## 变更内容

移除底部状态栏中的「主目录」字段，不再在主界面底部展示 HERMES_HOME 路径。

## 修复原因

桌面端 managed runtime 的 HERMES_HOME 路径很长，展示在底部状态栏会占用过多横向空间，影响其它状态信息的可读性。

## 用户影响

底部状态栏更紧凑，保留网关、模型、上下文、运行中数量、错误数和今日 Tokens 等更常用的信息。需要查看 runtime 路径时仍可通过设置页的 runtime/debug 信息确认。

## 验证

- `pnpm typecheck`
- `pnpm test:unit`
- `cargo check`
