### PR TITLE
[codex] 修复模型配置页交互和网关重连问题

### DIFF
--- a/web/src/hooks/use-profiles.ts
+++ b/web/src/hooks/use-profiles.ts
@@ -3,6 +3,7 @@ import { useAtomValue, useSetAtom } from "jotai";
 import { useMutation, useQuery, useQueryClient } from "@tanstack/react-query";
 import { deleteJSON, fetchJSON, postJSON, putJSON } from "@/lib/transport";
 import { runtime } from "@/lib/runtime";
+import { forceExistingGatewayReconnect } from "@/lib/gateway-client";
 import { reloadUiStore } from "@/lib/ui-store";
 import { activeProfileAtom, profileSwitchingAtom } from "@/stores/ui";
 import {
@@ -121,6 +122,7 @@ export function useSetActiveProfile() {
           const result = await window.hermesDesktop.switchProfile({ name });
           if (result.ok) {
             runtime.applySwitchProfileResult(result);
+            forceExistingGatewayReconnect("profile-switch");
             return { mode: "electron-restart", profileName: name };
           }
           // recoveredPreviousProfile=true means dashboard rolled back, the

--- a/web/src/hooks/use-runtime-update.ts
+++ b/web/src/hooks/use-runtime-update.ts
@@ -6,6 +6,7 @@ import type {
   RuntimeUpdateCheckResult,
 } from "@hermes/protocol";
 import { runtime } from "@/lib/runtime";
+import { forceExistingGatewayReconnect } from "@/lib/gateway-client";
 import { runtimeUpdatingAtom } from "@/stores/ui";
 
 const RUNTIME_INFO_KEY = ["desktop-runtime-info"] as const;
@@ -19,6 +20,7 @@ function hasRuntimeBridge(): boolean {
 async function refreshDesktopGateway(): Promise<void> {
   if (window.hermesDesktop?.refreshGatewayUrl) {
     await runtime.refreshGatewayUrl();
+    forceExistingGatewayReconnect("runtime-update");
   }
 }
 

--- a/web/src/hooks/use-yolo-mode.ts
+++ b/web/src/hooks/use-yolo-mode.ts
@@ -1,6 +1,7 @@
 import { useMutation, useQuery, useQueryClient } from "@tanstack/react-query";
 import { useSetAtom } from "jotai";
 import { runtime } from "@/lib/runtime";
+import { forceExistingGatewayReconnect } from "@/lib/gateway-client";
 import { reloadUiStore } from "@/lib/ui-store";
 import { profileSwitchingAtom } from "@/stores/ui";
 import { PROFILE_AWARE_QUERY_KEYS } from "@/hooks/use-profiles";
@@ -47,6 +48,7 @@ export function useSetYoloMode() {
         }
         if (result.restarted) {
           runtime.applyYoloRestartResult(result);
+          forceExistingGatewayReconnect("yolo-restart");
         }
         return { enabled: result.enabled, restarted: result.restarted };
       } finally {

--- a/web/src/lib/gateway-client.ts
+++ b/web/src/lib/gateway-client.ts
@@ -601,6 +601,10 @@ export function getGatewayClient(): GatewayClientLike {
   return instance;
 }
 
+export function forceExistingGatewayReconnect(reason = "runtime-restart"): void {
+  instance?.forceReconnect(reason);
+}
+
 export function getActiveTransport(): GatewayTransport | null {
   return activeTransport;
 }

--- a/web/src/lib/gateway-sse-client.test.ts
+++ b/web/src/lib/gateway-sse-client.test.ts
@@ -480,6 +480,97 @@ describe("GatewaySseClient", () => {
     expect(request.mock.calls[0]?.[0].headers?.["X-Hermes-Client-Id"]).toBe("cid-tauri");
   });
 
+  it("resolves a Tauri reconnect when the server echoes an existing client_id", async () => {
+    vi.useRealTimers();
+    const listeners = new Map<string, (event: { payload: string }) => void>();
+    const refreshGatewayUrl = vi.fn(async () => ({
+      gatewayUrl: "ws://127.0.0.1:9119/api/ws?token=fresh-token",
+      sessionToken: "fresh-token",
+    }));
+
+    (window as any).__TAURI_INTERNALS__ = {};
+    window.__HERMES_RUNTIME__ = {
+      platform: "tauri",
+      apiBaseUrl: "http://127.0.0.1:9119",
+      gatewayUrl: "ws://127.0.0.1:9119/api/ws?token=fresh-token",
+      sessionToken: "fresh-token",
+      transport: "sse",
+    };
+    window.__HERMES_SESSION_TOKEN__ = "fresh-token";
+    window.hermesDesktop = {
+      windowType: "tauri",
+      refreshGatewayUrl,
+      request: vi.fn(),
+    };
+
+    tauriMocks.listen.mockImplementation(
+      async (eventName: string, cb: (event: { payload: string }) => void) => {
+        listeners.set(eventName, cb);
+        return vi.fn();
+      },
+    );
+    tauriMocks.invoke.mockResolvedValue(undefined);
+
+    const client = new GatewaySseClient();
+    (client as any).clientId = "cid-reused";
+
+    const connectP = client.connect({ timeoutMs: 5_000 });
+    await vi.waitFor(() => expect(tauriMocks.invoke).toHaveBeenCalledOnce());
+
+    expect(tauriMocks.invoke.mock.calls[0]?.[1]).toEqual({
+      input: { clientId: "cid-reused" },
+    });
+
+    listeners.get("gateway-sse-event")?.({
+      payload: JSON.stringify({ client_id: "cid-reused" }),
+    });
+
+    await expect(connectP).resolves.toBeUndefined();
+    expect(client.state).toBe("open");
+  });
+
+  it("clears stale Tauri client_id when proxy connect times out", async () => {
+    const listeners = new Map<string, (event: { payload: string }) => void>();
+    const refreshGatewayUrl = vi.fn(async () => ({
+      gatewayUrl: "ws://127.0.0.1:9119/api/ws?token=fresh-token",
+      sessionToken: "fresh-token",
+    }));
+
+    (window as any).__TAURI_INTERNALS__ = {};
+    window.__HERMES_RUNTIME__ = {
+      platform: "tauri",
+      apiBaseUrl: "http://127.0.0.1:9119",
+      gatewayUrl: "ws://127.0.0.1:9119/api/ws?token=fresh-token",
+      sessionToken: "fresh-token",
+      transport: "sse",
+    };
+    window.__HERMES_SESSION_TOKEN__ = "fresh-token";
+    window.hermesDesktop = {
+      windowType: "tauri",
+      refreshGatewayUrl,
+      request: vi.fn(),
+    };
+
+    tauriMocks.listen.mockImplementation(
+      async (eventName: string, cb: (event: { payload: string }) => void) => {
+        listeners.set(eventName, cb);
+        return vi.fn();
+      },
+    );
+    tauriMocks.invoke.mockResolvedValue(undefined);
+
+    const client = new GatewaySseClient();
+    (client as any).clientId = "cid-stale";
+
+    const connectP = client.connect({ timeoutMs: 50 });
+    vi.advanceTimersByTime(51);
+
+    await expect(connectP).rejects.toThrow("Tauri SSE proxy connect timeout");
+    expect((client as any).clientId).toBeNull();
+    expect((client as any).tauriProxyConnected).toBe(false);
+    expect(client.state).toBe("error");
+  });
+
   it("close() tears down EventSource and resets state to idle", async () => {
     const client = new GatewaySseClient();
     const p = client.connect();

--- a/web/src/lib/gateway-sse-client.ts
+++ b/web/src/lib/gateway-sse-client.ts
@@ -555,6 +555,8 @@ export class GatewaySseClient implements GatewayClientLike {
       if (settled) return;
       settled = true;
       this.connectPromise = null;
+      this.clientId = null;
+      this.tauriProxyConnected = false;
       this.setState("error");
       reject(new Error("Tauri SSE proxy connect timeout"));
     }, timeoutMs);
@@ -569,6 +571,8 @@ export class GatewaySseClient implements GatewayClientLike {
         this.setState("open");
         resolve();
       } else {
+        this.clientId = null;
+        this.tauriProxyConnected = false;
         this.setState("error");
         reject(err ?? new Error("SSE proxy failed"));
       }
@@ -582,7 +586,7 @@ export class GatewaySseClient implements GatewayClientLike {
       this.tauriUnlisten = await listen<string>("gateway-sse-event", (event) => {
         try {
           const parsed = JSON.parse(event.payload);
-          if (parsed.client_id && !this.clientId) {
+          if (parsed.client_id) {
             this.clientId = parsed.client_id;
             const waiters = this.clientIdResolvers;
             this.clientIdResolvers = [];

--- a/web/src/lib/provider-catalog.test.ts
+++ b/web/src/lib/provider-catalog.test.ts
@@ -6,7 +6,9 @@ import {
   buildProviderConfigUpdate,
   buildProviderSettingsUpdate,
   fetchRemoteProviderCatalog,
+  getProviderCredentialPreview,
   getProviderEntry,
+  maskSecretPreview,
   providerHasSavedCredentials,
   sortProvidersForCnEdition,
   TOP5_PROVIDER_IDS,
@@ -289,6 +291,71 @@ describe("provider catalog config updates", () => {
 
     expect(getProviderEntry(config, preset.id).api_key).toBe("existing-key");
     expect(providerHasSavedCredentials(config, preset.id)).toBe(true);
+  });
+
+  it("masks local provider api_key previews with first and last four characters", () => {
+    expect(maskSecretPreview("sk-1234567890abcd")).toBe("sk-1...abcd");
+    expect(maskSecretPreview("short-key")).toBe("***");
+  });
+
+  it("prefers env redacted_value over config api_key for credential previews", () => {
+    const preset = BUILTIN_PROVIDER_CATALOG.providers.find((provider) => provider.id === "deepseek");
+    expect(preset).toBeTruthy();
+
+    const preview = getProviderCredentialPreview(
+      {
+        providers: {
+          deepseek: {
+            api_key: "config-secret-should-not-win",
+          },
+        },
+      },
+      {
+        DEEPSEEK_API_KEY: {
+          is_set: true,
+          redacted_value: "env-...tail",
+        },
+      },
+      preset!,
+    );
+
+    expect(preview).toBe("env-...tail");
+  });
+
+  it("falls back to locally masked config api_key when no env preview is available", () => {
+    const preset = BUILTIN_PROVIDER_CATALOG.providers.find((provider) => provider.id === "deepseek");
+    expect(preset).toBeTruthy();
+
+    const preview = getProviderCredentialPreview(
+      {
+        providers: {
+          deepseek: {
+            api_key: "abcd-1234567890",
+          },
+        },
+      },
+      undefined,
+      preset!,
+    );
+
+    expect(preview).toBe("abcd...7890");
+  });
+
+  it("treats env-only provider keys as saved credentials", () => {
+    const preset = BUILTIN_PROVIDER_CATALOG.providers.find((provider) => provider.id === "deepseek");
+    expect(preset).toBeTruthy();
+
+    expect(providerHasSavedCredentials(
+      {},
+      "deepseek",
+      {
+        DEEPSEEK_API_KEY: {
+          is_set: true,
+          redacted_value: "deep...tail",
+        },
+      },
+      preset!,
+    )).toBe(true);
   });
 
   it("loads remote catalog through fetchExternalJSON timeout path", async () => {

--- a/web/src/lib/provider-catalog.ts
+++ b/web/src/lib/provider-catalog.ts
@@ -34,6 +34,11 @@ export interface ProviderCatalog {
   providers: ProviderPreset[];
 }
 
+export type EnvVarPreviewMap = Record<string, {
+  is_set?: boolean;
+  redacted_value?: string | null;
+}>;
+
 /**
  * Providers we feature first in the Chinese community edition. Any change to
  * this list reorders the Models tab list and the onboarding picker.
@@ -74,7 +79,7 @@ export interface ProviderConfigInput {
   model: string;
 }
 
-export const BUILTIN_PROVIDER_CATALOG_VERSION = "2026.06.04";
+export const BUILTIN_PROVIDER_CATALOG_VERSION = "2026.06.05";
 
 export const BUILTIN_PROVIDER_CATALOG: ProviderCatalog = {
   version: BUILTIN_PROVIDER_CATALOG_VERSION,
@@ -164,8 +169,6 @@ export const BUILTIN_PROVIDER_CATALOG: ProviderCatalog = {
       models: [
         { id: "deepseek-v4-flash", supportsTools: true },
         { id: "deepseek-v4-pro", supportsTools: true, supportsReasoning: true },
-        { id: "deepseek-chat", supportsTools: true },
-        { id: "deepseek-reasoner", supportsReasoning: true },
       ],
     },
     {
@@ -444,11 +447,48 @@ export function getProviderEntry(config: Record<string, any> | undefined, provid
   return asRecord(asRecord(config?.providers)[providerId]);
 }
 
+export function maskSecretPreview(value: string): string {
+  const trimmed = value.trim();
+  if (!trimmed) return "";
+  if (trimmed.length < 12) return "***";
+  return `${trimmed.slice(0, 4)}...${trimmed.slice(-4)}`;
+}
+
+function envPreview(envVars: EnvVarPreviewMap | undefined, key: string | undefined): string | undefined {
+  const envKey = key?.trim();
+  if (!envKey) return undefined;
+  const info = envVars?.[envKey];
+  if (!info?.is_set) return undefined;
+  const preview = info.redacted_value?.trim();
+  return preview || undefined;
+}
+
+export function getProviderCredentialPreview(
+  config: Record<string, any> | undefined,
+  envVars: EnvVarPreviewMap | undefined,
+  provider: ProviderPreset,
+): string | undefined {
+  const entry = getProviderEntry(config, provider.id);
+  const previewFromProviderEnv = envPreview(envVars, provider.apiKeyLabel);
+  if (previewFromProviderEnv) return previewFromProviderEnv;
+
+  const previewFromEntryEnv = envPreview(envVars, String(entry.key_env || ""));
+  if (previewFromEntryEnv) return previewFromEntryEnv;
+
+  const rawApiKey = typeof entry.api_key === "string" ? entry.api_key : "";
+  return rawApiKey.trim() ? maskSecretPreview(rawApiKey) : undefined;
+}
+
 export function providerHasSavedCredentials(
   config: Record<string, any> | undefined,
   providerId: string,
+  envVars?: EnvVarPreviewMap,
+  provider?: ProviderPreset,
 ): boolean {
   const entry = getProviderEntry(config, providerId);
+  if (provider?.apiKeyLabel && envVars?.[provider.apiKeyLabel]?.is_set) return true;
+  const keyEnv = typeof entry.key_env === "string" ? entry.key_env : "";
+  if (keyEnv && envVars?.[keyEnv]?.is_set) return true;
   return Boolean(entry.api_key || entry.key_env);
 }
 

--- a/web/src/routes/config-migration.tsx
+++ b/web/src/routes/config-migration.tsx
@@ -8,6 +8,7 @@ import type {
   ConfigMigrationScanResult,
 } from "@hermes/protocol";
 import { runtime } from "@/lib/runtime";
+import { forceExistingGatewayReconnect } from "@/lib/gateway-client";
 import { reloadUiStore } from "@/lib/ui-store";
 import { activeProfileAtom, profileSwitchingAtom } from "@/stores/ui";
 import { SectionShell } from "./section-shell";
@@ -196,6 +197,7 @@ export function ConfigMigrationRoute() {
       setLastImport(result);
       if (!result.ok) throw new Error(result.error || "迁移失败");
       runtime.applyConfigMigrationResult(result);
+      forceExistingGatewayReconnect("config-migration");
       if (result.targetProfileName) setActiveProfile(result.targetProfileName);
       await reloadUiStore();
       await queryClient.invalidateQueries();

--- a/web/src/routes/settings-models-section.tsx
+++ b/web/src/routes/settings-models-section.tsx
@@ -10,6 +10,7 @@ import {
   BUILTIN_PROVIDER_CATALOG,
   buildProviderConfigUpdate,
   buildProviderSettingsUpdate,
+  getProviderCredentialPreview,
   getProviderEntry,
   providerHasSavedCredentials,
   sortProvidersForCnEdition,
@@ -658,8 +659,11 @@ export function ModelsSection() {
     ? getProviderEntry(config, selectedProvider.id)
     : {};
   const selectedHasCredentials = selectedProvider
-    ? providerHasSavedCredentials(config, selectedProvider.id)
+    ? providerHasSavedCredentials(config, selectedProvider.id, envVars, selectedProvider)
     : false;
+  const selectedProviderCredentialPreview = selectedProvider
+    ? getProviderCredentialPreview(config, envVars, selectedProvider)
+    : undefined;
   const selectedProviderCanOmitApiKey = selectedProvider
     ? isLocalProviderBaseUrl(providerForm.baseUrl || selectedProvider.baseUrl)
     : false;
@@ -675,8 +679,9 @@ export function ModelsSection() {
     [config],
   );
   const configuredCount = useMemo(
-    () => allProviders.filter((provider) => providerHasSavedCredentials(config, provider.id)).length,
-    [allProviders, config],
+    () => allProviders.filter((provider) =>
+      providerHasSavedCredentials(config, provider.id, envVars, provider)).length,
+    [allProviders, config, envVars],
   );
   const providerEnvEntries = useMemo(
     () => Object.entries(envVars ?? {})
@@ -1169,7 +1174,7 @@ export function ModelsSection() {
               </div>
               <div className={s.providerPresetList}>
                 {filteredProviders.map((provider) => {
-                  const configured = providerHasSavedCredentials(config, provider.id);
+                  const configured = providerHasSavedCredentials(config, provider.id, envVars, provider);
                   const current = currentProviderId === provider.id;
                   return (
                     <button
@@ -1225,7 +1230,7 @@ export function ModelsSection() {
                           value={providerForm.apiKey}
                           placeholder={
                             selectedHasCredentials
-                              ? "已保存"
+                              ? selectedProviderCredentialPreview ?? "已保存"
                               : selectedProviderCanOmitApiKey
                                 ? "本地服务一般可留空"
                                 : "粘贴 API Key"
@@ -1273,7 +1278,15 @@ export function ModelsSection() {
 
                     <div className={s.modelTags}>
                       {mergedModelOptions.slice(0, 8).map((id) => (
-                        <span key={id} className={s.modelTag}>{id}</span>
+                        <button
+                          key={id}
+                          type="button"
+                          className={s.modelTag}
+                          onClick={() => setProviderForm((prev) => ({ ...prev, model: id }))}
+                          title={`填入模型 ${id}`}
+                        >
+                          {id}
+                        </button>
                       ))}
                     </div>
 

--- a/web/src/routes/settings.module.css
+++ b/web/src/routes/settings.module.css
@@ -318,6 +318,8 @@
 }
 
 .modelTag {
+  appearance: none;
+  cursor: pointer;
   font-family: var(--h-font-mono);
   font-size: 11px;
   padding: 4px 10px;


### PR DESCRIPTION
## 变更内容

- 修复 Tauri SSE proxy 在 profile / runtime 重启后可能复用旧 client_id 导致连接超时的问题。
- 在 profile、YOLO、runtime update、config migration 等 dashboard 重启路径后主动重连已有 gateway client。
- 模型配置页的 API Key 输入框改为显示脱敏预览，优先复用 `/api/env` 返回的 `redacted_value`。
- Provider 列表和已配置计数支持识别 env-only key。
- 移除 DeepSeek 预设中过期的 `deepseek-chat` 和 `deepseek-reasoner`。
- 模型 chip 支持点击后直接填入模型输入框，不增加选中态。

## 原因和影响

profile 切换会重启 dashboard 并刷新 token，但 renderer 侧 SSE client 可能残留旧连接状态，用户随后聊天会看到 `Tauri SSE proxy connect timeout`。这次让连接握手和重启后的 client 状态更稳，同时改善模型配置页 debug 和录入体验。

Closes #110

## 验证

- `pnpm --filter @hermes/web exec vitest run src/lib/gateway-sse-client.test.ts`
- `pnpm --filter @hermes/web exec vitest run src/lib/provider-catalog.test.ts`
- `pnpm typecheck`
- `pnpm test:unit`
- `cargo check`
