### PR TITLE
[codex] 增加环境依赖检查

### DIFF
--- a/packages/protocol/src/channels.ts
+++ b/packages/protocol/src/channels.ts
@@ -137,6 +137,34 @@ export interface RuntimeInfo {
   lastError?: string;
 }
 
+
+export type EnvironmentCheckStatus = "ok" | "warning" | "error" | "unknown";
+
+export type EnvironmentCheckCategory = "core" | "runtime" | "tools" | "browser" | "paths";
+
+export interface EnvironmentCheckItem {
+  id: string;
+  category: EnvironmentCheckCategory;
+  label: string;
+  status: EnvironmentCheckStatus;
+  required: boolean;
+  summary: string;
+  version?: string;
+  path?: string;
+  details?: string;
+  recommendation?: string;
+}
+
+export interface EnvironmentCheckResult {
+  generatedAtMs: number;
+  platform: string;
+  arch: string;
+  runtimeRoot: string;
+  hermesHome: string;
+  currentProfile: string;
+  items: EnvironmentCheckItem[];
+}
+
 export interface RuntimeUpdateManifest {
   schemaVersion: number;
   channel: string;

--- a/src/commands/environment.rs
+++ b/src/commands/environment.rs
@@ -1,0 +1,28 @@
+use tauri::State;
+
+use crate::environment;
+use crate::error::AppError;
+use crate::state::AppState;
+
+#[tauri::command]
+pub async fn environment_check(
+    state: State<'_, AppState>,
+) -> Result<environment::EnvironmentCheckResult, AppError> {
+    let snapshot = {
+        let inner = state.inner.lock()?;
+        crate::state::AppStateInner {
+            api_base_url: inner.api_base_url.clone(),
+            gateway_url: inner.gateway_url.clone(),
+            hermes_home: inner.hermes_home.clone(),
+            hermes_home_base: inner.hermes_home_base.clone(),
+            session_token: inner.session_token.clone(),
+            current_profile: inner.current_profile.clone(),
+            dashboard_handle: None,
+            gateway_sse_stop: None,
+            dashboard_restart_in_flight: inner.dashboard_restart_in_flight,
+            last_runtime_error: inner.last_runtime_error.clone(),
+            yolo_mode: inner.yolo_mode,
+        }
+    };
+    Ok(environment::collect_environment_check(&snapshot).await)
+}

--- a/src/commands/mod.rs
+++ b/src/commands/mod.rs
@@ -2,6 +2,7 @@ pub mod api_proxy;
 pub mod backup;
 pub mod config_migration;
 pub mod debug_bundle;
+pub mod environment;
 pub mod file_dialogs;
 pub mod gateway;
 pub mod im_onboarding;

--- a/src/environment.rs
+++ b/src/environment.rs
@@ -1,0 +1,898 @@
+//! Desktop environment diagnostics.
+//!
+//! The desktop uses an isolated managed runtime, so these checks are deliberately
+//! read-only from the user's perspective: they report whether the runtime tree,
+//! dashboard, and optional helper tools are available, but they do not install or
+//! repair anything automatically.
+
+use serde::Serialize;
+use std::env;
+use std::ffi::OsString;
+use std::fs;
+use std::path::{Path, PathBuf};
+use std::process::Command;
+use std::time::{SystemTime, UNIX_EPOCH};
+
+use crate::process::{dashboard, runtime};
+use crate::state::AppStateInner;
+
+#[derive(Debug, Clone, Copy, Serialize, PartialEq, Eq)]
+#[serde(rename_all = "kebab-case")]
+pub enum EnvironmentCheckStatus {
+    Ok,
+    Warning,
+    Error,
+    Unknown,
+}
+
+#[derive(Debug, Clone, Copy, Serialize, PartialEq, Eq)]
+#[serde(rename_all = "kebab-case")]
+pub enum EnvironmentCheckCategory {
+    Core,
+    Runtime,
+    Tools,
+    Browser,
+    Paths,
+}
+
+#[derive(Debug, Clone, Serialize)]
+#[serde(rename_all = "camelCase")]
+pub struct EnvironmentCheckItem {
+    pub id: String,
+    pub category: EnvironmentCheckCategory,
+    pub label: String,
+    pub status: EnvironmentCheckStatus,
+    pub required: bool,
+    pub summary: String,
+    #[serde(skip_serializing_if = "Option::is_none")]
+    pub version: Option<String>,
+    #[serde(skip_serializing_if = "Option::is_none")]
+    pub path: Option<String>,
+    #[serde(skip_serializing_if = "Option::is_none")]
+    pub details: Option<String>,
+    #[serde(skip_serializing_if = "Option::is_none")]
+    pub recommendation: Option<String>,
+}
+
+#[derive(Debug, Clone, Serialize)]
+#[serde(rename_all = "camelCase")]
+pub struct EnvironmentCheckResult {
+    pub generated_at_ms: u64,
+    pub platform: String,
+    pub arch: String,
+    pub runtime_root: String,
+    pub hermes_home: String,
+    pub current_profile: String,
+    pub items: Vec<EnvironmentCheckItem>,
+}
+
+#[derive(Debug, Clone)]
+struct CommandProbe {
+    found: bool,
+    path: Option<PathBuf>,
+    version: Option<String>,
+    error: Option<String>,
+}
+
+trait EnvironmentPathValue {
+    fn to_environment_path_string(&self) -> String;
+}
+
+impl EnvironmentPathValue for &Path {
+    fn to_environment_path_string(&self) -> String {
+        self.to_string_lossy().to_string()
+    }
+}
+
+impl EnvironmentPathValue for &PathBuf {
+    fn to_environment_path_string(&self) -> String {
+        self.to_string_lossy().to_string()
+    }
+}
+
+impl EnvironmentPathValue for PathBuf {
+    fn to_environment_path_string(&self) -> String {
+        self.to_string_lossy().to_string()
+    }
+}
+
+impl EnvironmentPathValue for String {
+    fn to_environment_path_string(&self) -> String {
+        self.clone()
+    }
+}
+
+impl EnvironmentPathValue for &str {
+    fn to_environment_path_string(&self) -> String {
+        (*self).to_string()
+    }
+}
+
+impl EnvironmentCheckItem {
+    fn new(
+        id: &str,
+        category: EnvironmentCheckCategory,
+        label: &str,
+        status: EnvironmentCheckStatus,
+        required: bool,
+        summary: impl Into<String>,
+    ) -> Self {
+        Self {
+            id: id.to_string(),
+            category,
+            label: label.to_string(),
+            status,
+            required,
+            summary: summary.into(),
+            version: None,
+            path: None,
+            details: None,
+            recommendation: None,
+        }
+    }
+
+    fn version(mut self, version: Option<String>) -> Self {
+        self.version = version;
+        self
+    }
+
+    fn path(mut self, path: Option<impl EnvironmentPathValue>) -> Self {
+        self.path = path.map(|p| p.to_environment_path_string());
+        self
+    }
+
+    fn details(mut self, details: Option<impl Into<String>>) -> Self {
+        self.details = details.map(Into::into);
+        self
+    }
+
+    fn recommendation(mut self, recommendation: Option<impl Into<String>>) -> Self {
+        self.recommendation = recommendation.map(Into::into);
+        self
+    }
+}
+
+/// Fast startup preflight used by `main.rs` before downloading/spawning the
+/// managed runtime. This checks only directories that the boot path must write
+/// to and intentionally skips optional tools.
+pub fn check_bootstrap_environment(hermes_home: &str) -> Result<(), String> {
+    let runtime_root = runtime::runtime_root();
+    check_writable_dir(&runtime_root).map_err(|e| {
+        format!(
+            "runtime 目录不可写: {}。请检查磁盘权限，或设置 HERMES_DESKTOP_RUNTIME_ROOT 指向可写目录。错误: {}",
+            runtime_root.display(),
+            e
+        )
+    })?;
+
+    let hermes_home = PathBuf::from(hermes_home);
+    check_writable_dir(&hermes_home).map_err(|e| {
+        format!(
+            "HERMES_HOME 不可写: {}。请检查磁盘权限后重试。错误: {}",
+            hermes_home.display(),
+            e
+        )
+    })?;
+
+    let gateway_dir = runtime::gateway_runtime_dir();
+    check_writable_dir(&gateway_dir).map_err(|e| {
+        format!(
+            "gateway runtime 目录不可写: {}。请检查磁盘权限后重试。错误: {}",
+            gateway_dir.display(),
+            e
+        )
+    })?;
+
+    Ok(())
+}
+
+pub async fn collect_environment_check(inner: &AppStateInner) -> EnvironmentCheckResult {
+    let runtime_root = runtime::runtime_root();
+    let hermes_home = if inner.hermes_home.trim().is_empty() {
+        runtime::hermes_home_dir().to_string_lossy().to_string()
+    } else {
+        inner.hermes_home.clone()
+    };
+    let current = runtime::read_current_record();
+    let mut items = Vec::new();
+
+    items.push(check_writable_item(
+        "runtime-root",
+        EnvironmentCheckCategory::Core,
+        "Runtime 根目录",
+        true,
+        &runtime_root,
+        "runtime 根目录可写",
+        "runtime 根目录不可写，桌面端无法安装或更新 managed runtime",
+        Some("检查目录权限，或设置 HERMES_DESKTOP_RUNTIME_ROOT 指向可写目录"),
+    ));
+
+    items.push(check_writable_item(
+        "hermes-home",
+        EnvironmentCheckCategory::Core,
+        "HERMES_HOME",
+        true,
+        Path::new(&hermes_home),
+        "HERMES_HOME 可写",
+        "HERMES_HOME 不可写，配置、会话与日志无法保存",
+        Some("检查目录权限，或重新安装桌面端"),
+    ));
+
+    items.push(check_writable_item(
+        "gateway-runtime-dir",
+        EnvironmentCheckCategory::Core,
+        "Gateway runtime 目录",
+        true,
+        &runtime::gateway_runtime_dir(),
+        "Gateway runtime 目录可写",
+        "Gateway runtime 目录不可写，消息网关锁文件和运行态无法写入",
+        Some("检查 runtime 目录权限后重启桌面端"),
+    ));
+
+    match &current {
+        Some(record) => {
+            items.push(
+                EnvironmentCheckItem::new(
+                    "current-runtime-record",
+                    EnvironmentCheckCategory::Runtime,
+                    "current.json",
+                    EnvironmentCheckStatus::Ok,
+                    true,
+                    format!("已指向 runtime {}", record.runtime_version),
+                )
+                .path(Some(runtime::current_record_path_display())),
+            );
+
+            let executable = PathBuf::from(&record.executable_path);
+            if executable.is_file() {
+                items.push(
+                    EnvironmentCheckItem::new(
+                        "runtime-executable",
+                        EnvironmentCheckCategory::Runtime,
+                        "Runtime 可执行文件",
+                        EnvironmentCheckStatus::Ok,
+                        true,
+                        "runtime 可执行文件存在；版本信息来自 current.json",
+                    )
+                    .path(Some(&executable))
+                    .version(Some(format!(
+                        "{} / {}.{}",
+                        record.kernel_version, record.runtime_flavor, record.runtime_revision
+                    )))
+                    .recommendation(Some(
+                        "如果 dashboard 启动异常，请在高级/内核页重装或回滚 runtime",
+                    )),
+                );
+            } else {
+                items.push(
+                    EnvironmentCheckItem::new(
+                        "runtime-executable",
+                        EnvironmentCheckCategory::Runtime,
+                        "Runtime 可执行文件",
+                        EnvironmentCheckStatus::Error,
+                        true,
+                        "current.json 指向的 runtime 可执行文件不存在",
+                    )
+                    .path(Some(&executable))
+                    .recommendation(Some("在高级/内核页安装 runtime 更新，或重新安装桌面端")),
+                );
+            }
+        }
+        None => {
+            items.push(
+                EnvironmentCheckItem::new(
+                    "current-runtime-record",
+                    EnvironmentCheckCategory::Runtime,
+                    "current.json",
+                    EnvironmentCheckStatus::Error,
+                    true,
+                    "未找到 managed runtime 记录",
+                )
+                .path(Some(runtime::current_record_path_display()))
+                .recommendation(Some("重新启动桌面端，让内置 runtime 安装流程重新执行")),
+            );
+            items.push(
+                EnvironmentCheckItem::new(
+                    "runtime-executable",
+                    EnvironmentCheckCategory::Runtime,
+                    "Runtime 可执行文件",
+                    EnvironmentCheckStatus::Unknown,
+                    true,
+                    "runtime 尚未安装，无法检查可执行文件",
+                )
+                .recommendation(Some("等待首次启动安装完成，或重新安装桌面端")),
+            );
+        }
+    }
+
+    if inner.api_base_url.trim().is_empty() {
+        items.push(
+            EnvironmentCheckItem::new(
+                "dashboard-api",
+                EnvironmentCheckCategory::Runtime,
+                "Dashboard API",
+                EnvironmentCheckStatus::Unknown,
+                true,
+                "Dashboard 尚未写入 API 地址",
+            )
+            .recommendation(Some(
+                "等待启动完成；如长时间不变，请复制诊断信息排查 runtime 启动失败原因",
+            )),
+        );
+        items.push(EnvironmentCheckItem::new(
+            "dashboard-sse",
+            EnvironmentCheckCategory::Runtime,
+            "SSE 事件路由",
+            EnvironmentCheckStatus::Unknown,
+            true,
+            "Dashboard 尚未启动，无法检查 /api/v2/events",
+        ));
+    } else {
+        items.push(
+            check_dashboard_status(&inner.api_base_url, inner.session_token.as_deref()).await,
+        );
+        let supports_sse = dashboard::dashboard_supports_sse(&inner.api_base_url).await;
+        items.push(
+            EnvironmentCheckItem::new(
+                "dashboard-sse",
+                EnvironmentCheckCategory::Runtime,
+                "SSE 事件路由",
+                if supports_sse {
+                    EnvironmentCheckStatus::Ok
+                } else {
+                    EnvironmentCheckStatus::Error
+                },
+                true,
+                if supports_sse {
+                    "Dashboard 支持 /api/v2/events 与桌面端默认 SSE transport"
+                } else {
+                    "Dashboard 缺少 /api/v2/events，默认 SSE transport 会失败"
+                },
+            )
+            .path(Some(format!(
+                "{}/api/v2/events",
+                inner.api_base_url.trim_end_matches('/')
+            )))
+            .recommendation(
+                (!supports_sse)
+                    .then_some("升级 hermes-agent-cn runtime，或临时切换到 WebSocket transport"),
+            ),
+        );
+    }
+
+    items.push(tool_item(
+        "git",
+        "Git",
+        &["git"],
+        &["--version"],
+        false,
+        "Git 可用，用于源码更新、部分技能和仓库操作",
+        "Git 未找到；大多数基础功能可用，但源码/仓库相关能力会受限",
+        Some("安装 Git：macOS 可运行 xcode-select --install，Windows 安装 Git for Windows"),
+    ));
+    items.push(tool_item(
+        "bash",
+        "Bash / Git Bash",
+        bash_candidates().as_slice(),
+        &["--version"],
+        false,
+        "Bash 可用，终端工具可执行 POSIX shell 命令",
+        "Bash 未找到；Windows 上终端工具通常需要 Git Bash",
+        Some("Windows 请安装 Git for Windows；macOS/Linux 通常系统自带 bash"),
+    ));
+    items.push(check_node_item());
+    items.push(tool_item(
+        "npm",
+        "npm",
+        npm_candidates().as_slice(),
+        &["--version"],
+        false,
+        "npm 可用，可安装浏览器工具等 Node 依赖",
+        "npm 未找到；浏览器工具或部分扩展能力可能无法安装",
+        Some("安装 Node.js LTS，或确认 npm 所在目录已加入 PATH"),
+    ));
+    items.push(tool_item(
+        "ripgrep",
+        "ripgrep (rg)",
+        &["rg"],
+        &["--version"],
+        false,
+        "ripgrep 可用，文件搜索会更快",
+        "ripgrep 未找到；文件搜索会退回较慢实现或部分能力不可用",
+        Some("安装 ripgrep：brew install ripgrep / winget install BurntSushi.ripgrep.MSVC"),
+    ));
+    items.push(tool_item(
+        "ffmpeg",
+        "ffmpeg",
+        &["ffmpeg"],
+        &["-version"],
+        false,
+        "ffmpeg 可用，音视频处理能力可用",
+        "ffmpeg 未找到；音视频转码、部分语音/媒体能力会受限",
+        Some("安装 ffmpeg：brew install ffmpeg / winget install Gyan.FFmpeg"),
+    ));
+    let mut agent_browser = tool_item(
+        "agent-browser",
+        "agent-browser",
+        agent_browser_candidates().as_slice(),
+        &["--version"],
+        false,
+        "agent-browser CLI 可用，浏览器自动化能力更完整",
+        "agent-browser 未找到；浏览器自动化工具可能不可用",
+        Some("安装 Node.js 后运行 npm install -g agent-browser"),
+    );
+    agent_browser.category = EnvironmentCheckCategory::Browser;
+    items.push(agent_browser);
+    items.push(browser_executable_item(Path::new(&hermes_home)));
+
+    EnvironmentCheckResult {
+        generated_at_ms: now_ms(),
+        platform: current_platform_label(),
+        arch: std::env::consts::ARCH.to_string(),
+        runtime_root: runtime_root.to_string_lossy().to_string(),
+        hermes_home,
+        current_profile: inner.current_profile.clone(),
+        items,
+    }
+}
+
+async fn check_dashboard_status(api_base_url: &str, token: Option<&str>) -> EnvironmentCheckItem {
+    let url = format!("{}/api/status", api_base_url.trim_end_matches('/'));
+    let client = reqwest::Client::new();
+    let mut req = client.get(&url).timeout(std::time::Duration::from_secs(4));
+    if let Some(token) = token {
+        req = req.header("X-Hermes-Session-Token", token);
+    }
+    match req.send().await {
+        Ok(res) if res.status().is_success() => EnvironmentCheckItem::new(
+            "dashboard-api",
+            EnvironmentCheckCategory::Runtime,
+            "Dashboard API",
+            EnvironmentCheckStatus::Ok,
+            true,
+            format!("Dashboard API 可访问 ({})", res.status()),
+        )
+        .path(Some(api_base_url.to_string())),
+        Ok(res) => EnvironmentCheckItem::new(
+            "dashboard-api",
+            EnvironmentCheckCategory::Runtime,
+            "Dashboard API",
+            EnvironmentCheckStatus::Warning,
+            true,
+            format!("Dashboard API 返回 {}", res.status()),
+        )
+        .path(Some(api_base_url.to_string()))
+        .recommendation(Some("检查 dashboard 日志或重启桌面端")),
+        Err(err) => EnvironmentCheckItem::new(
+            "dashboard-api",
+            EnvironmentCheckCategory::Runtime,
+            "Dashboard API",
+            EnvironmentCheckStatus::Error,
+            true,
+            "Dashboard API 无法访问",
+        )
+        .path(Some(api_base_url.to_string()))
+        .details(Some(err.to_string()))
+        .recommendation(Some("检查 runtime 是否仍在运行，或重启桌面端")),
+    }
+}
+
+fn check_writable_item(
+    id: &str,
+    category: EnvironmentCheckCategory,
+    label: &str,
+    required: bool,
+    path: &Path,
+    ok_summary: &str,
+    fail_summary: &str,
+    recommendation: Option<&str>,
+) -> EnvironmentCheckItem {
+    match check_writable_dir(path) {
+        Ok(()) => EnvironmentCheckItem::new(
+            id,
+            category,
+            label,
+            EnvironmentCheckStatus::Ok,
+            required,
+            ok_summary,
+        )
+        .path(Some(path)),
+        Err(err) => EnvironmentCheckItem::new(
+            id,
+            category,
+            label,
+            EnvironmentCheckStatus::Error,
+            required,
+            fail_summary,
+        )
+        .path(Some(path))
+        .details(Some(err))
+        .recommendation(recommendation),
+    }
+}
+
+fn check_writable_dir(path: &Path) -> Result<(), String> {
+    fs::create_dir_all(path).map_err(|e| e.to_string())?;
+    let probe = path.join(format!(".hermes-env-check-{}", std::process::id()));
+    fs::write(&probe, b"ok").map_err(|e| e.to_string())?;
+    let _ = fs::remove_file(&probe);
+    Ok(())
+}
+
+fn tool_item(
+    id: &str,
+    label: &str,
+    commands: &[&str],
+    version_args: &[&str],
+    required: bool,
+    ok_summary: &str,
+    missing_summary: &str,
+    recommendation: Option<&str>,
+) -> EnvironmentCheckItem {
+    let probe = probe_commands(commands, version_args);
+    if probe.found {
+        let status = if probe.error.is_some() {
+            EnvironmentCheckStatus::Warning
+        } else {
+            EnvironmentCheckStatus::Ok
+        };
+        EnvironmentCheckItem::new(
+            id,
+            EnvironmentCheckCategory::Tools,
+            label,
+            status,
+            required,
+            ok_summary,
+        )
+        .path(probe.path.as_ref())
+        .version(probe.version)
+        .details(probe.error)
+        .recommendation(
+            (status == EnvironmentCheckStatus::Warning)
+                .then_some("命令存在但版本探测失败，请确认它可以在终端中正常运行"),
+        )
+    } else {
+        EnvironmentCheckItem::new(
+            id,
+            EnvironmentCheckCategory::Tools,
+            label,
+            if required {
+                EnvironmentCheckStatus::Error
+            } else {
+                EnvironmentCheckStatus::Warning
+            },
+            required,
+            missing_summary,
+        )
+        .details(probe.error)
+        .recommendation(recommendation)
+    }
+}
+
+fn check_node_item() -> EnvironmentCheckItem {
+    let probe = probe_commands(&["node"], &["--version"]);
+    if !probe.found {
+        return EnvironmentCheckItem::new(
+            "node",
+            EnvironmentCheckCategory::Tools,
+            "Node.js",
+            EnvironmentCheckStatus::Warning,
+            false,
+            "Node.js 未找到；浏览器工具和部分扩展能力可能不可用",
+        )
+        .details(probe.error)
+        .recommendation(Some("安装 Node.js LTS 20.19+ 或 22.12+"));
+    }
+
+    let version_text = probe.version.clone().unwrap_or_default();
+    let ok_version = node_satisfies_build(&version_text);
+    EnvironmentCheckItem::new(
+        "node",
+        EnvironmentCheckCategory::Tools,
+        "Node.js",
+        if ok_version {
+            EnvironmentCheckStatus::Ok
+        } else {
+            EnvironmentCheckStatus::Warning
+        },
+        false,
+        if ok_version {
+            "Node.js 版本满足桌面端与浏览器工具构建要求"
+        } else {
+            "Node.js 版本偏旧，浏览器工具或本地构建可能失败"
+        },
+    )
+    .path(probe.path.as_ref())
+    .version(probe.version)
+    .details(probe.error)
+    .recommendation((!ok_version).then_some("升级到 Node.js 20.19+ 或 22.12+"))
+}
+
+fn browser_executable_item(hermes_home: &Path) -> EnvironmentCheckItem {
+    let env_path = find_env_value(&hermes_home.join(".env"), "AGENT_BROWSER_EXECUTABLE_PATH");
+    match env_path {
+        Some(path) if Path::new(&path).is_file() => EnvironmentCheckItem::new(
+            "browser-executable",
+            EnvironmentCheckCategory::Browser,
+            "浏览器执行文件",
+            EnvironmentCheckStatus::Ok,
+            false,
+            "AGENT_BROWSER_EXECUTABLE_PATH 指向的浏览器存在",
+        )
+        .path(Some(path)),
+        Some(path) => EnvironmentCheckItem::new(
+            "browser-executable",
+            EnvironmentCheckCategory::Browser,
+            "浏览器执行文件",
+            EnvironmentCheckStatus::Warning,
+            false,
+            "AGENT_BROWSER_EXECUTABLE_PATH 已配置，但目标文件不存在",
+        )
+        .path(Some(path))
+        .recommendation(Some(
+            "更新 .env 中的 AGENT_BROWSER_EXECUTABLE_PATH，或重新安装浏览器工具",
+        )),
+        None => EnvironmentCheckItem::new(
+            "browser-executable",
+            EnvironmentCheckCategory::Browser,
+            "浏览器执行文件",
+            EnvironmentCheckStatus::Unknown,
+            false,
+            "未在 .env 中配置 AGENT_BROWSER_EXECUTABLE_PATH；浏览器工具会尝试使用自身默认策略",
+        )
+        .recommendation(Some(
+            "如浏览器工具不可用，可安装 agent-browser 或配置 AGENT_BROWSER_EXECUTABLE_PATH",
+        )),
+    }
+}
+
+fn find_env_value(path: &Path, key: &str) -> Option<String> {
+    let content = fs::read_to_string(path).ok()?;
+    for line in content.lines() {
+        let trimmed = line.trim();
+        if trimmed.is_empty() || trimmed.starts_with('#') {
+            continue;
+        }
+        let Some((left, right)) = trimmed.split_once('=') else {
+            continue;
+        };
+        if left.trim() != key {
+            continue;
+        }
+        let mut value = right.trim().to_string();
+        if (value.starts_with('"') && value.ends_with('"'))
+            || (value.starts_with('\'') && value.ends_with('\''))
+        {
+            value = value[1..value.len().saturating_sub(1)].to_string();
+        }
+        return Some(value).filter(|v| !v.trim().is_empty());
+    }
+    None
+}
+
+fn probe_commands(commands: &[&str], version_args: &[&str]) -> CommandProbe {
+    let mut missing = Vec::new();
+    for command in commands {
+        match find_on_path(command) {
+            Some(path) => {
+                let version_probe = run_version_command(&path, version_args);
+                return CommandProbe {
+                    found: true,
+                    path: Some(path),
+                    version: version_probe.version,
+                    error: version_probe.error,
+                };
+            }
+            None => missing.push(*command),
+        }
+    }
+    CommandProbe {
+        found: false,
+        path: None,
+        version: None,
+        error: Some(format!("未在 PATH 中找到 {}", missing.join(" / "))),
+    }
+}
+
+fn run_version_command(command: &Path, args: &[&str]) -> CommandProbe {
+    let output = Command::new(command)
+        .args(args)
+        .env("GIT_TERMINAL_PROMPT", "0")
+        .output();
+    match output {
+        Ok(output) => {
+            let stdout = String::from_utf8_lossy(&output.stdout).trim().to_string();
+            let stderr = String::from_utf8_lossy(&output.stderr).trim().to_string();
+            let first = stdout
+                .lines()
+                .chain(stderr.lines())
+                .find(|line| !line.trim().is_empty())
+                .map(|line| line.trim().to_string());
+            CommandProbe {
+                found: true,
+                path: Some(command.to_path_buf()),
+                version: first,
+                error: (!output.status.success()).then(|| {
+                    format!(
+                        "版本命令退出码 {}{}",
+                        output.status,
+                        if stderr.is_empty() {
+                            String::new()
+                        } else {
+                            format!(": {}", stderr)
+                        }
+                    )
+                }),
+            }
+        }
+        Err(err) => CommandProbe {
+            found: true,
+            path: Some(command.to_path_buf()),
+            version: None,
+            error: Some(err.to_string()),
+        },
+    }
+}
+
+fn find_on_path(command: &str) -> Option<PathBuf> {
+    let command_path = Path::new(command);
+    if command_path.is_absolute() || command.contains(std::path::MAIN_SEPARATOR) {
+        return command_path.is_file().then(|| command_path.to_path_buf());
+    }
+
+    let path = env::var_os("PATH")?;
+    let candidates = executable_candidates(command);
+    for dir in env::split_paths(&path) {
+        for candidate in &candidates {
+            let path = dir.join(candidate);
+            if path.is_file() {
+                return Some(path);
+            }
+        }
+    }
+    None
+}
+
+fn executable_candidates(command: &str) -> Vec<OsString> {
+    #[cfg(target_os = "windows")]
+    {
+        let mut out = Vec::new();
+        let has_ext = Path::new(command).extension().is_some();
+        if has_ext {
+            out.push(OsString::from(command));
+            return out;
+        }
+        let pathext = env::var("PATHEXT").unwrap_or_else(|_| ".COM;.EXE;.BAT;.CMD".to_string());
+        for ext in pathext.split(';').filter(|s| !s.is_empty()) {
+            out.push(OsString::from(format!("{}{}", command, ext)));
+            out.push(OsString::from(format!(
+                "{}{}",
+                command,
+                ext.to_ascii_lowercase()
+            )));
+        }
+        out.push(OsString::from(command));
+        out
+    }
+    #[cfg(not(target_os = "windows"))]
+    {
+        vec![OsString::from(command)]
+    }
+}
+
+fn bash_candidates() -> Vec<&'static str> {
+    #[cfg(target_os = "windows")]
+    {
+        vec!["bash", "bash.exe"]
+    }
+    #[cfg(not(target_os = "windows"))]
+    {
+        vec!["bash"]
+    }
+}
+
+fn npm_candidates() -> Vec<&'static str> {
+    #[cfg(target_os = "windows")]
+    {
+        vec!["npm.cmd", "npm.exe", "npm"]
+    }
+    #[cfg(not(target_os = "windows"))]
+    {
+        vec!["npm"]
+    }
+}
+
+fn agent_browser_candidates() -> Vec<&'static str> {
+    #[cfg(target_os = "windows")]
+    {
+        vec!["agent-browser.cmd", "agent-browser.exe", "agent-browser"]
+    }
+    #[cfg(not(target_os = "windows"))]
+    {
+        vec!["agent-browser"]
+    }
+}
+
+fn node_satisfies_build(version: &str) -> bool {
+    let Some((major, minor, _patch)) = parse_semverish(version) else {
+        return false;
+    };
+    major > 22 || (major == 22 && minor >= 12) || (major == 20 && minor >= 19)
+}
+
+fn parse_semverish(version: &str) -> Option<(u64, u64, u64)> {
+    let trimmed = version.trim().trim_start_matches('v');
+    let mut nums = trimmed
+        .split(|c: char| !c.is_ascii_digit())
+        .filter(|s| !s.is_empty());
+    let major = nums.next()?.parse().ok()?;
+    let minor = nums.next().unwrap_or("0").parse().ok()?;
+    let patch = nums.next().unwrap_or("0").parse().ok()?;
+    Some((major, minor, patch))
+}
+
+fn now_ms() -> u64 {
+    SystemTime::now()
+        .duration_since(UNIX_EPOCH)
+        .map(|d| d.as_millis() as u64)
+        .unwrap_or(0)
+}
+
+fn current_platform_label() -> String {
+    if cfg!(target_os = "windows") {
+        "windows".to_string()
+    } else if cfg!(target_os = "macos") {
+        "macos".to_string()
+    } else if cfg!(target_os = "linux") {
+        "linux".to_string()
+    } else {
+        std::env::consts::OS.to_string()
+    }
+}
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+    use pretty_assertions::assert_eq;
+
+    #[test]
+    fn node_version_policy_matches_vite_requirement() {
+        assert!(!node_satisfies_build("v20.18.1"));
+        assert!(node_satisfies_build("v20.19.0"));
+        assert!(!node_satisfies_build("v22.11.0"));
+        assert!(node_satisfies_build("v22.12.0"));
+        assert!(node_satisfies_build("v23.0.0"));
+    }
+
+    #[test]
+    fn semver_parser_accepts_common_version_lines() {
+        assert_eq!(parse_semverish("v22.12.0"), Some((22, 12, 0)));
+        assert_eq!(parse_semverish("node 20.19.1"), Some((20, 19, 1)));
+        assert_eq!(parse_semverish("git version 2.54.0"), Some((2, 54, 0)));
+        assert_eq!(parse_semverish("not a version"), None);
+    }
+
+    #[test]
+    fn env_value_parser_handles_quotes_and_comments() {
+        let dir = tempfile::tempdir().unwrap();
+        let env_file = dir.path().join(".env");
+        fs::write(
+            &env_file,
+            "# comment\nOPENAI_API_KEY=secret\nAGENT_BROWSER_EXECUTABLE_PATH=\"/Applications/Browser.app/bin\"\n",
+        )
+        .unwrap();
+        assert_eq!(
+            find_env_value(&env_file, "AGENT_BROWSER_EXECUTABLE_PATH"),
+            Some("/Applications/Browser.app/bin".to_string())
+        );
+        assert_eq!(find_env_value(&env_file, "MISSING"), None);
+    }
+
+    #[test]
+    fn writable_dir_probe_creates_missing_dir() {
+        let dir = tempfile::tempdir().unwrap();
+        let target = dir.path().join("nested");
+        check_writable_dir(&target).unwrap();
+        assert!(target.is_dir());
+    }
+}

--- a/src/environment.rs
+++ b/src/environment.rs
@@ -196,38 +196,38 @@ pub async fn collect_environment_check(inner: &AppStateInner) -> EnvironmentChec
     let current = runtime::read_current_record();
     let mut items = Vec::new();
 
-    items.push(check_writable_item(
-        "runtime-root",
-        EnvironmentCheckCategory::Core,
-        "Runtime 根目录",
-        true,
-        &runtime_root,
-        "runtime 根目录可写",
-        "runtime 根目录不可写，桌面端无法安装或更新 managed runtime",
-        Some("检查目录权限，或设置 HERMES_DESKTOP_RUNTIME_ROOT 指向可写目录"),
-    ));
+    items.push(check_writable_item(WritableCheck {
+        id: "runtime-root",
+        category: EnvironmentCheckCategory::Core,
+        label: "Runtime 根目录",
+        required: true,
+        path: &runtime_root,
+        ok_summary: "runtime 根目录可写",
+        fail_summary: "runtime 根目录不可写，桌面端无法安装或更新 managed runtime",
+        recommendation: Some("检查目录权限，或设置 HERMES_DESKTOP_RUNTIME_ROOT 指向可写目录"),
+    }));
 
-    items.push(check_writable_item(
-        "hermes-home",
-        EnvironmentCheckCategory::Core,
-        "HERMES_HOME",
-        true,
-        Path::new(&hermes_home),
-        "HERMES_HOME 可写",
-        "HERMES_HOME 不可写，配置、会话与日志无法保存",
-        Some("检查目录权限，或重新安装桌面端"),
-    ));
+    items.push(check_writable_item(WritableCheck {
+        id: "hermes-home",
+        category: EnvironmentCheckCategory::Core,
+        label: "HERMES_HOME",
+        required: true,
+        path: Path::new(&hermes_home),
+        ok_summary: "HERMES_HOME 可写",
+        fail_summary: "HERMES_HOME 不可写，配置、会话与日志无法保存",
+        recommendation: Some("检查目录权限，或重新安装桌面端"),
+    }));
 
-    items.push(check_writable_item(
-        "gateway-runtime-dir",
-        EnvironmentCheckCategory::Core,
-        "Gateway runtime 目录",
-        true,
-        &runtime::gateway_runtime_dir(),
-        "Gateway runtime 目录可写",
-        "Gateway runtime 目录不可写，消息网关锁文件和运行态无法写入",
-        Some("检查 runtime 目录权限后重启桌面端"),
-    ));
+    items.push(check_writable_item(WritableCheck {
+        id: "gateway-runtime-dir",
+        category: EnvironmentCheckCategory::Core,
+        label: "Gateway runtime 目录",
+        required: true,
+        path: &runtime::gateway_runtime_dir(),
+        ok_summary: "Gateway runtime 目录可写",
+        fail_summary: "Gateway runtime 目录不可写，消息网关锁文件和运行态无法写入",
+        recommendation: Some("检查 runtime 目录权限后重启桌面端"),
+    }));
 
     match &current {
         Some(record) => {
@@ -360,67 +360,71 @@ pub async fn collect_environment_check(inner: &AppStateInner) -> EnvironmentChec
         );
     }
 
-    items.push(tool_item(
-        "git",
-        "Git",
-        &["git"],
-        &["--version"],
-        false,
-        "Git 可用，用于源码更新、部分技能和仓库操作",
-        "Git 未找到；大多数基础功能可用，但源码/仓库相关能力会受限",
-        Some("安装 Git：macOS 可运行 xcode-select --install，Windows 安装 Git for Windows"),
-    ));
-    items.push(tool_item(
-        "bash",
-        "Bash / Git Bash",
-        bash_candidates().as_slice(),
-        &["--version"],
-        false,
-        "Bash 可用，终端工具可执行 POSIX shell 命令",
-        "Bash 未找到；Windows 上终端工具通常需要 Git Bash",
-        Some("Windows 请安装 Git for Windows；macOS/Linux 通常系统自带 bash"),
-    ));
+    items.push(tool_item(ToolCheck {
+        id: "git",
+        label: "Git",
+        commands: &["git"],
+        version_args: &["--version"],
+        required: false,
+        ok_summary: "Git 可用，用于源码更新、部分技能和仓库操作",
+        missing_summary: "Git 未找到；大多数基础功能可用，但源码/仓库相关能力会受限",
+        recommendation: Some(
+            "安装 Git：macOS 可运行 xcode-select --install，Windows 安装 Git for Windows",
+        ),
+    }));
+    items.push(tool_item(ToolCheck {
+        id: "bash",
+        label: "Bash / Git Bash",
+        commands: bash_candidates().as_slice(),
+        version_args: &["--version"],
+        required: false,
+        ok_summary: "Bash 可用，终端工具可执行 POSIX shell 命令",
+        missing_summary: "Bash 未找到；Windows 上终端工具通常需要 Git Bash",
+        recommendation: Some("Windows 请安装 Git for Windows；macOS/Linux 通常系统自带 bash"),
+    }));
     items.push(check_node_item());
-    items.push(tool_item(
-        "npm",
-        "npm",
-        npm_candidates().as_slice(),
-        &["--version"],
-        false,
-        "npm 可用，可安装浏览器工具等 Node 依赖",
-        "npm 未找到；浏览器工具或部分扩展能力可能无法安装",
-        Some("安装 Node.js LTS，或确认 npm 所在目录已加入 PATH"),
-    ));
-    items.push(tool_item(
-        "ripgrep",
-        "ripgrep (rg)",
-        &["rg"],
-        &["--version"],
-        false,
-        "ripgrep 可用，文件搜索会更快",
-        "ripgrep 未找到；文件搜索会退回较慢实现或部分能力不可用",
-        Some("安装 ripgrep：brew install ripgrep / winget install BurntSushi.ripgrep.MSVC"),
-    ));
-    items.push(tool_item(
-        "ffmpeg",
-        "ffmpeg",
-        &["ffmpeg"],
-        &["-version"],
-        false,
-        "ffmpeg 可用，音视频处理能力可用",
-        "ffmpeg 未找到；音视频转码、部分语音/媒体能力会受限",
-        Some("安装 ffmpeg：brew install ffmpeg / winget install Gyan.FFmpeg"),
-    ));
-    let mut agent_browser = tool_item(
-        "agent-browser",
-        "agent-browser",
-        agent_browser_candidates().as_slice(),
-        &["--version"],
-        false,
-        "agent-browser CLI 可用，浏览器自动化能力更完整",
-        "agent-browser 未找到；浏览器自动化工具可能不可用",
-        Some("安装 Node.js 后运行 npm install -g agent-browser"),
-    );
+    items.push(tool_item(ToolCheck {
+        id: "npm",
+        label: "npm",
+        commands: npm_candidates().as_slice(),
+        version_args: &["--version"],
+        required: false,
+        ok_summary: "npm 可用，可安装浏览器工具等 Node 依赖",
+        missing_summary: "npm 未找到；浏览器工具或部分扩展能力可能无法安装",
+        recommendation: Some("安装 Node.js LTS，或确认 npm 所在目录已加入 PATH"),
+    }));
+    items.push(tool_item(ToolCheck {
+        id: "ripgrep",
+        label: "ripgrep (rg)",
+        commands: &["rg"],
+        version_args: &["--version"],
+        required: false,
+        ok_summary: "ripgrep 可用，文件搜索会更快",
+        missing_summary: "ripgrep 未找到；文件搜索会退回较慢实现或部分能力不可用",
+        recommendation: Some(
+            "安装 ripgrep：brew install ripgrep / winget install BurntSushi.ripgrep.MSVC",
+        ),
+    }));
+    items.push(tool_item(ToolCheck {
+        id: "ffmpeg",
+        label: "ffmpeg",
+        commands: &["ffmpeg"],
+        version_args: &["-version"],
+        required: false,
+        ok_summary: "ffmpeg 可用，音视频处理能力可用",
+        missing_summary: "ffmpeg 未找到；音视频转码、部分语音/媒体能力会受限",
+        recommendation: Some("安装 ffmpeg：brew install ffmpeg / winget install Gyan.FFmpeg"),
+    }));
+    let mut agent_browser = tool_item(ToolCheck {
+        id: "agent-browser",
+        label: "agent-browser",
+        commands: agent_browser_candidates().as_slice(),
+        version_args: &["--version"],
+        required: false,
+        ok_summary: "agent-browser CLI 可用，浏览器自动化能力更完整",
+        missing_summary: "agent-browser 未找到；浏览器自动化工具可能不可用",
+        recommendation: Some("安装 Node.js 后运行 npm install -g agent-browser"),
+    });
     agent_browser.category = EnvironmentCheckCategory::Browser;
     items.push(agent_browser);
     items.push(browser_executable_item(Path::new(&hermes_home)));
@@ -477,37 +481,39 @@ async fn check_dashboard_status(api_base_url: &str, token: Option<&str>) -> Envi
     }
 }
 
-fn check_writable_item(
-    id: &str,
+struct WritableCheck<'a> {
+    id: &'a str,
     category: EnvironmentCheckCategory,
-    label: &str,
+    label: &'a str,
     required: bool,
-    path: &Path,
-    ok_summary: &str,
-    fail_summary: &str,
-    recommendation: Option<&str>,
-) -> EnvironmentCheckItem {
-    match check_writable_dir(path) {
+    path: &'a Path,
+    ok_summary: &'a str,
+    fail_summary: &'a str,
+    recommendation: Option<&'a str>,
+}
+
+fn check_writable_item(check: WritableCheck<'_>) -> EnvironmentCheckItem {
+    match check_writable_dir(check.path) {
         Ok(()) => EnvironmentCheckItem::new(
-            id,
-            category,
-            label,
+            check.id,
+            check.category,
+            check.label,
             EnvironmentCheckStatus::Ok,
-            required,
-            ok_summary,
+            check.required,
+            check.ok_summary,
         )
-        .path(Some(path)),
+        .path(Some(check.path)),
         Err(err) => EnvironmentCheckItem::new(
-            id,
-            category,
-            label,
+            check.id,
+            check.category,
+            check.label,
             EnvironmentCheckStatus::Error,
-            required,
-            fail_summary,
+            check.required,
+            check.fail_summary,
         )
-        .path(Some(path))
+        .path(Some(check.path))
         .details(Some(err))
-        .recommendation(recommendation),
+        .recommendation(check.recommendation),
     }
 }
 
@@ -519,17 +525,19 @@ fn check_writable_dir(path: &Path) -> Result<(), String> {
     Ok(())
 }
 
-fn tool_item(
-    id: &str,
-    label: &str,
-    commands: &[&str],
-    version_args: &[&str],
+struct ToolCheck<'a> {
+    id: &'a str,
+    label: &'a str,
+    commands: &'a [&'a str],
+    version_args: &'a [&'a str],
     required: bool,
-    ok_summary: &str,
-    missing_summary: &str,
-    recommendation: Option<&str>,
-) -> EnvironmentCheckItem {
-    let probe = probe_commands(commands, version_args);
+    ok_summary: &'a str,
+    missing_summary: &'a str,
+    recommendation: Option<&'a str>,
+}
+
+fn tool_item(check: ToolCheck<'_>) -> EnvironmentCheckItem {
+    let probe = probe_commands(check.commands, check.version_args);
     if probe.found {
         let status = if probe.error.is_some() {
             EnvironmentCheckStatus::Warning
@@ -537,12 +545,12 @@ fn tool_item(
             EnvironmentCheckStatus::Ok
         };
         EnvironmentCheckItem::new(
-            id,
+            check.id,
             EnvironmentCheckCategory::Tools,
-            label,
+            check.label,
             status,
-            required,
-            ok_summary,
+            check.required,
+            check.ok_summary,
         )
         .path(probe.path.as_ref())
         .version(probe.version)
@@ -553,19 +561,19 @@ fn tool_item(
         )
     } else {
         EnvironmentCheckItem::new(
-            id,
+            check.id,
             EnvironmentCheckCategory::Tools,
-            label,
-            if required {
+            check.label,
+            if check.required {
                 EnvironmentCheckStatus::Error
             } else {
                 EnvironmentCheckStatus::Warning
             },
-            required,
-            missing_summary,
+            check.required,
+            check.missing_summary,
         )
         .details(probe.error)
-        .recommendation(recommendation)
+        .recommendation(check.recommendation)
     }
 }
 

--- a/src/lib.rs
+++ b/src/lib.rs
@@ -1,4 +1,5 @@
 pub mod commands;
+pub mod environment;
 pub mod error;
 pub mod prevent_sleep;
 pub mod process;

--- a/src/main.rs
+++ b/src/main.rs
@@ -12,6 +12,7 @@ use std::sync::atomic::Ordering;
 
 use hermes_agent_cn::commands;
 use hermes_agent_cn::commands::profiles::read_active_profile_sticky;
+use hermes_agent_cn::environment;
 use hermes_agent_cn::process::{dashboard, runtime};
 use hermes_agent_cn::state::{AppState, DashboardHandle};
 use tauri::Emitter;
@@ -103,6 +104,11 @@ async fn acquire_managed_dashboard(
     resource_dir: Option<PathBuf>,
     install_bundled: bool,
 ) -> Result<DashboardHandle, String> {
+    emit_runtime_status(app, "checking-env", "正在检查本机环境...");
+    if let Err(err) = environment::check_bootstrap_environment(&options.hermes_home) {
+        return Err(record_bootstrap_error(app, err));
+    }
+
     if install_bundled && !install_bundled_runtime_for_bootstrap(app, resource_dir.as_deref()).await
     {
         // install_bundled_runtime_for_bootstrap already recorded the error.
@@ -470,6 +476,7 @@ fn main() {
             commands::file_dialogs::open_workspace_path,
             commands::file_dialogs::open_external_url,
             commands::debug_bundle::export_debug_bundle,
+            commands::environment::environment_check,
             commands::api_proxy::api_request,
             commands::api_proxy::external_request,
             commands::api_proxy::upload_file,

--- a/web/src/components/app-shell/advanced-sidebar.tsx
+++ b/web/src/components/app-shell/advanced-sidebar.tsx
@@ -7,6 +7,7 @@ import {
   FileText,
   HeartPulse,
   Info,
+  MonitorCog,
   SlidersHorizontal,
   type LucideIcon,
 } from "lucide-react";
@@ -29,6 +30,7 @@ const ADVANCED_ITEMS: readonly AdvancedItem[] = [
   { label: "常规", path: "/advanced", icon: SlidersHorizontal },
   { label: "配置", path: "/advanced/config", icon: FileCog },
   { label: "内核", path: "/advanced/kernel", icon: Cpu },
+  { label: "环境", path: "/advanced/env", icon: MonitorCog },
   { label: "关于", path: "/advanced/about", icon: Info },
 ];
 

--- a/web/src/hooks/use-environment-check.ts
+++ b/web/src/hooks/use-environment-check.ts
@@ -1,0 +1,21 @@
+import { useQuery } from "@tanstack/react-query";
+import type { EnvironmentCheckResult } from "@hermes/protocol";
+import { runtime } from "@/lib/runtime";
+
+const ENVIRONMENT_CHECK_KEY = ["desktop-environment-check"] as const;
+
+function hasEnvironmentBridge(): boolean {
+  return typeof window !== "undefined" &&
+    runtime.platform !== "web" &&
+    Boolean(window.hermesDesktop?.environmentCheck);
+}
+
+export function useEnvironmentCheck() {
+  return useQuery<EnvironmentCheckResult>({
+    queryKey: ENVIRONMENT_CHECK_KEY,
+    queryFn: () => window.hermesDesktop!.environmentCheck!(),
+    enabled: hasEnvironmentBridge(),
+    staleTime: 10_000,
+    refetchInterval: 60_000,
+  });
+}

--- a/web/src/lib/runtime.ts
+++ b/web/src/lib/runtime.ts
@@ -5,6 +5,7 @@ import type {
   ConfigMigrationImportResult,
   ConfigMigrationScanInput,
   ConfigMigrationScanResult,
+  EnvironmentCheckResult,
   FileUploadInput,
   HermesMessageMetadata,
   ImOnboardingApplyInput,
@@ -203,6 +204,7 @@ declare global {
       openWorkspacePath?(input: { path: string }): Promise<ElectronApiRequestResult>;
       openExternalUrl?(input: { url: string }): Promise<ElectronSimpleResult>;
       exportDebugBundle?(input?: ExportDebugBundleInput): Promise<ExportDebugBundleResult>;
+      environmentCheck?(): Promise<EnvironmentCheckResult>;
       getRuntimeConfig?(): Window["__HERMES_RUNTIME__"];
       refreshGatewayUrl?(): Promise<{ gatewayUrl: string; sessionToken?: string }>;
       getRuntimeInfo?(): Promise<RuntimeInfo>;

--- a/web/src/lib/tauri-bridge.ts
+++ b/web/src/lib/tauri-bridge.ts
@@ -14,6 +14,7 @@ import type {
   ConfigMigrationImportResult,
   ConfigMigrationScanInput,
   ConfigMigrationScanResult,
+  EnvironmentCheckResult,
   FilePickerResult,
   FileUploadInput,
   ImOnboardingApplyInput,
@@ -190,6 +191,10 @@ const tauriBridge = {
   async exportDebugBundle(input?: ExportDebugBundleInput): Promise<ExportDebugBundleResult> {
     const inv = await ensureInvoke();
     return inv("export_debug_bundle", { input: input ?? null });
+  },
+
+  async environmentCheck(): Promise<EnvironmentCheckResult> {
+    return invokeCommand("environment_check");
   },
 
   getRuntimeConfig() {
@@ -566,20 +571,36 @@ async function waitForBootstrap(
   readConfig: () => Promise<{ apiBaseUrl?: string }>,
   readRuntimeInfo: () => Promise<{ lastError?: string }>,
 ): Promise<{ failed: boolean; message: string }> {
-  const overlay = showBootstrapOverlay(initialMessage);
   const { listen } = await import("@tauri-apps/api/event");
 
   return new Promise((resolve) => {
+    let overlay: ReturnType<typeof showBootstrapOverlay> | null = null;
     let unlisten: (() => void) | null = null;
     let interval: number | null = null;
+    let showTimer: number | null = null;
     let settled = false;
+    let lastPhase = "starting";
+    let lastMessage = initialMessage;
+
+    const ensureOverlay = () => {
+      if (!overlay) {
+        overlay = showBootstrapOverlay(lastMessage || initialMessage);
+        overlay.update(lastPhase, lastMessage || initialMessage);
+      }
+      return overlay;
+    };
+
+    showTimer = window.setTimeout(() => {
+      if (!settled) ensureOverlay();
+    }, 1200);
 
     const finish = (result: { failed: boolean; message: string }) => {
       if (settled) return;
       settled = true;
       unlisten?.();
       if (interval !== null) window.clearInterval(interval);
-      if (!result.failed) overlay.dismiss();
+      if (showTimer !== null) window.clearTimeout(showTimer);
+      if (!result.failed) overlay?.dismiss();
       resolve(result);
     };
 
@@ -592,7 +613,9 @@ async function waitForBootstrap(
       void readRuntimeInfo()
         .then((info) => {
           if (info.lastError) {
-            overlay.update("error", info.lastError);
+            lastPhase = "error";
+            lastMessage = info.lastError;
+            ensureOverlay().update("error", info.lastError);
             finish({ failed: true, message: info.lastError });
           }
         })
@@ -601,14 +624,15 @@ async function waitForBootstrap(
 
     listen<{ phase: string; message: string }>("runtime-status", (event) => {
       const { phase, message } = event.payload;
-      overlay.update(phase, message);
+      lastPhase = phase;
+      if (message) lastMessage = message;
+      overlay?.update(phase, message);
       if (phase === "ready") {
         finish({ failed: false, message: "" });
       } else if (phase === "error") {
-        // Leave the overlay up so the user sees the error message; the
-        // process keeps running so they can read it. They'll need to
-        // close + relaunch (or fix the env / hit a "retry" button we
-        // add later).
+        // Error paths should be visible immediately even if the normal slow-start
+        // threshold has not elapsed yet.
+        ensureOverlay().update("error", message);
         finish({ failed: true, message });
       }
     }).then((fn) => {

--- a/web/src/routes/advanced.tsx
+++ b/web/src/routes/advanced.tsx
@@ -1,13 +1,15 @@
 import { Navigate, useLocation } from "react-router-dom";
 import { SectionShell } from "./section-shell";
 import { AboutSection, ConfigSection, GeneralSection, KernelSection } from "./settings";
+import { EnvironmentSection } from "./environment";
 
-type AdvancedSection = "general" | "config" | "kernel" | "about";
+type AdvancedSection = "general" | "config" | "kernel" | "env" | "about";
 
 const SECTION_META: Record<AdvancedSection, { title: string; sub: string }> = {
   general: { title: "常规", sub: "调整主题、密度和对话显示偏好。" },
   config: { title: "配置", sub: "编辑 Hermes config.yaml 中的高级配置项。" },
   kernel: { title: "内核", sub: "查看运行时、版本和本地路径信息。" },
+  env: { title: "环境", sub: "检查 managed runtime 与本机可选工具能力。" },
   about: { title: "关于", sub: "联系方式、社区入口和致谢信息。" },
 };
 
@@ -15,6 +17,7 @@ function sectionFromPath(pathname: string): AdvancedSection | null {
   if (pathname === "/advanced" || pathname === "/advanced/") return "general";
   if (pathname === "/advanced/config") return "config";
   if (pathname === "/advanced/kernel") return "kernel";
+  if (pathname === "/advanced/env") return "env";
   if (pathname === "/advanced/about") return "about";
   return null;
 }
@@ -31,6 +34,7 @@ export function AdvancedRoute() {
       {section === "general" && <GeneralSection showHeading={false} />}
       {section === "config" && <ConfigSection showHeading={false} />}
       {section === "kernel" && <KernelSection showHeading={false} />}
+      {section === "env" && <EnvironmentSection showHeading={false} />}
       {section === "about" && <AboutSection showHeading={false} />}
     </SectionShell>
   );

--- a/web/src/routes/environment.test.ts
+++ b/web/src/routes/environment.test.ts
@@ -1,0 +1,26 @@
+import { describe, expect, it } from "vitest";
+import type { EnvironmentCheckItem } from "@hermes/protocol";
+import { summarizeEnvironmentItems } from "./environment";
+
+function item(status: EnvironmentCheckItem["status"], required = false): EnvironmentCheckItem {
+  return {
+    id: `${status}-${required}`,
+    category: "core",
+    label: status,
+    status,
+    required,
+    summary: status,
+  };
+}
+
+describe("summarizeEnvironmentItems", () => {
+  it("counts ok, warning, error, and required errors", () => {
+    expect(summarizeEnvironmentItems([
+      item("ok", true),
+      item("warning"),
+      item("error"),
+      item("error", true),
+      item("unknown"),
+    ])).toEqual({ ok: 1, warnings: 1, errors: 2, requiredErrors: 1, total: 5 });
+  });
+});

--- a/web/src/routes/environment.tsx
+++ b/web/src/routes/environment.tsx
@@ -56,12 +56,6 @@ function groupItems(items: readonly EnvironmentCheckItem[]) {
   });
 }
 
-function statusTone(status: EnvironmentCheckStatus): "true" | "false" | undefined {
-  if (status === "ok") return "true";
-  if (status === "error" || status === "warning") return "false";
-  return undefined;
-}
-
 function formatGeneratedAt(value: number | undefined): string {
   if (!value) return "—";
   const date = new Date(value);
@@ -160,16 +154,20 @@ export function EnvironmentSection({ showHeading = true }: { showHeading?: boole
 
 function EnvironmentItemRow({ item, onOpenPath }: { item: EnvironmentCheckItem; onOpenPath: (path: string | undefined) => Promise<void> }) {
   return (
-    <div className={s.platformItem} data-active={item.status === "ok" ? "true" : undefined}>
-      <span>
-        <StatusIcon status={item.status} />
-        {item.label}
-        {item.required && <em>必需</em>}
-      </span>
-      <b data-tone={statusTone(item.status)}>{STATUS_LABELS[item.status]}</b>
-      <em>{item.summary}</em>
+    <div className={s.envCheckItem} data-status={item.status}>
+      <div className={s.envCheckHeader}>
+        <div className={s.envCheckTitle}>
+          <span className={s.envCheckIcon} data-status={item.status}>
+            <StatusIcon status={item.status} />
+          </span>
+          <span className={s.envCheckLabel}>{item.label}</span>
+          {item.required && <span className={s.envRequiredTag}>必需</span>}
+        </div>
+        <span className={s.envStatusTag} data-status={item.status}>{STATUS_LABELS[item.status]}</span>
+      </div>
+      <p className={s.envCheckSummary} data-status={item.status}>{item.summary}</p>
       {(item.version || item.path || item.details || item.recommendation) && (
-        <div className={s.runtimeGrid} style={{ marginTop: 8 }}>
+        <div className={[s.runtimeGrid, s.envCheckDetails].join(" ")}>
           {item.version && <RuntimeField label="版本" value={item.version} mono wide />}
           {item.path && <RuntimeField label="路径" value={item.path} mono wide />}
           {item.details && <RuntimeField label="详情" value={item.details} mono wide />}
@@ -177,7 +175,7 @@ function EnvironmentItemRow({ item, onOpenPath }: { item: EnvironmentCheckItem; 
         </div>
       )}
       {item.path && window.hermesDesktop?.openWorkspacePath && (
-        <button className={s.btn} type="button" onClick={() => void onOpenPath(item.path)} style={{ marginTop: 8 }}>
+        <button className={[s.btn, s.envOpenPathButton].join(" ")} type="button" onClick={() => void onOpenPath(item.path)}>
           <FolderOpen size={13} />
           打开路径
         </button>

--- a/web/src/routes/environment.tsx
+++ b/web/src/routes/environment.tsx
@@ -1,0 +1,237 @@
+import { useMemo, type ReactNode } from "react";
+import {
+  AlertTriangle,
+  CheckCircle2,
+  CircleHelp,
+  Copy,
+  FolderOpen,
+  MonitorCog,
+  RefreshCw,
+  ShieldCheck,
+  Terminal,
+  Wrench,
+  XCircle,
+} from "lucide-react";
+import type { EnvironmentCheckCategory, EnvironmentCheckItem, EnvironmentCheckResult, EnvironmentCheckStatus } from "@hermes/protocol";
+import { CopyButton } from "@/components/ui/copy-button";
+import { useEnvironmentCheck } from "@/hooks/use-environment-check";
+import s from "./settings.module.css";
+
+const CATEGORY_LABELS: Record<EnvironmentCheckCategory, string> = {
+  core: "核心环境",
+  runtime: "Managed Runtime",
+  tools: "本机工具",
+  browser: "浏览器能力",
+  paths: "路径",
+};
+
+const STATUS_LABELS: Record<EnvironmentCheckStatus, string> = {
+  ok: "正常",
+  warning: "注意",
+  error: "异常",
+  unknown: "未知",
+};
+
+const CATEGORY_ORDER: EnvironmentCheckCategory[] = ["core", "runtime", "tools", "browser", "paths"];
+
+export function summarizeEnvironmentItems(items: readonly EnvironmentCheckItem[]) {
+  const errors = items.filter((item) => item.status === "error").length;
+  const warnings = items.filter((item) => item.status === "warning").length;
+  const requiredErrors = items.filter((item) => item.required && item.status === "error").length;
+  const ok = items.filter((item) => item.status === "ok").length;
+  return { errors, warnings, requiredErrors, ok, total: items.length };
+}
+
+function groupItems(items: readonly EnvironmentCheckItem[]) {
+  const grouped = new Map<EnvironmentCheckCategory, EnvironmentCheckItem[]>();
+  for (const item of items) {
+    const list = grouped.get(item.category) ?? [];
+    list.push(item);
+    grouped.set(item.category, list);
+  }
+  return CATEGORY_ORDER.flatMap((category) => {
+    const list = grouped.get(category);
+    if (!list?.length) return [];
+    return [{ category, items: list }];
+  });
+}
+
+function statusTone(status: EnvironmentCheckStatus): "true" | "false" | undefined {
+  if (status === "ok") return "true";
+  if (status === "error" || status === "warning") return "false";
+  return undefined;
+}
+
+function formatGeneratedAt(value: number | undefined): string {
+  if (!value) return "—";
+  const date = new Date(value);
+  if (Number.isNaN(date.getTime())) return "—";
+  return date.toLocaleString("zh-CN", { hour12: false });
+}
+
+function diagnosticsPayload(data: EnvironmentCheckResult | undefined) {
+  return JSON.stringify({ generatedAt: new Date().toISOString(), environment: data ?? null }, null, 2);
+}
+
+export function EnvironmentSection({ showHeading = true }: { showHeading?: boolean }) {
+  const query = useEnvironmentCheck();
+  const data = query.data;
+  const summary = summarizeEnvironmentItems(data?.items ?? []);
+  const grouped = useMemo(() => groupItems(data?.items ?? []), [data?.items]);
+  const hasBridge = typeof window !== "undefined" && Boolean(window.hermesDesktop?.environmentCheck);
+  const healthy = summary.requiredErrors === 0 && summary.errors === 0;
+
+  const openPath = async (path: string | undefined) => {
+    if (!path || !window.hermesDesktop?.openWorkspacePath) return;
+    await window.hermesDesktop.openWorkspacePath({ path }).catch(() => undefined);
+  };
+
+  return (
+    <div>
+      {showHeading && <h2 className={s.heading}>环境</h2>}
+      <div className={s.aboutHero} data-ok={healthy && data ? "true" : undefined}>
+        <div className={s.aboutHeroMark}>{healthy ? <ShieldCheck size={24} /> : <MonitorCog size={24} />}</div>
+        <div className={s.aboutHeroBody}>
+          <div className={s.aboutEyebrow}>本机环境与依赖检查</div>
+          <h3>{data ? (healthy ? "核心环境正常" : "发现需要关注的环境项") : "正在读取环境状态"}</h3>
+          <p>
+            此页展示桌面端 managed runtime 必需环境，以及 Git、Node、ripgrep、ffmpeg、浏览器工具等可选能力。
+            可选依赖缺失不会阻止启动，但会影响对应工具能力。
+          </p>
+        </div>
+        <span className={s.statusBadge} data-on={healthy && data ? "true" : summary.errors ? "false" : undefined}>
+          {data ? `${summary.ok}/${summary.total} 正常` : query.isLoading ? "读取中" : "未连接"}
+        </span>
+      </div>
+
+      <div className={s.debugActionBar}>
+        <button className={s.btn} type="button" onClick={() => void query.refetch()} disabled={query.isFetching || !hasBridge}>
+          <RefreshCw size={13} />
+          {query.isFetching ? "刷新中" : "刷新检查"}
+        </button>
+        <CopyButton className={s.btn} text={() => diagnosticsPayload(data)}>
+          <Copy size={13} />
+          复制诊断 JSON
+        </CopyButton>
+        <button className={s.btn} type="button" onClick={() => void openPath(data?.runtimeRoot)} disabled={!data?.runtimeRoot || !window.hermesDesktop?.openWorkspacePath}>
+          <FolderOpen size={13} />
+          打开 runtime
+        </button>
+        <button className={s.btn} type="button" onClick={() => void openPath(data?.hermesHome)} disabled={!data?.hermesHome || !window.hermesDesktop?.openWorkspacePath}>
+          <FolderOpen size={13} />
+          打开 HERMES_HOME
+        </button>
+      </div>
+
+      {!hasBridge && <div className={s.runtimeMessage} data-tone="error">当前环境没有桌面端环境检查 bridge。</div>}
+      {query.isError && <div className={s.runtimeMessage} data-tone="error">环境检查失败：{query.error instanceof Error ? query.error.message : "unknown error"}</div>}
+
+      {data && (
+        <div className={s.aboutDebugGrid}>
+          <DebugCard icon={<MonitorCog size={15} />} title="环境摘要" sub="核心错误会影响启动；可选 warning 只影响对应能力" wide>
+            <div className={s.runtimeGrid}>
+              <RuntimeField label="平台" value={`${data.platform}-${data.arch}`} />
+              <RuntimeField label="档案" value={data.currentProfile} />
+              <RuntimeField label="生成时间" value={formatGeneratedAt(data.generatedAtMs)} />
+              <RuntimeField label="核心错误" value={summary.requiredErrors} />
+              <RuntimeField label="全部异常" value={summary.errors} />
+              <RuntimeField label="注意项" value={summary.warnings} />
+              <RuntimeField label="runtimeRoot" value={data.runtimeRoot} mono wide />
+              <RuntimeField label="HERMES_HOME" value={data.hermesHome} mono wide />
+            </div>
+          </DebugCard>
+
+          {grouped.map((group) => (
+            <DebugCard key={group.category} icon={categoryIcon(group.category)} title={CATEGORY_LABELS[group.category]} wide>
+              <div className={s.platformList}>
+                {group.items.map((item) => (
+                  <EnvironmentItemRow key={item.id} item={item} onOpenPath={openPath} />
+                ))}
+              </div>
+            </DebugCard>
+          ))}
+        </div>
+      )}
+
+      {!data && query.isLoading && <p className={s.desc}>正在检查本机环境…</p>}
+    </div>
+  );
+}
+
+function EnvironmentItemRow({ item, onOpenPath }: { item: EnvironmentCheckItem; onOpenPath: (path: string | undefined) => Promise<void> }) {
+  return (
+    <div className={s.platformItem} data-active={item.status === "ok" ? "true" : undefined}>
+      <span>
+        <StatusIcon status={item.status} />
+        {item.label}
+        {item.required && <em>必需</em>}
+      </span>
+      <b data-tone={statusTone(item.status)}>{STATUS_LABELS[item.status]}</b>
+      <em>{item.summary}</em>
+      {(item.version || item.path || item.details || item.recommendation) && (
+        <div className={s.runtimeGrid} style={{ marginTop: 8 }}>
+          {item.version && <RuntimeField label="版本" value={item.version} mono wide />}
+          {item.path && <RuntimeField label="路径" value={item.path} mono wide />}
+          {item.details && <RuntimeField label="详情" value={item.details} mono wide />}
+          {item.recommendation && <RuntimeField label="建议" value={item.recommendation} wide />}
+        </div>
+      )}
+      {item.path && window.hermesDesktop?.openWorkspacePath && (
+        <button className={s.btn} type="button" onClick={() => void onOpenPath(item.path)} style={{ marginTop: 8 }}>
+          <FolderOpen size={13} />
+          打开路径
+        </button>
+      )}
+    </div>
+  );
+}
+
+function StatusIcon({ status }: { status: EnvironmentCheckStatus }) {
+  if (status === "ok") return <CheckCircle2 size={13} />;
+  if (status === "error") return <XCircle size={13} />;
+  if (status === "warning") return <AlertTriangle size={13} />;
+  return <CircleHelp size={13} />;
+}
+
+function categoryIcon(category: EnvironmentCheckCategory): ReactNode {
+  if (category === "core" || category === "runtime") return <ShieldCheck size={15} />;
+  if (category === "tools") return <Terminal size={15} />;
+  if (category === "browser") return <Wrench size={15} />;
+  return <MonitorCog size={15} />;
+}
+
+function DebugCard({ icon, title, sub, children, wide }: {
+  icon: ReactNode;
+  title: string;
+  sub?: string;
+  children: ReactNode;
+  wide?: boolean;
+}) {
+  return (
+    <section className={s.debugCard} data-wide={wide ? "true" : undefined}>
+      <div className={s.debugCardHeader}>
+        <div className={s.debugCardIcon}>{icon}</div>
+        <div>
+          <h3>{title}</h3>
+          {sub && <p>{sub}</p>}
+        </div>
+      </div>
+      {children}
+    </section>
+  );
+}
+
+function RuntimeField({ label, value, mono, wide }: {
+  label: string;
+  value: string | number | boolean | undefined;
+  mono?: boolean;
+  wide?: boolean;
+}) {
+  const display = value === undefined || value === "" ? "—" : String(value);
+  return (
+    <div className={s.runtimeField} data-wide={wide ? "true" : undefined}>
+      <span>{label}</span>
+      <b data-mono={mono ? "true" : undefined}>{display}</b>
+    </div>
+  );
+}

--- a/web/src/routes/settings.module.css
+++ b/web/src/routes/settings.module.css
@@ -1011,6 +1011,158 @@
   font-size: 11px;
 }
 
+.envCheckItem {
+  display: flex;
+  flex-direction: column;
+  gap: 9px;
+  min-width: 0;
+  padding: 12px 14px;
+  border: 1px solid var(--h-line-soft);
+  border-radius: 10px;
+  background: var(--h-bg-pane);
+  color: var(--h-text-2);
+}
+
+.envCheckItem[data-status="ok"] {
+  border-color: color-mix(in srgb, var(--h-ok) 22%, var(--h-line-soft));
+}
+
+.envCheckHeader {
+  display: flex;
+  align-items: flex-start;
+  justify-content: space-between;
+  gap: 14px;
+  min-width: 0;
+}
+
+.envCheckTitle {
+  display: inline-flex;
+  align-items: center;
+  min-width: 0;
+  min-height: 24px;
+  gap: 7px;
+  color: var(--h-text);
+  font-size: 13px;
+  font-weight: 600;
+  line-height: 20px;
+}
+
+.envCheckIcon {
+  display: inline-flex;
+  width: 16px;
+  height: 16px;
+  flex: 0 0 16px;
+  align-items: center;
+  justify-content: center;
+  color: var(--h-text-3);
+}
+
+.envCheckIcon svg {
+  display: block;
+  width: 14px;
+  height: 14px;
+  stroke-width: 2;
+}
+
+.envCheckIcon[data-status="ok"] {
+  color: var(--h-ok);
+}
+
+.envCheckIcon[data-status="warning"] {
+  color: var(--h-warn);
+}
+
+.envCheckIcon[data-status="error"] {
+  color: var(--h-err);
+}
+
+.envCheckLabel {
+  min-width: 0;
+  overflow: hidden;
+  line-height: 20px;
+  text-overflow: ellipsis;
+  white-space: nowrap;
+}
+
+.envRequiredTag,
+.envStatusTag {
+  display: inline-flex;
+  align-items: center;
+  justify-content: center;
+  box-sizing: border-box;
+  height: 20px;
+  border-radius: var(--h-r-pill);
+  font-size: 11px;
+  font-weight: 600;
+  line-height: 1;
+  white-space: nowrap;
+}
+
+.envRequiredTag {
+  flex: 0 0 auto;
+  padding: 0 7px;
+  border: 1px solid color-mix(in srgb, var(--h-accent) 34%, var(--h-line));
+  color: var(--h-accent);
+  background: color-mix(in srgb, var(--h-accent-soft) 70%, transparent);
+}
+
+.envStatusTag {
+  flex: 0 0 auto;
+  min-width: 48px;
+  padding: 0 10px;
+  border: 1px solid transparent;
+}
+
+.envStatusTag[data-status="ok"] {
+  color: var(--h-ok);
+  border-color: color-mix(in srgb, var(--h-ok) 28%, var(--h-line));
+  background: var(--h-ok-soft);
+}
+
+.envStatusTag[data-status="warning"] {
+  color: var(--h-warn);
+  border-color: color-mix(in srgb, var(--h-warn) 30%, var(--h-line));
+  background: var(--h-warn-soft);
+}
+
+.envStatusTag[data-status="error"] {
+  color: var(--h-err);
+  border-color: color-mix(in srgb, var(--h-err) 30%, var(--h-line));
+  background: color-mix(in srgb, var(--h-err) 10%, transparent);
+}
+
+.envStatusTag[data-status="unknown"] {
+  color: var(--h-text-3);
+  border-color: var(--h-line);
+  background: var(--h-bg-chip);
+}
+
+.envCheckSummary {
+  margin: -2px 0 0;
+  color: var(--h-text-2);
+  font-size: 12px;
+  line-height: 1.55;
+}
+
+.envCheckSummary[data-status="error"] {
+  color: var(--h-err);
+}
+
+.envCheckSummary[data-status="warning"] {
+  color: var(--h-warn);
+}
+
+.envCheckDetails {
+  margin-top: 2px;
+  padding-top: 9px;
+  border-top: 1px solid var(--h-line-soft);
+}
+
+.envOpenPathButton {
+  align-self: flex-end;
+  margin-top: 0;
+}
+
 .commitList {
   display: grid;
   gap: 8px;


### PR DESCRIPTION
## 背景

参考 hermes-agent-cn 内核仓库 `apps/desktop` 的安装依赖检查思路，把当前 Tauri 桌面端的 managed runtime 架构补上只读环境诊断能力。启动阶段先做必要目录的快速 preflight，进入桌面端后在高级菜单新增“环境”页展示完整依赖状态。

## 改动

- 新增 Rust 环境诊断模块和 `environment_check` Tauri command，检查 runtime 根目录、HERMES_HOME、gateway runtime 目录、current.json、runtime 可执行文件、Dashboard API、SSE，以及 Git、Bash、Node.js、npm、ripgrep、ffmpeg、agent-browser 等可选工具。
- 在 managed dashboard 启动前增加 `checking-env` 阶段，目录不可写时直接通过现有启动错误链路反馈；正常快速启动时延迟显示启动遮罩，避免闪屏。
- 前端 protocol、Tauri bridge 和 hook 增加环境检查类型与调用入口。
- 高级菜单新增 `/advanced/env` 环境页，展示摘要、分类检查项、路径、版本、建议，并支持复制诊断 JSON 与打开相关目录。

## 验证

- `pnpm typecheck`
- `pnpm test:unit`
- `cargo check`
- `cargo test --all-features`
