### PR TITLE
fix: 导出备份后自动打开所在文件夹

### DIFF
--- a/web/src/routes/backup.test.ts
+++ b/web/src/routes/backup.test.ts
@@ -1,0 +1,14 @@
+import { describe, expect, it } from "vitest";
+import { containingDirectory } from "./backup";
+
+describe("containingDirectory", () => {
+  it("returns the parent folder for exported backup paths", () => {
+    expect(containingDirectory("/Users/alice/Downloads/hermes-backup.zip")).toBe("/Users/alice/Downloads");
+    expect(containingDirectory("C:\\Users\\alice\\Downloads\\hermes-backup.zip")).toBe("C:\\Users\\alice\\Downloads");
+  });
+
+  it("keeps filesystem roots as openable folders", () => {
+    expect(containingDirectory("/hermes-backup.zip")).toBe("/");
+    expect(containingDirectory("C:\\hermes-backup.zip")).toBe("C:\\");
+  });
+});

--- a/web/src/routes/backup.tsx
+++ b/web/src/routes/backup.tsx
@@ -19,9 +19,23 @@ function formatBytes(value: number | undefined): string {
   return `${(value / 1024 / 1024 / 1024).toFixed(1)} GB`;
 }
 
-function openBackupPath(path: string | undefined) {
-  if (!path || !window.hermesDesktop?.openWorkspacePath) return;
-  void window.hermesDesktop.openWorkspacePath({ path });
+export function containingDirectory(path: string | undefined): string | undefined {
+  const trimmed = path?.trim();
+  if (!trimmed) return undefined;
+  const normalized = trimmed.replace(/[\\/]+$/, "");
+  const slash = Math.max(normalized.lastIndexOf("/"), normalized.lastIndexOf("\\"));
+  if (slash < 0) return undefined;
+  if (slash === 0) return normalized.slice(0, 1);
+  if (slash === 2 && /^[A-Za-z]:[\\/]/.test(normalized)) return normalized.slice(0, 3);
+  return normalized.slice(0, slash);
+}
+
+async function openBackupDirectory(path: string | undefined): Promise<string | null> {
+  const target = containingDirectory(path) ?? path;
+  if (!target || !window.hermesDesktop?.openWorkspacePath) return null;
+  const result = await window.hermesDesktop.openWorkspacePath({ path: target });
+  if (result.ok) return null;
+  return result.body || result.statusText || "无法打开文件夹";
 }
 
 export function BackupRoute() {
@@ -51,7 +65,12 @@ export function BackupRoute() {
         return;
       }
       if (!result.ok) throw new Error(result.error || "导出备份失败");
-      setMessage(`已导出当前档案 ${result.profileName ?? ""} 的备份压缩包。`);
+      const openError = await openBackupDirectory(result.backupPath);
+      setMessage(
+        openError
+          ? `已导出当前档案 ${result.profileName ?? ""} 的备份压缩包，但自动打开文件夹失败：${openError}`
+          : `已导出当前档案 ${result.profileName ?? ""} 的备份压缩包，并已打开所在文件夹。`,
+      );
     } catch (err) {
       setError(err instanceof Error ? err.message : "导出备份失败");
     } finally {
@@ -169,11 +188,11 @@ export function BackupRoute() {
             <button
               type="button"
               className={settings.btn}
-              onClick={() => openBackupPath(lastExport.backupPath)}
+              onClick={() => void openBackupDirectory(lastExport.backupPath)}
               disabled={!lastExport.backupPath || !window.hermesDesktop?.openWorkspacePath}
             >
               <FolderOpen size={13} />
-              在文件管理器中打开
+              打开所在文件夹
             </button>
           </div>
         </section>


### PR DESCRIPTION
导出当前档案备份成功后，前端会自动打开备份 zip 所在文件夹，手动入口也改为打开所在文件夹而不是直接打开 zip。\n\n验证：\n- pnpm --filter @hermes/web typecheck\n- pnpm --filter @hermes/web test:unit