### PR TITLE
fix: 优化配置分类选项卡展示

### DIFF
--- a/web/src/routes/settings.module.css
+++ b/web/src/routes/settings.module.css
@@ -2030,43 +2030,41 @@
   padding: 4px 14px;
 }
 
-/* Config tabs (horizontal scrollable category bar — document-style underline) */
+/* Config tabs (wrapping category chips; avoid hidden horizontal overflow) */
 .configTabs {
   display: flex;
-  gap: 0;
-  padding: 0;
+  flex-wrap: wrap;
+  gap: 8px;
+  padding: 0 0 14px;
   margin: 0 0 16px;
-  overflow-x: auto;
+  overflow: visible;
   border-bottom: 1px solid var(--h-line-soft);
-  scrollbar-width: none;
-}
-.configTabs::-webkit-scrollbar {
-  display: none;
 }
 
 .configTab {
   display: flex;
   align-items: center;
   gap: 6px;
-  padding: 8px 14px;
-  border: 0;
-  border-bottom: 2px solid transparent;
-  border-radius: 0;
-  background: transparent;
+  min-height: 32px;
+  padding: 0 12px;
+  border: 1px solid var(--h-line);
+  border-radius: var(--h-r-pill);
+  background: var(--h-bg-chip);
   color: var(--h-text-3);
   font-size: 12px;
   cursor: pointer;
   font-family: var(--h-font-cn);
   white-space: nowrap;
-  transition: color 0.12s, border-color 0.12s;
-  margin-bottom: -1px;
+  transition: color 0.12s, border-color 0.12s, background 0.12s;
 }
 .configTab:hover {
   color: var(--h-text);
+  border-color: var(--h-accent-border);
 }
 .configTab[data-active="true"] {
   color: var(--h-text);
-  border-bottom-color: var(--h-text);
+  border-color: var(--h-accent-border);
+  background: var(--h-accent-soft);
   font-weight: 500;
 }
 

--- a/web/src/routes/settings.tsx
+++ b/web/src/routes/settings.tsx
@@ -231,9 +231,16 @@ export function ConfigSection({ showHeading = true }: SettingsSectionProps) {
       </div>
 
       {!isSearching && (
-        <div className={s.configTabs}>
+        <div className={s.configTabs} role="tablist" aria-label="配置分类">
           {categories.map((cat) => (
-            <button key={cat} className={s.configTab} data-active={cat === activeCategory} onClick={() => setActiveCategory(cat)}>
+            <button
+              key={cat}
+              className={s.configTab}
+              data-active={cat === activeCategory}
+              role="tab"
+              aria-selected={cat === activeCategory}
+              onClick={() => setActiveCategory(cat)}
+            >
               {CATEGORY_CN[cat] ?? cat}
               <span className={s.configTabCount}>{categoryCounts[cat] || 0}</span>
             </button>


### PR DESCRIPTION
## 变更

- 将配置页分类选项卡从隐藏滚动条的横向滚动改为自动换行的 chip。
- 右侧分类不再被遮挡，用户无需使用 Shift + 滚轮横向滚动。
- 为分类按钮补充 tablist/tab 语义。

## 验证

- `pnpm --filter @hermes/web typecheck`
- 浏览器验证 `/advanced/config` 中 15 个分类分成 2 行展示，且没有横向溢出。