### PR TITLE
[codex] 增加底部网关重启入口

### DIFF
--- a/src/commands/im_onboarding.rs
+++ b/src/commands/im_onboarding.rs
@@ -35,6 +35,7 @@ const WEIXIN_BASE_URL: &str = "https://ilinkai.weixin.qq.com";
 const WEIXIN_CDN_BASE_URL: &str = "https://novac2c.cdn.weixin.qq.com/c2c";
 const WEIXIN_CLIENT_VERSION: &str = "131584";
 const WEIXIN_QR_REFRESH_LIMIT: u8 = 3;
+const FEISHU_SCANNED_OPEN_ID_TOKEN: &str = "__HERMES_SCANNED_FEISHU_OPEN_ID__";
 
 const FEISHU_SECRET_KEYS: &[&str] = &[
     "FEISHU_APP_SECRET",
@@ -548,6 +549,45 @@ fn configured_for(
         }
     }
     result
+}
+
+fn resolve_feishu_scanned_open_id_token(
+    raw: &str,
+    scanned_open_id: Option<&str>,
+    key: &str,
+) -> Result<String, AppError> {
+    let trimmed = raw.trim();
+    if trimmed != FEISHU_SCANNED_OPEN_ID_TOKEN {
+        return Ok(trimmed.to_string());
+    }
+    scanned_open_id
+        .map(str::trim)
+        .filter(|value| !value.is_empty())
+        .map(str::to_string)
+        .ok_or_else(|| {
+            AppError::InvalidRequest(format!(
+                "Scanned Feishu open_id is not available; enter {key} manually"
+            ))
+        })
+}
+
+fn normalize_feishu_allowed_users(
+    raw: &str,
+    scanned_open_id: Option<&str>,
+) -> Result<String, AppError> {
+    let mut result: Vec<String> = Vec::new();
+    for item in raw
+        .split([',', '，', '\n', '\r', '\t', ' '])
+        .map(str::trim)
+        .filter(|value| !value.is_empty())
+    {
+        let resolved =
+            resolve_feishu_scanned_open_id_token(item, scanned_open_id, "FEISHU_ALLOWED_USERS")?;
+        if !result.iter().any(|existing| existing == &resolved) {
+            result.push(resolved);
+        }
+    }
+    Ok(result.join(","))
 }
 
 async fn feishu_registration_post(domain: &str, body: &[(&str, &str)]) -> Result<Value, AppError> {
@@ -1095,6 +1135,7 @@ fn apply_patch_from_input(
     let mut patch = input.settings.clone();
     match input.platform {
         ImPlatform::Feishu => {
+            let mut scanned_open_id: Option<String> = None;
             let credential = if let Some(flow_id) = &input.flow_id {
                 let flows = FLOWS.lock()?;
                 match flows.get(flow_id) {
@@ -1105,6 +1146,7 @@ fn apply_patch_from_input(
                 None
             };
             if let Some(credential) = credential {
+                scanned_open_id = credential.open_id.clone();
                 patch.insert("FEISHU_APP_ID".to_string(), credential.app_id);
                 patch.insert("FEISHU_APP_SECRET".to_string(), credential.app_secret);
                 patch.insert("FEISHU_DOMAIN".to_string(), credential.domain);
@@ -1122,6 +1164,22 @@ fn apply_patch_from_input(
             patch
                 .entry("FEISHU_CONNECTION_MODE".to_string())
                 .or_insert_with(|| "websocket".to_string());
+            if let Some(allowed_users) = patch.get("FEISHU_ALLOWED_USERS").cloned() {
+                patch.insert(
+                    "FEISHU_ALLOWED_USERS".to_string(),
+                    normalize_feishu_allowed_users(&allowed_users, scanned_open_id.as_deref())?,
+                );
+            }
+            if let Some(home_channel) = patch.get("FEISHU_HOME_CHANNEL").cloned() {
+                patch.insert(
+                    "FEISHU_HOME_CHANNEL".to_string(),
+                    resolve_feishu_scanned_open_id_token(
+                        &home_channel,
+                        scanned_open_id.as_deref(),
+                        "FEISHU_HOME_CHANNEL",
+                    )?,
+                );
+            }
         }
         ImPlatform::Weixin => {
             let credential = if let Some(flow_id) = &input.flow_id {
@@ -1628,6 +1686,63 @@ mod tests {
         };
         let err = apply_patch_from_input(&input).unwrap_err();
         assert!(err.to_string().contains("WEIXIN_ACCOUNT_ID"));
+    }
+
+    #[test]
+    fn feishu_apply_expands_scanned_open_id_tokens() {
+        let flow_id = "feishu-test-allowlist-token".to_string();
+        {
+            let mut flows = FLOWS.lock().unwrap();
+            flows.insert(
+                flow_id.clone(),
+                FlowState::Feishu(FeishuFlow {
+                    device_code: "device-test".to_string(),
+                    domain: "feishu".to_string(),
+                    interval_seconds: 5,
+                    expires_at: Instant::now() + Duration::from_secs(60),
+                    expires_at_ms: now_ms() + 60_000,
+                    credential: Some(FeishuCredential {
+                        app_id: "cli_test".to_string(),
+                        app_secret: "secret-test".to_string(),
+                        domain: "feishu".to_string(),
+                        open_id: Some("ou_scanner_123456".to_string()),
+                        bot_name: None,
+                        bot_open_id: None,
+                    }),
+                }),
+            );
+        }
+        let input = ImOnboardingApplyInput {
+            platform: ImPlatform::Feishu,
+            flow_id: Some(flow_id.clone()),
+            manual_credentials: None,
+            settings: BTreeMap::from([
+                ("FEISHU_ALLOW_ALL_USERS".to_string(), "false".to_string()),
+                (
+                    "FEISHU_ALLOWED_USERS".to_string(),
+                    format!(
+                        "{FEISHU_SCANNED_OPEN_ID_TOKEN}, ou_extra_1, {FEISHU_SCANNED_OPEN_ID_TOKEN}"
+                    ),
+                ),
+                (
+                    "FEISHU_HOME_CHANNEL".to_string(),
+                    FEISHU_SCANNED_OPEN_ID_TOKEN.to_string(),
+                ),
+            ]),
+            restart_gateway: Some(false),
+        };
+
+        let patch = apply_patch_from_input(&input).unwrap();
+
+        assert_eq!(
+            patch.get("FEISHU_ALLOWED_USERS").map(String::as_str),
+            Some("ou_scanner_123456,ou_extra_1")
+        );
+        assert_eq!(
+            patch.get("FEISHU_HOME_CHANNEL").map(String::as_str),
+            Some("ou_scanner_123456")
+        );
+        FLOWS.lock().unwrap().remove(&flow_id);
     }
 
     #[test]

--- a/web/src/components/app-shell/app-status-bar.module.css
+++ b/web/src/components/app-shell/app-status-bar.module.css
@@ -22,6 +22,12 @@
   line-height: 1;
 }
 
+.gatewayGroup {
+  display: inline-flex;
+  align-items: center;
+  gap: 8px;
+}
+
 .gatewayButton {
   appearance: none;
   border: 0;
@@ -43,6 +49,61 @@
   outline: 1px solid var(--h-accent-border);
   outline-offset: 3px;
   border-radius: var(--h-r-xs);
+}
+
+.restartButton {
+  appearance: none;
+  border: 1px solid var(--h-line);
+  border-radius: var(--h-r-xs);
+  min-height: 18px;
+  padding: 0 6px;
+  display: inline-flex;
+  align-items: center;
+  gap: 4px;
+  color: var(--h-text-2);
+  background: var(--h-bg-soft);
+  font: inherit;
+  font-size: 9.5px;
+  line-height: 1;
+  cursor: pointer;
+}
+
+.restartButton:hover:not(:disabled),
+.restartButton:focus-visible {
+  color: var(--h-accent);
+  border-color: var(--h-accent-border);
+  background: var(--h-bg-chip);
+}
+
+.restartButton:focus-visible {
+  outline: 1px solid var(--h-accent-border);
+  outline-offset: 2px;
+}
+
+.restartButton:disabled {
+  cursor: not-allowed;
+  opacity: 0.56;
+}
+
+.restartButton[data-state="starting"] svg,
+.restartButton[data-state="running"] svg {
+  animation: gateway-restart-spin 0.9s linear infinite;
+}
+
+.restartButton[data-state="success"] {
+  color: var(--moss);
+  border-color: color-mix(in srgb, var(--moss) 40%, var(--h-line));
+}
+
+.restartButton[data-state="error"] {
+  color: var(--rust);
+  border-color: color-mix(in srgb, var(--rust) 48%, var(--h-line));
+}
+
+@keyframes gateway-restart-spin {
+  to {
+    transform: rotate(-360deg);
+  }
 }
 
 .stat[data-tone="warn"] .val {
@@ -104,4 +165,16 @@
 
 .dot[data-state="unknown"] {
   background: var(--h-text-3);
+}
+
+.srOnly {
+  position: absolute;
+  width: 1px;
+  height: 1px;
+  padding: 0;
+  margin: -1px;
+  overflow: hidden;
+  clip: rect(0, 0, 0, 0);
+  white-space: nowrap;
+  border: 0;
 }

--- a/web/src/components/app-shell/app-status-bar.module.css
+++ b/web/src/components/app-shell/app-status-bar.module.css
@@ -55,8 +55,8 @@
   appearance: none;
   border: 1px solid var(--h-line);
   border-radius: var(--h-r-xs);
-  min-height: 18px;
-  padding: 0 6px;
+  min-height: 20px;
+  padding: 0 8px;
   display: inline-flex;
   align-items: center;
   gap: 4px;
@@ -83,6 +83,10 @@
 .restartButton:disabled {
   cursor: not-allowed;
   opacity: 0.56;
+}
+
+.restartButton[data-state="success"]:disabled {
+  opacity: 0.82;
 }
 
 .restartButton[data-state="starting"] svg,

--- a/web/src/components/app-shell/app-status-bar.tsx
+++ b/web/src/components/app-shell/app-status-bar.tsx
@@ -1,14 +1,17 @@
 import { useMemo } from "react";
 import { useAtomValue } from "jotai";
+import { RotateCcw } from "lucide-react";
 import { useStatus } from "@/hooks/use-status";
 import { useModelInfo } from "@/hooks/use-config";
 import { useSessions } from "@/hooks/use-sessions";
 import { useAnalytics } from "@/hooks/use-analytics";
+import { useGatewayRestartAction } from "@/hooks/use-gateway-restart";
 import { chatRuntimeBySessionAtom } from "@/stores/chat";
 import { dashboardPortFromUrl, dashboardUrlFromInputs } from "@/lib/dashboard-url";
 import { openExternalUrl } from "@/lib/external-links";
 import { isSessionRunning } from "@/lib/session-activity";
 import { formatTokens } from "@/lib/format";
+import { gatewayRestartButtonLabel, gatewayRestartTitle } from "@/lib/gateway-restart";
 import s from "./app-status-bar.module.css";
 
 function formatModelShort(model: string | null | undefined): string {
@@ -29,6 +32,7 @@ export function AppStatusBar() {
   const { data: sessions } = useSessions();
   const { data: analytics } = useAnalytics(1);
   const runtimeBySession = useAtomValue(chatRuntimeBySessionAtom);
+  const gatewayRestart = useGatewayRestartAction();
 
   const dashboardUrl = dashboardUrlFromInputs({
     healthUrl: status?.gateway_health_url,
@@ -64,17 +68,35 @@ export function AppStatusBar() {
 
   return (
     <footer className={s.statusbar} role="status" aria-label="运行状态">
-      <button
-        type="button"
-        className={`${s.stat} ${s.gatewayButton}`}
-        onClick={() => void openExternalUrl(dashboardUrl)}
-        title={`打开 ${dashboardUrl}`}
-        aria-label={`打开 Dashboard ${dashboardUrl}`}
-      >
-        <span className={s.dot} data-state={gatewayOnline ? "running" : "offline"} />
-        <span className={s.lbl}>网关</span>
-        <span className={s.val}>{port}</span>
-      </button>
+      <span className={s.gatewayGroup}>
+        <button
+          type="button"
+          className={`${s.stat} ${s.gatewayButton}`}
+          onClick={() => void openExternalUrl(dashboardUrl)}
+          title={`打开 ${dashboardUrl}`}
+          aria-label={`打开 Dashboard ${dashboardUrl}`}
+        >
+          <span className={s.dot} data-state={gatewayOnline ? "running" : "offline"} />
+          <span className={s.lbl}>网关</span>
+          <span className={s.val}>{port}</span>
+        </button>
+        <button
+          type="button"
+          className={s.restartButton}
+          data-state={gatewayRestart.phase}
+          onClick={() => void gatewayRestart.restart()}
+          disabled={gatewayRestart.locked || !gatewayOnline}
+          title={gatewayRestartTitle(gatewayRestart.phase, gatewayRestart.message)}
+          aria-label={gatewayRestartTitle(gatewayRestart.phase, gatewayRestart.message)}
+          aria-busy={gatewayRestart.busy}
+        >
+          <RotateCcw size={11} aria-hidden="true" />
+          <span>{gatewayRestartButtonLabel(gatewayRestart.phase)}</span>
+        </button>
+        <span className={s.srOnly} aria-live="polite">
+          {gatewayRestart.message ?? ""}
+        </span>
+      </span>
       <span className={s.sep} />
       <span className={s.stat}>
         <span className={s.lbl}>模型</span>

--- a/web/src/components/app-shell/app-status-bar.tsx
+++ b/web/src/components/app-shell/app-status-bar.tsx
@@ -65,6 +65,9 @@ export function AppStatusBar() {
 
   const todayTokens =
     (analytics?.daily?.[0]?.input_tokens ?? 0) + (analytics?.daily?.[0]?.output_tokens ?? 0);
+  const restartTitle = gatewayOnline || gatewayRestart.phase !== "idle"
+    ? gatewayRestartTitle(gatewayRestart.phase, gatewayRestart.message)
+    : "当前状态接口未确认在线，仍会尝试请求 Dashboard 重启 Gateway";
 
   return (
     <footer className={s.statusbar} role="status" aria-label="运行状态">
@@ -85,9 +88,9 @@ export function AppStatusBar() {
           className={s.restartButton}
           data-state={gatewayRestart.phase}
           onClick={() => void gatewayRestart.restart()}
-          disabled={gatewayRestart.locked || !gatewayOnline}
-          title={gatewayRestartTitle(gatewayRestart.phase, gatewayRestart.message)}
-          aria-label={gatewayRestartTitle(gatewayRestart.phase, gatewayRestart.message)}
+          disabled={gatewayRestart.locked}
+          title={restartTitle}
+          aria-label={restartTitle}
           aria-busy={gatewayRestart.busy}
         >
           <RotateCcw size={11} aria-hidden="true" />

--- a/web/src/hooks/use-gateway-restart.ts
+++ b/web/src/hooks/use-gateway-restart.ts
@@ -1,0 +1,190 @@
+import { useCallback, useEffect, useRef, useState } from "react";
+import { useQueryClient } from "@tanstack/react-query";
+import { fetchJSON, postJSON } from "@/lib/transport";
+import { forceExistingGatewayReconnect } from "@/lib/gateway-client";
+import { runtime } from "@/lib/runtime";
+import {
+  GATEWAY_RESTART_ACTION_NAME,
+  classifyGatewayActionStatus,
+  gatewayRestartResponseError,
+  isGatewayRestartBusy,
+  isGatewayRestartLocked,
+  type GatewayActionStatusResponse,
+  type GatewayRestartPhase,
+  type GatewayRestartResponse,
+} from "@/lib/gateway-restart";
+
+const POLL_INTERVAL_MS = 1_500;
+const MAX_POLL_ATTEMPTS = 40;
+const MAX_STATUS_FAILURES_BEFORE_FALLBACK = 2;
+const SUCCESS_RESET_MS = 10_000;
+
+interface GatewayRestartState {
+  phase: GatewayRestartPhase;
+  message: string | null;
+  pid?: number | null;
+}
+
+const INITIAL_STATE: GatewayRestartState = {
+  phase: "idle",
+  message: null,
+};
+
+function errorMessage(error: unknown): string {
+  if (error instanceof Error && error.message.trim()) return error.message;
+  return String(error || "Gateway 重启失败");
+}
+
+function sleep(ms: number): Promise<void> {
+  return new Promise((resolve) => {
+    window.setTimeout(resolve, ms);
+  });
+}
+
+export function useGatewayRestartAction() {
+  const queryClient = useQueryClient();
+  const [state, setReactState] = useState<GatewayRestartState>(INITIAL_STATE);
+  const stateRef = useRef(state);
+  const mountedRef = useRef(true);
+  const runIdRef = useRef(0);
+  const resetTimerRef = useRef<number | null>(null);
+
+  const setState = useCallback((next: GatewayRestartState) => {
+    stateRef.current = next;
+    if (mountedRef.current) setReactState(next);
+  }, []);
+
+  const clearResetTimer = useCallback(() => {
+    if (resetTimerRef.current) {
+      window.clearTimeout(resetTimerRef.current);
+      resetTimerRef.current = null;
+    }
+  }, []);
+
+  const scheduleSuccessReset = useCallback(() => {
+    clearResetTimer();
+    resetTimerRef.current = window.setTimeout(() => {
+      if (stateRef.current.phase === "success") {
+        setState(INITIAL_STATE);
+      }
+    }, SUCCESS_RESET_MS);
+  }, [clearResetTimer, setState]);
+
+  useEffect(() => {
+    return () => {
+      mountedRef.current = false;
+      clearResetTimer();
+      runIdRef.current += 1;
+    };
+  }, [clearResetTimer]);
+
+  const refreshAfterRestart = useCallback(async () => {
+    await Promise.allSettled([
+      runtime.refreshGatewayUrl(),
+      queryClient.invalidateQueries({ queryKey: ["status"] }),
+      queryClient.invalidateQueries({ queryKey: ["desktop-runtime-info"] }),
+    ]);
+    forceExistingGatewayReconnect("gateway-restart");
+  }, [queryClient]);
+
+  const finishSuccess = useCallback(async (runId: number, message: string) => {
+    if (!mountedRef.current || runIdRef.current !== runId) return;
+    setState({ phase: "success", message });
+    scheduleSuccessReset();
+    await refreshAfterRestart();
+  }, [refreshAfterRestart, scheduleSuccessReset, setState]);
+
+  const trackRestart = useCallback(async (runId: number) => {
+    let statusFailures = 0;
+
+    for (let attempt = 0; attempt < MAX_POLL_ATTEMPTS; attempt += 1) {
+      await sleep(POLL_INTERVAL_MS);
+      if (!mountedRef.current || runIdRef.current !== runId) return;
+
+      try {
+        const status = await fetchJSON<GatewayActionStatusResponse>(
+          `/api/actions/${encodeURIComponent(GATEWAY_RESTART_ACTION_NAME)}/status?lines=40`,
+        );
+        statusFailures = 0;
+        if (!mountedRef.current || runIdRef.current !== runId) return;
+
+        const classification = classifyGatewayActionStatus(status);
+        if (!classification.done) {
+          setState({
+            phase: "running",
+            message: classification.message,
+            pid: status.pid,
+          });
+          continue;
+        }
+
+        if (classification.ok) {
+          await finishSuccess(runId, classification.message);
+        } else {
+          setState({
+            phase: "error",
+            message: classification.message,
+            pid: status.pid,
+          });
+        }
+        return;
+      } catch {
+        statusFailures += 1;
+        if (statusFailures >= MAX_STATUS_FAILURES_BEFORE_FALLBACK) {
+          await finishSuccess(runId, "已发起 Gateway 重启，正在刷新连接…");
+          return;
+        }
+      }
+    }
+
+    await finishSuccess(runId, "已发起 Gateway 重启，正在后台完成…");
+  }, [finishSuccess, setState]);
+
+  const restart = useCallback(async () => {
+    if (isGatewayRestartBusy(stateRef.current.phase)) return;
+
+    clearResetTimer();
+    const runId = runIdRef.current + 1;
+    runIdRef.current = runId;
+    setState({ phase: "starting", message: "正在请求重启 Gateway…" });
+
+    try {
+      await runtime.refreshGatewayUrl();
+      if (!mountedRef.current || runIdRef.current !== runId) return;
+
+      const response = await postJSON<GatewayRestartResponse>("/api/gateway/restart", {});
+      if (!mountedRef.current || runIdRef.current !== runId) return;
+
+      const structuredError = gatewayRestartResponseError(response);
+      if (structuredError) throw new Error(structuredError);
+
+      const pid = response.pid ?? null;
+      setState({
+        phase: "running",
+        message: pid ? `已发起 Gateway 重启（PID ${pid}），等待完成…` : "已发起 Gateway 重启，等待完成…",
+        pid,
+      });
+      void trackRestart(runId);
+    } catch (error) {
+      if (!mountedRef.current || runIdRef.current !== runId) return;
+      setState({
+        phase: "error",
+        message: errorMessage(error),
+      });
+    }
+  }, [clearResetTimer, setState, trackRestart]);
+
+  const reset = useCallback(() => {
+    clearResetTimer();
+    runIdRef.current += 1;
+    setState(INITIAL_STATE);
+  }, [clearResetTimer, setState]);
+
+  return {
+    ...state,
+    busy: isGatewayRestartBusy(state.phase),
+    locked: isGatewayRestartLocked(state.phase),
+    restart,
+    reset,
+  };
+}

--- a/web/src/hooks/use-gateway-restart.ts
+++ b/web/src/hooks/use-gateway-restart.ts
@@ -1,15 +1,18 @@
 import { useCallback, useEffect, useRef, useState } from "react";
 import { useQueryClient } from "@tanstack/react-query";
 import { fetchJSON, postJSON } from "@/lib/transport";
+import { debugBus } from "@/lib/debug-bus";
 import { forceExistingGatewayReconnect } from "@/lib/gateway-client";
 import { runtime } from "@/lib/runtime";
 import {
   GATEWAY_RESTART_ACTION_NAME,
   classifyGatewayActionStatus,
   gatewayRestartResponseError,
+  isGatewayRestartObservedRunning,
   isGatewayRestartBusy,
   isGatewayRestartLocked,
   type GatewayActionStatusResponse,
+  type GatewayRuntimeStatus,
   type GatewayRestartPhase,
   type GatewayRestartResponse,
 } from "@/lib/gateway-restart";
@@ -38,6 +41,19 @@ function errorMessage(error: unknown): string {
 function sleep(ms: number): Promise<void> {
   return new Promise((resolve) => {
     window.setTimeout(resolve, ms);
+  });
+}
+
+function recordRestartDebug(
+  level: "info" | "warn" | "error",
+  summary: string,
+  payload?: Record<string, unknown>,
+): void {
+  debugBus.push({
+    type: "gateway",
+    level,
+    summary,
+    payload,
   });
 }
 
@@ -71,6 +87,7 @@ export function useGatewayRestartAction() {
   }, [clearResetTimer, setState]);
 
   useEffect(() => {
+    mountedRef.current = true;
     return () => {
       mountedRef.current = false;
       clearResetTimer();
@@ -89,6 +106,7 @@ export function useGatewayRestartAction() {
 
   const finishSuccess = useCallback(async (runId: number, message: string) => {
     if (!mountedRef.current || runIdRef.current !== runId) return;
+    recordRestartDebug("info", "Gateway restart completed", { message });
     setState({ phase: "success", message });
     scheduleSuccessReset();
     await refreshAfterRestart();
@@ -110,6 +128,16 @@ export function useGatewayRestartAction() {
 
         const classification = classifyGatewayActionStatus(status);
         if (!classification.done) {
+          const runtimeStatus = await fetchJSON<GatewayRuntimeStatus>("/api/status")
+            .catch(() => null);
+          if (
+            runtimeStatus &&
+            isGatewayRestartObservedRunning(status, runtimeStatus)
+          ) {
+            await finishSuccess(runId, "Gateway 重启已完成");
+            return;
+          }
+
           setState({
             phase: "running",
             message: classification.message,
@@ -121,6 +149,11 @@ export function useGatewayRestartAction() {
         if (classification.ok) {
           await finishSuccess(runId, classification.message);
         } else {
+          recordRestartDebug("error", "Gateway restart action failed", {
+            message: classification.message,
+            exitCode: status.exit_code,
+            pid: status.pid,
+          });
           setState({
             phase: "error",
             message: classification.message,
@@ -131,6 +164,9 @@ export function useGatewayRestartAction() {
       } catch {
         statusFailures += 1;
         if (statusFailures >= MAX_STATUS_FAILURES_BEFORE_FALLBACK) {
+          recordRestartDebug("warn", "Gateway restart status polling unavailable; assuming request was accepted", {
+            failures: statusFailures,
+          });
           await finishSuccess(runId, "已发起 Gateway 重启，正在刷新连接…");
           return;
         }
@@ -141,11 +177,20 @@ export function useGatewayRestartAction() {
   }, [finishSuccess, setState]);
 
   const restart = useCallback(async () => {
-    if (isGatewayRestartBusy(stateRef.current.phase)) return;
+    if (isGatewayRestartBusy(stateRef.current.phase)) {
+      recordRestartDebug("warn", "Gateway restart click ignored because another restart is running", {
+        phase: stateRef.current.phase,
+      });
+      return;
+    }
 
     clearResetTimer();
     const runId = runIdRef.current + 1;
     runIdRef.current = runId;
+    recordRestartDebug("info", "Gateway restart click accepted", {
+      platform: runtime.platform,
+      phase: stateRef.current.phase,
+    });
     setState({ phase: "starting", message: "正在请求重启 Gateway…" });
 
     try {
@@ -159,6 +204,10 @@ export function useGatewayRestartAction() {
       if (structuredError) throw new Error(structuredError);
 
       const pid = response.pid ?? null;
+      recordRestartDebug("info", "Gateway restart request accepted by dashboard", {
+        pid,
+        action: response.name ?? GATEWAY_RESTART_ACTION_NAME,
+      });
       setState({
         phase: "running",
         message: pid ? `已发起 Gateway 重启（PID ${pid}），等待完成…` : "已发起 Gateway 重启，等待完成…",
@@ -167,9 +216,11 @@ export function useGatewayRestartAction() {
       void trackRestart(runId);
     } catch (error) {
       if (!mountedRef.current || runIdRef.current !== runId) return;
+      const message = errorMessage(error);
+      recordRestartDebug("error", "Gateway restart request failed", { message });
       setState({
         phase: "error",
-        message: errorMessage(error),
+        message,
       });
     }
   }, [clearResetTimer, setState, trackRestart]);

--- a/web/src/lib/gateway-restart.test.ts
+++ b/web/src/lib/gateway-restart.test.ts
@@ -1,0 +1,82 @@
+import { describe, expect, it } from "vitest";
+import {
+  classifyGatewayActionStatus,
+  gatewayRestartButtonLabel,
+  gatewayRestartResponseError,
+  gatewayRestartTitle,
+  isGatewayRestartBusy,
+  isGatewayRestartLocked,
+  type GatewayActionStatusResponse,
+} from "./gateway-restart";
+
+function status(overrides: Partial<GatewayActionStatusResponse>): GatewayActionStatusResponse {
+  return {
+    name: "gateway-restart",
+    running: false,
+    exit_code: 0,
+    pid: null,
+    lines: [],
+    ...overrides,
+  };
+}
+
+describe("gateway restart helpers", () => {
+  it("marks starting and running phases as busy", () => {
+    expect(isGatewayRestartBusy("idle")).toBe(false);
+    expect(isGatewayRestartBusy("starting")).toBe(true);
+    expect(isGatewayRestartBusy("running")).toBe(true);
+    expect(isGatewayRestartBusy("success")).toBe(false);
+    expect(isGatewayRestartBusy("error")).toBe(false);
+  });
+
+  it("keeps the button locked through the post-restart success cooldown", () => {
+    expect(isGatewayRestartLocked("idle")).toBe(false);
+    expect(isGatewayRestartLocked("starting")).toBe(true);
+    expect(isGatewayRestartLocked("running")).toBe(true);
+    expect(isGatewayRestartLocked("success")).toBe(true);
+    expect(isGatewayRestartLocked("error")).toBe(false);
+  });
+
+  it("builds compact button labels and titles", () => {
+    expect(gatewayRestartButtonLabel("idle")).toBe("重启");
+    expect(gatewayRestartButtonLabel("running")).toBe("重启中…");
+    expect(gatewayRestartButtonLabel("success")).toBe("已完成");
+    expect(gatewayRestartButtonLabel("error")).toBe("重试");
+    expect(gatewayRestartTitle("running", "自定义状态")).toBe("自定义状态");
+  });
+
+  it("classifies running and successful action status", () => {
+    expect(classifyGatewayActionStatus(status({ running: true, pid: 1234 }))).toEqual({
+      done: false,
+      ok: false,
+      message: "Gateway 重启中（PID 1234）…",
+    });
+    expect(classifyGatewayActionStatus(status({ running: false, exit_code: 0 }))).toEqual({
+      done: true,
+      ok: true,
+      message: "Gateway 重启已完成",
+    });
+  });
+
+  it("classifies missing exit code as a completed fire-and-forget action", () => {
+    expect(classifyGatewayActionStatus(status({ running: false, exit_code: null }))).toEqual({
+      done: true,
+      ok: true,
+      message: "Gateway 重启已完成",
+    });
+  });
+
+  it("classifies non-zero exit code as failure", () => {
+    expect(classifyGatewayActionStatus(status({ running: false, exit_code: 75 }))).toEqual({
+      done: true,
+      ok: false,
+      message: "Gateway 重启失败（exit 75）",
+    });
+  });
+
+  it("extracts structured restart response errors", () => {
+    expect(gatewayRestartResponseError({ ok: true })).toBeNull();
+    expect(gatewayRestartResponseError({ ok: false, message: "无法重启" })).toBe("无法重启");
+    expect(gatewayRestartResponseError({ ok: false, error: "failed" })).toBe("failed");
+  });
+});

--- a/web/src/lib/gateway-restart.test.ts
+++ b/web/src/lib/gateway-restart.test.ts
@@ -6,6 +6,7 @@ import {
   gatewayRestartTitle,
   isGatewayRestartBusy,
   isGatewayRestartLocked,
+  isGatewayRestartObservedRunning,
   type GatewayActionStatusResponse,
 } from "./gateway-restart";
 
@@ -72,6 +73,25 @@ describe("gateway restart helpers", () => {
       ok: false,
       message: "Gateway 重启失败（exit 75）",
     });
+  });
+
+  it("treats a foreground gateway process as completed once /api/status sees it running", () => {
+    const action = status({ running: true, pid: 33560 });
+    expect(isGatewayRestartObservedRunning(action, {
+      gateway_running: true,
+      gateway_pid: 33560,
+      gateway_state: "running",
+    })).toBe(true);
+    expect(isGatewayRestartObservedRunning(action, {
+      gateway_running: true,
+      gateway_pid: 98288,
+      gateway_state: "running",
+    })).toBe(false);
+    expect(isGatewayRestartObservedRunning(action, {
+      gateway_running: false,
+      gateway_pid: 33560,
+      gateway_state: "stopped",
+    })).toBe(false);
   });
 
   it("extracts structured restart response errors", () => {

--- a/web/src/lib/gateway-restart.ts
+++ b/web/src/lib/gateway-restart.ts
@@ -24,6 +24,12 @@ export interface GatewayActionStatusClassification {
   message: string;
 }
 
+export interface GatewayRuntimeStatus {
+  gateway_running?: boolean;
+  gateway_pid?: number | null;
+  gateway_state?: string | null;
+}
+
 export function isGatewayRestartBusy(phase: GatewayRestartPhase): boolean {
   return phase === "starting" || phase === "running";
 }
@@ -74,6 +80,23 @@ export function classifyGatewayActionStatus(
     ok: false,
     message: `Gateway 重启失败（exit ${status.exit_code}）`,
   };
+}
+
+export function isGatewayRestartObservedRunning(
+  actionStatus: GatewayActionStatusResponse,
+  runtimeStatus: GatewayRuntimeStatus,
+): boolean {
+  if (!runtimeStatus.gateway_running) return false;
+  if (
+    actionStatus.pid &&
+    runtimeStatus.gateway_pid &&
+    actionStatus.pid !== runtimeStatus.gateway_pid
+  ) {
+    return false;
+  }
+
+  const state = (runtimeStatus.gateway_state ?? "").trim().toLowerCase();
+  return state === "" || state === "running" || state === "ready";
 }
 
 export function gatewayRestartResponseError(response: GatewayRestartResponse): string | null {

--- a/web/src/lib/gateway-restart.ts
+++ b/web/src/lib/gateway-restart.ts
@@ -1,0 +1,82 @@
+export const GATEWAY_RESTART_ACTION_NAME = "gateway-restart";
+
+export type GatewayRestartPhase = "idle" | "starting" | "running" | "success" | "error";
+
+export interface GatewayRestartResponse {
+  ok: boolean;
+  pid?: number | null;
+  name?: string | null;
+  error?: string | null;
+  message?: string | null;
+}
+
+export interface GatewayActionStatusResponse {
+  name: string;
+  running: boolean;
+  exit_code: number | null;
+  pid: number | null;
+  lines: string[];
+}
+
+export interface GatewayActionStatusClassification {
+  done: boolean;
+  ok: boolean;
+  message: string;
+}
+
+export function isGatewayRestartBusy(phase: GatewayRestartPhase): boolean {
+  return phase === "starting" || phase === "running";
+}
+
+export function isGatewayRestartLocked(phase: GatewayRestartPhase): boolean {
+  return phase === "starting" || phase === "running" || phase === "success";
+}
+
+export function gatewayRestartButtonLabel(phase: GatewayRestartPhase): string {
+  if (phase === "starting" || phase === "running") return "重启中…";
+  if (phase === "success") return "已完成";
+  if (phase === "error") return "重试";
+  return "重启";
+}
+
+export function gatewayRestartTitle(
+  phase: GatewayRestartPhase,
+  message?: string | null,
+): string {
+  if (message) return message;
+  if (phase === "starting" || phase === "running") return "正在重启 Gateway";
+  if (phase === "success") return "Gateway 重启已完成";
+  if (phase === "error") return "Gateway 重启失败，点击重试";
+  return "重启 Gateway";
+}
+
+export function classifyGatewayActionStatus(
+  status: GatewayActionStatusResponse,
+): GatewayActionStatusClassification {
+  if (status.running) {
+    return {
+      done: false,
+      ok: false,
+      message: status.pid ? `Gateway 重启中（PID ${status.pid}）…` : "Gateway 重启中…",
+    };
+  }
+
+  if (status.exit_code === 0 || status.exit_code === null) {
+    return {
+      done: true,
+      ok: true,
+      message: "Gateway 重启已完成",
+    };
+  }
+
+  return {
+    done: true,
+    ok: false,
+    message: `Gateway 重启失败（exit ${status.exit_code}）`,
+  };
+}
+
+export function gatewayRestartResponseError(response: GatewayRestartResponse): string | null {
+  if (response.ok) return null;
+  return response.message || response.error || "Gateway 重启请求失败";
+}

--- a/web/src/routes/im-onboarding.module.css
+++ b/web/src/routes/im-onboarding.module.css
@@ -1,8 +1,6 @@
 .wrap {
   min-height: 100%;
-  background:
-    radial-gradient(circle at 78% 4%, color-mix(in srgb, var(--h-accent) 10%, transparent), transparent 26%),
-    linear-gradient(180deg, var(--h-bg-app), var(--h-bg-app));
+  background: var(--h-bg-app);
 }
 .mainCol { min-width: 0; display: grid; gap: 14px; align-content: start; }
 .headBand { display: flex; justify-content: space-between; gap: 18px; padding: 24px; border: 1px solid var(--h-line); background: linear-gradient(135deg, var(--h-bg-pane), var(--h-bg-soft)); border-radius: var(--h-r-lg); box-shadow: var(--h-shadow); }
@@ -57,6 +55,7 @@
 .anchorBlock { scroll-margin-top: 16px; display: grid; gap: 12px; }
 .choiceGrid, .policyGrid { display: grid; grid-template-columns: repeat(3, minmax(0, 1fr)); gap: 10px; }
 .choiceGrid { grid-template-columns: repeat(2, minmax(0, 1fr)); }
+.policyGrid { grid-template-columns: repeat(auto-fit, minmax(180px, 1fr)); }
 .choiceCard, .policyCard { text-align: left; border: 1px solid var(--h-line); background: var(--h-bg-soft); border-radius: var(--h-r-md); padding: 14px; color: var(--h-text); cursor: pointer; }
 .choiceCard[data-active="true"], .policyCard[data-active="true"] { border-color: color-mix(in srgb, var(--h-accent) 55%, var(--h-line)); box-shadow: inset 0 0 0 1px color-mix(in srgb, var(--h-accent) 16%, transparent); }
 .choiceTop { display: flex; justify-content: space-between; align-items: center; margin-bottom: 12px; }
@@ -74,6 +73,12 @@
 .fieldControl input, .fieldControl select { width: 100%; height: 32px; border: 1px solid var(--h-line); background: var(--h-bg-input); color: var(--h-text); border-radius: var(--h-r-sm); padding: 0 10px; font-family: var(--h-font-ui); }
 .fieldControl input[type="password"], .field code, .urlPreview, .reviewTable code { font-family: var(--h-font-mono); }
 .field code { color: var(--h-text-3); font-size: 10px; overflow: hidden; text-overflow: ellipsis; }
+.identityNote { display: flex; align-items: flex-start; justify-content: space-between; gap: 12px; border: 1px solid color-mix(in srgb, var(--h-ok) 30%, var(--h-line)); border-radius: var(--h-r-md); background: color-mix(in srgb, var(--h-ok) 7%, var(--h-bg-soft)); padding: 10px 12px; color: var(--h-text-2); font-size: 12px; line-height: 1.65; }
+.identityNote b { color: var(--h-text); white-space: nowrap; }
+.identityNote span { min-width: 0; }
+.identityNote code, .checkToggle code { color: var(--h-accent); font-family: var(--h-font-mono); font-size: 11px; }
+.checkToggle { display: flex; align-items: center; gap: 9px; border: 1px solid var(--h-line-soft); border-radius: var(--h-r-md); background: var(--h-bg-soft); padding: 10px 12px; color: var(--h-text-2); font-size: 12px; cursor: pointer; }
+.checkToggle input { width: 14px; height: 14px; accent-color: var(--h-accent); }
 .qrSection { grid-template-columns: 256px 1fr; align-items: center; }
 .qrBox { width: 240px; height: 240px; display: grid; place-items: center; border-radius: var(--h-r-lg); border: 1px solid var(--h-line); background: var(--bone-100); overflow: hidden; }
 .qrBox img { width: 232px; height: 232px; display: block; }

--- a/web/src/routes/im-onboarding.module.css
+++ b/web/src/routes/im-onboarding.module.css
@@ -1,6 +1,5 @@
 .wrap {
   min-height: 100%;
-  background: var(--h-bg-app);
 }
 .mainCol { min-width: 0; display: grid; gap: 14px; align-content: start; }
 .headBand { display: flex; justify-content: space-between; gap: 18px; padding: 24px; border: 1px solid var(--h-line); background: linear-gradient(135deg, var(--h-bg-pane), var(--h-bg-soft)); border-radius: var(--h-r-lg); box-shadow: var(--h-shadow); }

--- a/web/src/routes/im-onboarding.test.ts
+++ b/web/src/routes/im-onboarding.test.ts
@@ -38,7 +38,6 @@ describe("im onboarding routing helpers", () => {
   it("documents Feishu chat readiness scopes in the onboarding flow", () => {
     expect(FEISHU_REQUIRED_SCOPES).toEqual([
       "im:message.p2p_msg:readonly",
-      "im:message.group_at_msg:readonly",
       "im:message:send_as_bot",
     ]);
     expect(FEISHU_RECOMMENDED_SCOPES).toContain("im:resource");

--- a/web/src/routes/im-onboarding.tsx
+++ b/web/src/routes/im-onboarding.tsx
@@ -13,7 +13,6 @@ import {
   RotateCw,
   Save,
   ScanLine,
-  Send,
   ShieldCheck,
   Stethoscope,
   X,
@@ -41,15 +40,12 @@ import { SectionShell } from "./section-shell";
 import s from "./im-onboarding.module.css";
 
 type ImSection = "feishu" | "weixin";
-type FeishuMethod = "qr" | "manual";
 type DmPolicy = "scanned" | "pairing" | "allowlist" | "open" | "disabled";
-type FeishuGroupPolicy = "mention" | "disabled";
 
 const FEISHU_DEVELOPER_URL = "https://open.feishu.cn/app";
 const FEISHU_SCANNED_OPEN_ID_TOKEN = "__HERMES_SCANNED_FEISHU_OPEN_ID__";
 export const FEISHU_REQUIRED_SCOPES = [
   "im:message.p2p_msg:readonly",
-  "im:message.group_at_msg:readonly",
   "im:message:send_as_bot",
 ] as const;
 export const FEISHU_RECOMMENDED_SCOPES = [
@@ -257,10 +253,10 @@ function FlowSteps({ platform, status, saved }: { platform: ImPlatform; status?:
   const scanned = status === "scanned" || status === "confirmed";
   const confirmed = status === "confirmed";
   const labels = platform === "feishu"
-    ? [["选择方式", "推荐扫码"], ["绑定应用", "用手机确认"], ["保存设置", "写入当前档案"], ["打开权限", "按提示勾选发布"], ["试发消息", "私聊和群聊验证"]]
+    ? [["扫码绑定", "用手机确认"], ["保存设置", "写入当前档案"], ["打开权限", "按提示勾选发布"], ["试发消息", "私聊验证"]]
     : [["环境检查", "确认能启动"], ["扫码绑定", "用微信确认"], ["访问范围", "设置可用用户"], ["保存验证", "重启后自动检查"]];
   const states = platform === "feishu"
-    ? [true, scanned || confirmed, saved, false, false]
+    ? [scanned || confirmed, saved, false, false]
     : [true, scanned || confirmed, confirmed, saved];
   return (
     <div className={s.flowSteps} aria-label="消息平台接入步骤">
@@ -387,12 +383,11 @@ function FeishuTestGuide({ result }: { result: ImOnboardingApplyResult | null })
         <div className={s.miniEyebrow}>LIVE TEST</div>
         <h3>最后发消息试一下</h3>
         <p>{result?.ok
-          ? "接收服务已经启动。现在去飞书里试两条：私聊机器人发 hi；群里 @机器人 发 hi。"
-          : "先保存、完成飞书后台设置并发布，再回来发消息验证。"}</p>
+          ? "接收服务已经启动。现在去飞书里私聊机器人发送 hi，确认能收到回复。"
+          : "先保存、完成飞书后台设置并发布，再回来私聊机器人验证。"}</p>
       </div>
       <div className={s.testCards}>
         <div><MessageSquareText size={15} /><b>私聊测试</b><span>给机器人发送 <code>hi</code>，应收到回复或配对提示。</span></div>
-        <div><Send size={15} /><b>群聊测试</b><span>把机器人拉入群并发送 <code>@机器人 hi</code>，默认只响应 @ 消息。</span></div>
       </div>
     </section>
   );
@@ -438,7 +433,7 @@ export function railPanels(platform: ImPlatform): RailPanelConfig[] {
           {
             title: "必须权限",
             items: Array.from(FEISHU_REQUIRED_SCOPES),
-            chips: ["单聊可收", "群聊 @ 可收", "机器人可发"],
+            chips: ["单聊可收", "机器人可发"],
           },
         ],
       },
@@ -473,7 +468,7 @@ export function railPanels(platform: ImPlatform): RailPanelConfig[] {
         sections: [
           {
             title: "快速排查",
-            items: ["私聊没反应：确认已开通私聊消息权限并发布", "群里没反应：确认已开通群聊 @ 消息权限，并且消息里 @ 了机器人", "能收不能发：确认已开通机器人发送消息权限", "事件日志为空：确认已订阅接收消息 v2.0 并发布版本"],
+            items: ["私聊没反应：确认已开通私聊消息权限并发布", "能收不能发：确认已开通机器人发送消息权限", "事件日志为空：确认已订阅接收消息 v2.0 并发布版本"],
           },
           {
             title: "日志关键词",
@@ -622,21 +617,12 @@ function FeishuRoute() {
   const begin = useBeginImOnboarding();
   const poll = usePollImOnboarding();
   const apply = useApplyImOnboarding("feishu");
-  const [method, setMethod] = useState<FeishuMethod>("qr");
-  const [domain, setDomain] = useState("feishu");
-  const [connectionMode, setConnectionMode] = useState("websocket");
+  const domain = "feishu";
+  const connectionMode = "websocket";
   const [dmPolicy, setDmPolicy] = useState<DmPolicy>("pairing");
-  const [groupPolicy, setGroupPolicy] = useState<FeishuGroupPolicy>("mention");
-  const [appId, setAppId] = useState("");
-  const [appSecret, setAppSecret] = useState("");
   const [allowedUsers, setAllowedUsers] = useState("");
   const [includeScannedOpenId, setIncludeScannedOpenId] = useState(true);
   const [homeChannel, setHomeChannel] = useState("");
-  const [webhookHost, setWebhookHost] = useState("127.0.0.1");
-  const [webhookPort, setWebhookPort] = useState("8765");
-  const [webhookPath, setWebhookPath] = useState("/feishu/webhook");
-  const [encryptKey, setEncryptKey] = useState("");
-  const [verificationToken, setVerificationToken] = useState("");
   const [flow, setFlow] = useState<ImOnboardingBeginResult | null>(null);
   const [pollResult, setPollResult] = useState<ImOnboardingPollResult | null>(null);
   const [result, setResult] = useState<ImOnboardingApplyResult | null>(null);
@@ -646,8 +632,7 @@ function FeishuRoute() {
   const status = pollResult?.status ?? flow?.status;
   const credential = pollResult?.credentialSummary;
   const scannedOpenId = isSet(credential?.openId) ? credential.openId : null;
-  const canApplyQr = method === "qr" && credential && pollResult?.status === "confirmed";
-  const canApplyManual = method === "manual" && appId.trim() && appSecret.trim();
+  const canApplyQr = Boolean(credential && pollResult?.status === "confirmed");
   const busy = begin.isPending || poll.isPending || apply.isPending;
   const jumpToQr = () => qrAnchorRef.current?.scrollIntoView({ behavior: "smooth", block: "start" });
 
@@ -675,11 +660,11 @@ function FeishuRoute() {
     return () => window.clearInterval(id);
   }, [flow?.flowId, flow?.intervalSeconds, pollResult?.status]);
   useEffect(() => {
-    if (method === "qr" && pollResult?.status === "confirmed" && scannedOpenId && dmPolicy === "pairing") {
+    if (pollResult?.status === "confirmed" && scannedOpenId && dmPolicy === "pairing") {
       setDmPolicy("scanned");
       setIncludeScannedOpenId(true);
     }
-  }, [method, pollResult?.status, scannedOpenId?.fingerprint, dmPolicy]);
+  }, [pollResult?.status, scannedOpenId?.fingerprint, dmPolicy]);
 
   const shouldAutoHomeChannel = Boolean(scannedOpenId) && !homeChannel.trim();
   const settings = () => {
@@ -696,23 +681,16 @@ function FeishuRoute() {
       FEISHU_CONNECTION_MODE: connectionMode,
       FEISHU_ALLOW_ALL_USERS: allowAll,
       FEISHU_ALLOWED_USERS: allowedList,
-      FEISHU_GROUP_POLICY: groupPolicy === "disabled" ? "disabled" : "open",
-      FEISHU_REQUIRE_MENTION: groupPolicy === "mention" ? "true" : "false",
+      FEISHU_GROUP_POLICY: "disabled",
+      FEISHU_REQUIRE_MENTION: "true",
       FEISHU_HOME_CHANNEL: shouldAutoHomeChannel ? FEISHU_SCANNED_OPEN_ID_TOKEN : homeChannel.trim(),
-      ...(connectionMode === "webhook" ? {
-        FEISHU_WEBHOOK_HOST: webhookHost.trim(),
-        FEISHU_WEBHOOK_PORT: webhookPort.trim(),
-        FEISHU_WEBHOOK_PATH: webhookPath.trim(),
-        FEISHU_ENCRYPT_KEY: encryptKey.trim(),
-        FEISHU_VERIFICATION_TOKEN: verificationToken.trim(),
-      } : {}),
     };
   };
   const save = () => {
     apply.mutate({
       platform: "feishu",
-      flowId: method === "qr" ? flow?.flowId : undefined,
-      manualCredentials: method === "manual" ? { appId, appSecret } : undefined,
+      flowId: flow?.flowId,
+      manualCredentials: undefined,
       settings: settings(),
       restartGateway: true,
     }, { onSuccess: setResult });
@@ -740,7 +718,6 @@ function FeishuRoute() {
     ["区域", `FEISHU_DOMAIN=${domain}`, "已选择"],
     ["私聊策略", `FEISHU_ALLOW_ALL_USERS=${dmPolicy === "open" ? "true" : "false"}`, dmPolicy === "scanned" ? "只允许扫码用户" : dmPolicy === "pairing" ? "需要确认" : dmPolicy],
     ["允许对话用户", `FEISHU_ALLOWED_USERS=${allowlistReview}`, allowlistStatus],
-    ["群聊策略", `FEISHU_GROUP_POLICY=${groupPolicy === "disabled" ? "disabled" : "open"}`, groupPolicy === "mention" ? "仅 @ 响应" : "关闭"],
     ["默认通知会话", `FEISHU_HOME_CHANNEL=${homeChannelReview}`, homeChannelStatus],
   ];
 
@@ -748,49 +725,25 @@ function FeishuRoute() {
     <SectionShell title="消息平台接入 · 飞书" sub="02 配置 / 023 消息平台接入" rail={<Rail platform="feishu" />} railLabel="飞书接入诊断边栏">
       <div className={s.wrap}>
         <main className={s.mainCol}>
-          <Hero platform="feishu" stateSub={`当前档案：${stateQuery.data?.currentProfile ?? "default"}`} onPrimary={method === "qr" ? start : save} primaryBusy={busy} />
+          <Hero platform="feishu" stateSub={`当前档案：${stateQuery.data?.currentProfile ?? "default"}`} onPrimary={start} primaryBusy={busy} />
           <ActionFeedback busy={begin.isPending} error={begin.error} flow={flow} status={status} onJump={jumpToQr} />
           <MetaStrip platform="feishu" profile={stateQuery.data?.currentProfile ?? "default"} statusData={statusQuery.data} configured={configured} />
           <FlowSteps platform="feishu" status={status} saved={Boolean(result?.ok)} />
-          <SectionTitle num="[ STEP 01 ]" title="先选择怎么接入" meta="新手推荐扫码；已有飞书应用再手动填写" />
-          <section className={s.section}><div className={s.choiceGrid}>
-            <ChoiceCard active={method === "qr"} icon="scan" badge="推荐" title="手机扫码接入" desc="用飞书手机端扫一下，桌面端会自动拿到应用信息。扫码后还需要按提示去飞书后台确认权限。" foot="推荐新手使用" onClick={() => setMethod("qr")} />
-            <ChoiceCard active={method === "manual"} icon="key" badge="高级" title="我已有飞书应用" desc="如果公司已经建好自建应用，可以在这里填写应用信息。" foot="适合熟悉飞书后台的用户" onClick={() => { setMethod("manual"); if (dmPolicy === "scanned") setDmPolicy("allowlist"); }} />
-          </div></section>
+          <div ref={qrAnchorRef} className={s.anchorBlock}>
+            <SectionTitle num="[ STEP 01 ]" title="用飞书扫码确认" meta={flow ? `每 ${flow.intervalSeconds} 秒自动检查一次；成功后继续下一步` : "二维码只在当前页面临时使用"} />
+            <QrPanel
+              data={pollResult?.qrScanData ?? flow?.qrScanData}
+              url={pollResult?.qrUrl ?? flow?.qrUrl}
+              status={status}
+              message={pollResult?.message ?? flow?.message}
+              onStart={start}
+              startLabel="开始扫码"
+              startBusy={begin.isPending}
+            />
+          </div>
+          <div className={s.sectionActions}><button className={`${s.btn} ${s.primary}`} onClick={start} disabled={busy}><ScanLine size={14} />生成二维码</button><button className={s.btn} onClick={pollOnce} disabled={!flow || busy}><RefreshCw size={14} />立即检查</button></div>
 
-          {method === "qr" ? <>
-            <div ref={qrAnchorRef} className={s.anchorBlock}>
-              <SectionTitle num="[ STEP 02A ]" title="用飞书扫码确认" meta={flow ? `每 ${flow.intervalSeconds} 秒自动检查一次；成功后继续下一步` : "二维码只在当前页面临时使用"} />
-              <QrPanel
-                data={pollResult?.qrScanData ?? flow?.qrScanData}
-                url={pollResult?.qrUrl ?? flow?.qrUrl}
-                status={status}
-                message={pollResult?.message ?? flow?.message}
-                onStart={start}
-                startLabel="开始扫码"
-                startBusy={begin.isPending}
-              />
-            </div>
-            <div className={s.sectionActions}><button className={`${s.btn} ${s.primary}`} onClick={start} disabled={busy}><ScanLine size={14} />生成二维码</button><button className={s.btn} onClick={pollOnce} disabled={!flow || busy}><RefreshCw size={14} />立即检查</button></div>
-          </> : <>
-            <SectionTitle num="[ STEP 02B ]" title="填写已有飞书应用" meta="密码类信息不会在诊断里明文显示" />
-            <section className={s.section}>
-              <Field label="区域" desc="选择你使用的是飞书中国版还是 Lark 国际版。" meta="FEISHU_DOMAIN"><select value={domain} onChange={(e) => setDomain(e.target.value)}><option value="feishu">飞书中国 · feishu</option><option value="lark">Lark 国际 · lark</option></select></Field>
-              <Field label="连接模式" desc="新手保持默认即可，不需要准备公网地址。" meta="FEISHU_CONNECTION_MODE"><select value={connectionMode} onChange={(e) => setConnectionMode(e.target.value)}><option value="websocket">长连接（推荐）</option><option value="webhook">回调模式（高级）</option></select></Field>
-              <Field label="App ID" desc="在飞书开放平台应用详情里复制。" meta="FEISHU_APP_ID"><input value={appId} onChange={(e) => setAppId(e.target.value)} placeholder="cli_xxx" /></Field>
-              <Field label="App Secret" desc="应用密钥，只保存在当前配置档案里。" meta="FEISHU_APP_SECRET"><input type="password" value={appSecret} onChange={(e) => setAppSecret(e.target.value)} placeholder="••••••••" /></Field>
-              {connectionMode === "webhook" && <>
-                <Field label="回调地址" desc="只有选择回调模式时才需要填写。" meta="FEISHU_WEBHOOK_HOST"><input value={webhookHost} onChange={(e) => setWebhookHost(e.target.value)} /></Field>
-                <Field label="回调端口" desc="本机接收飞书回调的端口。" meta="FEISHU_WEBHOOK_PORT"><input value={webhookPort} onChange={(e) => setWebhookPort(e.target.value)} /></Field>
-                <Field label="回调路径" desc="飞书后台里填写的回调路径。" meta="FEISHU_WEBHOOK_PATH"><input value={webhookPath} onChange={(e) => setWebhookPath(e.target.value)} /></Field>
-                <Field label="回调加密" desc="如果后台要求加密，填这里；不确定可以先留空。" meta="FEISHU_ENCRYPT_KEY"><input type="password" value={encryptKey} onChange={(e) => setEncryptKey(e.target.value)} /></Field>
-                <Field label="校验口令" desc="飞书后台的校验口令，不确定可以先留空。" meta="FEISHU_VERIFICATION_TOKEN"><input type="password" value={verificationToken} onChange={(e) => setVerificationToken(e.target.value)} /></Field>
-              </>}
-              <div className={s.sectionActions}><button className={`${s.btn} ${s.externalBtn}`} onClick={() => openExternal(FEISHU_DEVELOPER_URL)}><ExternalLink size={14} />打开飞书开发者后台</button></div>
-            </section>
-          </>}
-
-          <SectionTitle num="[ STEP 03 ]" title="保存设置并启动接收服务" meta="只会更新当前配置档案；飞书后台还需要继续按提示确认" />
+          <SectionTitle num="[ STEP 02 ]" title="保存设置并启动接收服务" meta="只会更新当前配置档案；飞书后台还需要继续按提示确认" />
           <section className={s.section}>
             <div className={s.policyGrid}>
               {scannedOpenId && <PolicyCard active={dmPolicy === "scanned"} title="只允许扫码用户" desc={`把本次扫码用户的 open_id（${last(scannedOpenId)}）写入允许列表。`} onClick={() => setDmPolicy("scanned")} />}
@@ -813,18 +766,17 @@ function FeishuRoute() {
               )}
               <Field label="允许对话用户 open_id" desc={scannedOpenId ? "可继续添加其他飞书用户 open_id；多个值用英文逗号分隔。" : "多个飞书 open_id 用英文逗号分隔；可从飞书消息事件 sender_id.open_id 获取。"} meta="FEISHU_ALLOWED_USERS"><input value={allowedUsers} onChange={(e) => setAllowedUsers(e.target.value)} placeholder="ou_xxx,ou_yyy" /></Field>
             </>}
-            <Field label="群聊策略" desc="为了避免刷屏，默认只有 @Hermes 时才回复。" meta="FEISHU_GROUP_POLICY"><select value={groupPolicy} onChange={(e) => setGroupPolicy(e.target.value as FeishuGroupPolicy)}><option value="mention">启用群聊，仅 @Hermes 时响应</option><option value="disabled">关闭群聊</option></select></Field>
             <Field label="默认通知会话" desc={scannedOpenId ? "用于定时任务和跨平台通知；留空会自动使用本次扫码用户的私聊。" : "用于定时任务和跨平台通知；扫码成功后会自动填到当前用户，也可以手动填 chat_id。"} meta="FEISHU_HOME_CHANNEL"><input value={homeChannel} onChange={(e) => setHomeChannel(e.target.value)} placeholder={scannedOpenId ? "留空自动使用扫码用户" : "oc_xxx 或留空"} /></Field>
           </section>
 
           <SectionTitle num="[ REVIEW ]" title="保存前看一眼" meta="密钥会自动打码；保存后继续去飞书后台确认" />
           {credential && <div className={s.summaryLine}>扫码结果：应用 ID {last(credential.appId)} · 应用密钥 {last(credential.appSecret)} · 扫码用户 open_id {last(credential.openId)} · 机器人 {credential.botName ?? "未探测"}</div>}
           <ReviewTable rows={rows} />
-          <div className={s.sectionActions}><button className={`${s.btn} ${s.primary}`} onClick={save} disabled={busy || !(canApplyQr || canApplyManual) || !allowPolicyReady}><Save size={14} />保存并启动接收服务</button></div>
+          <div className={s.sectionActions}><button className={`${s.btn} ${s.primary}`} onClick={save} disabled={busy || !canApplyQr || !allowPolicyReady}><Save size={14} />保存并启动接收服务</button></div>
           <ApplyResult result={result} />
-          <SectionTitle num="[ STEP 04 ]" title="打开飞书后台完成权限" meta="按清单勾选权限、订阅消息并发布版本" />
+          <SectionTitle num="[ STEP 03 ]" title="打开飞书后台完成权限" meta="按清单勾选权限、订阅消息并发布版本" />
           <FeishuBackendChecklist />
-          <SectionTitle num="[ STEP 05 ]" title="发一条消息试试" meta="私聊和群聊各试一次，确认真的能回复" />
+          <SectionTitle num="[ STEP 04 ]" title="发一条消息试试" meta="私聊机器人，确认真的能回复" />
           <FeishuTestGuide result={result} />
           {(begin.error || poll.error || apply.error || stateQuery.error) && <div className={s.errorBox}><XCircle size={16} />{textFromError(begin.error || poll.error || apply.error || stateQuery.error)}</div>}
         </main>

--- a/web/src/routes/im-onboarding.tsx
+++ b/web/src/routes/im-onboarding.tsx
@@ -42,10 +42,11 @@ import s from "./im-onboarding.module.css";
 
 type ImSection = "feishu" | "weixin";
 type FeishuMethod = "qr" | "manual";
-type DmPolicy = "pairing" | "allowlist" | "open" | "disabled";
+type DmPolicy = "scanned" | "pairing" | "allowlist" | "open" | "disabled";
 type FeishuGroupPolicy = "mention" | "disabled";
 
 const FEISHU_DEVELOPER_URL = "https://open.feishu.cn/app";
+const FEISHU_SCANNED_OPEN_ID_TOKEN = "__HERMES_SCANNED_FEISHU_OPEN_ID__";
 export const FEISHU_REQUIRED_SCOPES = [
   "im:message.p2p_msg:readonly",
   "im:message.group_at_msg:readonly",
@@ -67,6 +68,29 @@ export function sectionFromPath(pathname: string): ImSection | null {
 
 function last(value?: ImRedactedValue | null): string {
   return value?.redactedValue ?? "未设置";
+}
+
+function isSet(value?: ImRedactedValue | null): value is ImRedactedValue {
+  return Boolean(value?.isSet);
+}
+
+function splitAllowedUsers(value: string): string[] {
+  return value
+    .split(/[,，\s]+/g)
+    .map((item) => item.trim())
+    .filter(Boolean);
+}
+
+function compactList(items: string[]): string {
+  const seen = new Set<string>();
+  const out: string[] = [];
+  for (const item of items) {
+    const trimmed = item.trim();
+    if (!trimmed || seen.has(trimmed)) continue;
+    seen.add(trimmed);
+    out.push(trimmed);
+  }
+  return out.join(",");
 }
 
 export function statusText(status?: string): string {
@@ -409,7 +433,7 @@ export function railPanels(platform: ImPlatform): RailPanelConfig[] {
         sections: [
           {
             title: "最小闭环",
-            items: ["机器人能力已打开", "消息事件已订阅", `事件里包含 ${FEISHU_RECEIVE_EVENT}`, "应用已创建版本并发布"],
+            items: ["允许对话用户 open_id 已写入 FEISHU_ALLOWED_USERS", "机器人能力已打开", "消息事件已订阅", `事件里包含 ${FEISHU_RECEIVE_EVENT}`, "应用已创建版本并发布"],
           },
           {
             title: "必须权限",
@@ -606,6 +630,7 @@ function FeishuRoute() {
   const [appId, setAppId] = useState("");
   const [appSecret, setAppSecret] = useState("");
   const [allowedUsers, setAllowedUsers] = useState("");
+  const [includeScannedOpenId, setIncludeScannedOpenId] = useState(true);
   const [homeChannel, setHomeChannel] = useState("");
   const [webhookHost, setWebhookHost] = useState("127.0.0.1");
   const [webhookPort, setWebhookPort] = useState("8765");
@@ -620,6 +645,7 @@ function FeishuRoute() {
   const configured = stateQuery.data?.configured ?? {};
   const status = pollResult?.status ?? flow?.status;
   const credential = pollResult?.credentialSummary;
+  const scannedOpenId = isSet(credential?.openId) ? credential.openId : null;
   const canApplyQr = method === "qr" && credential && pollResult?.status === "confirmed";
   const canApplyManual = method === "manual" && appId.trim() && appSecret.trim();
   const busy = begin.isPending || poll.isPending || apply.isPending;
@@ -648,17 +674,31 @@ function FeishuRoute() {
     const id = window.setInterval(pollOnce, delay);
     return () => window.clearInterval(id);
   }, [flow?.flowId, flow?.intervalSeconds, pollResult?.status]);
+  useEffect(() => {
+    if (method === "qr" && pollResult?.status === "confirmed" && scannedOpenId && dmPolicy === "pairing") {
+      setDmPolicy("scanned");
+      setIncludeScannedOpenId(true);
+    }
+  }, [method, pollResult?.status, scannedOpenId?.fingerprint, dmPolicy]);
 
+  const shouldAutoHomeChannel = Boolean(scannedOpenId) && !homeChannel.trim();
   const settings = () => {
     const allowAll = dmPolicy === "open" ? "true" : "false";
+    const useScannedOpenId = Boolean(scannedOpenId) && (dmPolicy === "scanned" || (dmPolicy === "allowlist" && includeScannedOpenId));
+    const allowedList = dmPolicy === "scanned" || dmPolicy === "allowlist"
+      ? compactList([
+        ...(useScannedOpenId ? [FEISHU_SCANNED_OPEN_ID_TOKEN] : []),
+        ...splitAllowedUsers(allowedUsers),
+      ])
+      : "";
     return {
       FEISHU_DOMAIN: domain,
       FEISHU_CONNECTION_MODE: connectionMode,
       FEISHU_ALLOW_ALL_USERS: allowAll,
-      FEISHU_ALLOWED_USERS: dmPolicy === "allowlist" ? allowedUsers.replaceAll(" ", "") : "",
+      FEISHU_ALLOWED_USERS: allowedList,
       FEISHU_GROUP_POLICY: groupPolicy === "disabled" ? "disabled" : "open",
       FEISHU_REQUIRE_MENTION: groupPolicy === "mention" ? "true" : "false",
-      FEISHU_HOME_CHANNEL: homeChannel.trim(),
+      FEISHU_HOME_CHANNEL: shouldAutoHomeChannel ? FEISHU_SCANNED_OPEN_ID_TOKEN : homeChannel.trim(),
       ...(connectionMode === "webhook" ? {
         FEISHU_WEBHOOK_HOST: webhookHost.trim(),
         FEISHU_WEBHOOK_PORT: webhookPort.trim(),
@@ -677,12 +717,31 @@ function FeishuRoute() {
       restartGateway: true,
     }, { onSuccess: setResult });
   };
+  const manualAllowedCount = splitAllowedUsers(allowedUsers).length;
+  const useScannedOpenId = Boolean(scannedOpenId) && (dmPolicy === "scanned" || (dmPolicy === "allowlist" && includeScannedOpenId));
+  const allowPolicyReady = dmPolicy === "scanned"
+    ? Boolean(scannedOpenId)
+    : dmPolicy === "allowlist"
+      ? Boolean(useScannedOpenId || manualAllowedCount > 0)
+      : true;
+  const allowlistReview = dmPolicy === "scanned"
+    ? `扫码用户 ${last(scannedOpenId)}`
+    : dmPolicy === "allowlist"
+      ? compactList([
+        ...(useScannedOpenId ? [`扫码用户 ${last(scannedOpenId)}`] : []),
+        ...(manualAllowedCount > 0 ? [`手动 ${manualAllowedCount} 个`] : []),
+      ]) || "未填写"
+      : "";
+  const allowlistStatus = dmPolicy === "open" ? "未限制" : dmPolicy === "pairing" ? "走配对确认" : allowPolicyReady ? "可保存" : "缺少 open_id";
+  const homeChannelReview = shouldAutoHomeChannel ? `扫码用户 ${last(scannedOpenId)}` : homeChannel.trim();
+  const homeChannelStatus = shouldAutoHomeChannel ? "自动设置" : homeChannel.trim() ? "已填写" : "稍后设置";
   const rows: Array<[string, string, string]> = [
     ["连接模式", `FEISHU_CONNECTION_MODE=${connectionMode}`, connectionMode === "websocket" ? "推荐" : "高级"],
     ["区域", `FEISHU_DOMAIN=${domain}`, "已选择"],
-    ["私聊策略", `FEISHU_ALLOW_ALL_USERS=${dmPolicy === "open" ? "true" : "false"}`, dmPolicy === "pairing" ? "推荐：先确认" : dmPolicy],
+    ["私聊策略", `FEISHU_ALLOW_ALL_USERS=${dmPolicy === "open" ? "true" : "false"}`, dmPolicy === "scanned" ? "只允许扫码用户" : dmPolicy === "pairing" ? "需要确认" : dmPolicy],
+    ["允许对话用户", `FEISHU_ALLOWED_USERS=${allowlistReview}`, allowlistStatus],
     ["群聊策略", `FEISHU_GROUP_POLICY=${groupPolicy === "disabled" ? "disabled" : "open"}`, groupPolicy === "mention" ? "仅 @ 响应" : "关闭"],
-    ["首页频道", `FEISHU_HOME_CHANNEL=${homeChannel || ""}`, homeChannel ? "已填写" : "稍后设置"],
+    ["默认通知会话", `FEISHU_HOME_CHANNEL=${homeChannelReview}`, homeChannelStatus],
   ];
 
   return (
@@ -696,7 +755,7 @@ function FeishuRoute() {
           <SectionTitle num="[ STEP 01 ]" title="先选择怎么接入" meta="新手推荐扫码；已有飞书应用再手动填写" />
           <section className={s.section}><div className={s.choiceGrid}>
             <ChoiceCard active={method === "qr"} icon="scan" badge="推荐" title="手机扫码接入" desc="用飞书手机端扫一下，桌面端会自动拿到应用信息。扫码后还需要按提示去飞书后台确认权限。" foot="推荐新手使用" onClick={() => setMethod("qr")} />
-            <ChoiceCard active={method === "manual"} icon="key" badge="高级" title="我已有飞书应用" desc="如果公司已经建好自建应用，可以在这里填写应用信息。" foot="适合熟悉飞书后台的用户" onClick={() => setMethod("manual")} />
+            <ChoiceCard active={method === "manual"} icon="key" badge="高级" title="我已有飞书应用" desc="如果公司已经建好自建应用，可以在这里填写应用信息。" foot="适合熟悉飞书后台的用户" onClick={() => { setMethod("manual"); if (dmPolicy === "scanned") setDmPolicy("allowlist"); }} />
           </div></section>
 
           {method === "qr" ? <>
@@ -734,19 +793,34 @@ function FeishuRoute() {
           <SectionTitle num="[ STEP 03 ]" title="保存设置并启动接收服务" meta="只会更新当前配置档案；飞书后台还需要继续按提示确认" />
           <section className={s.section}>
             <div className={s.policyGrid}>
+              {scannedOpenId && <PolicyCard active={dmPolicy === "scanned"} title="只允许扫码用户" desc={`把本次扫码用户的 open_id（${last(scannedOpenId)}）写入允许列表。`} onClick={() => setDmPolicy("scanned")} />}
               <PolicyCard active={dmPolicy === "pairing"} title="需要确认再放行" desc="陌生用户先发起申请，管理员同意后可用。" onClick={() => setDmPolicy("pairing")} />
-              <PolicyCard active={dmPolicy === "allowlist"} title="只允许指定用户" desc="只让列表里的用户 ID 使用。" onClick={() => setDmPolicy("allowlist")} />
+              <PolicyCard active={dmPolicy === "allowlist"} title="只允许指定用户" desc="只让列表里的飞书 open_id 使用，可把扫码用户一起加入。" onClick={() => setDmPolicy("allowlist")} />
               <PolicyCard active={dmPolicy === "open"} warning title="所有私聊都可用" desc="方便试用，但不建议长期开放。" onClick={() => setDmPolicy("open")} />
             </div>
-            {dmPolicy === "allowlist" && <Field label="允许用户" desc="多个用户 ID 用英文逗号分隔；不知道用户 ID 可先跳过。" meta="FEISHU_ALLOWED_USERS"><input value={allowedUsers} onChange={(e) => setAllowedUsers(e.target.value)} /></Field>}
+            {scannedOpenId && (dmPolicy === "scanned" || dmPolicy === "allowlist") && (
+              <div className={s.identityNote}>
+                <b>已拿到扫码用户 open_id</b>
+                <span>界面只显示打码值 <code>{last(scannedOpenId)}</code>，保存时桌面端会把完整 open_id 写入 <code>FEISHU_ALLOWED_USERS</code>；默认通知会话留空时，也会自动写入 <code>FEISHU_HOME_CHANNEL</code>。</span>
+              </div>
+            )}
+            {dmPolicy === "allowlist" && <>
+              {scannedOpenId && (
+                <label className={s.checkToggle}>
+                  <input type="checkbox" checked={includeScannedOpenId} onChange={(e) => setIncludeScannedOpenId(e.target.checked)} />
+                  <span>同时加入本次扫码用户 <code>{last(scannedOpenId)}</code></span>
+                </label>
+              )}
+              <Field label="允许对话用户 open_id" desc={scannedOpenId ? "可继续添加其他飞书用户 open_id；多个值用英文逗号分隔。" : "多个飞书 open_id 用英文逗号分隔；可从飞书消息事件 sender_id.open_id 获取。"} meta="FEISHU_ALLOWED_USERS"><input value={allowedUsers} onChange={(e) => setAllowedUsers(e.target.value)} placeholder="ou_xxx,ou_yyy" /></Field>
+            </>}
             <Field label="群聊策略" desc="为了避免刷屏，默认只有 @Hermes 时才回复。" meta="FEISHU_GROUP_POLICY"><select value={groupPolicy} onChange={(e) => setGroupPolicy(e.target.value as FeishuGroupPolicy)}><option value="mention">启用群聊，仅 @Hermes 时响应</option><option value="disabled">关闭群聊</option></select></Field>
-            <Field label="默认通知会话" desc="用于定时任务和通知；不知道可以先留空。" meta="FEISHU_HOME_CHANNEL"><input value={homeChannel} onChange={(e) => setHomeChannel(e.target.value)} placeholder="oc_xxx 或留空" /></Field>
+            <Field label="默认通知会话" desc={scannedOpenId ? "用于定时任务和跨平台通知；留空会自动使用本次扫码用户的私聊。" : "用于定时任务和跨平台通知；扫码成功后会自动填到当前用户，也可以手动填 chat_id。"} meta="FEISHU_HOME_CHANNEL"><input value={homeChannel} onChange={(e) => setHomeChannel(e.target.value)} placeholder={scannedOpenId ? "留空自动使用扫码用户" : "oc_xxx 或留空"} /></Field>
           </section>
 
           <SectionTitle num="[ REVIEW ]" title="保存前看一眼" meta="密钥会自动打码；保存后继续去飞书后台确认" />
-          {credential && <div className={s.summaryLine}>扫码结果：应用 ID {last(credential.appId)} · 应用密钥 {last(credential.appSecret)} · 机器人 {credential.botName ?? "未探测"}</div>}
+          {credential && <div className={s.summaryLine}>扫码结果：应用 ID {last(credential.appId)} · 应用密钥 {last(credential.appSecret)} · 扫码用户 open_id {last(credential.openId)} · 机器人 {credential.botName ?? "未探测"}</div>}
           <ReviewTable rows={rows} />
-          <div className={s.sectionActions}><button className={`${s.btn} ${s.primary}`} onClick={save} disabled={busy || !(canApplyQr || canApplyManual)}><Save size={14} />保存并启动接收服务</button></div>
+          <div className={s.sectionActions}><button className={`${s.btn} ${s.primary}`} onClick={save} disabled={busy || !(canApplyQr || canApplyManual) || !allowPolicyReady}><Save size={14} />保存并启动接收服务</button></div>
           <ApplyResult result={result} />
           <SectionTitle num="[ STEP 04 ]" title="打开飞书后台完成权限" meta="按清单勾选权限、订阅消息并发布版本" />
           <FeishuBackendChecklist />

--- a/web/src/routes/settings.tsx
+++ b/web/src/routes/settings.tsx
@@ -27,6 +27,7 @@ import { useCronJobs, useCreateCronJob, useDeleteCronJob, useCronAction } from "
 import { useLogs } from "@/hooks/use-logs";
 import { useStatus } from "@/hooks/use-status";
 import { useYoloMode, useSetYoloMode, isYoloModeSupported } from "@/hooks/use-yolo-mode";
+import { useGatewayRestartAction } from "@/hooks/use-gateway-restart";
 import {
   useCheckRuntimeUpdate,
   useInstallRuntimeUpdate,
@@ -34,10 +35,10 @@ import {
   useRuntimeInfo,
 } from "@/hooks/use-runtime-update";
 import { composerSubmitShortcutAtom, showReasoningAtom, profileSwitchingAtom } from "@/stores/ui";
-import { postJSON } from "@/lib/transport";
 import { openExternalUrl } from "@/lib/external-links";
 import { buildNestedConfigUpdate, mergeConfigUpdate } from "@/lib/config-update";
 import { translateConfigField, translateConfigOption } from "@/lib/config-translations";
+import { gatewayRestartButtonLabel, gatewayRestartTitle } from "@/lib/gateway-restart";
 import type { ComposerSubmitShortcut } from "@/lib/composer-submit-shortcut";
 import type { ConfigSchemaField, CronJob, RuntimeInfo, RuntimeUpdateCheckResult } from "@hermes/protocol";
 import { CopyButton } from "@/components/ui/copy-button";
@@ -635,15 +636,9 @@ export function KernelSection({ showHeading = true }: SettingsSectionProps) {
   const checkRuntimeUpdate = useCheckRuntimeUpdate();
   const installRuntimeUpdate = useInstallRuntimeUpdate();
   const rollbackRuntime = useRollbackRuntime();
-  const [restarting, setRestarting] = useState(false);
+  const gatewayRestart = useGatewayRestartAction();
   const [runtimeMessage, setRuntimeMessage] = useState("");
   const [aboutMessage, setAboutMessage] = useState("");
-
-  const handleRestart = async () => {
-    setRestarting(true);
-    try { await postJSON("/api/gateway/restart", {}); }
-    finally { setTimeout(() => setRestarting(false), 3000); }
-  };
 
   const handleCheckRuntime = async () => {
     setRuntimeMessage("");
@@ -767,12 +762,23 @@ export function KernelSection({ showHeading = true }: SettingsSectionProps) {
           <FolderOpen size={13} />
           打开 runtime
         </button>
-        <button className={s.btnPrimary} onClick={handleRestart} disabled={restarting}>
+        <button
+          className={s.btnPrimary}
+          onClick={() => void gatewayRestart.restart()}
+          disabled={gatewayRestart.locked}
+          title={gatewayRestartTitle(gatewayRestart.phase, gatewayRestart.message)}
+          aria-busy={gatewayRestart.busy}
+        >
           <RotateCcw size={13} />
-          {restarting ? "重启中…" : "重启 Gateway"}
+          {gatewayRestart.phase === "idle" ? "重启 Gateway" : gatewayRestartButtonLabel(gatewayRestart.phase)}
         </button>
       </div>
       {aboutMessage && <div className={s.runtimeMessage} data-tone="error">{aboutMessage}</div>}
+      {gatewayRestart.message && (
+        <div className={s.runtimeMessage} data-tone={gatewayRestart.phase === "error" ? "error" : "normal"}>
+          {gatewayRestart.message}
+        </div>
+      )}
 
       <div className={s.aboutDebugGrid}>
         <DebugCard icon={<Server size={15} />} title="内核进程" sub="Dashboard 子进程与连接状态" wide>


### PR DESCRIPTION
## 变更说明

本 PR 在桌面端底部状态栏的“网关 9120”右侧补齐“重启”按钮，并复用官方 dashboard 的 `/api/gateway/restart` 行为来发起 Gateway 重启。

同时抽出 `useGatewayRestartAction`，让底部栏和高级设置页的“重启 Gateway”入口共用同一套状态、轮询和重连逻辑。重启完成后会刷新状态查询、runtime info，并主动触发现有 Gateway SSE/WebSocket 重连。

## 用户影响

用户可以直接在底部状态栏完成网关重启，不需要进入官方 dashboard 或高级设置页。按钮会展示“重启中…”、“已完成”或“重试”等短状态，便于确认操作是否已发起。

## 验证

- `pnpm typecheck`
- `pnpm --filter @hermes/web exec vitest run src/lib/gateway-restart.test.ts`
- `cargo check`

补充说明：完整 `pnpm test:unit` 当前仍有既有失败，位置是 `web/src/routes/im-onboarding.test.ts` 的 Feishu scope 断言，期望包含 `im:message.group_at_msg:readonly`，实际常量缺失；该失败与本次网关重启改动无关。