### PR TITLE
fix: 修复定时任务页面加载与触发反馈

### DIFF
--- a/packages/protocol/src/hermes-api.test.ts
+++ b/packages/protocol/src/hermes-api.test.ts
@@ -1,0 +1,40 @@
+import { describe, expect, it } from "vitest";
+import { CronJobsResponse } from "./hermes-api";
+
+describe("CronJobsResponse", () => {
+  it("parses current dashboard cron jobs with structured schedules", () => {
+    const jobs = CronJobsResponse.parse([
+      {
+        id: "38003fd5cfdd",
+        name: "Aa",
+        prompt: "aa",
+        schedule: { kind: "cron", expr: "0 9 * * *", display: "0 9 * * *" },
+        schedule_display: "0 9 * * *",
+        enabled: true,
+        state: "scheduled",
+        next_run_at: "2026-06-06T09:00:00+08:00",
+        last_run_at: null,
+        deliver: "local",
+        profile: "default",
+      },
+    ]);
+
+    expect(jobs[0]?.schedule).toEqual({ kind: "cron", expr: "0 9 * * *", display: "0 9 * * *" });
+    expect(jobs[0]?.next_run_at).toBe("2026-06-06T09:00:00+08:00");
+  });
+
+  it("keeps accepting legacy cron jobs with string schedules", () => {
+    const jobs = CronJobsResponse.parse([
+      {
+        id: "legacy",
+        schedule: "0 9 * * *",
+        enabled: false,
+        next_run: null,
+        last_run: null,
+      },
+    ]);
+
+    expect(jobs[0]?.schedule).toBe("0 9 * * *");
+    expect(jobs[0]?.enabled).toBe(false);
+  });
+});

--- a/packages/protocol/src/hermes-api.ts
+++ b/packages/protocol/src/hermes-api.ts
@@ -368,16 +368,41 @@ export type AnalyticsResponse = z.infer<typeof AnalyticsResponse>;
 
 // ── Cron (/api/cron/jobs) ─────────────────────────────────────────────
 
+export const CronSchedule = z.union([
+  z.string(),
+  z.object({
+    kind: z.string().optional(),
+    expr: z.string().optional(),
+    display: z.string().optional(),
+    value: z.string().optional(),
+  }).passthrough(),
+]).nullable().optional();
+export type CronSchedule = z.infer<typeof CronSchedule>;
+
 export const CronJob = z.object({
   id: z.string(),
-  name: z.string().optional(),
-  schedule: z.string(),
-  prompt: z.string().optional(),
-  deliver: z.string().optional(),
-  enabled: z.boolean(),
+  name: z.string().nullable().optional(),
+  schedule: CronSchedule,
+  schedule_display: z.string().nullable().optional(),
+  prompt: z.string().nullable().optional(),
+  script: z.string().nullable().optional(),
+  deliver: z.string().nullable().optional(),
+  enabled: z.boolean().default(true),
+  state: z.string().nullable().optional(),
   last_run: z.number().nullable().optional(),
   next_run: z.number().nullable().optional(),
-});
+  last_run_at: z.string().nullable().optional(),
+  next_run_at: z.string().nullable().optional(),
+  last_status: z.string().nullable().optional(),
+  last_error: z.string().nullable().optional(),
+  paused_at: z.string().nullable().optional(),
+  paused_reason: z.string().nullable().optional(),
+  created_at: z.string().nullable().optional(),
+  profile: z.string().nullable().optional(),
+  profile_name: z.string().nullable().optional(),
+  hermes_home: z.string().nullable().optional(),
+  is_default_profile: z.boolean().optional(),
+}).passthrough();
 export type CronJob = z.infer<typeof CronJob>;
 
 export const CronJobsResponse = z.array(CronJob);

--- a/web/src/hooks/use-cron.ts
+++ b/web/src/hooks/use-cron.ts
@@ -1,13 +1,15 @@
 import { useQuery, useMutation, useQueryClient } from "@tanstack/react-query";
 import { fetchJSON, postJSON, putJSON, deleteJSON } from "@/lib/transport";
 import { useActiveProfileName } from "@/hooks/use-profiles";
-import { CronJobsResponse, MutationOkResponse, type CronJob } from "@hermes/protocol";
+import { CronJob as CronJobSchema, CronJobsResponse, MutationOkResponse, type CronJob } from "@hermes/protocol";
 
 export function useCronJobs() {
   const profile = useActiveProfileName();
   return useQuery<CronJob[]>({
     queryKey: ["cron-jobs", profile],
-    queryFn: () => fetchJSON("/api/cron/jobs", undefined, CronJobsResponse),
+    queryFn: () => fetchJSON("/api/cron/jobs?profile=all", undefined, CronJobsResponse),
+    retry: 1,
+    staleTime: 30_000,
   });
 }
 
@@ -15,7 +17,7 @@ export function useCreateCronJob() {
   const qc = useQueryClient();
   return useMutation({
     mutationFn: (job: { prompt: string; schedule: string; name?: string; deliver?: string }) =>
-      postJSON("/api/cron/jobs", job, MutationOkResponse),
+      postJSON("/api/cron/jobs", job, CronJobSchema),
     onSuccess: () => qc.invalidateQueries({ queryKey: ["cron-jobs"] }),
   });
 }
@@ -24,7 +26,7 @@ export function useUpdateCronJob() {
   const qc = useQueryClient();
   return useMutation({
     mutationFn: ({ id, updates }: { id: string; updates: Record<string, any> }) =>
-      putJSON(`/api/cron/jobs/${id}`, { updates }, MutationOkResponse),
+      putJSON(`/api/cron/jobs/${id}`, { updates }, CronJobSchema),
     onSuccess: () => qc.invalidateQueries({ queryKey: ["cron-jobs"] }),
   });
 }
@@ -41,7 +43,7 @@ export function useCronAction() {
   const qc = useQueryClient();
   return useMutation({
     mutationFn: ({ id, action }: { id: string; action: "pause" | "resume" | "trigger" }) =>
-      postJSON(`/api/cron/jobs/${id}/${action}`, {}, MutationOkResponse),
+      postJSON(`/api/cron/jobs/${id}/${action}`, {}, CronJobSchema),
     onSuccess: () => qc.invalidateQueries({ queryKey: ["cron-jobs"] }),
   });
 }

--- a/web/src/routes/memory.tsx
+++ b/web/src/routes/memory.tsx
@@ -288,7 +288,7 @@ export function MemoryRoute() {
                   className={s.profileTextarea}
                   value={userContent}
                   onChange={(event) => { setUserContent(event.target.value); setUserDirty(true); }}
-                  placeholder="例如：姓名小林。使用 macOS 和 zsh。偏好简洁但完整的中文回答。"
+                  placeholder="姓名小李，使用 macOS 和 zsh，偏好简洁的中文回答。"
                   rows={9}
                 />
                 <div className={`${s.formActions} ${s.profileFooter}`}>

--- a/web/src/routes/settings.module.css
+++ b/web/src/routes/settings.module.css
@@ -247,6 +247,35 @@
   background: var(--h-bg-chip);
 }
 
+.cronFeedback {
+  margin: 12px 0;
+  padding: 10px 12px;
+  border-radius: var(--h-r-md);
+  border: 1px solid var(--h-line);
+  color: var(--h-text-2);
+  background: var(--h-bg-app);
+  font-size: 12px;
+  line-height: 1.5;
+}
+
+.cronFeedback[data-tone="ok"] {
+  color: var(--h-ok);
+  border-color: color-mix(in srgb, var(--h-ok) 36%, transparent);
+  background: var(--h-ok-soft);
+}
+
+.cronFeedback[data-tone="info"] {
+  color: var(--h-accent);
+  border-color: color-mix(in srgb, var(--h-accent) 36%, transparent);
+  background: color-mix(in srgb, var(--h-accent) 12%, transparent);
+}
+
+.cronFeedback[data-tone="error"] {
+  color: var(--h-danger, #d45c5c);
+  border-color: color-mix(in srgb, var(--h-danger, #d45c5c) 36%, transparent);
+  background: color-mix(in srgb, var(--h-danger, #d45c5c) 12%, transparent);
+}
+
 .envStatusBadge {
   min-width: 68px;
   gap: 6px;

--- a/web/src/routes/settings.tsx
+++ b/web/src/routes/settings.tsx
@@ -39,7 +39,7 @@ import { openExternalUrl } from "@/lib/external-links";
 import { buildNestedConfigUpdate, mergeConfigUpdate } from "@/lib/config-update";
 import { translateConfigField, translateConfigOption } from "@/lib/config-translations";
 import type { ComposerSubmitShortcut } from "@/lib/composer-submit-shortcut";
-import type { ConfigSchemaField, RuntimeInfo, RuntimeUpdateCheckResult } from "@hermes/protocol";
+import type { ConfigSchemaField, CronJob, RuntimeInfo, RuntimeUpdateCheckResult } from "@hermes/protocol";
 import { CopyButton } from "@/components/ui/copy-button";
 import wechatCommunityQr from "@/assets/wechat-community-qr.png";
 import s from "./settings.module.css";
@@ -328,8 +328,74 @@ export function SkillsSection() {
 
 /* ── Cron Jobs ───────────────────────────────────────────────────────── */
 
+function cronText(value: unknown): string {
+  return typeof value === "string" ? value.trim() : "";
+}
+
+function cronScheduleDisplay(job: CronJob): string {
+  const schedule = job.schedule;
+  if (cronText(job.schedule_display)) return cronText(job.schedule_display);
+  if (typeof schedule === "string") return cronText(schedule) || "未设置";
+  if (schedule && typeof schedule === "object") {
+    return cronText(schedule.display) || cronText(schedule.expr) || cronText(schedule.value) || "未设置";
+  }
+  return "未设置";
+}
+
+function cronTitle(job: CronJob): string {
+  return cronText(job.name) || cronText(job.prompt).slice(0, 60) || cronText(job.script).slice(0, 60) || job.id;
+}
+
+function cronPromptPreview(job: CronJob): string {
+  return cronText(job.prompt) || (cronText(job.script) ? `脚本：${cronText(job.script)}` : "无任务描述");
+}
+
+function cronState(job: CronJob): string {
+  return cronText(job.state) || (job.enabled ? "scheduled" : "paused");
+}
+
+function cronStateLabel(job: CronJob): string {
+  const state = cronState(job);
+  if (state === "scheduled") return "计划中";
+  if (state === "paused") return "暂停";
+  if (state === "running") return "执行中";
+  if (state === "completed") return "已完成";
+  if (state === "error") return "错误";
+  return job.enabled ? "启用" : "暂停";
+}
+
+function cronResultLine(job: CronJob): string | null {
+  const status = cronText(job.last_status);
+  if (!status) return null;
+  if (status === "ok") return "上次结果：成功";
+  if (status === "error") return `上次结果：失败${cronText(job.last_error) ? ` · ${cronText(job.last_error)}` : ""}`;
+  return `上次结果：${status}`;
+}
+
+function cronIsPaused(job: CronJob): boolean {
+  return !job.enabled || cronState(job) === "paused";
+}
+
+function formatCronTime(value: string | number | null | undefined): string {
+  if (value == null) return "—";
+  const date = typeof value === "number"
+    ? new Date(value < 1_000_000_000_000 ? value * 1000 : value)
+    : new Date(value);
+  if (Number.isNaN(date.getTime())) return "—";
+  return date.toLocaleString();
+}
+
+function cronActionError(error: unknown): string {
+  return error instanceof Error ? error.message : String(error || "请求失败");
+}
+
+type CronFeedback = {
+  tone: "ok" | "info" | "error";
+  message: string;
+};
+
 export function CronSection() {
-  const { data: jobs, isLoading } = useCronJobs();
+  const { data: jobs, isLoading, isError, error, refetch } = useCronJobs();
   const createJob = useCreateCronJob();
   const deleteJob = useDeleteCronJob();
   const cronAction = useCronAction();
@@ -337,45 +403,118 @@ export function CronSection() {
   const [newName, setNewName] = useState("");
   const [newSchedule, setNewSchedule] = useState("");
   const [newPrompt, setNewPrompt] = useState("");
+  const [feedback, setFeedback] = useState<CronFeedback | null>(null);
+  const refreshTimersRef = useRef<number[]>([]);
+
+  const clearQueuedRefreshes = useCallback(() => {
+    refreshTimersRef.current.forEach((id) => window.clearTimeout(id));
+    refreshTimersRef.current = [];
+  }, []);
+
+  const queueFollowUpRefreshes = useCallback(() => {
+    clearQueuedRefreshes();
+    refreshTimersRef.current = [2_000, 8_000, 30_000, 65_000].map((delay) =>
+      window.setTimeout(() => void refetch(), delay),
+    );
+  }, [clearQueuedRefreshes, refetch]);
+
+  useEffect(() => clearQueuedRefreshes, [clearQueuedRefreshes]);
 
   const handleCreate = () => {
     if (!newSchedule || !newPrompt) return;
-    createJob.mutate({ name: newName || undefined, schedule: newSchedule, prompt: newPrompt });
-    setShowNew(false);
-    setNewName("");
-    setNewSchedule("");
-    setNewPrompt("");
+    createJob.mutate(
+      { name: newName || undefined, schedule: newSchedule, prompt: newPrompt },
+      {
+        onSuccess: (job) => {
+          setShowNew(false);
+          setNewName("");
+          setNewSchedule("");
+          setNewPrompt("");
+          setFeedback({ tone: "ok", message: `已创建定时任务「${cronTitle(job)}」。` });
+        },
+        onError: (err) => setFeedback({ tone: "error", message: `创建定时任务失败：${cronActionError(err)}` }),
+      },
+    );
+  };
+
+  const handleCronAction = (job: CronJob, action: "pause" | "resume" | "trigger") => {
+    cronAction.mutate(
+      { id: job.id, action },
+      {
+        onSuccess: (updated) => {
+          if (action === "trigger") {
+            setFeedback({
+              tone: "info",
+              message: `已触发「${cronTitle(updated)}」，内核会在下一次调度 tick 执行，通常 60 秒内会刷新运行结果。`,
+            });
+            queueFollowUpRefreshes();
+            return;
+          }
+          setFeedback({
+            tone: "ok",
+            message: `${action === "pause" ? "已暂停" : "已恢复"}「${cronTitle(updated)}」。`,
+          });
+        },
+        onError: (err) => {
+          const actionLabel = action === "pause" ? "暂停" : action === "resume" ? "恢复" : "触发";
+          setFeedback({ tone: "error", message: `${actionLabel}定时任务失败：${cronActionError(err)}` });
+        },
+      },
+    );
+  };
+
+  const handleDelete = (job: CronJob) => {
+    deleteJob.mutate(job.id, {
+      onSuccess: () => setFeedback({ tone: "ok", message: `已删除定时任务「${cronTitle(job)}」。` }),
+      onError: (err) => setFeedback({ tone: "error", message: `删除定时任务失败：${cronActionError(err)}` }),
+    });
   };
 
   return (
     <div>
       <p className={s.desc}>Agent 会按计划自动执行这些任务。</p>
-      {isLoading && <div className={s.desc}>加载中…</div>}
-      {jobs && jobs.length === 0 && !showNew && <div className={s.desc}>暂无定时任务。</div>}
-      {jobs?.map((job) => (
-        <div key={job.id} className={s.row}>
-          <div className={s.rowLeft}>
-            <div className={s.rowLabel}>{job.name || job.id}</div>
-            <div className={s.rowSub}>{job.schedule} · {job.prompt?.slice(0, 60)}</div>
-          </div>
-          <div className={s.rowRight} style={{ gap: 6 }}>
-            <span className={s.statusBadge} data-on={job.enabled}>{job.enabled ? "启用" : "暂停"}</span>
-            <button className={s.btn} onClick={() => cronAction.mutate({ id: job.id, action: job.enabled ? "pause" : "resume" })}>
-              {job.enabled ? "暂停" : "恢复"}
-            </button>
-            <button className={s.btn} onClick={() => cronAction.mutate({ id: job.id, action: "trigger" })}>触发</button>
-            <button className={s.btnDanger} onClick={() => deleteJob.mutate(job.id)}>删除</button>
-          </div>
+      {feedback && (
+        <div className={s.cronFeedback} data-tone={feedback.tone} role={feedback.tone === "error" ? "alert" : "status"}>
+          {feedback.message}
         </div>
-      ))}
+      )}
+      {isLoading && <div className={s.desc}>加载中…</div>}
+      {isError && (
+        <div className={s.providerDetail} style={{ marginTop: 12 }}>
+          <div className={s.desc}>加载定时任务失败：{error instanceof Error ? error.message : String(error)}</div>
+          <button className={s.btn} onClick={() => void refetch()}>重试</button>
+        </div>
+      )}
+      {!isLoading && !isError && jobs && jobs.length === 0 && !showNew && <div className={s.desc}>暂无定时任务。</div>}
+      {!isError && jobs?.map((job) => {
+        const paused = cronIsPaused(job);
+        return (
+          <div key={`${job.profile ?? "default"}:${job.id}`} className={s.row}>
+            <div className={s.rowLeft}>
+              <div className={s.rowLabel}>{cronTitle(job)}</div>
+              <div className={s.rowSub}>{cronScheduleDisplay(job)} · {cronPromptPreview(job).slice(0, 60)}</div>
+              <div className={s.rowSub}>下次：{formatCronTime(job.next_run_at ?? job.next_run)} · 上次：{formatCronTime(job.last_run_at ?? job.last_run)}</div>
+              {cronResultLine(job) && <div className={s.rowSub}>{cronResultLine(job)}</div>}
+            </div>
+            <div className={s.rowRight} style={{ gap: 6 }}>
+              <span className={s.statusBadge} data-on={!paused}>{cronStateLabel(job)}</span>
+              <button className={s.btn} disabled={cronAction.isPending || deleteJob.isPending} onClick={() => handleCronAction(job, paused ? "resume" : "pause")}>
+                {paused ? "恢复" : "暂停"}
+              </button>
+              <button className={s.btn} disabled={cronAction.isPending || deleteJob.isPending} onClick={() => handleCronAction(job, "trigger")}>触发</button>
+              <button className={s.btnDanger} disabled={cronAction.isPending || deleteJob.isPending} onClick={() => handleDelete(job)}>删除</button>
+            </div>
+          </div>
+        );
+      })}
       {showNew ? (
         <div className={s.providerDetail} style={{ marginTop: 12 }}>
           <FieldRow label="名称（可选）" value={newName} onChange={setNewName} />
           <FieldRow label="Cron 表达式" value={newSchedule} onChange={setNewSchedule} placeholder="0 9 * * *" />
           <FieldRow label="Prompt" value={newPrompt} onChange={setNewPrompt} placeholder="每天执行的任务描述…" />
           <div className={s.providerActions}>
-            <button className={s.btnPrimary} onClick={handleCreate}>创建</button>
-            <button className={s.btn} onClick={() => setShowNew(false)}>取消</button>
+            <button className={s.btnPrimary} onClick={handleCreate} disabled={createJob.isPending}>创建</button>
+            <button className={s.btn} onClick={() => setShowNew(false)} disabled={createJob.isPending}>取消</button>
           </div>
         </div>
       ) : (


### PR DESCRIPTION
## 变更

- 更新用户画像输入框 placeholder 文案。
- 兼容新版 cron job 返回结构，修复桌面端定时任务列表加载失败和不显示已有任务的问题。
- 新增定时任务创建、触发、暂停、恢复、删除的局部反馈。
- 触发任务后自动排队刷新列表，便于观察下次运行时间和最近执行结果。
- 增加协议测试覆盖新版结构化 schedule 和旧版字符串 schedule。

## 验证

- `pnpm typecheck`
- `pnpm test:unit`
- `cargo check`
- 浏览器验证 `/cron` 能显示同一内核已有任务，并且点击“触发”后出现反馈。