### PR TITLE
[codex] 优化对话入口与轮次定位

### DIFF
--- a/web/src/components/app-shell/workbench-sidebar.tsx
+++ b/web/src/components/app-shell/workbench-sidebar.tsx
@@ -136,7 +136,7 @@ export function WorkbenchSidebar() {
       <button type="button" className={s.newTask} onClick={() => navigate("/")}>
         <span className={s.newTaskLead}>
           <Plus size={14} strokeWidth={2.2} />
-          <span>新建任务</span>
+          <span>新建对话</span>
         </span>
         <span className={s.newTaskKbd}>⌘ N</span>
       </button>
@@ -175,7 +175,7 @@ export function WorkbenchSidebar() {
             <span className={s.sideItemIcon}>
               <Folder size={14} />
             </span>
-            <span className={s.sideItemLabel}>项目列表</span>
+            <span className={s.sideItemLabel}>工作空间</span>
           </button>
         </section>
 

--- a/web/src/components/chat/message-timeline.module.css
+++ b/web/src/components/chat/message-timeline.module.css
@@ -2,11 +2,70 @@
   flex: 1;
   min-height: 0;
   overflow-y: auto;
+  position: relative;
   /* Reserve gutter on BOTH sides so the messages column stays centered to
      the same axis as the composer below — otherwise the right-side
      scrollbar shifts the centered child left by half its width and
      visually misaligns from the (scrollbar-less) composer container. */
   scrollbar-gutter: stable both-edges;
+}
+
+.turnRailWrap {
+  position: sticky;
+  top: 50%;
+  z-index: 5;
+  width: 100%;
+  height: 0;
+  pointer-events: none;
+}
+
+.turnRail {
+  position: absolute;
+  right: max(12px, calc((100% - 780px) / 2 - 30px));
+  display: flex;
+  flex-direction: column;
+  align-items: center;
+  gap: 8px;
+  transform: translateY(-50%);
+  border: 1px solid transparent;
+  border-radius: var(--h-r-pill);
+  background: color-mix(in srgb, var(--h-bg-pane) 72%, transparent);
+  padding: 7px 5px;
+  opacity: 0.72;
+  pointer-events: auto;
+  transition: opacity 0.14s ease, background-color 0.14s ease, border-color 0.14s ease;
+}
+
+.turnRail:hover {
+  border-color: var(--h-line-soft);
+  background: color-mix(in srgb, var(--h-bg-pane) 92%, transparent);
+  opacity: 1;
+}
+
+.turnDot {
+  width: 8px;
+  height: 8px;
+  border: 1px solid color-mix(in srgb, var(--h-text-3) 55%, transparent);
+  border-radius: var(--h-r-pill);
+  background: var(--h-text-3);
+  padding: 0;
+  cursor: pointer;
+  opacity: 0.46;
+  transition: width 0.14s ease, height 0.14s ease, opacity 0.14s ease, background-color 0.14s ease, transform 0.14s ease;
+}
+
+.turnDot:hover {
+  background: var(--h-text-2);
+  opacity: 0.86;
+  transform: scale(1.16);
+}
+
+.turnDot[data-active="true"] {
+  width: 8px;
+  height: 18px;
+  border-color: var(--h-accent);
+  background: var(--h-accent);
+  opacity: 1;
 }
 
 .messages {

--- a/web/src/components/chat/message-timeline.test.tsx
+++ b/web/src/components/chat/message-timeline.test.tsx
@@ -86,4 +86,34 @@ describe("MessageTimeline", () => {
     expect(html).toContain("chart.png");
     expect(html).toContain("/Users/enzo/Downloads/chart.png");
   });
+
+  it("shows turn navigation for multi-turn conversations", () => {
+    const messages: ChatMessage[] = [
+      { id: "user-1", role: "user", createdAt: 1, text: "第一轮问题" },
+      { id: "assistant-1", role: "assistant", createdAt: 2, text: "第一轮回答" },
+      { id: "user-2", role: "user", createdAt: 3, text: "第二轮追问" },
+      { id: "assistant-2", role: "assistant", createdAt: 4, text: "第二轮回答" },
+    ];
+
+    const html = ReactDOMServer.renderToStaticMarkup(
+      <MessageTimeline messages={messages} />,
+    );
+
+    expect(html).toContain("aria-label=\"对话轮次定位\"");
+    expect(html).toContain("aria-label=\"定位到第 1 轮对话\"");
+    expect(html).toContain("aria-label=\"定位到第 2 轮对话\"");
+  });
+
+  it("does not show turn navigation for a single user turn", () => {
+    const messages: ChatMessage[] = [
+      { id: "user-1", role: "user", createdAt: 1, text: "只有一轮" },
+      { id: "assistant-1", role: "assistant", createdAt: 2, text: "回答" },
+    ];
+
+    const html = ReactDOMServer.renderToStaticMarkup(
+      <MessageTimeline messages={messages} />,
+    );
+
+    expect(html).not.toContain("对话轮次定位");
+  });
 });

--- a/web/src/components/chat/message-timeline.tsx
+++ b/web/src/components/chat/message-timeline.tsx
@@ -31,6 +31,12 @@ interface MessageTimelineProps {
   progressModel?: string;
 }
 
+interface TurnAnchor {
+  id: string;
+  index: number;
+  title: string;
+}
+
 function formatDay(timestamp: number): string {
   const date = new Date(timestamp);
   const now = new Date();
@@ -51,6 +57,13 @@ function formatTime(timestamp: number): string {
     hour: "2-digit",
     minute: "2-digit",
   });
+}
+
+function turnAnchorTitle(message: ChatMessage, index: number): string {
+  const preview = getCopyableText(message)?.replace(/\s+/g, " ").trim();
+  return preview
+    ? `第 ${index + 1} 轮：${truncateMiddle(preview, 34)}`
+    : `第 ${index + 1} 轮`;
 }
 
 const PROGRESS_TRANSLATIONS: Record<string, string> = {
@@ -654,11 +667,13 @@ export function MessageTimeline({
 }: MessageTimelineProps) {
   const containerRef = useRef<HTMLDivElement>(null);
   const messagesRef = useRef<HTMLDivElement>(null);
+  const turnAnchorRefs = useRef<Map<string, HTMLDivElement>>(new Map());
   const nearBottomRef = useRef(true);
   const autoAnchorRef = useRef(false);
   const autoAnchorTimerRef = useRef<number | null>(null);
   const messageCountRef = useRef(0);
   const firstMessageIdRef = useRef<string | undefined>(undefined);
+  const [activeTurnId, setActiveTurnId] = useState<string | null>(null);
   const visibleMessages = useMemo(
     () =>
       messages.filter(
@@ -671,6 +686,70 @@ export function MessageTimeline({
       ),
     [messages],
   );
+  const turnAnchors = useMemo<TurnAnchor[]>(() => {
+    const anchors: TurnAnchor[] = [];
+    for (const message of visibleMessages) {
+      if (message.role !== "user") continue;
+      const index = anchors.length;
+      anchors.push({
+        id: message.id,
+        index,
+        title: turnAnchorTitle(message, index),
+      });
+    }
+    return anchors;
+  }, [visibleMessages]);
+  const showTurnRail = turnAnchors.length > 1;
+
+  const setTurnAnchorNode = useCallback((id: string, node: HTMLDivElement | null) => {
+    if (node) {
+      turnAnchorRefs.current.set(id, node);
+    } else {
+      turnAnchorRefs.current.delete(id);
+    }
+  }, []);
+
+  const updateActiveTurnFromScroll = useCallback(() => {
+    const container = containerRef.current;
+    if (!container || turnAnchors.length < 2) return;
+
+    const containerRect = container.getBoundingClientRect();
+    const thresholdY = containerRect.top + Math.min(container.clientHeight * 0.35, 180);
+    let currentId = turnAnchors[0]?.id ?? null;
+
+    for (const turn of turnAnchors) {
+      const node = turnAnchorRefs.current.get(turn.id);
+      if (!node) continue;
+      if (node.getBoundingClientRect().top <= thresholdY) {
+        currentId = turn.id;
+      } else {
+        break;
+      }
+    }
+
+    if (currentId) {
+      setActiveTurnId((previous) => previous === currentId ? previous : currentId);
+    }
+  }, [turnAnchors]);
+
+  const scrollToTurn = useCallback((id: string) => {
+    const container = containerRef.current;
+    const node = turnAnchorRefs.current.get(id);
+    if (!container || !node) return;
+
+    if (autoAnchorTimerRef.current !== null) {
+      window.clearTimeout(autoAnchorTimerRef.current);
+      autoAnchorTimerRef.current = null;
+    }
+    autoAnchorRef.current = false;
+
+    const containerRect = container.getBoundingClientRect();
+    const nodeRect = node.getBoundingClientRect();
+    const top = container.scrollTop + nodeRect.top - containerRect.top - 12;
+    nearBottomRef.current = container.scrollHeight - top - container.clientHeight < 120;
+    container.scrollTo({ top, behavior: "smooth" });
+    setActiveTurnId(id);
+  }, []);
 
   const scrollToBottom = useCallback((behavior: ScrollBehavior = "auto") => {
     const container = containerRef.current;
@@ -680,6 +759,26 @@ export function MessageTimeline({
       behavior,
     });
   }, []);
+
+  useEffect(() => {
+    const knownIds = new Set(turnAnchors.map((turn) => turn.id));
+    for (const id of Array.from(turnAnchorRefs.current.keys())) {
+      if (!knownIds.has(id)) turnAnchorRefs.current.delete(id);
+    }
+  }, [turnAnchors]);
+
+  useEffect(() => {
+    if (turnAnchors.length < 2) {
+      setActiveTurnId((previous) => previous === null ? previous : null);
+      return;
+    }
+
+    const hasActive = activeTurnId != null && turnAnchors.some((turn) => turn.id === activeTurnId);
+    if (hasActive && !nearBottomRef.current) return;
+
+    const lastId = turnAnchors[turnAnchors.length - 1]?.id ?? null;
+    setActiveTurnId((previous) => previous === lastId ? previous : lastId);
+  }, [activeTurnId, turnAnchors]);
 
   useIsomorphicLayoutEffect(() => {
     const previousMessageCount = messageCountRef.current;
@@ -766,6 +865,7 @@ export function MessageTimeline({
     }
     nearBottomRef.current =
       container.scrollHeight - container.scrollTop - container.clientHeight < 120;
+    updateActiveTurnFromScroll();
   };
 
   return (
@@ -776,6 +876,27 @@ export function MessageTimeline({
       role="log"
       aria-live="polite"
     >
+      {showTurnRail ? (
+        <div className={s.turnRailWrap}>
+          <nav className={s.turnRail} aria-label="对话轮次定位">
+            {turnAnchors.map((turn) => {
+              const active = turn.id === activeTurnId;
+              return (
+                <button
+                  key={turn.id}
+                  type="button"
+                  className={s.turnDot}
+                  data-active={active ? "true" : undefined}
+                  aria-current={active ? "step" : undefined}
+                  aria-label={`定位到第 ${turn.index + 1} 轮对话`}
+                  title={turn.title}
+                  onClick={() => scrollToTurn(turn.id)}
+                />
+              );
+            })}
+          </nav>
+        </div>
+      ) : null}
       <div ref={messagesRef} className={s.messages}>
         {loading ? <div className={s.empty}>加载对话中...</div> : null}
         {!loading && visibleMessages.length === 0 && !statusMessage && !pendingApproval ? (
@@ -790,7 +911,11 @@ export function MessageTimeline({
           const showDate = !previous || formatDay(previous.createdAt) !== formatDay(message.createdAt);
           const isLast = index === visibleMessages.length - 1;
           return (
-            <div key={message.id}>
+            <div
+              key={message.id}
+              ref={message.role === "user" ? (node) => setTurnAnchorNode(message.id, node) : undefined}
+              data-turn-anchor={message.role === "user" ? "true" : undefined}
+            >
               {showDate ? <div className={s.dateSeparator}>{formatDay(message.createdAt)}</div> : null}
               <MessageBubble
                 message={message}


### PR DESCRIPTION
## 变更内容

- 将侧边栏「新建任务」改为「新建对话」，将「项目列表」改为「工作空间」。
- 在多轮对话详情页右侧增加轮次定位点，支持快速跳转到对应用户发起的对话轮次，并随滚动高亮当前轮次。
- 为轮次定位补充单元测试，覆盖多轮显示与单轮隐藏。

## 影响

这次改动优化了桌面端对话入口文案，并提升长对话中的浏览和定位效率；不涉及后端接口或数据结构变更。

## 验证

- `pnpm typecheck`
- `pnpm test:unit`
- `cargo check`
