### PR TITLE
[codex] 修复历史会话统计显示

### DIFF
--- a/web/src/components/chat/message-adapter.test.ts
+++ b/web/src/components/chat/message-adapter.test.ts
@@ -6,6 +6,7 @@ import {
   type SessionMessage,
 } from "@hermes/protocol";
 import {
+  attachTurnStatsMetadata,
   deriveAssistantStats,
   hermesUIMessageToChatMessage,
   hermesUIMessagesToChatMessages,
@@ -534,6 +535,69 @@ describe("message adapter", () => {
 
     expect(merged).toHaveLength(1);
     expect(merged[0]?.id).toBe("live-assistant-10");
+  });
+
+  it("keeps persisted stats when a matching live message has no metadata", () => {
+    const stored = [
+      uiMessage({
+        id: "stored-assistant-10",
+        parts: [{ type: "text", text: "完成" }],
+        metadata: {
+          usage: { tokensInput: 10, tokensOutput: 20, tokensTotal: 30 },
+          timing: { startedAt: 1_000, firstTokenAt: 1_250, completedAt: 2_000 },
+          model: "deepseek-v4-flash",
+        },
+      }),
+    ];
+    const live = [
+      uiMessage({
+        id: "live-assistant-10",
+        parts: [{ type: "text", text: "完成" }],
+      }),
+    ];
+
+    const merged = mergeHermesUIMessages(stored, live);
+    const chat = hermesUIMessagesToChatMessages(merged);
+
+    expect(merged).toHaveLength(1);
+    expect(merged[0]?.id).toBe("live-assistant-10");
+    expect(chat[0]?.stats).toMatchObject({
+      ttftMs: 250,
+      durationMs: 1_000,
+      tokensTotal: 30,
+      model: "deepseek-v4-flash",
+    });
+  });
+
+  it("enriches stored messages from turn stats metadata and scalar columns", () => {
+    const messages = [
+      uiMessage({
+        id: "stored-assistant-20",
+        parts: [{ type: "text", text: "完成" }],
+        metadata: { finishReason: "stop" },
+      }),
+    ];
+
+    const enriched = attachTurnStatsMetadata(messages, [
+      {
+        id: "stat-1",
+        sessionId: "s1",
+        turnIndex: 1,
+        metadata: { usage: { tokensTotal: 30 } },
+        model: "deepseek-v4-flash",
+        ttftMs: 250,
+        durationMs: 1_000,
+      },
+    ]);
+    const chat = hermesUIMessagesToChatMessages(enriched);
+
+    expect(chat[0]?.stats).toMatchObject({
+      ttftMs: 250,
+      durationMs: 1_000,
+      tokensTotal: 30,
+      model: "deepseek-v4-flash",
+      finishReason: "stop",
+    });
   });
 
   it("prefers stored complete assistant over a stale streaming partial", () => {

--- a/web/src/components/chat/message-adapter.ts
+++ b/web/src/components/chat/message-adapter.ts
@@ -378,11 +378,9 @@ function mergeAssistantMessages(current: HermesUIMessage, incoming: HermesUIMess
     ...current,
     status: current.status === "error" || incoming.status === "error" ? "error" : current.status,
     parts: mergeParts(current.parts, incoming.parts),
-    metadata: {
-      ...current.metadata,
-      ...incoming.metadata,
+    metadata: mergeMessageMetadata(current.metadata, incoming.metadata, {
       persistedId: current.metadata?.persistedId ?? incoming.metadata?.persistedId,
-    },
+    }),
   };
 }
 
@@ -556,8 +554,7 @@ function statsHashFromMessage(message: HermesUIMessage): string | undefined {
 }
 
 function metadataFromTurnStats(stat: UiTurnStats): HermesMessageMetadata | undefined {
-  if (stat.metadata) return stat.metadata;
-  const metadata: HermesMessageMetadata = {};
+  const metadata: HermesMessageMetadata = { ...(stat.metadata ?? {}) };
   const usage: NonNullable<HermesMessageMetadata["usage"]> = {};
   const timing: NonNullable<HermesMessageMetadata["timing"]> = {};
 
@@ -576,13 +573,43 @@ function metadataFromTurnStats(stat: UiTurnStats): HermesMessageMetadata | undef
   if (typeof stat.ttftMs === "number") timing.ttftMs = stat.ttftMs;
   if (typeof stat.durationMs === "number") timing.durationMs = stat.durationMs;
 
-  if (Object.keys(usage).length > 0) metadata.usage = usage;
-  if (Object.keys(timing).length > 0) metadata.timing = timing;
-  if (stat.model) metadata.model = stat.model;
-  if (stat.finishReason) metadata.finishReason = stat.finishReason;
-  if (typeof stat.costUsd === "number") metadata.costUsd = stat.costUsd;
-  if (stat.costStatus) metadata.costStatus = stat.costStatus;
+  if (Object.keys(usage).length > 0) {
+    metadata.usage = { ...metadata.usage, ...usage };
+  }
+  if (Object.keys(timing).length > 0) {
+    metadata.timing = { ...metadata.timing, ...timing };
+  }
+  if (!metadata.model && stat.model) metadata.model = stat.model;
+  if (!metadata.finishReason && stat.finishReason) metadata.finishReason = stat.finishReason;
+  if (metadata.costUsd === undefined && typeof stat.costUsd === "number") metadata.costUsd = stat.costUsd;
+  if (!metadata.costStatus && stat.costStatus) metadata.costStatus = stat.costStatus;
 
+  return Object.keys(metadata).length > 0 ? metadata : undefined;
+}
+
+function mergeMessageMetadata(
+  base: HermesMessageMetadata | undefined,
+  override: HermesMessageMetadata | undefined,
+  forced?: Partial<HermesMessageMetadata>,
+): HermesMessageMetadata | undefined {
+  if (!base && !override && !forced) return undefined;
+  const metadata: HermesMessageMetadata = {
+    ...(base ?? {}),
+    ...(override ?? {}),
+    ...(forced ?? {}),
+  };
+  if (base?.usage || override?.usage) {
+    metadata.usage = {
+      ...(base?.usage ?? {}),
+      ...(override?.usage ?? {}),
+    };
+  }
+  if (base?.timing || override?.timing) {
+    metadata.timing = {
+      ...(base?.timing ?? {}),
+      ...(override?.timing ?? {}),
+    };
+  }
   return Object.keys(metadata).length > 0 ? metadata : undefined;
 }
 
@@ -612,11 +639,9 @@ export function attachTurnStatsMetadata(
     used.add(statIndex);
     return {
       ...message,
-      metadata: {
-        ...message.metadata,
-        ...metadata,
+      metadata: mergeMessageMetadata(message.metadata, metadata, {
         persistedId: message.metadata?.persistedId ?? metadata.persistedId,
-      },
+      }),
     };
   });
 }
@@ -847,17 +872,31 @@ function consolidateAssistantMessages(messages: HermesUIMessage[]): HermesUIMess
         ...last,
         status: msg.status === "error" || last.status === "error" ? "error" : msg.status,
         parts: mergeParts(last.parts, msg.parts),
-        metadata: {
-          ...last.metadata,
-          ...msg.metadata,
+        metadata: mergeMessageMetadata(last.metadata, msg.metadata, {
           persistedId: last.metadata?.persistedId ?? msg.metadata?.persistedId,
-        },
+        }),
       };
     } else {
       result.push(msg);
     }
   }
   return result;
+}
+
+function mergeMatchedMessage(storedMessage: HermesUIMessage, liveMessage: HermesUIMessage): HermesUIMessage {
+  const liveWins = !(
+    storedMessage.role === "assistant" &&
+    storedMessage.status === "complete" &&
+    liveMessage.status === "streaming"
+  );
+  const selected = liveWins ? liveMessage : storedMessage;
+  const fallback = liveWins ? storedMessage : liveMessage;
+  return {
+    ...selected,
+    metadata: mergeMessageMetadata(fallback.metadata, selected.metadata, {
+      persistedId: selected.metadata?.persistedId ?? fallback.metadata?.persistedId,
+    }),
+  };
 }
 
 export function mergeHermesUIMessages(
@@ -885,13 +924,7 @@ export function mergeHermesUIMessages(
 
     usedLiveIndexes.add(liveIndex);
     const liveMessage = consolidatedLive[liveIndex]!;
-    merged.push(
-      storedMessage.role === "assistant" &&
-        storedMessage.status === "complete" &&
-        liveMessage.status === "streaming"
-        ? storedMessage
-        : liveMessage,
-    );
+    merged.push(mergeMatchedMessage(storedMessage, liveMessage));
   }
 
   consolidatedLive.forEach((liveMessage, index) => {

--- a/web/src/routes/detail.tsx
+++ b/web/src/routes/detail.tsx
@@ -20,6 +20,7 @@ import { prepareComposerPrompt } from "@/lib/composer-prompt";
 import { formatElapsedTimer } from "@/lib/format";
 import { getGatewayClient } from "@/lib/gateway-client";
 import { getUiTurnStats, type UiTurnStats } from "@/lib/ui-store";
+import { resolveSessionIdAliases } from "@/lib/session-map";
 import {
   buildComposerContextUsage,
   estimateRenderedContextTokens,
@@ -187,8 +188,16 @@ export function DetailRoute() {
     let cancelled = false;
     setTurnStats([]);
     if (!taskId) return;
-    void getUiTurnStats(taskId).then((stats) => {
-      if (!cancelled) setTurnStats(stats);
+    const aliases = resolveSessionIdAliases(taskId, { includeExpired: true });
+    void Promise.all(aliases.map((id) => getUiTurnStats(id))).then((results) => {
+      if (cancelled) return;
+      const deduped = new Map<string, UiTurnStats>();
+      results.flat().forEach((stat) => deduped.set(stat.id, stat));
+      setTurnStats(Array.from(deduped.values()).sort((a, b) =>
+        (a.completedAt ?? a.createdAt ?? 0) - (b.completedAt ?? b.createdAt ?? 0) ||
+        (a.createdAt ?? 0) - (b.createdAt ?? 0) ||
+        a.id.localeCompare(b.id)
+      ));
     });
     return () => {
       cancelled = true;


### PR DESCRIPTION
## 变更内容

修复历史会话详情页里高级统计数据不显示的问题，重点保留 TTFT、耗时、token 用量和模型信息。

## 根因

历史消息从本地 UI store 读到了 turn stats，但详情页合并 stored message 和 live/runtime message 时会让匹配到的 live message 覆盖 stored message；当 live message 没有 metadata 时，已经附加到 stored message 上的 `usage` / `timing` 被一起丢掉。

## 实现

- 合并消息时深度合并 `metadata.usage` 和 `metadata.timing`，避免统计字段被覆盖。
- 读取 turn stats 时同时查询 session alias，兼容 persistent id 与 gateway id 不一致的历史会话。
- 增加回归测试覆盖 stored 有统计、live 无 metadata，以及 turn stats 标量列补齐 metadata 的场景。

## 验证

- `pnpm typecheck`
- `pnpm test:unit`
- `cargo check`