### PR TITLE
[codex] 修复长会话历史首屏白屏

### DIFF
--- a/web/src/components/chat/message-timeline.tsx
+++ b/web/src/components/chat/message-timeline.tsx
@@ -1,4 +1,4 @@
-import { useEffect, useMemo, useRef, useState } from "react";
+import { useCallback, useEffect, useLayoutEffect, useMemo, useRef, useState } from "react";
 import type { ReactNode } from "react";
 import { useAtomValue } from "jotai";
 import { AlertTriangle, ChevronRight, Info } from "lucide-react";
@@ -18,6 +18,8 @@ import {
   formatTokens,
 } from "@/lib/format";
 import type { SessionUsageResult } from "@hermes/protocol";
+
+const useIsomorphicLayoutEffect = typeof window === "undefined" ? useEffect : useLayoutEffect;
 
 interface MessageTimelineProps {
   messages: ChatMessage[];
@@ -651,8 +653,12 @@ export function MessageTimeline({
   progressModel,
 }: MessageTimelineProps) {
   const containerRef = useRef<HTMLDivElement>(null);
+  const messagesRef = useRef<HTMLDivElement>(null);
   const nearBottomRef = useRef(true);
+  const autoAnchorRef = useRef(false);
+  const autoAnchorTimerRef = useRef<number | null>(null);
   const messageCountRef = useRef(0);
+  const firstMessageIdRef = useRef<string | undefined>(undefined);
   const visibleMessages = useMemo(
     () =>
       messages.filter(
@@ -666,20 +672,98 @@ export function MessageTimeline({
     [messages],
   );
 
-  useEffect(() => {
-    const previousMessageCount = messageCountRef.current;
-    messageCountRef.current = visibleMessages.length;
+  const scrollToBottom = useCallback((behavior: ScrollBehavior = "auto") => {
     const container = containerRef.current;
-    if (!container || !nearBottomRef.current) return;
+    if (!container) return;
     container.scrollTo({
       top: container.scrollHeight,
-      behavior: previousMessageCount === visibleMessages.length ? "auto" : "smooth",
+      behavior,
     });
-  }, [visibleMessages, statusMessage, pendingApproval]);
+  }, []);
+
+  useIsomorphicLayoutEffect(() => {
+    const previousMessageCount = messageCountRef.current;
+    const previousFirstMessageId = firstMessageIdRef.current;
+    const nextFirstMessageId = visibleMessages[0]?.id;
+    const sessionChanged =
+      previousFirstMessageId !== undefined &&
+      nextFirstMessageId !== undefined &&
+      previousFirstMessageId !== nextFirstMessageId;
+
+    messageCountRef.current = visibleMessages.length;
+    firstMessageIdRef.current = nextFirstMessageId;
+
+    if (visibleMessages.length === 0) {
+      nearBottomRef.current = true;
+      return;
+    }
+
+    if (sessionChanged) {
+      nearBottomRef.current = true;
+    }
+
+    const container = containerRef.current;
+    if (!container || !nearBottomRef.current) return;
+    const initialHistoryRender = previousMessageCount === 0 || sessionChanged;
+    scrollToBottom(initialHistoryRender ? "auto" : "smooth");
+
+    // 长会话里 Markdown、表格、代码块等内容会在本次提交后继续改变实际高度。
+    // 初次进入历史会话时不要依赖一次平滑滚动，否则 WebKit/Tauri 里可能先滚到
+    // 一个尚未稳定的中间位置，用户看到空白，手动滚动后才触发重绘。
+    if (initialHistoryRender) {
+      autoAnchorRef.current = true;
+      if (autoAnchorTimerRef.current !== null) {
+        window.clearTimeout(autoAnchorTimerRef.current);
+      }
+      window.requestAnimationFrame(() => {
+        scrollToBottom("auto");
+        window.requestAnimationFrame(() => scrollToBottom("auto"));
+      });
+      autoAnchorTimerRef.current = window.setTimeout(() => {
+        scrollToBottom("auto");
+        nearBottomRef.current = true;
+        autoAnchorRef.current = false;
+        autoAnchorTimerRef.current = null;
+      }, 650);
+    }
+  }, [pendingApproval, scrollToBottom, statusMessage, visibleMessages]);
+
+  useEffect(() => {
+    const container = containerRef.current;
+    const messagesElement = messagesRef.current;
+    if (!container || !messagesElement || typeof ResizeObserver === "undefined") return;
+
+    let frame = 0;
+    const anchorToBottom = () => {
+      if (!nearBottomRef.current && !autoAnchorRef.current) return;
+      container.scrollTop = container.scrollHeight;
+    };
+    const observer = new ResizeObserver(() => {
+      window.cancelAnimationFrame(frame);
+      frame = window.requestAnimationFrame(anchorToBottom);
+    });
+    observer.observe(messagesElement);
+    return () => {
+      window.cancelAnimationFrame(frame);
+      observer.disconnect();
+    };
+  }, []);
+
+  useEffect(() => {
+    return () => {
+      if (autoAnchorTimerRef.current !== null) {
+        window.clearTimeout(autoAnchorTimerRef.current);
+      }
+    };
+  }, []);
 
   const handleScroll = () => {
     const container = containerRef.current;
     if (!container) return;
+    if (autoAnchorRef.current) {
+      nearBottomRef.current = true;
+      return;
+    }
     nearBottomRef.current =
       container.scrollHeight - container.scrollTop - container.clientHeight < 120;
   };
@@ -692,7 +776,7 @@ export function MessageTimeline({
       role="log"
       aria-live="polite"
     >
-      <div className={s.messages}>
+      <div ref={messagesRef} className={s.messages}>
         {loading ? <div className={s.empty}>加载对话中...</div> : null}
         {!loading && visibleMessages.length === 0 && !statusMessage && !pendingApproval ? (
           <div className={s.empty}>


### PR DESCRIPTION
## 变更内容

修复长会话从对话历史进入详情页时首屏可能出现空白的问题。

## 根因

目标会话的数据接口返回很快，问题不是加载慢，而是历史消息首次渲染时内容高度尚未稳定就执行了自动滚动。Markdown、表格和代码块后续继续撑高布局后，滚动位置没有继续锚定到底部，在 Tauri/WebKit 下容易表现为空白，需要用户手动滚动后才恢复。

## 修复方式

在 `MessageTimeline` 初次渲染历史消息时使用同步布局滚动，并在短时间内保持底部锚定；同时用 `ResizeObserver` 监听消息容器高度变化，确保后续内容撑高时继续贴底。用户主动离开底部后仍保持原有行为，不会强行抢滚动。

## 验证

- `pnpm typecheck`
- `pnpm test:unit`
- `cargo check`
- 使用临时 Vite 页面验证 `20260606_153413_ae4de4` 进入详情页后能自动稳定到底部，不再停在中间或空白。
