### PR TITLE
[codex] 支持对话流图片消息渲染

### DIFF
--- a/packages/protocol/src/hermes-api.ts
+++ b/packages/protocol/src/hermes-api.ts
@@ -2,6 +2,16 @@ import { z } from "zod";
 
 const NullableStringAsEmpty = z.string().nullable().optional().transform((value) => value ?? "");
 
+function stringifyMessageContent(value: unknown): string | null {
+  if (typeof value === "string") return value;
+  if (value == null) return null;
+  try {
+    return JSON.stringify(value);
+  } catch {
+    return String(value);
+  }
+}
+
 // ── Status (/api/status) ──────────────────────────────────────────────
 
 export const PlatformStatus = z.object({
@@ -56,6 +66,34 @@ export const SessionSummary = z.object({
 });
 export type SessionSummary = z.infer<typeof SessionSummary>;
 
+export const HermesImageSource = z.union([
+  z.string(),
+  z
+    .object({
+      url: z.string().optional(),
+      src: z.string().optional(),
+      path: z.string().optional(),
+      data: z.string().optional(),
+      image_url: z.unknown().optional(),
+      imageUrl: z.unknown().optional(),
+      alt: z.string().optional(),
+      title: z.string().optional(),
+      name: z.string().optional(),
+      filename: z.string().optional(),
+      file_name: z.string().optional(),
+      mimeType: z.string().optional(),
+      mime_type: z.string().optional(),
+      mediaType: z.string().optional(),
+      contentType: z.string().optional(),
+      content_type: z.string().optional(),
+      is_image: z.boolean().optional(),
+    })
+    .passthrough(),
+]);
+export type HermesImageSource = z.infer<typeof HermesImageSource>;
+
+const MessageContent = z.unknown().transform(stringifyMessageContent);
+
 export const SessionDetail = SessionSummary.extend({
   last_active: z.number().optional(),
 }).passthrough();
@@ -82,7 +120,8 @@ export const SessionMessage = z.object({
   // returns null for roles it doesn't know how to draw, which drops
   // those rows cleanly without crashing the parse.
   role: z.string(),
-  content: z.union([z.string(), z.null()]),
+  content: MessageContent,
+  images: z.array(HermesImageSource).optional(),
   tool_call_id: z.string().nullable(),
   tool_calls: z.any().nullable(),
   tool_name: z.string().nullable(),
@@ -152,6 +191,29 @@ const HermesProgressMessagePart = z.object({
   text: z.string(),
 });
 
+const HermesImageMessagePart = z
+  .object({
+    type: z.literal("image"),
+    url: z.string().optional(),
+    src: z.string().optional(),
+    path: z.string().optional(),
+    data: z.string().optional(),
+    image_url: z.unknown().optional(),
+    imageUrl: z.unknown().optional(),
+    alt: z.string().optional(),
+    title: z.string().optional(),
+    name: z.string().optional(),
+    filename: z.string().optional(),
+    file_name: z.string().optional(),
+    mimeType: z.string().optional(),
+    mime_type: z.string().optional(),
+    mediaType: z.string().optional(),
+    contentType: z.string().optional(),
+    content_type: z.string().optional(),
+    is_image: z.boolean().optional(),
+  })
+  .passthrough();
+
 const HermesToolMessagePart = z
   .object({
     type: z.literal("tool"),
@@ -177,6 +239,7 @@ export const HermesMessagePart = z.discriminatedUnion("type", [
   HermesTextMessagePart,
   HermesReasoningMessagePart,
   HermesProgressMessagePart,
+  HermesImageMessagePart,
   HermesToolMessagePart,
   HermesNoticeMessagePart,
 ]);

--- a/packages/protocol/src/session-log.ts
+++ b/packages/protocol/src/session-log.ts
@@ -52,6 +52,7 @@ export function sessionLogToMessages(
       session_id: sessionId,
       role,
       content: asString(msg.content),
+      images: Array.isArray(msg.images) ? msg.images as SessionMessage["images"] : undefined,
       tool_call_id: asNullableString(msg.tool_call_id),
       tool_calls: msg.tool_calls ?? null,
       tool_name: asNullableString(msg.tool_name),

--- a/web/src/components/chat/chat-types.ts
+++ b/web/src/components/chat/chat-types.ts
@@ -1,10 +1,13 @@
-import type { AssistantTurnBlock, ToolEntry } from "@/stores/chat";
+import type { AssistantTurnBlock, ImageEntry, ToolEntry } from "@/stores/chat";
 
 export type ChatRole = "user" | "assistant" | "system" | "tool";
 
 export interface ChatToolItem extends ToolEntry {
   arguments?: Record<string, unknown>;
+  images?: ChatImageItem[];
 }
+
+export type ChatImageItem = ImageEntry;
 
 export interface AssistantMessageStats {
   ttftMs?: number;
@@ -28,6 +31,7 @@ export interface ChatMessage {
   createdAt: number;
   text?: string;
   reasoning?: string;
+  images?: ChatImageItem[];
   tools?: ChatToolItem[];
   blocks?: AssistantTurnBlock[];
   status?: "streaming" | "complete" | "error";

--- a/web/src/components/chat/markdown-renderer.tsx
+++ b/web/src/components/chat/markdown-renderer.tsx
@@ -2,6 +2,7 @@ import { cjk } from "@streamdown/cjk";
 import { math } from "@streamdown/math";
 import type { ComponentProps } from "react";
 import { Streamdown } from "streamdown";
+import { MessageImage } from "./message-image";
 
 interface MarkdownTextProps {
   text: string;
@@ -42,7 +43,26 @@ function MarkdownAnchor({
   );
 }
 
-const streamdownComponents = { a: MarkdownAnchor };
+function MarkdownImage({
+  src,
+  alt,
+  title,
+  node: _node,
+  ..._props
+}: ComponentProps<"img"> & { node?: unknown }) {
+  return (
+    <MessageImage
+      image={{
+        url: typeof src === "string" ? src : undefined,
+        alt: typeof alt === "string" && alt ? alt : undefined,
+        title: typeof title === "string" && title ? title : undefined,
+        name: typeof alt === "string" && alt ? alt : undefined,
+      }}
+    />
+  );
+}
+
+const streamdownComponents = { a: MarkdownAnchor, img: MarkdownImage };
 
 export function MarkdownText({ text, streaming = false }: MarkdownTextProps) {
   return (

--- a/web/src/components/chat/message-adapter.test.ts
+++ b/web/src/components/chat/message-adapter.test.ts
@@ -64,6 +64,7 @@ describe("protocol schemas", () => {
       parts: [
         { type: "reasoning", text: "plan" },
         { type: "tool", toolCallId: "call-1", name: "read_file", state: "done", output: "ok" },
+        { type: "image", url: "https://example.test/chart.png", alt: "chart" },
         { type: "text", text: "done" },
         { type: "notice", level: "warning", text: "quota low" },
       ],
@@ -81,6 +82,7 @@ describe("protocol schemas", () => {
     expect(parsed.parts.map((part) => part.type)).toEqual([
       "reasoning",
       "tool",
+      "image",
       "text",
       "notice",
     ]);
@@ -250,6 +252,43 @@ describe("message adapter", () => {
       status: "streaming",
     });
     expect(message?.blocks).toEqual([{ type: "progress", text: "ಠ_ಠ deliberating..." }]);
+  });
+
+  it("preserves structured image parts as renderable chat images", () => {
+    const message = hermesUIMessageToChatMessage(uiMessage({
+      id: "assistant-image",
+      parts: [
+        { type: "text", text: "这是图片：" },
+        { type: "image", url: "https://example.test/result.png", alt: "生成结果" },
+      ],
+    }));
+
+    expect(message?.text).toBe("这是图片：");
+    expect(message?.images).toEqual([
+      expect.objectContaining({
+        url: "https://example.test/result.png",
+        alt: "生成结果",
+      }),
+    ]);
+    expect(message?.blocks?.map((block) => block.type)).toEqual(["text", "image"]);
+  });
+
+  it("turns legacy message images fields into image parts instead of dropping them", () => {
+    const messages = legacySessionMessagesToHermesUIMessages([
+      sessionMessage({
+        id: 1,
+        role: "user",
+        content: "看这张图",
+        images: [{ url: "/api/session/s1/files/chart.png", alt: "chart" }],
+      }),
+    ]);
+    const chat = hermesUIMessagesToChatMessages(messages);
+
+    expect(messages[0]?.parts.map((part) => part.type)).toEqual(["text", "image"]);
+    expect(chat[0]?.images?.[0]).toMatchObject({
+      url: "/api/session/s1/files/chart.png",
+      alt: "chart",
+    });
   });
 
   it("merges historical tool call/result pairs into one compact assistant turn", () => {

--- a/web/src/components/chat/message-adapter.ts
+++ b/web/src/components/chat/message-adapter.ts
@@ -11,11 +11,17 @@ import {
   normalizeReasoningText,
 } from "@/lib/reasoning-filter";
 import { stripHermesUiWorkspaceContext } from "@/lib/composer-prompt";
+import {
+  dedupeImageParts,
+  extractImagePartsFromUnknown,
+  imagePartFromSource,
+} from "@/lib/message-images";
 import { stableTextHash, type UiTurnStats } from "@/lib/ui-store";
 import type { AssistantTurnBlock } from "@/stores/chat";
-import type { AssistantMessageStats, ChatMessage, ChatToolItem } from "./chat-types";
+import type { AssistantMessageStats, ChatImageItem, ChatMessage, ChatToolItem } from "./chat-types";
 
 type HermesToolPart = Extract<HermesMessagePart, { type: "tool" }>;
+type HermesImagePart = Extract<HermesMessagePart, { type: "image" }>;
 
 export interface HermesUIMessageUpdate {
   sessionId: string;
@@ -52,6 +58,134 @@ function displayUnknown(value: unknown): string | undefined {
   } catch {
     return String(value);
   }
+}
+
+const HERMES_UI_IMAGE_BLOCK_RE = /\[Hermes UI Image\]\nname=([^\n]*)\ndescription:\n([\s\S]*?)\n\[\/Hermes UI Image\]/g;
+const IMAGE_FALLBACK_RE = /\[You can examine it with vision_analyze using image_url: ([^\]\n]+)\]/g;
+
+function parseJsonContent(value: string | null | undefined): unknown | undefined {
+  const text = value?.trim();
+  if (!text || !/^[{[]/.test(text)) return undefined;
+  try {
+    return JSON.parse(text);
+  } catch {
+    return undefined;
+  }
+}
+
+function imagePartToEntry(part: HermesImagePart): ChatImageItem {
+  const record = part as Record<string, unknown>;
+  const url =
+    part.url ||
+    part.src ||
+    part.path ||
+    part.data ||
+    (typeof record.image_url === "string" ? record.image_url : undefined) ||
+    (record.image_url && typeof record.image_url === "object"
+      ? (record.image_url as Record<string, unknown>).url
+      : undefined);
+  const name = part.name || part.filename || part.file_name || (typeof url === "string" && !url.startsWith("data:")
+    ? url.replace(/\\/g, "/").split("/").pop()
+    : undefined);
+  return {
+    ...(typeof url === "string" && url ? { url } : {}),
+    ...(part.alt || name ? { alt: part.alt || name } : {}),
+    ...(part.title ? { title: part.title } : {}),
+    ...(name ? { name } : {}),
+    ...(part.mimeType || part.mime_type || part.mediaType || part.contentType || part.content_type
+      ? { mimeType: part.mimeType || part.mime_type || part.mediaType || part.contentType || part.content_type }
+      : {}),
+  };
+}
+
+function imagePartsFromMessageImages(images: SessionMessage["images"]): HermesImagePart[] {
+  if (!images?.length) return [];
+  return dedupeImageParts(images.flatMap((image, index) => {
+    const part = imagePartFromSource(image, `image-${index + 1}`);
+    return part ? [part] : [];
+  }));
+}
+
+function imagePartsFromTransportText(text: string | null | undefined): HermesImagePart[] {
+  if (!text) return [];
+  const parts: HermesImagePart[] = [];
+
+  for (const match of text.matchAll(IMAGE_FALLBACK_RE)) {
+    const path = match[1]?.trim();
+    if (!path) continue;
+    const part = imagePartFromSource(path);
+    if (part) parts.push(part);
+  }
+
+  for (const match of text.matchAll(HERMES_UI_IMAGE_BLOCK_RE)) {
+    const name = match[1]?.trim();
+    const description = match[2]?.trim();
+    const extracted = extractImagePartsFromUnknown(description);
+    if (extracted.length) {
+      parts.push(...extracted.map((part) => ({
+        ...part,
+        ...(name ? { name, alt: part.alt || name } : {}),
+      })));
+      continue;
+    }
+    const part = imagePartFromSource({ name, alt: name || "图片附件" });
+    if (part) parts.push(part);
+  }
+
+  return dedupeImageParts(parts);
+}
+
+function textAndImagesFromStructuredContent(content: string | null | undefined): {
+  text?: string;
+  images: HermesImagePart[];
+} {
+  const parsed = parseJsonContent(content);
+  if (parsed === undefined) {
+    return {
+      text: content ?? undefined,
+      images: imagePartsFromTransportText(content),
+    };
+  }
+
+  const textParts: string[] = [];
+  const imageParts: HermesImagePart[] = [];
+  const visit = (value: unknown) => {
+    if (typeof value === "string") {
+      textParts.push(value);
+      return;
+    }
+    if (Array.isArray(value)) {
+      value.forEach(visit);
+      return;
+    }
+    if (!value || typeof value !== "object") return;
+    const record = value as Record<string, unknown>;
+    if (typeof record.text === "string") textParts.push(record.text);
+    if (typeof record.content === "string" && record.type === "text") textParts.push(record.content);
+    const direct = imagePartFromSource(record);
+    if (direct && (
+      record.type === "image" ||
+      record.type === "image_url" ||
+      record.type === "input_image" ||
+      record.type === "output_image" ||
+      record.is_image === true
+    )) {
+      imageParts.push(direct);
+    } else {
+      imageParts.push(...extractImagePartsFromUnknown(record));
+    }
+  };
+
+  visit(parsed);
+  const images = dedupeImageParts([
+    ...imageParts,
+    ...imagePartsFromTransportText(content),
+  ]);
+  if (!textParts.length && !images.length) return { text: content ?? undefined, images: [] };
+  return {
+    text: textParts.join("\n").trim() || undefined,
+    images,
+  };
 }
 
 function normalizeAssistantBlocks(
@@ -190,13 +324,18 @@ export function legacySessionMessageToHermesUIMessage(msg: SessionMessage): Herm
     };
   }
 
-  const text = normalizeContent(msg.content);
+  const content = textAndImagesFromStructuredContent(msg.content);
+  const text = normalizeContent(content.text);
   const reasoning = normalizeContent(
     normalizeReasoningText(msg.reasoning_content ?? msg.reasoning ?? undefined),
   );
   const tools = parseToolCalls(msg.tool_calls, createdAt);
   const parts: HermesMessagePart[] = [];
   if (text) parts.push({ type: "text", text });
+  parts.push(...dedupeImageParts([
+    ...content.images,
+    ...imagePartsFromMessageImages(msg.images),
+  ]));
   if (reasoning) parts.push({ type: "reasoning", text: reasoning });
   tools.forEach((tool) => parts.push(tool));
 
@@ -318,6 +457,7 @@ export function messagesResponseToHermesUIMessages(response: MessagesResponse | 
 
 function toolPartToToolEntry(part: HermesToolPart, message: HermesUIMessage): ChatToolItem {
   const input = parseToolInput(part.input);
+  const images = extractImagePartsFromUnknown(part.output).map(imagePartToEntry);
   return {
     tool_id: part.toolCallId,
     name: part.name,
@@ -329,6 +469,7 @@ function toolPartToToolEntry(part: HermesToolPart, message: HermesUIMessage): Ch
     startedAt: part.startedAt ?? message.createdAt,
     completedAt: part.completedAt,
     arguments: input.arguments,
+    images: images.length ? images : undefined,
   };
 }
 
@@ -350,6 +491,10 @@ function partsToBlocks(
     }
     if (part.type === "progress") {
       if (options.includeProgress) blocks.push({ type: "progress", text: part.text });
+      continue;
+    }
+    if (part.type === "image") {
+      blocks.push({ type: "image", image: imagePartToEntry(part) });
       continue;
     }
     if (part.type === "tool") {
@@ -384,6 +529,13 @@ function noticeTextFromParts(parts: HermesMessagePart[]): string | undefined {
   return normalizeContent(text);
 }
 
+function imagesFromParts(parts: HermesMessagePart[]): ChatImageItem[] | undefined {
+  const images = parts
+    .filter((part): part is HermesImagePart => part.type === "image")
+    .map(imagePartToEntry);
+  return images.length ? images : undefined;
+}
+
 function messageHasErrorNotice(message: HermesUIMessage): boolean {
   return message.parts.some((part) => part.type === "notice" && part.level === "error");
 }
@@ -396,6 +548,9 @@ function statsHashFromMessage(message: HermesUIMessage): string | undefined {
   return stableTextHash([
     textFromParts(message.parts),
     reasoningFromParts(message.parts),
+    imagesFromParts(message.parts)
+      ?.map((image) => [image.url, image.name, image.alt].filter(Boolean).join(" "))
+      .join("\n"),
     toolText,
   ].filter(Boolean).join("\n"));
 }
@@ -552,6 +707,7 @@ export function hermesUIMessageToChatMessage(msg: HermesUIMessage): ChatMessage 
     ? noticeTextFromParts(msg.parts) ?? textFromParts(msg.parts)
     : textFromParts(msg.parts);
   const reasoning = reasoningFromParts(msg.parts);
+  const images = imagesFromParts(msg.parts);
   const blocks = msg.role === "assistant"
     ? partsToBlocks(msg, { includeProgress })
     : undefined;
@@ -559,7 +715,7 @@ export function hermesUIMessageToChatMessage(msg: HermesUIMessage): ChatMessage 
     ?.filter((block): block is Extract<AssistantTurnBlock, { type: "tool" }> => block.type === "tool")
     .map((block) => block.tool);
 
-  if (!text && !reasoning && !tools?.length && !blocks?.length) return null;
+  if (!text && !reasoning && !images?.length && !tools?.length && !blocks?.length) return null;
 
   return {
     id: msg.id,
@@ -567,6 +723,7 @@ export function hermesUIMessageToChatMessage(msg: HermesUIMessage): ChatMessage 
     createdAt: msg.createdAt,
     text,
     reasoning,
+    images,
     tools: tools?.length ? tools : undefined,
     blocks,
     status: msg.status,
@@ -610,6 +767,14 @@ function canonicalReasoning(message: HermesUIMessage): string {
   return comparableText(reasoningFromParts(message.parts));
 }
 
+function canonicalImages(message: HermesUIMessage): string {
+  return comparableText(
+    imagesFromParts(message.parts)
+      ?.map((image) => [image.url, image.name, image.alt].filter(Boolean).join(" "))
+      .join("\n"),
+  );
+}
+
 function canonicalToolComparable(message: HermesUIMessage): string {
   return message.parts
     .filter((part): part is HermesToolPart => part.type === "tool")
@@ -640,6 +805,8 @@ function isSameCanonicalMessage(stored: HermesUIMessage, live: HermesUIMessage):
   const liveText = canonicalText(live);
   const storedReasoning = canonicalReasoning(stored);
   const liveReasoning = canonicalReasoning(live);
+  const storedImages = canonicalImages(stored);
+  const liveImages = canonicalImages(live);
 
   if (stored.role === "assistant") {
     if (storedText || liveText) {
@@ -663,11 +830,12 @@ function isSameCanonicalMessage(stored: HermesUIMessage, live: HermesUIMessage):
 
       return false;
     }
+    if (storedImages || liveImages) return storedImages === liveImages;
     return canonicalToolComparable(stored) !== "" &&
       canonicalToolComparable(stored) === canonicalToolComparable(live);
   }
 
-  return storedText === liveText && storedReasoning === liveReasoning;
+  return storedText === liveText && storedReasoning === liveReasoning && storedImages === liveImages;
 }
 
 function consolidateAssistantMessages(messages: HermesUIMessage[]): HermesUIMessage[] {

--- a/web/src/components/chat/message-image.tsx
+++ b/web/src/components/chat/message-image.tsx
@@ -1,0 +1,78 @@
+import { useMemo, useState } from "react";
+import { ImageOff } from "lucide-react";
+import { safeImageSrc } from "@/lib/message-images";
+import type { ChatImageItem } from "./chat-types";
+import s from "./message-timeline.module.css";
+
+interface MessageImageProps {
+  image: ChatImageItem;
+}
+
+function imageLabel(image: ChatImageItem): string {
+  return image.alt || image.name || image.title || "图片";
+}
+
+function visibleSource(value: string): string {
+  if (value.length <= 96) return value;
+  return `${value.slice(0, 48)}…${value.slice(-28)}`;
+}
+
+function ImagePlaceholder({
+  image,
+  reason,
+}: {
+  image: ChatImageItem;
+  reason: "unsupported" | "failed";
+}) {
+  const label = imageLabel(image);
+  const source = image.url?.trim();
+  const safe = safeImageSrc(source);
+
+  return (
+    <div className={s.imageFallback} role={reason === "failed" ? "alert" : "status"}>
+      <ImageOff size={18} strokeWidth={1.8} aria-hidden="true" />
+      <span className={s.imageFallbackBody}>
+        <span className={s.imageFallbackTitle}>
+          {reason === "failed" ? "图片加载失败" : "图片暂不能直接预览"}
+        </span>
+        <span className={s.imageFallbackMeta}>{label}</span>
+        {source ? (
+          safe ? (
+            <a href={safe} target="_blank" rel="noreferrer" title={source}>
+              打开原图
+            </a>
+          ) : (
+            <code title={source}>{visibleSource(source)}</code>
+          )
+        ) : null}
+      </span>
+    </div>
+  );
+}
+
+export function MessageImage({ image }: MessageImageProps) {
+  const [failed, setFailed] = useState(false);
+  const src = useMemo(() => safeImageSrc(image.url), [image.url]);
+  const label = imageLabel(image);
+
+  if (!src) return <ImagePlaceholder image={image} reason="unsupported" />;
+  if (failed) return <ImagePlaceholder image={image} reason="failed" />;
+
+  return (
+    <a
+      className={s.imageFrame}
+      href={src}
+      target="_blank"
+      rel="noreferrer"
+      title={image.title || label}
+    >
+      <img
+        src={src}
+        alt={label}
+        loading="lazy"
+        decoding="async"
+        onError={() => setFailed(true)}
+      />
+    </a>
+  );
+}

--- a/web/src/components/chat/message-timeline.module.css
+++ b/web/src/components/chat/message-timeline.module.css
@@ -235,6 +235,94 @@
   text-decoration: underline;
 }
 
+.imageBlock,
+.messageImages,
+.toolImages {
+  display: flex;
+  flex-wrap: wrap;
+  gap: 10px;
+  margin: 8px 0;
+}
+
+.messageImages {
+  margin-top: 10px;
+}
+
+.imageFrame {
+  display: inline-flex;
+  max-width: min(100%, 520px);
+  max-height: 360px;
+  overflow: hidden;
+  border: 1px solid var(--h-line-soft);
+  border-radius: 12px;
+  background: var(--h-bg-pane);
+  color: inherit;
+  text-decoration: none;
+}
+
+.imageFrame:hover {
+  border-color: color-mix(in srgb, var(--h-accent) 40%, var(--h-line-soft));
+  text-decoration: none;
+}
+
+.imageFrame img {
+  display: block;
+  max-width: 100%;
+  max-height: 360px;
+  object-fit: contain;
+}
+
+.imageFallback {
+  display: inline-grid;
+  grid-template-columns: auto minmax(0, 1fr);
+  gap: 10px;
+  align-items: start;
+  max-width: min(100%, 520px);
+  padding: 12px 14px;
+  border: 1px solid var(--h-line-soft);
+  border-radius: 12px;
+  background: var(--h-bg-pane);
+  color: var(--h-text-2);
+  line-height: 1.45;
+}
+
+.imageFallback svg {
+  margin-top: 2px;
+  color: var(--h-text-3);
+}
+
+.imageFallbackBody {
+  min-width: 0;
+  display: flex;
+  flex-direction: column;
+  gap: 3px;
+}
+
+.imageFallbackTitle {
+  color: var(--h-text);
+  font-size: 13px;
+  font-weight: 600;
+}
+
+.imageFallbackMeta {
+  color: var(--h-text-2);
+  font-size: 12px;
+}
+
+.imageFallback code {
+  align-self: flex-start;
+  max-width: 100%;
+  overflow: hidden;
+  border-radius: 5px;
+  background: var(--h-bg-code);
+  padding: 2px 6px;
+  color: var(--h-text-3);
+  font-family: var(--h-font-mono);
+  font-size: 11px;
+  text-overflow: ellipsis;
+  white-space: nowrap;
+}
+
 .messageText :global(.task-list-item) {
   list-style: none;
 }
@@ -256,10 +344,16 @@
 .turnText + .reasoning,
 .turnText + .progressBlock,
 .turnText + .toolChain,
+.turnText + .imageBlock,
+.imageBlock + .turnText,
+.imageBlock + .toolChain,
+.imageBlock + .progressBlock,
+.imageBlock + .reasoning,
 .reasoning + .toolChain,
 .reasoning + .turnText,
 .toolChain + .progressBlock,
-.toolChain + .turnText {
+.toolChain + .turnText,
+.toolChain + .imageBlock {
   margin-top: 10px;
 }
 

--- a/web/src/components/chat/message-timeline.test.tsx
+++ b/web/src/components/chat/message-timeline.test.tsx
@@ -1,6 +1,7 @@
 import ReactDOMServer from "react-dom/server";
 import { describe, expect, it } from "vitest";
 
+import { MarkdownText } from "./markdown-renderer";
 import { MessageTimeline } from "./message-timeline";
 import type { ChatMessage } from "./chat-types";
 
@@ -58,4 +59,31 @@ describe("MessageTimeline", () => {
     expect(html).not.toContain("1.0M tokens");
   });
 
+  it("renders Markdown image syntax as an image preview", () => {
+    const html = ReactDOMServer.renderToStaticMarkup(
+      <MarkdownText text="结果图：![趋势图](https://example.test/chart.png)" />,
+    );
+
+    expect(html).toContain("https://example.test/chart.png");
+    expect(html).toContain("alt=\"趋势图\"");
+  });
+
+  it("shows a readable fallback for unsupported local image URLs", () => {
+    const messages: ChatMessage[] = [
+      {
+        id: "user-image",
+        role: "user",
+        createdAt: 1,
+        images: [{ url: "/Users/enzo/Downloads/chart.png", alt: "chart.png", name: "chart.png" }],
+      },
+    ];
+
+    const html = ReactDOMServer.renderToStaticMarkup(
+      <MessageTimeline messages={messages} />,
+    );
+
+    expect(html).toContain("图片暂不能直接预览");
+    expect(html).toContain("chart.png");
+    expect(html).toContain("/Users/enzo/Downloads/chart.png");
+  });
 });

--- a/web/src/components/chat/message-timeline.tsx
+++ b/web/src/components/chat/message-timeline.tsx
@@ -4,6 +4,7 @@ import { useAtomValue } from "jotai";
 import { AlertTriangle, ChevronRight, Info } from "lucide-react";
 import { showReasoningAtom } from "@/stores/ui";
 import type { AssistantMessageStats, ChatMessage, ChatToolItem } from "./chat-types";
+import { MessageImage } from "./message-image";
 import { MessageText } from "./message-text";
 import { CopyButton } from "@/components/ui/copy-button";
 import s from "./message-timeline.module.css";
@@ -194,7 +195,8 @@ function ToolCard({ tool }: { tool: ChatToolItem }) {
         : undefined,
   );
   const body = tool.error ?? tool.summary ?? tool.preview;
-  const hasBody = Boolean(body || tool.arguments);
+  const hasImages = Boolean(tool.images?.length);
+  const hasBody = Boolean(body || tool.arguments || hasImages);
 
   return (
     <div className={s.toolCard} data-status={tool.status}>
@@ -216,6 +218,16 @@ function ToolCard({ tool }: { tool: ChatToolItem }) {
       </button>
       {open && hasBody ? (
         <div className={s.toolBody}>
+          {hasImages ? (
+            <div className={s.toolImages}>
+              {tool.images!.map((image, index) => (
+                <MessageImage
+                  key={`${image.url ?? image.name ?? image.alt ?? "image"}-${index}`}
+                  image={image}
+                />
+              ))}
+            </div>
+          ) : null}
           {tool.arguments ? (
             <pre>{JSON.stringify(tool.arguments, null, 2)}</pre>
           ) : null}
@@ -365,6 +377,15 @@ function MessageBlocks({ message, streaming, turnStartedAt, sessionUsage, progre
       items.push(
         <div key={`text-${index}`} className={s.turnText}>
           <MessageText text={block.text} streaming={streaming && index === blocks.length - 1} />
+        </div>,
+      );
+      return;
+    }
+
+    if (block.type === "image") {
+      items.push(
+        <div key={`image-${index}`} className={s.imageBlock}>
+          <MessageImage image={block.image} />
         </div>,
       );
       return;
@@ -586,6 +607,16 @@ function MessageBubble({ message, turnStartedAt, sessionUsage, progressModel }: 
           ) : (
             <>
               {message.text ? <MessageText text={message.text} streaming={streaming} /> : null}
+              {message.images?.length ? (
+                <div className={s.messageImages}>
+                  {message.images.map((image, index) => (
+                    <MessageImage
+                      key={`${image.url ?? image.name ?? image.alt ?? "image"}-${index}`}
+                      image={image}
+                    />
+                  ))}
+                </div>
+              ) : null}
               {showReasoning && message.reasoning ? (
                 <ReasoningBlock text={message.reasoning} streaming={streaming && !message.text} />
               ) : null}
@@ -628,6 +659,7 @@ export function MessageTimeline({
         (message) =>
           message.text ||
           message.reasoning ||
+          message.images?.length ||
           message.tools?.length ||
           message.blocks?.length,
       ),

--- a/web/src/hooks/use-create-and-send-session.ts
+++ b/web/src/hooks/use-create-and-send-session.ts
@@ -43,6 +43,17 @@ export function useCreateAndSendSession() {
     const sessionId = await (options?.createSession ?? createSession)();
     const title = titleFromPrompt(payload.text || payload.attachments[0]?.name || "");
     const optimisticDisplayText = buildComposerDisplayText(payload);
+    const optimisticDisplayImages = payload.attachments
+      .filter((attachment) => attachment.kind === "image")
+      .map((attachment) => ({
+        url: attachment.previewUrl && !attachment.previewUrl.startsWith("blob:")
+          ? attachment.previewUrl
+          : attachment.path,
+        alt: attachment.name,
+        title: attachment.name,
+        name: attachment.name,
+        mimeType: attachment.mimeType,
+      }));
 
     if (payload.modelSelection?.model) {
       rememberSessionModelOverride(sessionId, payload.modelSelection);
@@ -52,7 +63,7 @@ export function useCreateAndSendSession() {
       rememberSessionWorkspace(sessionId, payload.workspacePath);
     }
 
-    beginPrompt(sessionId, optimisticDisplayText, submittedAt);
+    beginPrompt(sessionId, optimisticDisplayText, submittedAt, optimisticDisplayImages);
     setActiveSessionId(sessionId);
     navigate(`/tasks/${sessionId}`);
 
@@ -78,6 +89,7 @@ export function useCreateAndSendSession() {
         });
         await sendPrompt(sessionId, prepared.promptText, {
           displayText: prepared.displayText,
+          displayImages: prepared.displayImages,
           skipOptimisticStart: true,
         });
       } catch (err) {

--- a/web/src/hooks/use-gateway.ts
+++ b/web/src/hooks/use-gateway.ts
@@ -35,6 +35,7 @@ import {
   setSessionErrorAtom,
   startPromptAtom,
   terminateAllStreamsAtom,
+  type ImageEntry,
 } from "@/stores/chat";
 
 type GatewayState = ReturnType<typeof getGatewayClient>["state"];
@@ -201,10 +202,10 @@ export function useGateway() {
   }, [ensureSubscribed, setGwSessionId]);
 
   const beginPrompt = useCallback(
-    (sessionId: string, text: string, now?: number) => {
+    (sessionId: string, text: string, now?: number, images?: ImageEntry[]) => {
       ensureSubscribed();
       ensureChatSession(sessionId);
-      startPrompt({ sessionId, text, now });
+      startPrompt({ sessionId, text, now, images });
     },
     [ensureChatSession, ensureSubscribed, startPrompt],
   );
@@ -236,12 +237,21 @@ export function useGateway() {
     async (
       sessionId: string,
       text: string,
-      options?: { displayText?: string; images?: string[]; skipOptimisticStart?: boolean },
+      options?: {
+        displayText?: string;
+        images?: string[];
+        displayImages?: ImageEntry[];
+        skipOptimisticStart?: boolean;
+      },
     ) => {
       ensureSubscribed();
       ensureChatSession(sessionId);
       if (!options?.skipOptimisticStart) {
-        startPrompt({ sessionId, text: options?.displayText ?? text });
+        startPrompt({
+          sessionId,
+          text: options?.displayText ?? text,
+          images: options?.displayImages,
+        });
       }
 
       try {

--- a/web/src/lib/composer-prompt.ts
+++ b/web/src/lib/composer-prompt.ts
@@ -99,6 +99,27 @@ function attachmentDisplayName(attachment: ComposerAttachment): string {
   return attachment.uploadedName || attachment.name || fileNameFromPath(attachment.path ?? "");
 }
 
+function readFileAsDataUrl(file: File): Promise<string | undefined> {
+  if (typeof FileReader === "undefined") return Promise.resolve(undefined);
+  return new Promise((resolve) => {
+    const reader = new FileReader();
+    reader.addEventListener("load", () => {
+      resolve(typeof reader.result === "string" ? reader.result : undefined);
+    }, { once: true });
+    reader.addEventListener("error", () => resolve(undefined), { once: true });
+    reader.readAsDataURL(file);
+  });
+}
+
+async function imageDisplayUrl(attachment: ComposerAttachment, path: string): Promise<string | undefined> {
+  if (attachment.file?.type.startsWith("image/")) {
+    const dataUrl = await readFileAsDataUrl(attachment.file);
+    if (dataUrl) return dataUrl;
+  }
+  if (attachment.previewUrl && !attachment.previewUrl.startsWith("blob:")) return attachment.previewUrl;
+  return path || undefined;
+}
+
 export function buildComposerDisplayText(payload: ComposerSubmitPayload): string {
   const text = payload.text.trim();
   const attachments = payload.attachments.map(attachmentDisplayName);
@@ -120,8 +141,25 @@ export async function prepareComposerPrompt(
     detectDroppedPath(sessionId: string, path: string): Promise<InputDetectDropResult>;
     onAttachmentUpdate?(id: string, patch: Partial<ComposerAttachment>): void;
   },
-): Promise<{ promptText: string; displayText: string }> {
+): Promise<{
+  promptText: string;
+  displayText: string;
+  displayImages: Array<{
+    url?: string;
+    alt?: string;
+    title?: string;
+    name?: string;
+    mimeType?: string;
+  }>;
+}> {
   const parts: string[] = [];
+  const displayImages: Array<{
+    url?: string;
+    alt?: string;
+    title?: string;
+    name?: string;
+    mimeType?: string;
+  }> = [];
 
   for (const attachment of payload.attachments) {
     try {
@@ -177,6 +215,14 @@ export async function prepareComposerPrompt(
             IMAGE_BLOCK_END,
           ].join("\n"));
         }
+        const label = attached.name || uploadedName || attachment.name || fileNameFromPath(path);
+        displayImages.push({
+          url: await imageDisplayUrl(attachment, attached.path || path),
+          alt: label,
+          title: label,
+          name: label,
+          mimeType: attachment.mimeType,
+        });
         helpers.onAttachmentUpdate?.(attachment.id, { status: "done", progress: 100 });
         continue;
       }
@@ -214,5 +260,6 @@ export async function prepareComposerPrompt(
   return {
     promptText,
     displayText: buildComposerDisplayText(payload),
+    displayImages,
   };
 }

--- a/web/src/lib/message-images.ts
+++ b/web/src/lib/message-images.ts
@@ -1,0 +1,232 @@
+import type { HermesImageSource, HermesMessagePart } from "@hermes/protocol";
+import { fileNameFromPath, isImagePath } from "@/lib/composer-prompt";
+
+export type HermesImagePart = Extract<HermesMessagePart, { type: "image" }>;
+
+const MARKDOWN_IMAGE_RE = /!\[([^\]\n]*)\]\(\s*(?:<([^>\n]+)>|([^\s)"'\n]+))(?:\s+["'][^"'\n]*["'])?\s*\)/g;
+const BARE_IMAGE_RE = /(?:data:image\/[a-z0-9.+-]+;[^\s<>"')]+|https?:\/\/[^\s<>"')]+\.(?:apng|avif|bmp|gif|heic|heif|jpe?g|png|tiff?|webp)(?:[?#][^\s<>"')]*)?|(?:\.{0,2}\/|\/|[A-Za-z]:[\\/]|\\\\|~[\\/])?[^\s<>"')]+\.(?:apng|avif|bmp|gif|heic|heif|jpe?g|png|tiff?|webp)(?:[?#][^\s<>"')]*)?)/gi;
+
+const IMAGE_TYPE_VALUES = new Set([
+  "image",
+  "image_url",
+  "input_image",
+  "output_image",
+  "local_image",
+  "file_image",
+]);
+
+const URL_KEYS = [
+  "url",
+  "src",
+  "path",
+  "data",
+  "href",
+  "imageUrl",
+  "image_url",
+  "file",
+  "filename",
+  "file_name",
+] as const;
+
+const NAME_KEYS = ["name", "filename", "file_name", "title", "alt"] as const;
+const MIME_KEYS = ["mimeType", "mime_type", "mediaType", "contentType", "content_type"] as const;
+
+function asRecord(value: unknown): Record<string, unknown> | undefined {
+  return value && typeof value === "object" && !Array.isArray(value)
+    ? value as Record<string, unknown>
+    : undefined;
+}
+
+function firstString(record: Record<string, unknown>, keys: readonly string[]): string | undefined {
+  for (const key of keys) {
+    const value = record[key];
+    if (typeof value === "string" && value.trim()) return value.trim();
+  }
+  return undefined;
+}
+
+function imageUrlFromNested(value: unknown): string | undefined {
+  if (typeof value === "string" && value.trim()) return value.trim();
+  const record = asRecord(value);
+  if (!record) return undefined;
+  return firstString(record, URL_KEYS);
+}
+
+function imageUrlFromRecord(record: Record<string, unknown>): string | undefined {
+  for (const key of URL_KEYS) {
+    const direct = record[key];
+    const value = key === "image_url" || key === "imageUrl"
+      ? imageUrlFromNested(direct)
+      : typeof direct === "string" && direct.trim()
+        ? direct.trim()
+        : undefined;
+    if (value) return value;
+  }
+  return undefined;
+}
+
+function imageMetadataFromRecord(record: Record<string, unknown>) {
+  return {
+    alt: firstString(record, ["alt", "name", "title"]),
+    title: firstString(record, ["title"]),
+    name: firstString(record, NAME_KEYS),
+    mimeType: firstString(record, MIME_KEYS),
+  };
+}
+
+export function isLikelyLocalFilePath(value: string): boolean {
+  const trimmed = value.trim();
+  return (
+    /^(?:file):/i.test(trimmed) ||
+    /^(?:~[\\/]|[A-Za-z]:[\\/]|\\\\)/.test(trimmed) ||
+    /^\/(?:Applications|Library|System|Users|Volumes|bin|dev|etc|home|opt|private|sbin|tmp|usr|var)(?:\/|$)/.test(trimmed)
+  );
+}
+
+export function isImageReference(value: string): boolean {
+  const trimmed = value.trim();
+  if (!trimmed) return false;
+  if (/^data:image\//i.test(trimmed)) return true;
+  if (isImagePath(trimmed)) return true;
+  try {
+    const parsed = new URL(trimmed, "http://hermes.local");
+    return isImagePath(parsed.pathname);
+  } catch {
+    return false;
+  }
+}
+
+export function safeImageSrc(value: string | undefined): string | undefined {
+  const trimmed = value?.trim();
+  if (!trimmed || /[\u0000-\u001f\u007f]/.test(trimmed)) return undefined;
+
+  if (/^data:image\/svg\+xml/i.test(trimmed)) return undefined;
+  if (/^data:image\//i.test(trimmed)) return trimmed;
+  if (/^(?:https?|blob):/i.test(trimmed)) return trimmed;
+  if (/^(?:javascript|vbscript|file|data):/i.test(trimmed)) return undefined;
+  if (/^[A-Za-z][A-Za-z0-9+.-]*:/i.test(trimmed)) return undefined;
+  if (isLikelyLocalFilePath(trimmed)) return undefined;
+
+  return trimmed;
+}
+
+function imagePartFromTrustedString(value: string, fallbackName?: string): HermesImagePart | null {
+  const url = value.trim();
+  if (!url) return null;
+  const name = fallbackName?.trim() || (url.startsWith("data:") ? undefined : fileNameFromPath(url));
+  return {
+    type: "image",
+    url,
+    alt: name,
+    name,
+  };
+}
+
+export function imagePartFromSource(
+  value: HermesImageSource | unknown,
+  fallbackName?: string,
+): HermesImagePart | null {
+  if (typeof value === "string") return imagePartFromTrustedString(value, fallbackName);
+
+  const record = asRecord(value);
+  if (!record) return null;
+
+  const url = imageUrlFromRecord(record);
+  const metadata = imageMetadataFromRecord(record);
+  const name = metadata.name || fallbackName || (url && !url.startsWith("data:") ? fileNameFromPath(url) : undefined);
+  if (!url && !name && !metadata.alt && !metadata.title) return null;
+
+  return {
+    type: "image",
+    ...(url ? { url } : {}),
+    ...(metadata.alt || name ? { alt: metadata.alt || name } : {}),
+    ...(metadata.title ? { title: metadata.title } : {}),
+    ...(name ? { name } : {}),
+    ...(metadata.mimeType ? { mimeType: metadata.mimeType } : {}),
+  };
+}
+
+function recordLooksImageLike(record: Record<string, unknown>, url: string | undefined): boolean {
+  if (record.is_image === true) return true;
+  const type = firstString(record, ["type", ...MIME_KEYS]);
+  if (type?.toLowerCase().startsWith("image/")) return true;
+  if (type && IMAGE_TYPE_VALUES.has(type.toLowerCase())) return true;
+  return Boolean(url && isImageReference(url));
+}
+
+export function imagePartFromPossibleImage(value: unknown, fallbackName?: string): HermesImagePart | null {
+  if (typeof value === "string") {
+    return isImageReference(value) ? imagePartFromTrustedString(value, fallbackName) : null;
+  }
+
+  const record = asRecord(value);
+  if (!record) return null;
+  const url = imageUrlFromRecord(record);
+  if (!recordLooksImageLike(record, url)) return null;
+  return imagePartFromSource(record, fallbackName);
+}
+
+export function extractMarkdownImageParts(text: string): HermesImagePart[] {
+  const parts: HermesImagePart[] = [];
+  for (const match of text.matchAll(MARKDOWN_IMAGE_RE)) {
+    const alt = match[1]?.trim();
+    const url = (match[2] ?? match[3] ?? "").trim();
+    const part = imagePartFromTrustedString(url, alt || undefined);
+    if (part) {
+      parts.push({
+        ...part,
+        ...(alt ? { alt, name: part.name || alt } : {}),
+      });
+    }
+  }
+  return dedupeImageParts(parts);
+}
+
+function extractBareImageParts(text: string): HermesImagePart[] {
+  const parts: HermesImagePart[] = [];
+  for (const match of text.matchAll(BARE_IMAGE_RE)) {
+    const raw = match[0]?.trim();
+    if (!raw || !isImageReference(raw)) continue;
+    const part = imagePartFromTrustedString(raw);
+    if (part) parts.push(part);
+  }
+  return dedupeImageParts(parts);
+}
+
+export function extractImagePartsFromUnknown(value: unknown, depth = 0): HermesImagePart[] {
+  if (value == null || depth > 4) return [];
+
+  if (typeof value === "string") {
+    return dedupeImageParts([
+      ...extractMarkdownImageParts(value),
+      ...extractBareImageParts(value),
+    ]);
+  }
+
+  if (Array.isArray(value)) {
+    return dedupeImageParts(value.flatMap((item) => extractImagePartsFromUnknown(item, depth + 1)));
+  }
+
+  const record = asRecord(value);
+  if (!record) return [];
+
+  const direct = imagePartFromPossibleImage(record);
+  const nested = Object.entries(record).flatMap(([key, item]) => {
+    if (direct && URL_KEYS.includes(key as typeof URL_KEYS[number])) return [];
+    if (key === "arguments" || key === "input") return [];
+    return extractImagePartsFromUnknown(item, depth + 1);
+  });
+  return dedupeImageParts(direct ? [direct, ...nested] : nested);
+}
+
+export function dedupeImageParts(parts: HermesImagePart[]): HermesImagePart[] {
+  const seen = new Set<string>();
+  const result: HermesImagePart[] = [];
+  for (const part of parts) {
+    const key = (part.url || part.path || part.name || part.alt || "").trim();
+    if (!key || seen.has(key)) continue;
+    seen.add(key);
+    result.push(part);
+  }
+  return result;
+}

--- a/web/src/routes/detail.tsx
+++ b/web/src/routes/detail.tsx
@@ -247,6 +247,7 @@ export function DetailRoute() {
     });
     await sendPrompt(gatewaySessionId, prepared.promptText, {
       displayText: prepared.displayText,
+      displayImages: prepared.displayImages,
     });
   }, [attachImage, detectDroppedPath, ensureGatewaySession, restSessionId, sendPrompt, taskId]);
 

--- a/web/src/stores/chat.ts
+++ b/web/src/stores/chat.ts
@@ -11,6 +11,10 @@ import {
   normalizeCliThinkingProgress,
   normalizeReasoningText,
 } from "@/lib/reasoning-filter";
+import {
+  dedupeImageParts,
+  imagePartFromSource,
+} from "@/lib/message-images";
 import { resolvePersistentSessionId } from "@/lib/session-map";
 import { recordUiTurnStats, stableTextHash } from "@/lib/ui-store";
 
@@ -26,10 +30,19 @@ export interface ToolEntry {
   completedAt?: number;
 }
 
+export interface ImageEntry {
+  url?: string;
+  alt?: string;
+  title?: string;
+  name?: string;
+  mimeType?: string;
+}
+
 export type AssistantTurnBlock =
   | { type: "text"; text: string }
   | { type: "reasoning"; text: string }
   | { type: "progress"; text: string }
+  | { type: "image"; image: ImageEntry }
   | { type: "tool"; tool: ToolEntry };
 
 export interface PendingApproval {
@@ -162,6 +175,52 @@ function looseComparableText(value: string | undefined): string {
 
 function withoutProgressParts(parts: HermesMessagePart[]): HermesMessagePart[] {
   return parts.filter((part) => part.type !== "progress");
+}
+
+function imagePartsFromPayload(payload: Record<string, any>): HermesMessagePart[] {
+  const sources = Array.isArray(payload.images)
+    ? payload.images
+    : payload.image !== undefined
+      ? [payload.image]
+      : payload.image_url !== undefined
+        ? [payload.image_url]
+        : [];
+
+  return dedupeImageParts(
+    sources.flatMap((source: unknown, index: number) => {
+      const part = imagePartFromSource(source, `image-${index + 1}`);
+      return part ? [part] : [];
+    }),
+  );
+}
+
+function appendImageParts(parts: HermesMessagePart[], images: HermesMessagePart[]): HermesMessagePart[] {
+  if (!images.length) return parts;
+  const progressIndex = parts.findIndex((part) => part.type === "progress");
+  const base = progressIndex === -1
+    ? parts
+    : [...parts.slice(0, progressIndex), ...parts.slice(progressIndex + 1)];
+  const currentImages = base.filter((part): part is Extract<HermesMessagePart, { type: "image" }> =>
+    part.type === "image"
+  );
+  const nextImages = dedupeImageParts([
+    ...currentImages,
+    ...images.filter((part): part is Extract<HermesMessagePart, { type: "image" }> => part.type === "image"),
+  ]);
+  const imageKeys = new Set(nextImages.map((part) => part.url || part.path || part.name || part.alt).filter(Boolean));
+  const withoutDuplicateImages = base.filter((part) => {
+    if (part.type !== "image") return true;
+    const key = part.url || part.path || part.name || part.alt;
+    return !key || !imageKeys.has(key);
+  });
+  const merged = [...withoutDuplicateImages, ...nextImages];
+  return progressIndex === -1
+    ? merged
+    : [
+      ...merged.slice(0, progressIndex),
+      parts[progressIndex]!,
+      ...merged.slice(progressIndex),
+    ];
 }
 
 function terminateRunningTools(parts: HermesMessagePart[]): HermesMessagePart[] {
@@ -444,6 +503,7 @@ function finalizeAssistantParts(
   if (finalReasoning) {
     parts = upsertReasoningPart(parts, finalReasoning);
   }
+  parts = appendImageParts(parts, imagePartsFromPayload(payload));
 
   return parts;
 }
@@ -482,6 +542,7 @@ export function reduceGatewayEvent(
 
     case "message.delta": {
       const text = typeof payload.text === "string" ? payload.text : "";
+      const images = imagePartsFromPayload(payload);
       const id = activeAssistantId(runtime, now);
       const next = updateActiveAssistant(
         clearProviderStatus({
@@ -497,7 +558,7 @@ export function reduceGatewayEvent(
         (message) => ({
           ...message,
           status: "streaming",
-          parts: appendTextPart(message.parts, text),
+          parts: appendImageParts(appendTextPart(message.parts, text), images),
         }),
       );
       return next;
@@ -898,9 +959,15 @@ export const recoverCompletedTurnFromStoredMessagesAtom = atom(
 
 export const startPromptAtom = atom(
   null,
-  (_get, set, params: { sessionId: string; text: string; now?: number }) => {
+  (_get, set, params: { sessionId: string; text: string; images?: ImageEntry[]; now?: number }) => {
     const now = params.now ?? Date.now();
     const assistantId = assistantClientId(now);
+    const userParts: HermesMessagePart[] = [];
+    if (params.text) userParts.push({ type: "text", text: params.text });
+    for (const image of params.images ?? []) {
+      const part = imagePartFromSource(image);
+      if (part) userParts.push(part);
+    }
     set(gwSessionIdAtom, params.sessionId);
     set(chatRuntimeBySessionAtom, (state) =>
       updateSessionRuntime(state, params.sessionId, (runtime) => ({
@@ -913,7 +980,7 @@ export const startPromptAtom = atom(
             role: "user",
             createdAt: now,
             status: "complete",
-            parts: [{ type: "text", text: params.text }],
+            parts: userParts.length ? userParts : [{ type: "text", text: params.text }],
           },
           {
             id: assistantId,
@@ -938,6 +1005,7 @@ function textForStatsHash(message: HermesUIMessage): string {
   return message.parts
     .flatMap((part) => {
       if (part.type === "text" || part.type === "reasoning") return [part.text];
+      if (part.type === "image") return [part.url, part.path, part.name, part.alt].filter(Boolean) as string[];
       if (part.type === "tool") {
         let output = "";
         if (typeof part.output === "string") {


### PR DESCRIPTION
## 概述

修复 #114，对话流现在可以稳定展示图片消息，而不是在协议解析、adapter 转换或渲染阶段被丢弃。

## 改动

- 在协议层新增 `image` message part，并保留 legacy `images` 字段。
- 在消息 adapter 中把结构化图片、历史消息图片字段、Hermes UI 图片上下文和工具输出中的图片引用转成可渲染图片。
- 为 Markdown 图片语法接入统一图片组件，支持尺寸约束、打开原图和失败占位。
- 对不可直接预览的本地路径或不安全 URL 显示可读降级信息。
- 补充 Markdown 图片、结构化 image part、legacy images 字段和本地路径降级展示测试。

## 验证

- `pnpm typecheck`
- `pnpm test:unit`
- `cargo check`

<!-- gk-ai-analysis-start:1990fb1e7d7b243bd6ca00454fc97580b97b13a0 -->
<!-- gk-ai-analysis-data:eyJzdW1tYXJ5IjoiQWRkcyBzdXBwb3J0IGZvciByZW5kZXJpbmcgaW1hZ2UgbWVzc2FnZXMgaW4gdGhlIGNoYXQgVUkgYnkgcGFyc2luZywgYWRhcHRpbmcsIGFuZCBzZWN1cmVseSBkaXNwbGF5aW5nIGltYWdlcyBmcm9tIHRoZSBwcm90b2NvbCBzdHJlYW0uIiwia2V5SW5zaWdodHMiOlt7InRpdGxlIjoiUHJvdG9jb2wgY2hhbmdlcyBmb3IgaW1hZ2Ugc3VwcG9ydCIsImRlc2NyaXB0aW9uIjoiQWRkZWQgYEhlcm1lc0ltYWdlU291cmNlYCBhbmQgYEhlcm1lc0ltYWdlTWVzc2FnZVBhcnRgIHRvIHRoZSBwcm90b2NvbCBkZWZpbml0aW9uLCBhbGxvd2luZyBzdHJ1Y3R1cmVkIGltYWdlIHJlcHJlc2VudGF0aW9uIGFsb25nc2lkZSB0ZXh0IGFuZCB0b29scy4iLCJzZXZlcml0eSI6Im1lZGl1bSIsImZpbGVQYXRoIjoicGFja2FnZXMvcHJvdG9jb2wvc3JjL2hlcm1lcy1hcGkudHMiLCJsaW5lU3RhcnQiOjY5fSx7InRpdGxlIjoiU2FmZSBpbWFnZSBoYW5kbGluZyBhbmQgZmFsbGJhY2siLCJkZXNjcmlwdGlvbiI6IkludHJvZHVjZWQgYHNhZmVJbWFnZVNyY2AgdG8gZmlsdGVyIG91dCBwb3RlbnRpYWxseSBoYXJtZnVsIFVSSXMgKGxpa2UgamF2YXNjcmlwdC92YnNjcmlwdCBvciBsb2NhbCBmaWxlcyksIGNvdXBsZWQgd2l0aCBhIGZhbGxiYWNrIFVJIGNvbXBvbmVudCAoYE1lc3NhZ2VJbWFnZWApIHdoZW4gcHJldmlld3MgZmFpbCBvciBhcmUgZGVlbWVkIHVuc2FmZS4iLCJzZXZlcml0eSI6Im1lZGl1bSIsImZpbGVQYXRoIjoid2ViL3NyYy9saWIvbWVzc2FnZS1pbWFnZXMudHMiLCJsaW5lU3RhcnQiOjk3fSx7InRpdGxlIjoiSW1hZ2UgZXh0cmFjdGlvbiBmcm9tIGxlZ2FjeSBwYXlsb2FkcyIsImRlc2NyaXB0aW9uIjoiQWRkZWQgYGltYWdlUGFydHNGcm9tVHJhbnNwb3J0VGV4dGAgYW5kIGB0ZXh0QW5kSW1hZ2VzRnJvbVN0cnVjdHVyZWRDb250ZW50YCB0byBleHRyYWN0IGltYWdlIFVSTHMgYW5kIG1ldGFkYXRhIGZyb20gdW5zdHJ1Y3R1cmVkIHRleHQgZm9ybWF0cyBvciBsZWdhY3kgVUkgY29udGV4dHMuIiwic2V2ZXJpdHkiOiJsb3ciLCJmaWxlUGF0aCI6IndlYi9zcmMvY29tcG9uZW50cy9jaGF0L21lc3NhZ2UtYWRhcHRlci50cyIsImxpbmVTdGFydCI6MTA1fV0sImlzc3VlcyI6W10sInN1Z2dlc3Rpb25zIjpbXSwic2VjdXJpdHkiOltdfQ== -->
<!-- gk-ai-analysis-end:1990fb1e7d7b243bd6ca00454fc97580b97b13a0 -->

<!-- gitkraken-review-badge-begin -->
---
<a href="https://gitkraken.dev/review/github/Eynzof/hermes-agent-cn-desktop/pull/122?source=pr_review_chip">
  <picture>
    <source media="(prefers-color-scheme: dark)" srcset="https://gitkraken.dev/images/figures/gitkraken-review-badge-dark.svg">
    <img src="https://gitkraken.dev/images/figures/gitkraken-review-badge-light.svg" alt="Open with GitKraken">
  </picture>
</a>
<!-- gitkraken-review-badge-end -->