### PR TITLE
[codex] 修复 P2 IPC 错误与 runtime 公钥解析

### DIFF
--- a/src/error.rs
+++ b/src/error.rs
@@ -99,11 +99,101 @@ pub enum AppError {
     Internal(String),
 }
 
+#[derive(Serialize)]
+#[serde(rename_all = "camelCase")]
+struct AppErrorIpc {
+    code: &'static str,
+    kind: &'static str,
+    message: String,
+    #[serde(skip_serializing_if = "Option::is_none")]
+    details: Option<serde_json::Value>,
+}
+
+impl AppError {
+    pub fn code(&self) -> &'static str {
+        match self {
+            AppError::DashboardStartup(_) => "dashboard_startup",
+            AppError::DashboardUnreachable(_) => "dashboard_unreachable",
+            AppError::DashboardProbe(_) => "dashboard_probe",
+            AppError::SseConnect(_) => "sse_connect",
+            AppError::SseStream(_) => "sse_stream",
+            AppError::RuntimeManifestNotConfigured => "runtime_manifest_not_configured",
+            AppError::RuntimeCheckFailed(_) => "runtime_check_failed",
+            AppError::RuntimeDownloadFailed(_) => "runtime_download_failed",
+            AppError::RuntimeSignatureInvalid(_) => "runtime_signature_invalid",
+            AppError::RuntimeChecksumMismatch { .. } => "runtime_checksum_mismatch",
+            AppError::RuntimeExtractFailed(_) => "runtime_extract_failed",
+            AppError::RuntimeSmokeFailed(_) => "runtime_smoke_failed",
+            AppError::RuntimeInstallFailed(_) => "runtime_install_failed",
+            AppError::RuntimeUnavailable(_) => "runtime_unavailable",
+            AppError::RuntimeNoPreviousVersion => "runtime_no_previous_version",
+            AppError::ProfileInvalidName(_) => "profile_invalid_name",
+            AppError::ProfileDirMissing(_) => "profile_dir_missing",
+            AppError::ProfileSwitchInFlight => "profile_switch_in_flight",
+            AppError::ProfileNotOwner => "profile_not_owner",
+            AppError::ProfileSwitchFailed(_) => "profile_switch_failed",
+            AppError::InvalidRequest(_) => "invalid_request",
+            AppError::ProxyError(_) => "proxy_error",
+            AppError::OriginViolation(_) => "origin_violation",
+            AppError::FileError(_) => "file_error",
+            AppError::StateLockPoisoned => "state_lock_poisoned",
+            AppError::NotReady => "not_ready",
+            AppError::Internal(_) => "internal",
+        }
+    }
+
+    pub fn kind(&self) -> &'static str {
+        match self {
+            AppError::DashboardStartup(_)
+            | AppError::DashboardUnreachable(_)
+            | AppError::DashboardProbe(_) => "dashboard",
+            AppError::SseConnect(_) | AppError::SseStream(_) => "sse",
+            AppError::RuntimeManifestNotConfigured
+            | AppError::RuntimeCheckFailed(_)
+            | AppError::RuntimeDownloadFailed(_)
+            | AppError::RuntimeSignatureInvalid(_)
+            | AppError::RuntimeChecksumMismatch { .. }
+            | AppError::RuntimeExtractFailed(_)
+            | AppError::RuntimeSmokeFailed(_)
+            | AppError::RuntimeInstallFailed(_)
+            | AppError::RuntimeUnavailable(_)
+            | AppError::RuntimeNoPreviousVersion => "runtime",
+            AppError::ProfileInvalidName(_)
+            | AppError::ProfileDirMissing(_)
+            | AppError::ProfileSwitchInFlight
+            | AppError::ProfileNotOwner
+            | AppError::ProfileSwitchFailed(_) => "profile",
+            AppError::InvalidRequest(_)
+            | AppError::ProxyError(_)
+            | AppError::OriginViolation(_) => "api_proxy",
+            AppError::FileError(_) => "file",
+            AppError::StateLockPoisoned | AppError::NotReady => "state",
+            AppError::Internal(_) => "internal",
+        }
+    }
+
+    fn details(&self) -> Option<serde_json::Value> {
+        match self {
+            AppError::RuntimeChecksumMismatch { expected, actual } => {
+                Some(serde_json::json!({ "expected": expected, "actual": actual }))
+            }
+            _ => None,
+        }
+    }
+}
+
 // Tauri requires Serialize to return errors to the frontend.
-// We serialize as the Display string — the frontend sees a human-readable message.
+// Keep the human-readable message, but preserve a stable code/kind so the
+// frontend can choose recovery UI without parsing localized text.
 impl Serialize for AppError {
     fn serialize<S: serde::Serializer>(&self, serializer: S) -> Result<S::Ok, S::Error> {
-        serializer.serialize_str(&self.to_string())
+        AppErrorIpc {
+            code: self.code(),
+            kind: self.kind(),
+            message: self.to_string(),
+            details: self.details(),
+        }
+        .serialize(serializer)
     }
 }
 
@@ -182,10 +272,30 @@ mod tests {
     }
 
     #[test]
-    fn serialize_emits_display_string() {
+    fn serialize_emits_structured_ipc_error() {
         let err = AppError::DashboardStartup("boom".to_string());
-        let json = serde_json::to_string(&err).unwrap();
-        assert_eq!(json, "\"Dashboard startup failed: boom\"");
+        let json: serde_json::Value = serde_json::to_value(&err).unwrap();
+        assert_eq!(
+            json,
+            serde_json::json!({
+                "code": "dashboard_startup",
+                "kind": "dashboard",
+                "message": "Dashboard startup failed: boom"
+            })
+        );
+    }
+
+    #[test]
+    fn serialize_checksum_error_includes_machine_readable_details() {
+        let err = AppError::RuntimeChecksumMismatch {
+            expected: "abc".to_string(),
+            actual: "def".to_string(),
+        };
+        let json: serde_json::Value = serde_json::to_value(&err).unwrap();
+        assert_eq!(json["code"], "runtime_checksum_mismatch");
+        assert_eq!(json["kind"], "runtime");
+        assert_eq!(json["details"]["expected"], "abc");
+        assert_eq!(json["details"]["actual"], "def");
     }
 
     #[test]

--- a/src/process/runtime.rs
+++ b/src/process/runtime.rs
@@ -1025,24 +1025,11 @@ fn verify_signature_with_key(
     public_key_pem: &str,
 ) -> Result<(), String> {
     use base64::Engine;
+    use ed25519_dalek::pkcs8::DecodePublicKey;
     use ed25519_dalek::{Signature, VerifyingKey};
 
-    // Parse PEM to extract the 32-byte public key
-    let pem_body: String = public_key_pem
-        .lines()
-        .filter(|l| !l.starts_with("-----"))
-        .collect();
-    let der = base64::engine::general_purpose::STANDARD
-        .decode(pem_body.trim())
+    let key = VerifyingKey::from_public_key_pem(public_key_pem.trim())
         .map_err(|e| format!("Invalid public key PEM: {}", e))?;
-    // Ed25519 SPKI DER: the last 32 bytes are the raw public key
-    if der.len() < 32 {
-        return Err("Public key DER too short".to_string());
-    }
-    let raw_key = &der[der.len() - 32..];
-    let key_bytes: [u8; 32] = raw_key.try_into().map_err(|_| "Invalid key length")?;
-    let key =
-        VerifyingKey::from_bytes(&key_bytes).map_err(|e| format!("Invalid public key: {}", e))?;
 
     let sig_bytes = base64::engine::general_purpose::STANDARD
         .decode(&manifest.signature)
@@ -2241,11 +2228,25 @@ mod tests {
 
     #[test]
     fn verify_rejects_too_short_der() {
-        // PEM body must base64-decode to ≥ 32 bytes for raw key extraction.
         let bad_pem = "-----BEGIN PUBLIC KEY-----\nAAAA\n-----END PUBLIC KEY-----\n";
         let m = fixture_manifest();
         let err = verify_signature_with_key(&m, bad_pem).unwrap_err();
-        assert!(err.contains("Public key DER too short"));
+        assert!(err.contains("Invalid public key PEM"));
+    }
+
+    #[test]
+    fn verify_rejects_raw_key_pem_without_spki_envelope() {
+        let (key, pem) = test_keypair();
+        let mut m = fixture_manifest();
+        sign_manifest(&key, &mut m);
+
+        let raw_key_pem = format!(
+            "-----BEGIN PUBLIC KEY-----\n{}\n-----END PUBLIC KEY-----\n",
+            base64::engine::general_purpose::STANDARD.encode(key.verifying_key().to_bytes())
+        );
+        assert!(verify_signature_with_key(&m, &pem).is_ok());
+        let err = verify_signature_with_key(&m, &raw_key_pem).unwrap_err();
+        assert!(err.contains("Invalid public key PEM"));
     }
 
     #[test]

--- a/web/src/lib/tauri-bridge.test.ts
+++ b/web/src/lib/tauri-bridge.test.ts
@@ -1,5 +1,10 @@
 import { afterEach, beforeEach, describe, expect, it, vi } from "vitest";
-import { arrayBufferToBase64, installTauriBridge, isTauriDevMode } from "./tauri-bridge";
+import {
+  arrayBufferToBase64,
+  installTauriBridge,
+  isTauriDevMode,
+  normalizeTauriInvokeError,
+} from "./tauri-bridge";
 
 const mockInvoke = vi.fn();
 
@@ -73,5 +78,26 @@ describe("isTauriDevMode", () => {
     expect(mockInvoke).toHaveBeenCalledWith("open_external_url", {
       input: { url: "https://hermesagent.org.cn" },
     });
+  });
+
+  it("normalizes structured Tauri IPC errors while preserving code and kind", () => {
+    const error = normalizeTauriInvokeError({
+      code: "not_ready",
+      kind: "state",
+      message: "Desktop runtime not ready",
+      details: { phase: "starting-dashboard" },
+    });
+
+    expect(error).toBeInstanceOf(Error);
+    expect(error.message).toBe("Desktop runtime not ready");
+    expect((error as any).code).toBe("not_ready");
+    expect((error as any).kind).toBe("state");
+    expect((error as any).details).toEqual({ phase: "starting-dashboard" });
+  });
+
+  it("normalizes legacy string Tauri IPC errors", () => {
+    const error = normalizeTauriInvokeError("Desktop runtime not ready");
+    expect(error).toBeInstanceOf(Error);
+    expect(error.message).toBe("Desktop runtime not ready");
   });
 });

--- a/web/src/lib/tauri-bridge.ts
+++ b/web/src/lib/tauri-bridge.ts
@@ -102,23 +102,58 @@ async function ensureInvoke() {
   return invoke;
 }
 
+export interface TauriIpcError extends Error {
+  code?: string;
+  kind?: string;
+  details?: unknown;
+  raw?: unknown;
+}
+
+function isRecord(value: unknown): value is Record<string, unknown> {
+  return typeof value === "object" && value !== null;
+}
+
+export function normalizeTauriInvokeError(error: unknown): Error {
+  if (error instanceof Error) return error;
+
+  if (isRecord(error)) {
+    const message = typeof error.message === "string" && error.message.trim()
+      ? error.message
+      : JSON.stringify(error);
+    const normalized = new Error(message) as TauriIpcError;
+    if (typeof error.code === "string") normalized.code = error.code;
+    if (typeof error.kind === "string") normalized.kind = error.kind;
+    if ("details" in error) normalized.details = error.details;
+    normalized.raw = error;
+    return normalized;
+  }
+
+  return new Error(String(error));
+}
+
+async function invokeCommand<T = any>(command: string, args?: Record<string, unknown>): Promise<T> {
+  const inv = await ensureInvoke();
+  try {
+    return await inv<T>(command, args);
+  } catch (error) {
+    throw normalizeTauriInvokeError(error);
+  }
+}
+
 const tauriBridge = {
   windowType: "tauri" as const,
 
   async request(input: ApiRequestInput): Promise<ApiRequestResult> {
-    const inv = await ensureInvoke();
-    return inv("api_request", { input });
+    return invokeCommand("api_request", { input });
   },
 
   async externalRequest(input: ApiRequestInput): Promise<ApiRequestResult> {
-    const inv = await ensureInvoke();
-    return inv("external_request", { input });
+    return invokeCommand("external_request", { input });
   },
 
   async uploadFile(input: FileUploadInput): Promise<ApiRequestResult> {
-    const inv = await ensureInvoke();
     const base64 = arrayBufferToBase64(input.data);
-    return inv("upload_file", {
+    return invokeCommand("upload_file", {
       input: {
         sessionId: input.sessionId,
         name: input.name,
@@ -129,28 +164,23 @@ const tauriBridge = {
   },
 
   async pickFiles(): Promise<FilePickerResult> {
-    const inv = await ensureInvoke();
-    return inv("pick_files");
+    return invokeCommand("pick_files");
   },
 
   async pickDirectory(): Promise<FilePickerResult> {
-    const inv = await ensureInvoke();
-    return inv("pick_directory");
+    return invokeCommand("pick_directory");
   },
 
   async createWorkspaceProject(): Promise<FilePickerResult> {
-    const inv = await ensureInvoke();
-    return inv("create_workspace_project");
+    return invokeCommand("create_workspace_project");
   },
 
   async openWorkspacePath(input: { path: string }): Promise<ApiRequestResult> {
-    const inv = await ensureInvoke();
-    return inv("open_workspace_path", { input });
+    return invokeCommand("open_workspace_path", { input });
   },
 
   async openExternalUrl(input: { url: string }): Promise<{ ok: boolean; message?: string | null }> {
-    const inv = await ensureInvoke();
-    return inv("open_external_url", { input });
+    return invokeCommand("open_external_url", { input });
   },
 
   getRuntimeConfig() {
@@ -158,154 +188,124 @@ const tauriBridge = {
   },
 
   async refreshGatewayUrl(): Promise<{ gatewayUrl: string; sessionToken?: string }> {
-    const inv = await ensureInvoke();
-    return inv("refresh_gateway_url");
+    return invokeCommand("refresh_gateway_url");
   },
 
   async getRuntimeInfo(): Promise<RuntimeInfo> {
-    const inv = await ensureInvoke();
-    return inv("runtime_info");
+    return invokeCommand("runtime_info");
   },
 
   async checkRuntimeUpdate(): Promise<RuntimeUpdateCheckResult> {
-    const inv = await ensureInvoke();
-    return inv("runtime_check_update");
+    return invokeCommand("runtime_check_update");
   },
 
   async installRuntimeUpdate(): Promise<RuntimeInstallUpdateResult> {
-    const inv = await ensureInvoke();
-    return inv("runtime_install_update");
+    return invokeCommand("runtime_install_update");
   },
 
   async rollbackRuntime(): Promise<RuntimeInstallUpdateResult> {
-    const inv = await ensureInvoke();
-    return inv("runtime_rollback");
+    return invokeCommand("runtime_rollback");
   },
 
   async switchProfile(input: SwitchProfileInput): Promise<SwitchProfileResult> {
-    const inv = await ensureInvoke();
-    return inv("switch_profile", { input });
+    return invokeCommand("switch_profile", { input });
   },
 
 
   async scanConfigMigration(input?: ConfigMigrationScanInput): Promise<ConfigMigrationScanResult> {
-    const inv = await ensureInvoke();
-    return inv("config_migration_scan", { input: input ?? null });
+    return invokeCommand("config_migration_scan", { input: input ?? null });
   },
 
   async importConfigMigration(input: ConfigMigrationImportInput): Promise<ConfigMigrationImportResult> {
-    const inv = await ensureInvoke();
-    return inv("config_migration_import", { input });
+    return invokeCommand("config_migration_import", { input });
   },
 
   async getYoloMode(): Promise<YoloModeStatus> {
-    const inv = await ensureInvoke();
-    return inv("get_yolo_mode");
+    return invokeCommand("get_yolo_mode");
   },
 
   async setYoloMode(input: SetYoloModeInput): Promise<SetYoloModeResult> {
-    const inv = await ensureInvoke();
-    return inv("set_yolo_mode", { input });
+    return invokeCommand("set_yolo_mode", { input });
   },
 
   async imOnboardingState(input: ImOnboardingStateInput): Promise<ImOnboardingStateResult> {
-    const inv = await ensureInvoke();
-    return inv("im_onboarding_state", { input });
+    return invokeCommand("im_onboarding_state", { input });
   },
 
   async imOnboardingBegin(input: ImOnboardingBeginInput): Promise<ImOnboardingBeginResult> {
-    const inv = await ensureInvoke();
-    return inv("im_onboarding_begin", { input });
+    return invokeCommand("im_onboarding_begin", { input });
   },
 
   async imOnboardingPoll(input: ImOnboardingPollInput): Promise<ImOnboardingPollResult> {
-    const inv = await ensureInvoke();
-    return inv("im_onboarding_poll", { input });
+    return invokeCommand("im_onboarding_poll", { input });
   },
 
   async imOnboardingApply(input: ImOnboardingApplyInput): Promise<ImOnboardingApplyResult> {
-    const inv = await ensureInvoke();
-    return inv("im_onboarding_apply", { input });
+    return invokeCommand("im_onboarding_apply", { input });
   },
 
   async readSkillMarkdown(input: { name: string }): Promise<SkillMarkdownResult> {
-    const inv = await ensureInvoke();
-    return inv("read_skill_markdown", { input });
+    return invokeCommand("read_skill_markdown", { input });
   },
 
   async readMemory() {
-    const inv = await ensureInvoke();
-    return inv("read_memory");
+    return invokeCommand("read_memory");
   },
 
   async addMemoryEntry(content: string) {
-    const inv = await ensureInvoke();
-    return inv("add_memory_entry", { content });
+    return invokeCommand("add_memory_entry", { content });
   },
 
   async updateMemoryEntry(index: number, content: string) {
-    const inv = await ensureInvoke();
-    return inv("update_memory_entry", { index, content });
+    return invokeCommand("update_memory_entry", { index, content });
   },
 
   async removeMemoryEntry(index: number) {
-    const inv = await ensureInvoke();
-    return inv("remove_memory_entry", { index });
+    return invokeCommand("remove_memory_entry", { index });
   },
 
   async writeUserProfile(content: string) {
-    const inv = await ensureInvoke();
-    return inv("write_user_profile", { content });
+    return invokeCommand("write_user_profile", { content });
   },
 
   async uiStoreSnapshot(): Promise<UiStoreSnapshot> {
-    const inv = await ensureInvoke();
-    return inv("ui_store_snapshot");
+    return invokeCommand("ui_store_snapshot");
   },
 
   async uiStoreSetKv(input: { key: string; value: unknown }): Promise<boolean> {
-    const inv = await ensureInvoke();
-    return inv("ui_store_set_kv", { input });
+    return invokeCommand("ui_store_set_kv", { input });
   },
 
   async uiStoreRemoveKv(input: { key: string }): Promise<boolean> {
-    const inv = await ensureInvoke();
-    return inv("ui_store_remove_kv", { input });
+    return invokeCommand("ui_store_remove_kv", { input });
   },
 
   async uiStoreRecordTurnStats(input: UiTurnStats): Promise<boolean> {
-    const inv = await ensureInvoke();
-    return inv("ui_store_record_turn_stats", { input });
+    return invokeCommand("ui_store_record_turn_stats", { input });
   },
 
   async uiStoreGetTurnStats(input: { sessionId: string }): Promise<UiTurnStats[]> {
-    const inv = await ensureInvoke();
-    return inv("ui_store_get_turn_stats", { input });
+    return invokeCommand("ui_store_get_turn_stats", { input });
   },
 
   async uiStoreRecordEvent(input: UiEventInput): Promise<boolean> {
-    const inv = await ensureInvoke();
-    return inv("ui_store_record_event", { input });
+    return invokeCommand("ui_store_record_event", { input });
   },
 
   async terminalStart(input: TerminalStartInput): Promise<TerminalStartResult> {
-    const inv = await ensureInvoke();
-    return inv("terminal_start", { input });
+    return invokeCommand("terminal_start", { input });
   },
 
   async terminalWrite(input: { terminalId: string; data: string }): Promise<boolean> {
-    const inv = await ensureInvoke();
-    return inv("terminal_write", { input });
+    return invokeCommand("terminal_write", { input });
   },
 
   async terminalResize(input: { terminalId: string; cols: number; rows: number }): Promise<boolean> {
-    const inv = await ensureInvoke();
-    return inv("terminal_resize", { input });
+    return invokeCommand("terminal_resize", { input });
   },
 
   async terminalClose(input: { terminalId: string }): Promise<boolean> {
-    const inv = await ensureInvoke();
-    return inv("terminal_close", { input });
+    return invokeCommand("terminal_close", { input });
   },
 
   onTerminalOutput(handler: (event: TerminalEventPayload) => void): () => void {
@@ -601,9 +601,7 @@ async function waitForBootstrap(
 }
 
 export async function installTauriBridge(): Promise<void> {
-  const inv = await ensureInvoke();
-
-  let config = await inv<{
+  let config = await invokeCommand<{
     apiBaseUrl: string;
     gatewayUrl: string;
     sessionToken?: string;
@@ -630,8 +628,8 @@ export async function installTauriBridge(): Promise<void> {
   if (!config.apiBaseUrl) {
     const result = await waitForBootstrap(
       "正在启动Hermes Agent内核...",
-      () => inv("get_runtime_config"),
-      () => inv("runtime_info"),
+      () => invokeCommand("get_runtime_config"),
+      () => invokeCommand("runtime_info"),
     );
     if (result.failed) {
       // Leave the overlay up — the user needs to see the message
@@ -640,7 +638,7 @@ export async function installTauriBridge(): Promise<void> {
       // we never mounted React; the overlay IS the UI right now.
       throw new Error(`runtime bootstrap failed: ${result.message}`);
     }
-    config = await inv("get_runtime_config");
+    config = await invokeCommand("get_runtime_config");
   }
 
   const transport = (config.transport === "ws" || config.transport === "sse")


### PR DESCRIPTION
## 变更内容

本次修复两个仍然属实且适合快速处理的 P2 问题：

- 修复 #47：runtime 更新签名校验改用 ed25519-dalek 的 PKCS#8/SPKI PEM 解析，不再依赖 DER 末 32 字节截取。
- 修复 #40：Tauri IPC 错误改为结构化序列化，保留稳定的 `code`、`kind`、`message` 和可选 `details`，前端 bridge 兼容结构化错误与旧 string 错误。

## 影响

前端后续可以根据 IPC 错误类型展示更准确的恢复提示，runtime 公钥解析也不再依赖脆弱的 DER 布局假设。

## 验证

- `pnpm typecheck`
- `pnpm test:unit`
- `cargo fmt --check`
- `cargo check`
- `cargo test --all-features`
