### PR TITLE
[codex] 添加 Skill 市场页签

### DIFF
--- a/web/src/routes/skills.module.css
+++ b/web/src/routes/skills.module.css
@@ -1,5 +1,5 @@
 /* =============================================================
-   Skills page — 内置 / 我的 双 tab，列表-详情 split 布局
+   Skills page — 内置 / 我的 / 市场 三 tab，列表-详情 split 布局
    ============================================================= */
 
 .page {
@@ -866,4 +866,124 @@
   padding: 28px 36px;
   color: var(--h-text-3);
   font-size: 13px;
+}
+
+/* === Skill 市场 === */
+.marketPage {
+  flex: 1;
+  min-height: 0;
+  overflow-y: auto;
+  padding: 34px 36px 60px;
+  background:
+    radial-gradient(circle at 15% 0, color-mix(in srgb, var(--h-accent) 12%, transparent), transparent 32%),
+    var(--h-bg-pane);
+}
+.marketHero {
+  max-width: 780px;
+  margin-bottom: 24px;
+}
+.marketEyebrow {
+  display: inline-flex;
+  margin-bottom: 10px;
+  font-family: var(--h-font-mono);
+  font-size: 11px;
+  letter-spacing: 0.08em;
+  text-transform: uppercase;
+  color: var(--h-accent);
+}
+.marketHero h1 {
+  margin: 0;
+  color: var(--h-text);
+  font-size: 28px;
+  font-weight: 650;
+  letter-spacing: -0.02em;
+  line-height: 1.18;
+}
+.marketHero p {
+  max-width: 680px;
+  margin: 12px 0 0;
+  color: var(--h-text-2);
+  font-size: 14px;
+  line-height: 1.78;
+}
+.marketGrid {
+  display: grid;
+  grid-template-columns: repeat(2, minmax(0, 1fr));
+  gap: 16px;
+}
+.marketCard {
+  display: flex;
+  min-height: 260px;
+  flex-direction: column;
+  gap: 12px;
+  padding: 24px;
+  border: 1px solid var(--h-line);
+  border-radius: 18px;
+  background:
+    linear-gradient(180deg, color-mix(in srgb, var(--h-accent) 8%, transparent), transparent 42%),
+    var(--h-bg-pane);
+  color: var(--h-text);
+  text-decoration: none;
+  box-shadow: 0 18px 42px color-mix(in srgb, #000 12%, transparent);
+  transition:
+    border-color 160ms ease,
+    box-shadow 160ms ease,
+    transform 160ms ease;
+}
+.marketCard:hover,
+.marketCard:focus-visible {
+  transform: translateY(-2px);
+  border-color: var(--h-accent-border);
+  box-shadow: 0 24px 54px color-mix(in srgb, #000 18%, transparent);
+  color: var(--h-text);
+  outline: none;
+  text-decoration: none;
+}
+.marketCardHead {
+  display: flex;
+  align-items: baseline;
+  justify-content: space-between;
+  gap: 12px;
+  flex-wrap: wrap;
+}
+.marketCardHead h2 {
+  margin: 0;
+  color: var(--h-text);
+  font-size: 22px;
+  font-weight: 650;
+  line-height: 1.2;
+}
+.marketCardHead span {
+  color: var(--h-text-3);
+  font-family: var(--h-font-mono);
+  font-size: 11.5px;
+  letter-spacing: -0.01em;
+}
+.marketTagline {
+  margin: 0;
+  color: var(--h-text);
+  font-size: 14px;
+  font-weight: 600;
+  line-height: 1.7;
+}
+.marketWhy {
+  margin: 0;
+  color: var(--h-text-2);
+  font-size: 13px;
+  line-height: 1.72;
+}
+.marketCta {
+  display: inline-flex;
+  align-items: center;
+  gap: 6px;
+  margin-top: auto;
+  color: var(--h-accent);
+  font-size: 12.5px;
+  font-weight: 600;
+}
+
+@media (max-width: 980px) {
+  .marketGrid {
+    grid-template-columns: 1fr;
+  }
 }

--- a/web/src/routes/skills.tsx
+++ b/web/src/routes/skills.tsx
@@ -1,5 +1,17 @@
 import { useMemo, useState } from "react";
-import { Copy, Folder, Info, Languages, Lock, Package, Plus, RefreshCw, User } from "lucide-react";
+import {
+  Copy,
+  ExternalLink,
+  Folder,
+  Info,
+  Languages,
+  Lock,
+  Package,
+  Plus,
+  RefreshCw,
+  Store,
+  User,
+} from "lucide-react";
 import type { SkillInfo } from "@hermes/protocol";
 import { useSkillMarkdown, useSkills, useToggleSkill } from "@/hooks/use-skills";
 import { Pill, Dot } from "@/components/ui/pill";
@@ -14,9 +26,53 @@ import { TopBarActions } from "@/components/top-bar/top-bar";
 import { CopyButton } from "@/components/ui/copy-button";
 import s from "./skills.module.css";
 
-type Tab = "builtin" | "user";
+type Tab = "builtin" | "user" | "market";
 type Filter = "all" | "enabled" | "disabled";
 type Lang = "zh" | "en";
+
+type Marketplace = {
+  name: string;
+  url: string;
+  host: string;
+  tagline: string;
+  why: string;
+  cta: string;
+};
+
+const marketplaces: Marketplace[] = [
+  {
+    name: "虾评",
+    url: "https://xiaping.coze.com/",
+    host: "xiaping.coze.com",
+    tagline: "精品 Skill 分享评测平台，470+ 个 Skill 按场景分类。",
+    why: "有排行榜、合集和真实评测，能看到别人在用什么、哪些好用，找 Skill 不用一个个翻。覆盖开发辅助、效率工具、办公、自媒体、设计等 17+ 类。",
+    cta: "去虾评逛逛",
+  },
+  {
+    name: "SkillHub",
+    url: "https://skillhub.cn/skills",
+    host: "skillhub.cn",
+    tagline: "腾讯维护的 AI Skill 社区，面向中国用户，精选 Top 50。",
+    why: "由腾讯团队运营，每个 Skill 都经过安全审核和多维度评估再上架。数量不堆，挑的都是靠谱货，适合不想自己一个个鉴别的人。",
+    cta: "去 SkillHub 看精选",
+  },
+  {
+    name: "Skills.sh",
+    url: "https://www.skills.sh/",
+    host: "skills.sh",
+    tagline: "开放 Agent Skills 生态目录，有排行榜、趋势榜和安装量。",
+    why: "如果你想知道大家最近在装什么，先看这里很省事。它把 GitHub 上的 Skill 做成榜单和主题目录，支持 Claude Code、Codex、Cursor 等工具，适合用来找灵感、看热度、追踪新技能。",
+    cta: "去 Skills.sh 看榜单",
+  },
+  {
+    name: "SkillsMP",
+    url: "https://skillsmp.com/zh",
+    host: "skillsmp.com",
+    tagline: "中文 Agent Skills 市场，支持搜索、职业筛选和分类浏览。",
+    why: "当你已经知道自己要解决什么问题时，它更像一本可搜索的技能黄页。可以按职业、用途、作者和热度筛选，也能查看质量指标，适合从海量开源 Skill 里快速缩小范围。",
+    cta: "去 SkillsMP 搜 Skill",
+  },
+];
 
 function skillOrigin(skill: SkillInfo): "builtin" | "user" | "external" {
   return skill.origin ?? (skill.name.startsWith("user/") ? "user" : "builtin");
@@ -56,7 +112,7 @@ export function SkillsRoute() {
     };
   }, [skills]);
 
-  const currentList = tab === "builtin" ? builtin : user;
+  const currentList = tab === "builtin" ? builtin : tab === "user" ? user : [];
   const enabledCount = (skills ?? []).filter((sk) => sk.enabled).length;
 
   // 过滤 + 搜索
@@ -130,7 +186,7 @@ export function SkillsRoute() {
         </div>
       </div>
 
-      {/* 顶部 tab：内置 / 我的 */}
+      {/* 顶部 tab：内置 / 我的 / 市场 */}
       <div className={s.toptabs}>
         <button
           type="button"
@@ -158,18 +214,34 @@ export function SkillsRoute() {
           我的 Skills
           <span className={s.toptabCount}>{user.length}</span>
         </button>
+        <button
+          type="button"
+          className={s.toptab}
+          data-active={tab === "market"}
+          onClick={() => {
+            setTab("market");
+            setSelectedName(null);
+          }}
+        >
+          <Store size={14} />
+          Skill 市场
+        </button>
         <span className={s.toptabSpacer} />
         <span className={s.toptabHint}>
           <Info size={13} />
           {tab === "builtin"
             ? "内置 Skill 由 Hermes 团队维护，仅可启用 / 禁用"
-            : "自建 Skill 保存在"}
+            : tab === "user"
+              ? "自建 Skill 保存在"
+              : "精选 Skill 市场与目录，点击卡片会在外部浏览器打开"}
           {tab === "user" && <code>~/.hermes/skills/user/</code>}
         </span>
       </div>
 
       {/* 主体 */}
-      {isLoading ? (
+      {tab === "market" ? (
+        <SkillMarket />
+      ) : isLoading ? (
         <div className={s.statePane}>加载中…</div>
       ) : isError ? (
         <div className={s.statePane}>
@@ -568,5 +640,43 @@ function UserEmptyState() {
         </button>
       </div>
     </div>
+  );
+}
+
+function SkillMarket() {
+  return (
+    <section className={s.marketPage}>
+      <div className={s.marketHero}>
+        <span className={s.marketEyebrow}>Skill Market</span>
+        <h1>好用的 Skill 去哪找？</h1>
+        <p>
+          下面几个网站适合用来找 Skill：有的像精选书单，帮你先筛一遍；有的像搜索引擎，
+          适合按场景慢慢淘。找到合适的 Skill 后，可以按对方页面说明安装到当前 Hermes 环境。
+        </p>
+      </div>
+
+      <div className={s.marketGrid} aria-label="高质量 Skill 市场与目录">
+        {marketplaces.map((item) => (
+          <a
+            key={item.url}
+            className={s.marketCard}
+            href={item.url}
+            target="_blank"
+            rel="noreferrer"
+          >
+            <div className={s.marketCardHead}>
+              <h2>{item.name}</h2>
+              <span>{item.host}</span>
+            </div>
+            <p className={s.marketTagline}>{item.tagline}</p>
+            <p className={s.marketWhy}>{item.why}</p>
+            <span className={s.marketCta}>
+              {item.cta}
+              <ExternalLink size={13} />
+            </span>
+          </a>
+        ))}
+      </div>
+    </section>
   );
 }


### PR DESCRIPTION
## 变更内容

在桌面端 Skills 页面新增「Skill 市场」页签，并以卡片形式展示四个外部 Skill 市场入口：虾评、SkillHub、Skills.sh 和 SkillsMP。

## 影响

用户可以在「我的 Skills」右侧直接进入 Skill 市场页面，通过外部浏览器打开对应市场链接查找可用 Skill。该改动仅涉及前端展示和样式，不改变 Skill 安装、同步或后端接口行为。

## 验证

- `pnpm typecheck`
- `pnpm test:unit`
- `cargo check`
- 本地 Vite `/skills` 页面冒烟检查，确认「Skill 市场」页签可切换并展示四张卡片。