### PR TITLE
feat: 增加发送快捷键设置并优化展示

### DIFF
--- a/web/src/components/chat/goose-composer.tsx
+++ b/web/src/components/chat/goose-composer.tsx
@@ -14,6 +14,11 @@ import type { ModelOptionsResult } from "@hermes/protocol";
 import { fileNameFromPath } from "@/lib/composer-prompt";
 import { contextUsageRisk } from "@/lib/context-usage";
 import {
+  composerSubmitShortcutHint,
+  shouldSubmitComposerKey,
+  type ComposerSubmitShortcut,
+} from "@/lib/composer-submit-shortcut";
+import {
   normalizeWorkspacePath,
   readWorkspacePath,
   rememberWorkspaceProject,
@@ -72,8 +77,8 @@ interface GooseComposerProps {
   headerLabel?: string;
   /** Empty-state hints shown only in big variant when textarea is empty. */
   hints?: ComposerHint[];
-  /** Keyboard shortcut for submitting; plain Enter keeps the existing chat behavior. */
-  submitShortcut?: "enter" | "shift-enter";
+  /** Keyboard shortcut for submitting; defaults to Enter send and Shift+Enter newline. */
+  submitShortcut?: ComposerSubmitShortcut;
   loadingPlaceholder?: string;
   modelPicker?: ComposerModelPickerProps;
   contextUsage?: ComposerContextUsage | null;
@@ -87,7 +92,7 @@ function messageFromError(error: unknown): string {
 export function GooseComposer({
   onSend,
   onStop,
-  placeholder = "发送消息...",
+  placeholder = "发送消息，Enter 发送，Shift+Enter 换行…",
   initial = "",
   autoFocus = false,
   disabled = false,
@@ -362,17 +367,20 @@ export function GooseComposer({
   };
 
   const handleKeyDown = (event: KeyboardEvent<HTMLTextAreaElement>) => {
-    if (event.nativeEvent.isComposing || event.key !== "Enter" || event.altKey) return;
-    const shouldSubmit =
-      submitShortcut === "shift-enter"
-        ? event.shiftKey
-        : !event.shiftKey;
+    const shouldSubmit = shouldSubmitComposerKey({
+      key: event.key,
+      shiftKey: event.shiftKey,
+      altKey: event.altKey,
+      isComposing: event.nativeEvent.isComposing,
+    }, submitShortcut);
 
     if (shouldSubmit) {
       event.preventDefault();
       void send();
     }
   };
+
+  const submitHint = composerSubmitShortcutHint(submitShortcut);
 
   const handlePaste = (event: ClipboardEvent<HTMLTextAreaElement>) => {
     if (controlsDisabled) return;
@@ -667,7 +675,7 @@ export function GooseComposer({
                 onClick={() => void send()}
                 disabled={!canSend}
                 aria-label="发送消息"
-                title="发送消息"
+                title={`发送消息（${submitHint}）`}
               >
                 <SendIcon />
                 <span>发送</span>

--- a/web/src/components/chat/goose-composer.tsx
+++ b/web/src/components/chat/goose-composer.tsx
@@ -9,6 +9,7 @@ import {
   type DragEvent,
   type KeyboardEvent,
 } from "react";
+import { useAtomValue } from "jotai";
 import { Cpu, Folder, Plus } from "lucide-react";
 import type { ModelOptionsResult } from "@hermes/protocol";
 import { fileNameFromPath } from "@/lib/composer-prompt";
@@ -18,6 +19,7 @@ import {
   shouldSubmitComposerKey,
   type ComposerSubmitShortcut,
 } from "@/lib/composer-submit-shortcut";
+import { composerSubmitShortcutAtom } from "@/stores/ui";
 import {
   normalizeWorkspacePath,
   readWorkspacePath,
@@ -77,7 +79,7 @@ interface GooseComposerProps {
   headerLabel?: string;
   /** Empty-state hints shown only in big variant when textarea is empty. */
   hints?: ComposerHint[];
-  /** Keyboard shortcut for submitting; defaults to Enter send and Shift+Enter newline. */
+  /** Keyboard shortcut for submitting; defaults to the global composer setting. */
   submitShortcut?: ComposerSubmitShortcut;
   loadingPlaceholder?: string;
   modelPicker?: ComposerModelPickerProps;
@@ -92,7 +94,7 @@ function messageFromError(error: unknown): string {
 export function GooseComposer({
   onSend,
   onStop,
-  placeholder = "发送消息，Enter 发送，Shift+Enter 换行…",
+  placeholder,
   initial = "",
   autoFocus = false,
   disabled = false,
@@ -103,11 +105,13 @@ export function GooseComposer({
   headerLabel = "新任务",
   loadingPlaceholder,
   hints,
-  submitShortcut = "enter",
+  submitShortcut,
   modelPicker,
   contextUsage,
   initialWorkspacePath = "",
 }: GooseComposerProps) {
+  const configuredSubmitShortcut = useAtomValue(composerSubmitShortcutAtom);
+  const effectiveSubmitShortcut = submitShortcut ?? configuredSubmitShortcut;
   const isBig = variant === "big";
   const [value, setValue] = useState(initial);
   const [attachments, setAttachments] = useState<ComposerAttachment[]>([]);
@@ -370,9 +374,10 @@ export function GooseComposer({
     const shouldSubmit = shouldSubmitComposerKey({
       key: event.key,
       shiftKey: event.shiftKey,
+      ctrlKey: event.ctrlKey,
       altKey: event.altKey,
       isComposing: event.nativeEvent.isComposing,
-    }, submitShortcut);
+    }, effectiveSubmitShortcut);
 
     if (shouldSubmit) {
       event.preventDefault();
@@ -380,7 +385,8 @@ export function GooseComposer({
     }
   };
 
-  const submitHint = composerSubmitShortcutHint(submitShortcut);
+  const submitHint = composerSubmitShortcutHint(effectiveSubmitShortcut);
+  const resolvedPlaceholder = placeholder ?? `发送消息，${submitHint}…`;
 
   const handlePaste = (event: ClipboardEvent<HTMLTextAreaElement>) => {
     if (controlsDisabled) return;
@@ -572,7 +578,7 @@ export function GooseComposer({
           onChange={(event) => setValue(event.target.value)}
           onKeyDown={handleKeyDown}
           onPaste={handlePaste}
-          placeholder={loading ? (loadingPlaceholder || "Hermes 正在响应...") : placeholder}
+          placeholder={loading ? (loadingPlaceholder || "Hermes 正在响应...") : resolvedPlaceholder}
           rows={1}
           className={s.textarea}
           disabled={disabled}

--- a/web/src/components/panel/panel-composer.tsx
+++ b/web/src/components/panel/panel-composer.tsx
@@ -1,5 +1,5 @@
 import { useCallback, useEffect, useMemo, useRef, useState } from "react";
-import { useAtom } from "jotai";
+import { useAtom, useAtomValue } from "jotai";
 import { useNavigate, useSearchParams } from "react-router-dom";
 import { useGateway } from "@/hooks/use-gateway";
 import { useCreateAndSendSession } from "@/hooks/use-create-and-send-session";
@@ -8,12 +8,14 @@ import { useModelOptions } from "@/hooks/use-model-options";
 import { resolveModelContextWindow } from "@/lib/model-context";
 import { readLastUsedModel, rememberLastUsedModel } from "@/lib/last-used-model";
 import { recordModelUsage } from "@/lib/model-usage-log";
+import { composerSubmitShortcutHint } from "@/lib/composer-submit-shortcut";
 import {
   normalizeWorkspacePath,
   rememberWorkspaceProject,
   writeWorkspacePath,
 } from "@/lib/workspaces";
 import { composerPrefillAtom } from "@/stores/panel";
+import { composerSubmitShortcutAtom } from "@/stores/ui";
 import { GooseComposer } from "@/components/chat/goose-composer";
 import type {
   ComposerModelSelection,
@@ -39,8 +41,10 @@ export function PanelComposer() {
   );
   const [prefilledText, setPrefilledText] = useState("");
   const [prefill, setPrefill] = useAtom(composerPrefillAtom);
+  const composerSubmitShortcut = useAtomValue(composerSubmitShortcutAtom);
   const wrapperRef = useRef<HTMLDivElement>(null);
   const initialWorkspacePath = normalizeWorkspacePath(searchParams.get("workspace"));
+  const submitShortcutHint = composerSubmitShortcutHint(composerSubmitShortcut);
 
   useEffect(() => {
     if (!initialWorkspacePath) return;
@@ -134,7 +138,7 @@ export function PanelComposer() {
         onSend={onSend}
         initial={prefilledText}
         initialWorkspacePath={initialWorkspacePath}
-        placeholder="描述你想完成的任务，Enter 发送，Shift+Enter 换行…"
+        placeholder={`描述你想完成的任务，${submitShortcutHint}…`}
         variant="big"
         headerLabel="新任务"
         hints={[

--- a/web/src/components/panel/panel-composer.tsx
+++ b/web/src/components/panel/panel-composer.tsx
@@ -134,8 +134,7 @@ export function PanelComposer() {
         onSend={onSend}
         initial={prefilledText}
         initialWorkspacePath={initialWorkspacePath}
-        placeholder="描述你想完成的任务，Shift+Enter 发送…"
-        submitShortcut="shift-enter"
+        placeholder="描述你想完成的任务，Enter 发送，Shift+Enter 换行…"
         variant="big"
         headerLabel="新任务"
         hints={[

--- a/web/src/lib/composer-submit-shortcut.test.ts
+++ b/web/src/lib/composer-submit-shortcut.test.ts
@@ -5,16 +5,20 @@ describe("shouldSubmitComposerKey", () => {
   it("uses Enter to submit and Shift+Enter to insert a newline by default", () => {
     expect(shouldSubmitComposerKey({ key: "Enter" })).toBe(true);
     expect(shouldSubmitComposerKey({ key: "Enter", shiftKey: true })).toBe(false);
+    expect(shouldSubmitComposerKey({ key: "Enter", ctrlKey: true })).toBe(false);
   });
 
-  it("can still represent Shift+Enter submit for future settings", () => {
-    expect(shouldSubmitComposerKey({ key: "Enter" }, "shift-enter")).toBe(false);
-    expect(shouldSubmitComposerKey({ key: "Enter", shiftKey: true }, "shift-enter")).toBe(true);
+  it("uses Ctrl+Enter to submit when the shortcut preference selects it", () => {
+    expect(shouldSubmitComposerKey({ key: "Enter" }, "ctrl-enter")).toBe(false);
+    expect(shouldSubmitComposerKey({ key: "Enter", shiftKey: true }, "ctrl-enter")).toBe(false);
+    expect(shouldSubmitComposerKey({ key: "Enter", ctrlKey: true }, "ctrl-enter")).toBe(true);
+    expect(shouldSubmitComposerKey({ key: "Enter", ctrlKey: true, shiftKey: true }, "ctrl-enter")).toBe(false);
   });
 
   it("does not submit during IME composition or Alt+Enter", () => {
     expect(shouldSubmitComposerKey({ key: "Enter", isComposing: true })).toBe(false);
     expect(shouldSubmitComposerKey({ key: "Enter", altKey: true })).toBe(false);
+    expect(shouldSubmitComposerKey({ key: "Enter", ctrlKey: true, altKey: true }, "ctrl-enter")).toBe(false);
     expect(shouldSubmitComposerKey({ key: "a" })).toBe(false);
   });
 });
@@ -22,6 +26,6 @@ describe("shouldSubmitComposerKey", () => {
 describe("composerSubmitShortcutHint", () => {
   it("keeps UI hints aligned with the selected shortcut", () => {
     expect(composerSubmitShortcutHint()).toBe("Enter 发送；Shift+Enter 换行");
-    expect(composerSubmitShortcutHint("shift-enter")).toBe("Shift+Enter 发送；Enter 换行");
+    expect(composerSubmitShortcutHint("ctrl-enter")).toBe("Ctrl+Enter 发送；Enter 换行");
   });
 });

--- a/web/src/lib/composer-submit-shortcut.test.ts
+++ b/web/src/lib/composer-submit-shortcut.test.ts
@@ -1,0 +1,27 @@
+import { describe, expect, it } from "vitest";
+import { composerSubmitShortcutHint, shouldSubmitComposerKey } from "./composer-submit-shortcut";
+
+describe("shouldSubmitComposerKey", () => {
+  it("uses Enter to submit and Shift+Enter to insert a newline by default", () => {
+    expect(shouldSubmitComposerKey({ key: "Enter" })).toBe(true);
+    expect(shouldSubmitComposerKey({ key: "Enter", shiftKey: true })).toBe(false);
+  });
+
+  it("can still represent Shift+Enter submit for future settings", () => {
+    expect(shouldSubmitComposerKey({ key: "Enter" }, "shift-enter")).toBe(false);
+    expect(shouldSubmitComposerKey({ key: "Enter", shiftKey: true }, "shift-enter")).toBe(true);
+  });
+
+  it("does not submit during IME composition or Alt+Enter", () => {
+    expect(shouldSubmitComposerKey({ key: "Enter", isComposing: true })).toBe(false);
+    expect(shouldSubmitComposerKey({ key: "Enter", altKey: true })).toBe(false);
+    expect(shouldSubmitComposerKey({ key: "a" })).toBe(false);
+  });
+});
+
+describe("composerSubmitShortcutHint", () => {
+  it("keeps UI hints aligned with the selected shortcut", () => {
+    expect(composerSubmitShortcutHint()).toBe("Enter 发送；Shift+Enter 换行");
+    expect(composerSubmitShortcutHint("shift-enter")).toBe("Shift+Enter 发送；Enter 换行");
+  });
+});

--- a/web/src/lib/composer-submit-shortcut.ts
+++ b/web/src/lib/composer-submit-shortcut.ts
@@ -1,8 +1,9 @@
-export type ComposerSubmitShortcut = "enter" | "shift-enter";
+export type ComposerSubmitShortcut = "enter" | "ctrl-enter";
 
 export interface ComposerKeyState {
   key: string;
   shiftKey?: boolean;
+  ctrlKey?: boolean;
   altKey?: boolean;
   isComposing?: boolean;
 }
@@ -12,11 +13,16 @@ export function shouldSubmitComposerKey(
   shortcut: ComposerSubmitShortcut = "enter",
 ): boolean {
   if (keyState.isComposing || keyState.altKey || keyState.key !== "Enter") return false;
-  return shortcut === "shift-enter" ? Boolean(keyState.shiftKey) : !keyState.shiftKey;
+
+  if (shortcut === "ctrl-enter") {
+    return Boolean(keyState.ctrlKey) && !keyState.shiftKey;
+  }
+
+  return !keyState.shiftKey && !keyState.ctrlKey;
 }
 
 export function composerSubmitShortcutHint(shortcut: ComposerSubmitShortcut = "enter"): string {
-  return shortcut === "shift-enter"
-    ? "Shift+Enter 发送；Enter 换行"
+  return shortcut === "ctrl-enter"
+    ? "Ctrl+Enter 发送；Enter 换行"
     : "Enter 发送；Shift+Enter 换行";
 }

--- a/web/src/lib/composer-submit-shortcut.ts
+++ b/web/src/lib/composer-submit-shortcut.ts
@@ -1,0 +1,22 @@
+export type ComposerSubmitShortcut = "enter" | "shift-enter";
+
+export interface ComposerKeyState {
+  key: string;
+  shiftKey?: boolean;
+  altKey?: boolean;
+  isComposing?: boolean;
+}
+
+export function shouldSubmitComposerKey(
+  keyState: ComposerKeyState,
+  shortcut: ComposerSubmitShortcut = "enter",
+): boolean {
+  if (keyState.isComposing || keyState.altKey || keyState.key !== "Enter") return false;
+  return shortcut === "shift-enter" ? Boolean(keyState.shiftKey) : !keyState.shiftKey;
+}
+
+export function composerSubmitShortcutHint(shortcut: ComposerSubmitShortcut = "enter"): string {
+  return shortcut === "shift-enter"
+    ? "Shift+Enter 发送；Enter 换行"
+    : "Enter 发送；Shift+Enter 换行";
+}

--- a/web/src/routes/analytics.tsx
+++ b/web/src/routes/analytics.tsx
@@ -3,7 +3,7 @@ import { SectionShell } from "./section-shell";
 
 export function AnalyticsRoute() {
   return (
-    <SectionShell title="数据分析" sub="查看 Token、费用、会话与模型维度的使用趋势。">
+    <SectionShell title="数据分析" sub="查看 Token、会话与模型维度的使用趋势。">
       <AnalyticsSection showHeading={false} />
     </SectionShell>
   );

--- a/web/src/routes/console.tsx
+++ b/web/src/routes/console.tsx
@@ -21,9 +21,9 @@ interface CommandAction {
 
 const QUICK_COMMANDS: CommandAction[] = [
   {
-    label: "打开 Hermes TUI",
-    command: "hermes --tui",
-    desc: "进入 Hermes 交互式界面，直接按提示完成对话、配置和接入操作。",
+    label: "打开 Hermes",
+    command: "hermes",
+    desc: "进入 Hermes 命令入口，直接按提示完成对话、配置和接入操作。",
   },
   {
     label: "查看接入状态",
@@ -132,7 +132,7 @@ export function ConsoleRoute() {
 
     const writeBanner = () => {
       term.writeln("\x1b[38;5;214mHermes\x1b[0m \x1b[38;5;81mConsole\x1b[0m");
-      term.writeln("这里是真实终端。你可以直接输入 Hermes 命令，也可以点下方常用操作自动填入。推荐先运行 hermes --tui。");
+      term.writeln("这里是真实终端。你可以直接输入 Hermes 命令，也可以点下方常用操作自动填入。推荐先运行 hermes。");
       if (autoPurpose === "gatewaySetup") {
         term.writeln("正在为你打开消息平台接入向导\r\n");
       } else if (autoPurpose === "gatewayStatus") {
@@ -338,7 +338,7 @@ export function ConsoleRoute() {
           <div className={s.panel}>
             <div className={s.panelTitle}>接入提示</div>
             <p className={s.helpText}>
-              推荐先点击“打开 Hermes TUI”。进入交互式界面后，你可以按提示完成对话、配置和飞书、微信等消息入口接入。
+              推荐先点击“打开 Hermes”。进入 Hermes 命令入口后，你可以按提示完成对话、配置和飞书、微信等消息入口接入。
             </p>
             <p className={s.helpText}>
               这个终端默认使用当前档案的 <code>HERMES_HOME</code>，不会切到其它档案，也不会读浏览器里的临时状态。

--- a/web/src/routes/detail.tsx
+++ b/web/src/routes/detail.tsx
@@ -385,7 +385,7 @@ export function DetailRoute() {
       <div className={s.composerArea}>
         <GooseComposer
           onSend={onSend}
-          placeholder="发送消息…"
+          placeholder="发送消息，Enter 发送，Shift+Enter 换行…"
           loadingPlaceholder={composerLoadingPlaceholder}
           showMeta={false}
           loading={runtimeIsBusy}

--- a/web/src/routes/detail.tsx
+++ b/web/src/routes/detail.tsx
@@ -385,7 +385,6 @@ export function DetailRoute() {
       <div className={s.composerArea}>
         <GooseComposer
           onSend={onSend}
-          placeholder="发送消息，Enter 发送，Shift+Enter 换行…"
           loadingPlaceholder={composerLoadingPlaceholder}
           showMeta={false}
           loading={runtimeIsBusy}

--- a/web/src/routes/settings-analytics-section.tsx
+++ b/web/src/routes/settings-analytics-section.tsx
@@ -74,7 +74,6 @@ export function AnalyticsSection({ showHeading = true }: { showHeading?: boolean
           label="总 Tokens"
           value={formatLargeNum((totals.total_input ?? 0) + (totals.total_output ?? 0))}
         />
-        <StatCard label="总费用" value={`$${(totals.total_estimated_cost ?? 0).toFixed(4)}`} />
         <StatCard label="会话数" value={String(totals.total_sessions ?? 0)} />
         <StatCard label="API 调用" value={String(totals.total_api_calls ?? 0)} />
       </div>
@@ -85,11 +84,8 @@ export function AnalyticsSection({ showHeading = true }: { showHeading?: boolean
           <div className={s.rowLeft}>
             <div className={s.rowLabel}>{model.model}</div>
           </div>
-          <div className={s.rowRight} style={{ gap: 12 }}>
+          <div className={s.rowRight}>
             <span className={s.rowSub}>{formatLargeNum(model.input_tokens + model.output_tokens)} tok</span>
-            {model.estimated_cost != null && (
-              <span className={s.rowSub}>${model.estimated_cost.toFixed(4)}</span>
-            )}
           </div>
         </div>
       ))}
@@ -98,7 +94,7 @@ export function AnalyticsSection({ showHeading = true }: { showHeading?: boolean
       <div className={s.logBlock}>
         {data.daily.map((day) => (
           <div key={day.day} className={s.logLine}>
-            {day.day} — {day.sessions} 会话 · {formatLargeNum(day.input_tokens + day.output_tokens)} tok · ${day.estimated_cost.toFixed(4)}
+            {day.day} — {day.sessions} 会话 · {formatLargeNum(day.input_tokens + day.output_tokens)} tok
           </div>
         ))}
       </div>

--- a/web/src/routes/settings.tsx
+++ b/web/src/routes/settings.tsx
@@ -802,7 +802,7 @@ export function AboutSection({ showHeading = true }: SettingsSectionProps) {
           <div className={s.aboutEyebrow}>Hermes Agent 中文社区桌面版</div>
           <h3>联系与致谢</h3>
           <p>
-            这里会放中文社区桌面版的联系方式、社区入口、项目链接和致谢信息。
+            致谢，联系方式及项目链接。
           </p>
         </div>
       </div>

--- a/web/src/routes/settings.tsx
+++ b/web/src/routes/settings.tsx
@@ -33,11 +33,12 @@ import {
   useRollbackRuntime,
   useRuntimeInfo,
 } from "@/hooks/use-runtime-update";
-import { showReasoningAtom, profileSwitchingAtom } from "@/stores/ui";
+import { composerSubmitShortcutAtom, showReasoningAtom, profileSwitchingAtom } from "@/stores/ui";
 import { postJSON } from "@/lib/transport";
 import { openExternalUrl } from "@/lib/external-links";
 import { buildNestedConfigUpdate, mergeConfigUpdate } from "@/lib/config-update";
 import { translateConfigField, translateConfigOption } from "@/lib/config-translations";
+import type { ComposerSubmitShortcut } from "@/lib/composer-submit-shortcut";
 import type { ConfigSchemaField, RuntimeInfo, RuntimeUpdateCheckResult } from "@hermes/protocol";
 import { CopyButton } from "@/components/ui/copy-button";
 import wechatCommunityQr from "@/assets/wechat-community-qr.png";
@@ -52,6 +53,7 @@ interface SettingsSectionProps {
 export function GeneralSection({ showHeading = true }: SettingsSectionProps) {
   const { config, update } = useTheme();
   const [showReasoning, setShowReasoning] = useAtom(showReasoningAtom);
+  const [composerSubmitShortcut, setComposerSubmitShortcut] = useAtom(composerSubmitShortcutAtom);
 
   return (
     <div>
@@ -64,6 +66,9 @@ export function GeneralSection({ showHeading = true }: SettingsSectionProps) {
       } />
       <Row label="显示推理过程" sub="在会话中展示模型的思考和推理内容" right={
         <RadioGroup value={showReasoning ? "on" : "off"} options={[{ value: "off", label: "隐藏" }, { value: "on", label: "显示" }]} onChange={(v) => setShowReasoning(v === "on")} />
+      } />
+      <Row label="发送快捷键" sub="控制对话输入框的提交方式；未触发发送的 Enter 会保留为换行。" right={
+        <RadioGroup value={composerSubmitShortcut} options={[{ value: "enter", label: "Enter 发送" }, { value: "ctrl-enter", label: "Ctrl+Enter 发送" }]} onChange={(v) => setComposerSubmitShortcut(v as ComposerSubmitShortcut)} />
       } />
       {isYoloModeSupported() && <YoloDangerZone />}
     </div>

--- a/web/src/stores/ui.test.ts
+++ b/web/src/stores/ui.test.ts
@@ -71,6 +71,33 @@ describe("showReasoningAtom (persisted)", () => {
   });
 });
 
+describe("composerSubmitShortcutAtom (persisted)", () => {
+  it("defaults to Enter submit when nothing is stored", async () => {
+    const { composerSubmitShortcutAtom } = await loadUi();
+    const store = createStore();
+    expect(store.get(composerSubmitShortcutAtom)).toBe("enter");
+  });
+
+  it("restores Ctrl+Enter submit from the UI store", async () => {
+    const { composerSubmitShortcutAtom } = await loadUi({
+      "hermes.composer-submit-shortcut": "ctrl-enter",
+    });
+    const store = createStore();
+    expect(store.get(composerSubmitShortcutAtom)).toBe("ctrl-enter");
+  });
+
+  it("persists shortcut changes and normalizes unsupported values", async () => {
+    const { composerSubmitShortcutAtom, uiStore } = await loadUi();
+    const store = createStore();
+    store.set(composerSubmitShortcutAtom, "ctrl-enter");
+    expect(uiStore.readUiValue("hermes.composer-submit-shortcut", "")).toBe("ctrl-enter");
+
+    store.set(composerSubmitShortcutAtom, "shift-enter" as never);
+    expect(store.get(composerSubmitShortcutAtom)).toBe("enter");
+    expect(uiStore.readUiValue("hermes.composer-submit-shortcut", "")).toBe("enter");
+  });
+});
+
 describe("profileSwitchingAtom", () => {
   it("defaults to { active: false }", async () => {
     const { profileSwitchingAtom } = await loadUi();

--- a/web/src/stores/ui.ts
+++ b/web/src/stores/ui.ts
@@ -1,4 +1,5 @@
 import { atom } from "jotai";
+import type { ComposerSubmitShortcut } from "@/lib/composer-submit-shortcut";
 import { readUiValue, writeUiValue } from "@/lib/ui-store";
 
 export const activeSessionIdAtom = atom<string | null>(null);
@@ -29,6 +30,24 @@ export const showReasoningAtom = atom(
   (_get, set, next: boolean) => {
     set(showReasoningBaseAtom, next);
     writeUiValue("hermes.show-reasoning", next);
+  },
+);
+
+const COMPOSER_SUBMIT_SHORTCUT_KEY = "hermes.composer-submit-shortcut";
+
+function normalizeComposerSubmitShortcut(value: unknown): ComposerSubmitShortcut {
+  return value === "ctrl-enter" ? "ctrl-enter" : "enter";
+}
+
+const composerSubmitShortcutBaseAtom = atom<ComposerSubmitShortcut>(
+  normalizeComposerSubmitShortcut(readUiValue(COMPOSER_SUBMIT_SHORTCUT_KEY, "enter")),
+);
+export const composerSubmitShortcutAtom = atom(
+  (get) => get(composerSubmitShortcutBaseAtom),
+  (_get, set, next: ComposerSubmitShortcut) => {
+    const value = normalizeComposerSubmitShortcut(next);
+    set(composerSubmitShortcutBaseAtom, value);
+    writeUiValue(COMPOSER_SUBMIT_SHORTCUT_KEY, value);
   },
 );
 


### PR DESCRIPTION
## 变更

- 统一新会话与正式对话的发送快捷键逻辑，并在常规设置中支持 Enter / Ctrl+Enter 切换。
- 移除 Console 页推荐命令中的 `--tui`，避免本地 runtime 缺少 TUI 资源时报错。
- 数据分析页暂时隐藏所有费用相关展示字段。

## 验证

- `pnpm typecheck`
- `pnpm test:unit`
- `cargo check`
- `pnpm --filter @hermes/web typecheck`