### PR TITLE
[codex] 修复记忆页卡死并优化健康状态入口

### DIFF
--- a/web/src/components/app-shell/app-status-bar.module.css
+++ b/web/src/components/app-shell/app-status-bar.module.css
@@ -22,6 +22,29 @@
   line-height: 1;
 }
 
+.gatewayButton {
+  appearance: none;
+  border: 0;
+  padding: 0;
+  background: transparent;
+  color: inherit;
+  font: inherit;
+  cursor: pointer;
+}
+
+.gatewayButton:hover .lbl,
+.gatewayButton:hover .val,
+.gatewayButton:focus-visible .lbl,
+.gatewayButton:focus-visible .val {
+  color: var(--h-accent);
+}
+
+.gatewayButton:focus-visible {
+  outline: 1px solid var(--h-accent-border);
+  outline-offset: 3px;
+  border-radius: var(--h-r-xs);
+}
+
 .stat[data-tone="warn"] .val {
   color: var(--amber);
 }

--- a/web/src/components/app-shell/app-status-bar.tsx
+++ b/web/src/components/app-shell/app-status-bar.tsx
@@ -5,11 +5,11 @@ import { useModelInfo } from "@/hooks/use-config";
 import { useSessions } from "@/hooks/use-sessions";
 import { useAnalytics } from "@/hooks/use-analytics";
 import { chatRuntimeBySessionAtom } from "@/stores/chat";
+import { dashboardPortFromUrl, dashboardUrlFromInputs } from "@/lib/dashboard-url";
+import { openExternalUrl } from "@/lib/external-links";
 import { isSessionRunning } from "@/lib/session-activity";
 import { formatTokens } from "@/lib/format";
 import s from "./app-status-bar.module.css";
-
-const DEFAULT_DESKTOP_DASHBOARD_PORT = "9120";
 
 function formatModelShort(model: string | null | undefined): string {
   if (!model) return "—";
@@ -23,27 +23,6 @@ function formatContext(ctx: number | null | undefined): string {
   return `${ctx}`;
 }
 
-function portFromUrl(url: string | null | undefined): string | null {
-  if (!url) return null;
-  try {
-    return new URL(url).port || null;
-  } catch {
-    return null;
-  }
-}
-
-function dashboardPortFallback(): string {
-  if (typeof window === "undefined") return DEFAULT_DESKTOP_DASHBOARD_PORT;
-  return portFromUrl(window.__HERMES_RUNTIME__?.dashboardApiBaseUrl)
-    ?? portFromUrl(window.__HERMES_RUNTIME__?.apiBaseUrl)
-    ?? portFromUrl(import.meta.env.VITE_HERMES_DASHBOARD_ORIGIN)
-    ?? DEFAULT_DESKTOP_DASHBOARD_PORT;
-}
-
-function portFromHealthUrl(url: string | null | undefined): string {
-  return portFromUrl(url) ?? dashboardPortFallback();
-}
-
 export function AppStatusBar() {
   const { data: status, isError: statusError } = useStatus();
   const { data: modelInfo } = useModelInfo();
@@ -51,7 +30,12 @@ export function AppStatusBar() {
   const { data: analytics } = useAnalytics(1);
   const runtimeBySession = useAtomValue(chatRuntimeBySessionAtom);
 
-  const port = portFromHealthUrl(status?.gateway_health_url);
+  const dashboardUrl = dashboardUrlFromInputs({
+    healthUrl: status?.gateway_health_url,
+    runtimeConfig: typeof window === "undefined" ? null : window.__HERMES_RUNTIME__,
+    envOrigin: import.meta.env.VITE_HERMES_DASHBOARD_ORIGIN,
+  });
+  const port = dashboardPortFromUrl(dashboardUrl);
   const gatewayOnline = !!status && !statusError;
 
   const modelLabel = formatModelShort(modelInfo?.model);
@@ -80,11 +64,17 @@ export function AppStatusBar() {
 
   return (
     <footer className={s.statusbar} role="status" aria-label="运行状态">
-      <span className={s.stat}>
+      <button
+        type="button"
+        className={`${s.stat} ${s.gatewayButton}`}
+        onClick={() => void openExternalUrl(dashboardUrl)}
+        title={`打开 ${dashboardUrl}`}
+        aria-label={`打开 Dashboard ${dashboardUrl}`}
+      >
         <span className={s.dot} data-state={gatewayOnline ? "running" : "offline"} />
         <span className={s.lbl}>网关</span>
         <span className={s.val}>{port}</span>
-      </span>
+      </button>
       <span className={s.sep} />
       <span className={s.stat}>
         <span className={s.lbl}>模型</span>

--- a/web/src/hooks/use-memory.ts
+++ b/web/src/hooks/use-memory.ts
@@ -81,7 +81,7 @@ export function useSaveUserProfile() {
   });
 }
 
-export function useMemoryProviders() {
+export function useMemoryProviders(options: { enabled?: boolean } = {}) {
   const profile = useActiveProfileName();
   return useQuery<MemoryProvidersState>({
     queryKey: ["memory-providers", profile],
@@ -94,6 +94,7 @@ export function useMemoryProviders() {
       };
     },
     staleTime: 30_000,
+    enabled: options.enabled,
   });
 }
 

--- a/web/src/lib/dashboard-url.test.ts
+++ b/web/src/lib/dashboard-url.test.ts
@@ -1,0 +1,31 @@
+import { describe, expect, it } from "vitest";
+import { dashboardPortFromUrl, dashboardUrlFromInputs } from "./dashboard-url";
+
+describe("dashboardUrlFromInputs", () => {
+  it("opens the dashboard origin from gateway health URLs", () => {
+    expect(dashboardUrlFromInputs({ healthUrl: "http://127.0.0.1:9120/api/gateway/health" })).toBe(
+      "http://localhost:9120/",
+    );
+  });
+
+  it("falls back to runtime config and then the desktop default", () => {
+    expect(dashboardUrlFromInputs({ runtimeConfig: { apiBaseUrl: "http://127.0.0.1:9567" } })).toBe(
+      "http://localhost:9567/",
+    );
+    expect(dashboardUrlFromInputs({})).toBe("http://localhost:9120/");
+  });
+
+  it("does not accept non-browser or relative URLs", () => {
+    expect(dashboardUrlFromInputs({ healthUrl: "file:///tmp/x", envOrigin: "/api" })).toBe(
+      "http://localhost:9120/",
+    );
+  });
+});
+
+describe("dashboardPortFromUrl", () => {
+  it("extracts explicit and default HTTP ports", () => {
+    expect(dashboardPortFromUrl("http://localhost:9120/")).toBe("9120");
+    expect(dashboardPortFromUrl("http://localhost/")).toBe("80");
+    expect(dashboardPortFromUrl("bad")).toBe("9120");
+  });
+});

--- a/web/src/lib/dashboard-url.ts
+++ b/web/src/lib/dashboard-url.ts
@@ -1,0 +1,60 @@
+const DEFAULT_DESKTOP_DASHBOARD_PORT = "9120";
+
+interface DashboardRuntimeConfig {
+  apiBaseUrl?: string;
+  dashboardApiBaseUrl?: string;
+}
+
+interface DashboardUrlInputs {
+  healthUrl?: string | null;
+  runtimeConfig?: DashboardRuntimeConfig | null;
+  envOrigin?: string | null;
+}
+
+function parseHttpUrl(raw: string | null | undefined): URL | null {
+  const value = String(raw ?? "").trim();
+  if (!value) return null;
+  try {
+    const url = new URL(value);
+    if (url.protocol !== "http:" && url.protocol !== "https:") return null;
+    if (!url.hostname) return null;
+    return url;
+  } catch {
+    return null;
+  }
+}
+
+function loopbackDisplayHost(hostname: string): string {
+  return ["127.0.0.1", "::1", "[::1]", "localhost"].includes(hostname)
+    ? "localhost"
+    : hostname;
+}
+
+function originFromUrl(url: URL): string {
+  const host = loopbackDisplayHost(url.hostname);
+  const port = url.port ? `:${url.port}` : "";
+  return `${url.protocol}//${host}${port}/`;
+}
+
+export function dashboardUrlFromInputs(inputs: DashboardUrlInputs): string {
+  const candidates = [
+    inputs.healthUrl,
+    inputs.runtimeConfig?.dashboardApiBaseUrl,
+    inputs.runtimeConfig?.apiBaseUrl,
+    inputs.envOrigin,
+  ];
+
+  for (const candidate of candidates) {
+    const url = parseHttpUrl(candidate);
+    if (url) return originFromUrl(url);
+  }
+
+  return `http://localhost:${DEFAULT_DESKTOP_DASHBOARD_PORT}/`;
+}
+
+export function dashboardPortFromUrl(raw: string | null | undefined): string {
+  const url = parseHttpUrl(raw);
+  if (!url) return DEFAULT_DESKTOP_DASHBOARD_PORT;
+  if (url.port) return url.port;
+  return url.protocol === "https:" ? "443" : "80";
+}

--- a/web/src/lib/health-subtitle.test.ts
+++ b/web/src/lib/health-subtitle.test.ts
@@ -1,0 +1,25 @@
+import { describe, expect, it } from "vitest";
+import { formatHealthSubtitle } from "./health-subtitle";
+
+function status(overrides: Partial<Parameters<typeof formatHealthSubtitle>[0]> = {}) {
+  return {
+    gateway_running: false,
+    gateway_state: "",
+    version: "0.15.2",
+    ...overrides,
+  };
+}
+
+describe("formatHealthSubtitle", () => {
+  it("uses human-readable dashboard states instead of exposing raw unknown", () => {
+    expect(formatHealthSubtitle(status({ gateway_state: "unknown" }), false)).toBe("Dashboard 就绪 · v0.15.2");
+    expect(formatHealthSubtitle(status({ gateway_state: "" }), false)).toBe("Dashboard 就绪 · v0.15.2");
+    expect(formatHealthSubtitle(status({ gateway_state: "stopped" }), false)).toBe("Dashboard 就绪 · v0.15.2");
+  });
+
+  it("keeps clear labels for loading, offline, and running states", () => {
+    expect(formatHealthSubtitle(undefined, false)).toBe("加载中…");
+    expect(formatHealthSubtitle(status(), true)).toBe("Dashboard 离线");
+    expect(formatHealthSubtitle(status({ gateway_running: true }), false)).toBe("Gateway 运行中 · v0.15.2");
+  });
+});

--- a/web/src/lib/health-subtitle.ts
+++ b/web/src/lib/health-subtitle.ts
@@ -1,0 +1,35 @@
+import type { StatusResponse } from "@hermes/protocol";
+
+type HealthSubtitleStatus = Pick<StatusResponse, "gateway_running" | "gateway_state" | "version">;
+
+function versionLabel(version: string | undefined): string {
+  const clean = version?.trim();
+  return clean ? `v${clean}` : "版本未知";
+}
+
+function gatewayStateLabel(status: HealthSubtitleStatus): string {
+  const rawState = status.gateway_state?.trim() ?? "";
+  const state = rawState.toLowerCase();
+
+  if (status.gateway_running || state === "running") return "Gateway 运行中";
+  if (state === "starting" || state === "initializing") return "Gateway 启动中";
+  if (state === "error" || state === "failed" || state === "crashed") return "Gateway 异常";
+
+  // P-009 后聊天传输走 in-process dispatch，daemon 不运行也可以是健康状态。
+  // 因此后端返回空值、unknown 或 stopped 时，页头应表达 Dashboard 已可用，
+  // 不要把 raw gateway_state 暴露给用户造成误解。
+  if (!state || state === "unknown" || state === "stopped" || state === "null") {
+    return "Dashboard 就绪";
+  }
+
+  return `Gateway ${rawState}`;
+}
+
+export function formatHealthSubtitle(
+  status: HealthSubtitleStatus | undefined,
+  isError: boolean,
+): string {
+  if (isError) return "Dashboard 离线";
+  if (!status) return "加载中…";
+  return `${gatewayStateLabel(status)} · ${versionLabel(status.version)}`;
+}

--- a/web/src/lib/memory-page-stats.test.ts
+++ b/web/src/lib/memory-page-stats.test.ts
@@ -1,0 +1,46 @@
+import { describe, expect, it } from "vitest";
+import { formatMemoryPageStat, memoryPageStats } from "./memory-page-stats";
+import type { MemoryInfo } from "./runtime";
+
+function memoryInfo(overrides: Partial<MemoryInfo> = {}): MemoryInfo {
+  const base: MemoryInfo = {
+    memory: {
+      content: "alpha\n§\nbeta",
+      exists: true,
+      lastModified: 1,
+      entries: [
+        { index: 0, content: "alpha" },
+        { index: 1, content: "beta" },
+      ],
+      charCount: 12,
+      charLimit: 2200,
+    },
+    user: {
+      content: "用户画像",
+      exists: true,
+      lastModified: 1,
+      charCount: 4,
+      charLimit: 1375,
+    },
+    stats: { totalSessions: 999, totalMessages: 888 },
+  };
+  return { ...base, ...overrides };
+}
+
+describe("memoryPageStats", () => {
+  it("derives page-local stats without depending on session totals", () => {
+    expect(memoryPageStats(memoryInfo())).toEqual([
+      { label: "记忆", value: 2 },
+      { label: "记忆字符", value: 12 },
+      { label: "画像字符", value: 4 },
+    ]);
+  });
+});
+
+describe("formatMemoryPageStat", () => {
+  it("formats finite positive integers and clamps invalid values to zero", () => {
+    expect(formatMemoryPageStat(12345.8)).toBe("12,345");
+    expect(formatMemoryPageStat(Number.NaN)).toBe("0");
+    expect(formatMemoryPageStat(-3)).toBe("0");
+  });
+});

--- a/web/src/lib/memory-page-stats.ts
+++ b/web/src/lib/memory-page-stats.ts
@@ -1,0 +1,19 @@
+import type { MemoryInfo } from "@/lib/runtime";
+
+export interface MemoryPageStat {
+  label: string;
+  value: number;
+}
+
+export function memoryPageStats(data: MemoryInfo): MemoryPageStat[] {
+  return [
+    { label: "记忆", value: data.memory.entries.length },
+    { label: "记忆字符", value: data.memory.charCount },
+    { label: "画像字符", value: data.user.charCount },
+  ];
+}
+
+export function formatMemoryPageStat(value: number): string {
+  if (!Number.isFinite(value) || value <= 0) return "0";
+  return Math.floor(value).toLocaleString();
+}

--- a/web/src/routes/health.tsx
+++ b/web/src/routes/health.tsx
@@ -1,14 +1,11 @@
 import { useStatus } from "@/hooks/use-status";
 import { HealthGrid } from "@/components/panel/health-grid";
+import { formatHealthSubtitle } from "@/lib/health-subtitle";
 import { SectionShell } from "./section-shell";
 
 export function HealthRoute() {
   const { data: status, isError } = useStatus();
-  const sub = isError
-    ? "Dashboard 离线"
-    : status
-      ? `${status.gateway_state || "unknown"} · v${status.version}`
-      : "加载中…";
+  const sub = formatHealthSubtitle(status, isError);
   return (
     <SectionShell title="健康检查" sub={sub}>
       <HealthGrid />

--- a/web/src/routes/memory.tsx
+++ b/web/src/routes/memory.tsx
@@ -1,6 +1,5 @@
 import { useEffect, useMemo, useState } from "react";
 import { Brain, Check, ExternalLink, Plus, RefreshCw, Trash2 } from "lucide-react";
-import { useSessions } from "@/hooks/use-sessions";
 import {
   useAddMemoryEntry,
   useMemory,
@@ -11,6 +10,7 @@ import {
   useUpdateMemoryEntry,
   type MemoryProviderOption,
 } from "@/hooks/use-memory";
+import { memoryPageStats, formatMemoryPageStat } from "@/lib/memory-page-stats";
 import { SectionShell } from "./section-shell";
 import s from "./memory.module.css";
 
@@ -59,6 +59,10 @@ function providerDescription(provider: MemoryProviderOption): string {
   return PROVIDER_DESCRIPTIONS[key] ?? (raw || "外置记忆系统。");
 }
 
+function errorMessage(error: unknown): string {
+  return error instanceof Error ? error.message : String(error);
+}
+
 function CapacityBar({ label, used, limit }: { label: string; used: number; limit: number }) {
   const pct = limit > 0 ? Math.min(100, Math.round((used / limit) * 100)) : 0;
   const tone = pct > 90 ? "err" : pct > 70 ? "warn" : "ok";
@@ -77,15 +81,13 @@ function CapacityBar({ label, used, limit }: { label: string; used: number; limi
 
 export function MemoryRoute() {
   const memoryQuery = useMemory();
-  const sessionsQuery = useSessions(500);
-  const providersQuery = useMemoryProviders();
+  const [tab, setTab] = useState<"entries" | "profile" | "providers">("entries");
+  const providersQuery = useMemoryProviders({ enabled: tab === "providers" });
   const setProvider = useSetMemoryProvider();
   const addEntry = useAddMemoryEntry();
   const updateEntry = useUpdateMemoryEntry();
   const removeEntry = useRemoveMemoryEntry();
   const saveUser = useSaveUserProfile();
-
-  const [tab, setTab] = useState<"entries" | "profile" | "providers">("entries");
   const [showAdd, setShowAdd] = useState(false);
   const [newEntry, setNewEntry] = useState("");
   const [editingIndex, setEditingIndex] = useState<number | null>(null);
@@ -102,14 +104,7 @@ export function MemoryRoute() {
     setUserContent(data.user.content);
   }, [data, userDirty]);
 
-  const stats = useMemo(() => {
-    const sessions = sessionsQuery.data?.sessions ?? [];
-    return {
-      totalSessions: sessionsQuery.data?.total ?? data?.stats.totalSessions ?? 0,
-      totalMessages: sessions.reduce((sum, sess) => sum + sess.message_count, 0) || data?.stats.totalMessages || 0,
-      memories: data?.memory.entries.length ?? 0,
-    };
-  }, [data?.memory.entries.length, data?.stats.totalMessages, data?.stats.totalSessions, sessionsQuery.data]);
+  const stats = useMemo(() => data ? memoryPageStats(data) : [], [data]);
 
   const providers = useMemo(() => {
     const builtin: MemoryProviderOption = { name: "builtin", description: PROVIDER_DESCRIPTIONS.builtin };
@@ -123,6 +118,7 @@ export function MemoryRoute() {
   }, [providersQuery.data?.options]);
 
   const activeProvider = providersQuery.data?.active || "builtin";
+  const activeProviderLabel = providersQuery.data ? activeProvider : "配置";
   const isLoading = memoryQuery.isLoading;
   const error = memoryQuery.error || addEntry.error || updateEntry.error || saveUser.error;
 
@@ -166,7 +162,12 @@ export function MemoryRoute() {
 
   return (
     <SectionShell title="记忆" sub="MEMORY.md / USER.md" right={right}>
-      {isLoading || !data ? (
+      {memoryQuery.isError && !data ? (
+        <div className={s.memoryPage}>
+          <div className={s.errorState}>无法读取记忆：{errorMessage(memoryQuery.error)}</div>
+          <button type="button" className={s.secondaryButton} onClick={() => void memoryQuery.refetch()}>重试</button>
+        </div>
+      ) : isLoading || !data ? (
         <div className={s.emptyState}>加载记忆中…</div>
       ) : (
         <div className={s.memoryPage}>
@@ -175,9 +176,12 @@ export function MemoryRoute() {
           </p>
 
           <div className={s.statsGrid}>
-            <div className={s.statCard}><span>{stats.totalSessions}</span><small>会话</small></div>
-            <div className={s.statCard}><span>{stats.totalMessages}</span><small>消息</small></div>
-            <div className={s.statCard}><span>{stats.memories}</span><small>记忆</small></div>
+            {stats.map((item) => (
+              <div key={item.label} className={s.statCard}>
+                <span>{formatMemoryPageStat(item.value)}</span>
+                <small>{item.label}</small>
+              </div>
+            ))}
           </div>
 
           <div className={s.capacityGrid}>
@@ -193,11 +197,11 @@ export function MemoryRoute() {
               用户画像 <span>{timeAgo(data.user.lastModified)}</span>
             </button>
             <button type="button" data-active={tab === "providers" ? "true" : undefined} onClick={() => setTab("providers")}>
-              外置记忆系统 <span>{activeProvider}</span>
+              外置记忆系统 <span>{activeProviderLabel}</span>
             </button>
           </div>
 
-          {error && <div className={s.errorState}>{error instanceof Error ? error.message : String(error)}</div>}
+          {error && <div className={s.errorState}>{errorMessage(error)}</div>}
 
           {tab === "entries" && (
             <section className={s.panel}>


### PR DESCRIPTION
## 变更内容

本 PR 修复 Windows 版本进入 `/memory` 页面可能卡死的问题，并顺手优化健康检查页头与左下角网关入口体验。

- `/memory` 页面初始加载不再额外请求 500 条会话，避免大 payload 或同步解析导致页面卡住。
- 外置记忆系统列表改为进入对应 tab 后再请求，降低记忆页首屏压力。
- 记忆读取失败时展示可重试错误状态，不再一直停留在加载态。
- 健康检查页头不再透出 raw `unknown`，改为 `Dashboard 就绪 · v版本号` 等用户可理解文案。
- 左下角“网关 9120”变为可点击入口，可打开当前 Dashboard 地址，默认 `http://localhost:9120/`。

## 验证

已运行并通过：

```bash
pnpm typecheck
pnpm test:unit
cargo check
```