### PR TITLE
fix: render sent replies immediately in resumed sessions

### DIFF
--- a/web/src/hooks/use-session-resolution.test.ts
+++ b/web/src/hooks/use-session-resolution.test.ts
@@ -1,0 +1,99 @@
+import { beforeEach, describe, expect, it } from "vitest";
+import type { HermesUIMessage } from "@hermes/protocol";
+import {
+  createEmptyChatRuntime,
+  type ChatRuntimeBySession,
+  type ChatSessionRuntime,
+} from "@/stores/chat";
+import { __resetUiStoreForTests, writeUiValue } from "@/lib/ui-store";
+import { rememberSessionMapping } from "@/lib/session-map";
+import { resolveSessionRuntime } from "./use-session-resolution";
+
+const MAP_KEY = "hermes:gateway-session-map";
+
+function userMessage(sessionId: string, text: string): HermesUIMessage {
+  return {
+    id: `u-${text}`,
+    sessionId,
+    role: "user",
+    createdAt: 1,
+    status: "complete",
+    parts: [{ type: "text", text }],
+  };
+}
+
+function runtimeWith(sessionId: string, text: string): ChatSessionRuntime {
+  return { ...createEmptyChatRuntime(1), messages: [userMessage(sessionId, text)] };
+}
+
+function firstText(runtime: ChatSessionRuntime): string | undefined {
+  const part = runtime.messages[0]?.parts[0];
+  return part && part.type === "text" ? part.text : undefined;
+}
+
+describe("resolveSessionRuntime", () => {
+  beforeEach(() => {
+    __resetUiStoreForTests();
+  });
+
+  it("reads the live runtime when the persisted map still holds a stale duplicate", () => {
+    // Regression for the invisible-reply bug: a resumed session accumulated two
+    // gateway ids for one persistent id (e.g. a map persisted across an app
+    // relaunch). The route id is the persistent id; the optimistic send wrote
+    // into the *live* gateway bucket. Resolution must land on that bucket, not
+    // the empty runtimeBySession[persistentId] fallback.
+    writeUiValue(MAP_KEY, {
+      "gw-stale": { persistentId: "sess-1", ts: Date.now() - 60_000 },
+      "gw-live": { persistentId: "sess-1", ts: Date.now() - 1_000 },
+    });
+    const runtimeBySession: ChatRuntimeBySession = {
+      "gw-live": runtimeWith("gw-live", "just sent"),
+    };
+
+    const resolved = resolveSessionRuntime("sess-1", "gw-live", runtimeBySession);
+
+    expect(resolved.runtimeSessionId).toBe("gw-live");
+    expect(firstText(resolved.runtime)).toBe("just sent");
+    expect(resolved.isLiveSession).toBe(true);
+    expect(resolved.restSessionId).toBe("sess-1");
+  });
+
+  it("does not bleed a different background-streaming session into the current view", () => {
+    // Session B is the live gateway session (streaming in the background) while
+    // the route is showing session A. Preferring the live gwSessionId must be
+    // gated on it mapping to the *same* persistent session, or detail would
+    // render B's transcript under A.
+    rememberSessionMapping("gw-A", "persistent-A");
+    rememberSessionMapping("gw-B", "persistent-B");
+    const runtimeBySession: ChatRuntimeBySession = {
+      "gw-A": runtimeWith("gw-A", "from A"),
+      "gw-B": runtimeWith("gw-B", "from B"),
+    };
+
+    const resolved = resolveSessionRuntime("persistent-A", "gw-B", runtimeBySession);
+
+    expect(resolved.runtimeSessionId).toBe("gw-A");
+    expect(firstText(resolved.runtime)).toBe("from A");
+  });
+
+  it("resolves a fresh new-task session keyed directly by its gateway id", () => {
+    const runtimeBySession: ChatRuntimeBySession = {
+      "gw-new": runtimeWith("gw-new", "hi"),
+    };
+
+    const resolved = resolveSessionRuntime("gw-new", "gw-new", runtimeBySession);
+
+    expect(resolved.runtimeSessionId).toBe("gw-new");
+    expect(firstText(resolved.runtime)).toBe("hi");
+    expect(resolved.isGatewayLinked).toBe(true);
+    expect(resolved.isLiveSession).toBe(true);
+  });
+
+  it("falls back to an empty idle runtime for an unknown session", () => {
+    const resolved = resolveSessionRuntime("unknown", null, {});
+
+    expect(resolved.runtime.messages).toHaveLength(0);
+    expect(resolved.runtimeIsBusy).toBe(false);
+    expect(resolved.isLiveSession).toBe(false);
+  });
+});

--- a/web/src/hooks/use-session-resolution.ts
+++ b/web/src/hooks/use-session-resolution.ts
@@ -4,53 +4,89 @@ import {
   chatRuntimeBySessionAtom,
   createEmptyChatRuntime,
   gwSessionIdAtom,
+  type ChatRuntimeBySession,
+  type ChatSessionRuntime,
 } from "@/stores/chat";
 import { isRuntimeRunning } from "@/lib/session-activity";
 import { resolveGatewaySessionId, resolvePersistentSessionId } from "@/lib/session-map";
+
+export interface SessionResolution {
+  restSessionId: string | undefined;
+  activeMappedGatewaySessionId: string | undefined;
+  runtimeSessionId: string | undefined;
+  usageGatewaySessionId: string | undefined;
+  runtime: ChatSessionRuntime;
+  runtimeIsBusy: boolean;
+  isGatewayLinked: boolean;
+  isLiveSession: boolean;
+}
+
+// Pure so it can be unit-tested without React. Decides which runtime bucket the
+// detail view should render for `taskId`.
+export function resolveSessionRuntime(
+  taskId: string | undefined,
+  gwSessionId: string | null,
+  runtimeBySession: ChatRuntimeBySession,
+): SessionResolution {
+  const restSessionId = resolvePersistentSessionId(taskId);
+
+  // The live gateway session is the ground truth for what is streaming *right
+  // now*. When it belongs to the same persistent session this route is showing,
+  // prefer it directly. One persistent id can map to several gateway ids, so the
+  // reverse lookup (resolveGatewaySessionId) is ambiguous, but the forward
+  // lookup off the live id is not. Trusting the live id keeps the optimistic
+  // user message + streaming assistant reading from the bucket the send wrote
+  // into, instead of an orphaned empty runtime — even if the map is still dirty.
+  const liveGatewaySessionId =
+    gwSessionId && resolvePersistentSessionId(gwSessionId) === restSessionId
+      ? gwSessionId
+      : undefined;
+  const mappedGatewaySessionId = liveGatewaySessionId ?? resolveGatewaySessionId(taskId);
+  const activeMappedGatewaySessionId =
+    mappedGatewaySessionId &&
+    (gwSessionId === mappedGatewaySessionId || runtimeBySession[mappedGatewaySessionId])
+      ? mappedGatewaySessionId
+      : undefined;
+  const runtimeSessionId =
+    taskId && runtimeBySession[taskId] ? taskId : activeMappedGatewaySessionId;
+  const runtime = taskId
+    ? runtimeBySession[runtimeSessionId ?? taskId] ?? createEmptyChatRuntime()
+    : createEmptyChatRuntime();
+  const runtimeIsBusy = isRuntimeRunning(runtime);
+  const isGatewayLinked = Boolean(
+    taskId &&
+      (gwSessionId === taskId ||
+        gwSessionId === activeMappedGatewaySessionId ||
+        resolvePersistentSessionId(gwSessionId ?? undefined) === restSessionId),
+  );
+
+  // Stay in live mode whenever runtime messages have unsynced content, regardless
+  // of streamStatus. Live messages carry richer metadata (TTFT, duration, cost)
+  // than REST stored messages, so detail can deduplicate them against stored data.
+  const isLiveSession =
+    isGatewayLinked ||
+    runtimeIsBusy ||
+    runtime.pendingApprovals.length > 0 ||
+    runtime.messages.length > 0;
+
+  return {
+    restSessionId,
+    activeMappedGatewaySessionId,
+    runtimeSessionId,
+    usageGatewaySessionId: runtimeSessionId ?? activeMappedGatewaySessionId,
+    runtime,
+    runtimeIsBusy,
+    isGatewayLinked,
+    isLiveSession,
+  };
+}
 
 export function useSessionResolution(taskId: string | undefined) {
   const gwSessionId = useAtomValue(gwSessionIdAtom);
   const runtimeBySession = useAtomValue(chatRuntimeBySessionAtom);
 
-  return useMemo(() => {
-    const restSessionId = resolvePersistentSessionId(taskId);
-    const mappedGatewaySessionId = resolveGatewaySessionId(taskId);
-    const activeMappedGatewaySessionId =
-      mappedGatewaySessionId &&
-      (gwSessionId === mappedGatewaySessionId || runtimeBySession[mappedGatewaySessionId])
-        ? mappedGatewaySessionId
-        : undefined;
-    const runtimeSessionId =
-      taskId && runtimeBySession[taskId] ? taskId : activeMappedGatewaySessionId;
-    const runtime = taskId
-      ? runtimeBySession[runtimeSessionId ?? taskId] ?? createEmptyChatRuntime()
-      : createEmptyChatRuntime();
-    const runtimeIsBusy = isRuntimeRunning(runtime);
-    const isGatewayLinked = Boolean(
-      taskId &&
-        (gwSessionId === taskId ||
-          gwSessionId === activeMappedGatewaySessionId ||
-          resolvePersistentSessionId(gwSessionId ?? undefined) === restSessionId),
-    );
-
-    // Stay in live mode whenever runtime messages have unsynced content, regardless
-    // of streamStatus. Live messages carry richer metadata (TTFT, duration, cost)
-    // than REST stored messages, so detail can deduplicate them against stored data.
-    const isLiveSession =
-      isGatewayLinked ||
-      runtimeIsBusy ||
-      runtime.pendingApprovals.length > 0 ||
-      runtime.messages.length > 0;
-
-    return {
-      restSessionId,
-      activeMappedGatewaySessionId,
-      runtimeSessionId,
-      usageGatewaySessionId: runtimeSessionId ?? activeMappedGatewaySessionId,
-      runtime,
-      runtimeIsBusy,
-      isGatewayLinked,
-      isLiveSession,
-    };
-  }, [gwSessionId, runtimeBySession, taskId]);
+  return useMemo(
+    () => resolveSessionRuntime(taskId, gwSessionId, runtimeBySession),
+    [gwSessionId, runtimeBySession, taskId],
+  );
 }

--- a/web/src/lib/session-map.test.ts
+++ b/web/src/lib/session-map.test.ts
@@ -102,4 +102,17 @@ describe("session-map", () => {
     expect(resolvePersistentSessionId(undefined)).toBeUndefined();
     expect(resolveGatewaySessionId(undefined)).toBeUndefined();
   });
+
+  it("resolves to the most recent gateway id when several map to one session", () => {
+    // A resumed session accumulates several gateway ids over time (app relaunch,
+    // reconnect, session.busy → interrupt → re-resume). The live one is the
+    // newest; resolution must return it, not the first-inserted stale id — else
+    // detail renders an empty runtime bucket and a freshly-sent message stays
+    // invisible until a REST refetch.
+    writeUiValue("hermes:gateway-session-map", {
+      "gw-stale": { persistentId: "sess-1", ts: Date.now() - 60_000 },
+      "gw-live": { persistentId: "sess-1", ts: Date.now() - 1_000 },
+    });
+    expect(resolveGatewaySessionId("sess-1")).toBe("gw-live");
+  });
 });

--- a/web/src/lib/session-map.ts
+++ b/web/src/lib/session-map.ts
@@ -77,12 +77,20 @@ export function resolveGatewaySessionId(sessionId: string | undefined): string |
   if (!sessionId) return undefined;
   const map = readMap();
   const now = Date.now();
+  // Several gateway ids can point at one persistent id (a map persisted across
+  // an app relaunch, a reconnect / re-resume minting a fresh id). Object
+  // iteration order is insertion order, so returning the first match hands back
+  // the *oldest* (dead) id — detail then renders an empty runtime bucket while
+  // the live one keeps streaming. Pick the newest live mapping instead.
+  let bestId: string | undefined;
+  let bestTs = -Infinity;
   for (const [gatewayId, entry] of Object.entries(map)) {
-    if (entry.persistentId === sessionId && now - entry.ts < MAX_AGE_MS) {
-      return gatewayId;
+    if (entry.persistentId === sessionId && now - entry.ts < MAX_AGE_MS && entry.ts > bestTs) {
+      bestId = gatewayId;
+      bestTs = entry.ts;
     }
   }
-  return undefined;
+  return bestId;
 }
 
 interface ResolveSessionIdAliasOptions {


### PR DESCRIPTION
## 现象

在一个**已恢复的会话**（已有一问一答）里发出新回复后，消息看不到——必须**切到会话列表再切回来**才显形。

## 根因

不是后端没存（dashboard `/api/sessions/.../messages` 里确实有该消息），也不是渲染组件过滤了文本，而是 **「持久会话 ID ↔ gateway 临时会话 ID」的反向映射选错了 id**。

一个持久会话会在**持久化**的 `hermes:gateway-session-map` 里累积出多个 gateway id（应用重启后 map 存活、重连、`session.busy` 后 re-resume 各产生一个），而 `chatRuntimeBySession` 是内存态、重启即空。旧 `resolveGatewaySessionId` 按对象**插入顺序返回第一个匹配项 = 最旧、已失效的那个**：

1. 发送 → `resumeSession` 产生新 gateway id `gw-live`，乐观消息写进 `runtimeBySession[gw-live]`。
2. 渲染时 `resolveGatewaySessionId(persistentId)` 却返回旧的 `gw-stale`。
3. `activeMappedGatewaySessionId` 校验失败 → `runtime` 回退到空的 `runtimeBySession[persistentId]`。
4. 乐观消息（在 `gw-live` bucket）成了孤儿，当前页看不到。
5. 切走切回 → REST 重新加载已落盘历史 → 显形（误以为"修好了"）。

## 修复（两处纯读侧，不改 map 数据）

刻意**不动 `rememberSessionMapping`**，以保留新增的 `resolveSessionIdAliases`（及 `workspaces.ts`）所依赖的「一持久 id ↔ 多 gateway id」多对一关系。

- **`session-map.ts`**：`resolveGatewaySessionId` 改为按 `ts` 返回**最新**的活跃映射。顺带修正了直接调用它的 `interruptSession` / `session-rename`，避免操作到已失效的会话。
- **`use-session-resolution.ts`**：抽出纯函数 `resolveSessionRuntime`，优先采用「当前已连接且**映射到同一持久会话**」的 `gwSessionId`（gated on 同一会话，避免后台正在 streaming 的另一个会话串进当前页）。走无歧义的正向查找，**即便 map 仍是脏的也能读对 runtime**。

## 测试

- 新增回归：脏 map 多映射、跨会话串台 guard、新任务会话、未知会话。
- `pnpm typecheck` ✅　`pnpm test:unit` → web 382 全过 ✅

## 关联

与 #107（`fix/message-order-after-reply`，回复完成后用户消息**排序**到 Hermes 回复下方）是**不同根因**：那条是合并时把未匹配 live 消息追加到末尾导致的**排序**问题；本 PR 修的是**可见性**问题。两者可独立合入。

🤖 Generated with [Claude Code](https://claude.com/claude-code)