### PR TITLE
[codex] 增强桌面端日志页复制与导出能力

### DIFF
--- a/packages/protocol/src/channels.ts
+++ b/packages/protocol/src/channels.ts
@@ -51,6 +51,20 @@ export interface FilePickerResult {
   paths: string[];
 }
 
+export interface ExportLogSnapshotInput {
+  fileName: string;
+  content: string;
+  format: "log" | "jsonl";
+}
+
+export interface ExportLogSnapshotResult {
+  ok: boolean;
+  canceled: boolean;
+  path?: string;
+  bytes: number;
+  error?: string;
+}
+
 export interface WorkspacePathInput {
   path: string;
 }

--- a/src/commands/log_export.rs
+++ b/src/commands/log_export.rs
@@ -1,0 +1,183 @@
+use serde::{Deserialize, Serialize};
+use std::fs;
+use std::path::PathBuf;
+
+use crate::error::{AppError, AppResult};
+
+#[derive(Debug, Clone, Copy, Deserialize)]
+#[serde(rename_all = "lowercase")]
+pub enum LogSnapshotFormat {
+    Log,
+    Jsonl,
+}
+
+impl LogSnapshotFormat {
+    fn extension(self) -> &'static str {
+        match self {
+            LogSnapshotFormat::Log => "log",
+            LogSnapshotFormat::Jsonl => "jsonl",
+        }
+    }
+
+    fn filter_label(self) -> &'static str {
+        match self {
+            LogSnapshotFormat::Log => "日志文件",
+            LogSnapshotFormat::Jsonl => "JSON Lines 日志",
+        }
+    }
+}
+
+#[derive(Deserialize)]
+#[serde(rename_all = "camelCase")]
+pub struct ExportLogSnapshotInput {
+    pub file_name: String,
+    pub content: String,
+    pub format: LogSnapshotFormat,
+}
+
+#[derive(Serialize)]
+#[serde(rename_all = "camelCase")]
+pub struct ExportLogSnapshotResult {
+    pub ok: bool,
+    pub canceled: bool,
+    #[serde(skip_serializing_if = "Option::is_none")]
+    pub path: Option<String>,
+    pub bytes: u64,
+    #[serde(skip_serializing_if = "Option::is_none")]
+    pub error: Option<String>,
+}
+
+#[tauri::command]
+pub async fn export_log_snapshot(
+    app: tauri::AppHandle,
+    input: ExportLogSnapshotInput,
+) -> AppResult<ExportLogSnapshotResult> {
+    let Some(path) =
+        choose_log_save_path(app, safe_file_name(&input.file_name, input.format)).await?
+    else {
+        return Ok(ExportLogSnapshotResult {
+            ok: false,
+            canceled: true,
+            path: None,
+            bytes: 0,
+            error: None,
+        });
+    };
+
+    let path = ensure_extension(path, input.format);
+    let bytes = input.content.len() as u64;
+    let write_path = path.clone();
+    let content = input.content;
+
+    let write_result =
+        tauri::async_runtime::spawn_blocking(move || fs::write(&write_path, content))
+            .await
+            .map_err(|e| AppError::Internal(e.to_string()))?;
+
+    match write_result {
+        Ok(()) => Ok(ExportLogSnapshotResult {
+            ok: true,
+            canceled: false,
+            path: Some(path.to_string_lossy().to_string()),
+            bytes,
+            error: None,
+        }),
+        Err(err) => Ok(ExportLogSnapshotResult {
+            ok: false,
+            canceled: false,
+            path: Some(path.to_string_lossy().to_string()),
+            bytes: 0,
+            error: Some(err.to_string()),
+        }),
+    }
+}
+
+async fn choose_log_save_path(
+    app: tauri::AppHandle,
+    file_name: String,
+) -> AppResult<Option<PathBuf>> {
+    use tauri_plugin_dialog::DialogExt;
+
+    let format = if file_name.to_lowercase().ends_with(".jsonl") {
+        LogSnapshotFormat::Jsonl
+    } else {
+        LogSnapshotFormat::Log
+    };
+    let extensions = [format.extension()];
+    let (tx, rx) = tokio::sync::oneshot::channel();
+    app.dialog()
+        .file()
+        .set_title("导出 Hermes 日志")
+        .set_file_name(file_name)
+        .add_filter(format.filter_label(), &extensions)
+        .save_file(move |path| {
+            let result = path.and_then(|p| p.as_path().map(|path| path.to_path_buf()));
+            let _ = tx.send(result);
+        });
+    rx.await.map_err(|e| AppError::Internal(e.to_string()))
+}
+
+fn safe_file_name(file_name: &str, format: LogSnapshotFormat) -> String {
+    let mut cleaned = file_name
+        .trim()
+        .chars()
+        .map(|ch| match ch {
+            '/' | '\\' | ':' | '*' | '?' | '"' | '<' | '>' | '|' => '_',
+            ch if ch.is_control() => '_',
+            ch => ch,
+        })
+        .collect::<String>();
+
+    if cleaned.is_empty() || cleaned == "." || cleaned == ".." {
+        cleaned = "hermes-logs".to_string();
+    }
+
+    let extension = format.extension();
+    let suffix = format!(".{extension}");
+    if !cleaned.to_lowercase().ends_with(&suffix) {
+        cleaned.push('.');
+        cleaned.push_str(extension);
+    }
+    cleaned
+}
+
+fn ensure_extension(mut path: PathBuf, format: LogSnapshotFormat) -> PathBuf {
+    let extension = format.extension();
+    let has_extension = path
+        .extension()
+        .and_then(|ext| ext.to_str())
+        .is_some_and(|ext| ext.eq_ignore_ascii_case(extension));
+    if !has_extension {
+        path.set_extension(extension);
+    }
+    path
+}
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+
+    #[test]
+    fn safe_file_name_removes_path_separators_and_adds_extension() {
+        assert_eq!(
+            safe_file_name("../bad:name", LogSnapshotFormat::Log),
+            ".._bad_name.log"
+        );
+        assert_eq!(
+            safe_file_name("gateway.JSONL", LogSnapshotFormat::Jsonl),
+            "gateway.JSONL"
+        );
+    }
+
+    #[test]
+    fn ensure_extension_replaces_missing_or_different_extension() {
+        assert_eq!(
+            ensure_extension(PathBuf::from("/tmp/hermes"), LogSnapshotFormat::Jsonl),
+            PathBuf::from("/tmp/hermes.jsonl")
+        );
+        assert_eq!(
+            ensure_extension(PathBuf::from("/tmp/hermes.txt"), LogSnapshotFormat::Log),
+            PathBuf::from("/tmp/hermes.log")
+        );
+    }
+}

--- a/src/commands/mod.rs
+++ b/src/commands/mod.rs
@@ -6,6 +6,7 @@ pub mod environment;
 pub mod file_dialogs;
 pub mod gateway;
 pub mod im_onboarding;
+pub mod log_export;
 pub mod memory;
 pub mod profiles;
 pub mod restart;

--- a/src/main.rs
+++ b/src/main.rs
@@ -475,6 +475,7 @@ fn main() {
             commands::file_dialogs::create_workspace_project,
             commands::file_dialogs::open_workspace_path,
             commands::file_dialogs::open_external_url,
+            commands::log_export::export_log_snapshot,
             commands::debug_bundle::export_debug_bundle,
             commands::environment::environment_check,
             commands::api_proxy::api_request,

--- a/web/src/lib/debug-redact.test.ts
+++ b/web/src/lib/debug-redact.test.ts
@@ -65,4 +65,8 @@ describe("redactSummary", () => {
   it("leaves plain summaries untouched", () => {
     expect(redactSummary("message.complete · sid=abc")).toBe("message.complete · sid=abc");
   });
+  it("masks sensitive key-value fragments in log text", () => {
+    expect(redactSummary("gateway failed token=secret-value api_key='sk-abcdefghijklmnop1234567890'"))
+      .toBe("gateway failed token=*** api_key='***'");
+  });
 });

--- a/web/src/lib/debug-redact.ts
+++ b/web/src/lib/debug-redact.ts
@@ -17,9 +17,16 @@ const SENSITIVE_KEYS = [
 ];
 
 const SENSITIVE_KEY_SET = new Set(SENSITIVE_KEYS.map((k) => k.toLowerCase()));
+const SENSITIVE_TEXT_KEYS = [...SENSITIVE_KEYS, "token"] as const;
 
 const BEARER_RE = /(Bearer\s+)([A-Za-z0-9_.\-+/=]{8,})/gi;
 const LONG_TOKEN_RE = /\b(sk-[A-Za-z0-9_\-]{16,}|gh[pous]_[A-Za-z0-9_]{20,}|xox[abprsu]-[A-Za-z0-9-]{10,})\b/g;
+const SENSITIVE_TEXT_KEY_RE = new RegExp(
+  `(^|[\\s,{\\[])(` +
+    SENSITIVE_TEXT_KEYS.map((key) => key.replace(/[.*+?^${}()|[\]\\]/g, "\\$&")).join("|") +
+    `)(\\s*[:=]\\s*)(["']?)([^"'\\s,;&}]+)(["']?)`,
+  "gi",
+);
 
 const MASK = "***";
 const MAX_DEPTH = 6;
@@ -27,7 +34,11 @@ const MAX_DEPTH = 6;
 function maskString(value: string): string {
   return value
     .replace(BEARER_RE, (_, prefix) => `${prefix}${MASK}`)
-    .replace(LONG_TOKEN_RE, MASK);
+    .replace(LONG_TOKEN_RE, MASK)
+    .replace(SENSITIVE_TEXT_KEY_RE, (_match, prefix, key, sep, openQuote, _secret, closeQuote) => {
+      const quote = openQuote && closeQuote ? openQuote : "";
+      return `${prefix}${key}${sep}${quote}${MASK}${quote}`;
+    });
 }
 
 function isSensitiveKey(key: string): boolean {

--- a/web/src/lib/logs-viewer.test.ts
+++ b/web/src/lib/logs-viewer.test.ts
@@ -1,0 +1,72 @@
+import { describe, expect, it } from "vitest";
+import {
+  buildLogJsonl,
+  buildLogText,
+  createLogExportFileName,
+  filterLogLines,
+  parseLogsSearchParams,
+} from "./logs-viewer";
+
+describe("logs-viewer helpers", () => {
+  it("falls back to safe defaults for invalid query values", () => {
+    const state = parseLogsSearchParams(new URLSearchParams("file=evil&level=nope&component=bad&lines=999&live=no&redact=0"));
+
+    expect(state).toMatchObject({
+      file: "agent",
+      level: "ALL",
+      component: "all",
+      lines: 200,
+      live: false,
+      redact: false,
+    });
+  });
+
+  it("accepts source as an alias for component", () => {
+    const state = parseLogsSearchParams(new URLSearchParams("source=gateway&level=error&lines=500&q=timeout"));
+
+    expect(state.component).toBe("gateway");
+    expect(state.level).toBe("ERROR");
+    expect(state.lines).toBe(500);
+    expect(state.q).toBe("timeout");
+  });
+
+  it("filters visible lines by all search terms case-insensitively", () => {
+    const lines = [
+      "INFO gateway connected",
+      "ERROR gateway token expired",
+      "ERROR agent timeout",
+    ];
+
+    expect(filterLogLines(lines, "error gateway")).toEqual(["ERROR gateway token expired"]);
+  });
+
+  it("builds redacted plain text for copying and .log export", () => {
+    const text = buildLogText(["ERROR token=secret-value Bearer abcdefghij"], { redact: true });
+
+    expect(text).toBe("ERROR token=*** Bearer ***\n");
+  });
+
+  it("builds JSONL with parsed metadata", () => {
+    const jsonl = buildLogJsonl(["2026-06-07 10:11:12 [gateway] WARN token=secret-value"], {
+      file: "gateway",
+      redact: true,
+    });
+    const row = JSON.parse(jsonl.trim()) as Record<string, unknown>;
+
+    expect(row).toMatchObject({
+      file: "gateway",
+      lineNumber: 1,
+      level: "WARNING",
+      source: "gateway",
+      timestamp: "2026-06-07 10:11:12",
+      message: "2026-06-07 10:11:12 [gateway] WARN token=***",
+    });
+  });
+
+  it("creates deterministic export file names", () => {
+    expect(createLogExportFileName(
+      { file: "agent", format: "jsonl" },
+      new Date("2026-06-07T10:11:12.000Z"),
+    )).toBe("hermes-logs-agent-20260607-101112.jsonl");
+  });
+});

--- a/web/src/lib/logs-viewer.ts
+++ b/web/src/lib/logs-viewer.ts
@@ -1,0 +1,160 @@
+import { redactSummary } from "./debug-redact";
+
+export const LOG_FILE_OPTIONS = ["agent", "errors", "gateway"] as const;
+export const LOG_LEVEL_OPTIONS = ["ALL", "DEBUG", "INFO", "WARNING", "ERROR"] as const;
+export const LOG_COMPONENT_OPTIONS = ["all", "gateway", "agent", "tools", "cli", "cron", "mcp", "skill", "task"] as const;
+export const LOG_LINE_COUNT_OPTIONS = [50, 100, 200, 500] as const;
+
+export type LogFileOption = (typeof LOG_FILE_OPTIONS)[number];
+export type LogLevelOption = (typeof LOG_LEVEL_OPTIONS)[number];
+export type LogComponentOption = (typeof LOG_COMPONENT_OPTIONS)[number];
+export type LogExportFormat = "log" | "jsonl";
+export type LogLineTone = "error" | "warning" | "debug" | "info";
+
+export interface LogsQueryState {
+  file: LogFileOption;
+  level: LogLevelOption;
+  component: LogComponentOption;
+  lines: (typeof LOG_LINE_COUNT_OPTIONS)[number];
+  q: string;
+  live: boolean;
+  redact: boolean;
+}
+
+export interface BuildLogExportOptions {
+  file: string;
+  redact: boolean;
+}
+
+export const DEFAULT_LOGS_QUERY: LogsQueryState = {
+  file: "agent",
+  level: "ALL",
+  component: "all",
+  lines: 200,
+  q: "",
+  live: true,
+  redact: true,
+};
+
+function isOneOf<T extends readonly string[]>(value: string | null, options: T): value is T[number] {
+  return value !== null && (options as readonly string[]).includes(value);
+}
+
+function normalizeLineCount(value: string | null): LogsQueryState["lines"] {
+  const parsed = Number(value);
+  if (LOG_LINE_COUNT_OPTIONS.includes(parsed as LogsQueryState["lines"])) {
+    return parsed as LogsQueryState["lines"];
+  }
+  return DEFAULT_LOGS_QUERY.lines;
+}
+
+function normalizeBoolean(value: string | null, fallback: boolean): boolean {
+  if (value === null) return fallback;
+  const normalized = value.trim().toLowerCase();
+  if (["0", "false", "off", "no"].includes(normalized)) return false;
+  if (["1", "true", "on", "yes"].includes(normalized)) return true;
+  return fallback;
+}
+
+export function parseLogsSearchParams(params: URLSearchParams): LogsQueryState {
+  const file = params.get("file");
+  const level = params.get("level")?.toUpperCase() ?? null;
+  const component = params.get("component") ?? params.get("source");
+
+  return {
+    file: isOneOf(file, LOG_FILE_OPTIONS) ? file : DEFAULT_LOGS_QUERY.file,
+    level: isOneOf(level, LOG_LEVEL_OPTIONS) ? level : DEFAULT_LOGS_QUERY.level,
+    component: isOneOf(component, LOG_COMPONENT_OPTIONS) ? component : DEFAULT_LOGS_QUERY.component,
+    lines: normalizeLineCount(params.get("lines")),
+    q: params.get("q")?.trim() ?? DEFAULT_LOGS_QUERY.q,
+    live: normalizeBoolean(params.get("live"), DEFAULT_LOGS_QUERY.live),
+    redact: normalizeBoolean(params.get("redact"), DEFAULT_LOGS_QUERY.redact),
+  };
+}
+
+export function logsQueryToSearchParams(query: LogsQueryState): URLSearchParams {
+  const params = new URLSearchParams();
+  params.set("file", query.file);
+  params.set("level", query.level);
+  params.set("component", query.component);
+  params.set("lines", String(query.lines));
+  params.set("live", query.live ? "1" : "0");
+  params.set("redact", query.redact ? "1" : "0");
+  if (query.q.trim()) params.set("q", query.q.trim());
+  return params;
+}
+
+export function classifyLogLine(line: string): LogLineTone {
+  const upper = line.toUpperCase();
+  if (upper.includes("ERROR") || upper.includes("CRITICAL") || upper.includes("FATAL")) return "error";
+  if (upper.includes("WARNING") || upper.includes("WARN")) return "warning";
+  if (upper.includes("DEBUG")) return "debug";
+  return "info";
+}
+
+export function logLevelFromLine(line: string): Exclude<LogLevelOption, "ALL"> {
+  const tone = classifyLogLine(line);
+  if (tone === "error") return "ERROR";
+  if (tone === "warning") return "WARNING";
+  if (tone === "debug") return "DEBUG";
+  return "INFO";
+}
+
+export function filterLogLines(lines: string[], query: string): string[] {
+  const terms = query
+    .trim()
+    .toLowerCase()
+    .split(/\s+/u)
+    .filter(Boolean);
+  if (terms.length === 0) return lines;
+  return lines.filter((line) => {
+    const haystack = line.toLowerCase();
+    return terms.every((term) => haystack.includes(term));
+  });
+}
+
+export function redactLogLine(line: string): string {
+  return redactSummary(line);
+}
+
+export function buildLogText(lines: string[], options: { redact: boolean }): string {
+  if (lines.length === 0) return "";
+  const body = options.redact ? lines.map(redactLogLine).join("\n") : lines.join("\n");
+  return `${body}\n`;
+}
+
+function parseTimestamp(line: string): string | null {
+  const match = line.match(/\b\d{4}-\d{2}-\d{2}(?:[T\s]\d{2}:\d{2}:\d{2}(?:[.,]\d{3,6})?(?:Z|[+-]\d{2}:?\d{2})?)?\b/u);
+  return match?.[0] ?? null;
+}
+
+function parseSource(line: string): string | null {
+  const match = line.match(/\[([A-Za-z0-9_.:-]{2,})\]/u);
+  return match?.[1] ?? null;
+}
+
+export function buildLogJsonl(lines: string[], options: BuildLogExportOptions): string {
+  if (lines.length === 0) return "";
+  return lines
+    .map((line, index) => {
+      const raw = options.redact ? redactLogLine(line) : line;
+      return JSON.stringify({
+        file: options.file,
+        lineNumber: index + 1,
+        level: logLevelFromLine(raw),
+        source: parseSource(raw),
+        timestamp: parseTimestamp(raw),
+        message: raw,
+        raw,
+      });
+    })
+    .join("\n") + "\n";
+}
+
+export function createLogExportFileName(
+  input: { file: string; format: LogExportFormat },
+  now = new Date(),
+): string {
+  const stamp = now.toISOString().replace(/[-:]/g, "").replace(/\.\d{3}Z$/u, "Z").replace("T", "-").replace("Z", "");
+  return `hermes-logs-${input.file}-${stamp}.${input.format}`;
+}

--- a/web/src/lib/runtime.ts
+++ b/web/src/lib/runtime.ts
@@ -6,6 +6,8 @@ import type {
   ConfigMigrationScanInput,
   ConfigMigrationScanResult,
   EnvironmentCheckResult,
+  ExportLogSnapshotInput,
+  ExportLogSnapshotResult,
   FileUploadInput,
   HermesMessageMetadata,
   ImOnboardingApplyInput,
@@ -215,6 +217,7 @@ declare global {
       createWorkspaceProject?(): Promise<ElectronFilePickerResult>;
       openWorkspacePath?(input: { path: string }): Promise<ElectronApiRequestResult>;
       openExternalUrl?(input: { url: string }): Promise<ElectronSimpleResult>;
+      exportLogSnapshot?(input: ExportLogSnapshotInput): Promise<ExportLogSnapshotResult>;
       exportDebugBundle?(input?: ExportDebugBundleInput): Promise<ExportDebugBundleResult>;
       environmentCheck?(): Promise<EnvironmentCheckResult>;
       getRuntimeConfig?(): Window["__HERMES_RUNTIME__"];

--- a/web/src/lib/tauri-bridge.test.ts
+++ b/web/src/lib/tauri-bridge.test.ts
@@ -86,6 +86,24 @@ describe("isTauriDevMode", () => {
     });
   });
 
+  it("exposes log snapshot export through Tauri IPC", async () => {
+    await installTauriBridge();
+
+    await window.hermesDesktop?.exportLogSnapshot?.({
+      fileName: "hermes-logs-agent.log",
+      content: "hello\n",
+      format: "log",
+    });
+
+    expect(mockInvoke).toHaveBeenCalledWith("export_log_snapshot", {
+      input: {
+        fileName: "hermes-logs-agent.log",
+        content: "hello\n",
+        format: "log",
+      },
+    });
+  });
+
   it("exposes external URL opening through Tauri IPC", async () => {
     await installTauriBridge();
 

--- a/web/src/lib/tauri-bridge.ts
+++ b/web/src/lib/tauri-bridge.ts
@@ -15,6 +15,8 @@ import type {
   ConfigMigrationScanInput,
   ConfigMigrationScanResult,
   EnvironmentCheckResult,
+  ExportLogSnapshotInput,
+  ExportLogSnapshotResult,
   FilePickerResult,
   FileUploadInput,
   ImOnboardingApplyInput,
@@ -188,6 +190,10 @@ const tauriBridge = {
 
   async openExternalUrl(input: { url: string }): Promise<{ ok: boolean; message?: string | null }> {
     return invokeCommand("open_external_url", { input });
+  },
+
+  async exportLogSnapshot(input: ExportLogSnapshotInput): Promise<ExportLogSnapshotResult> {
+    return invokeCommand("export_log_snapshot", { input });
   },
 
   async exportDebugBundle(input?: ExportDebugBundleInput): Promise<ExportDebugBundleResult> {

--- a/web/src/routes/logs.module.css
+++ b/web/src/routes/logs.module.css
@@ -1,0 +1,305 @@
+.page {
+  display: grid;
+  gap: 12px;
+  min-width: 0;
+}
+
+.toolbar {
+  display: flex;
+  flex-wrap: wrap;
+  align-items: center;
+  gap: 10px;
+  padding: 12px;
+  border: 1px solid var(--h-line-soft);
+  border-radius: var(--h-r-lg);
+  background: var(--h-bg-pane);
+}
+
+.filterGroup {
+  display: flex;
+  align-items: center;
+  gap: 7px;
+  min-width: 0;
+}
+
+.filterLabel {
+  color: var(--h-text-3);
+  font-size: 11px;
+  white-space: nowrap;
+}
+
+.segmented {
+  display: flex;
+  flex-wrap: wrap;
+  gap: 3px;
+  padding: 3px;
+  border: 1px solid var(--h-line-soft);
+  border-radius: var(--h-r-sm);
+  background: var(--h-bg-chip);
+}
+
+.segmentButton,
+.actionButton,
+.toggleButton,
+.actionLink {
+  min-height: 28px;
+  display: inline-flex;
+  align-items: center;
+  justify-content: center;
+  gap: 6px;
+  border: 1px solid transparent;
+  border-radius: var(--h-r-sm);
+  color: var(--h-text-2);
+  background: transparent;
+  font-size: 12px;
+  font-family: var(--h-font-ui);
+  line-height: 1;
+  white-space: nowrap;
+  text-decoration: none;
+  cursor: pointer;
+  transition: color 0.12s, background-color 0.12s, border-color 0.12s, opacity 0.12s;
+}
+
+.segmentButton {
+  min-height: 23px;
+  padding: 0 8px;
+  font-family: var(--h-font-mono);
+  font-size: 10.5px;
+}
+
+.segmentButton:hover,
+.actionButton:hover,
+.toggleButton:hover,
+.actionLink:hover {
+  color: var(--h-text);
+  border-color: var(--h-line);
+  background: var(--h-bg-soft);
+}
+
+.segmentButton[data-active="true"] {
+  color: var(--h-text);
+  background: var(--h-bg-pane);
+  border-color: var(--h-line);
+  font-weight: 600;
+}
+
+.searchBox {
+  min-width: min(320px, 100%);
+  flex: 1 1 280px;
+  height: 34px;
+  display: flex;
+  align-items: center;
+  gap: 8px;
+  padding: 0 11px;
+  border: 1px solid var(--h-line);
+  border-radius: var(--h-r-md);
+  background: var(--h-bg-input);
+  color: var(--h-text-3);
+}
+
+.searchBox input {
+  width: 100%;
+  min-width: 0;
+  border: 0;
+  outline: 0;
+  background: transparent;
+  color: var(--h-text);
+  font-size: 12px;
+}
+
+.actions {
+  display: flex;
+  flex-wrap: wrap;
+  align-items: center;
+  gap: 8px;
+}
+
+.actionButton,
+.toggleButton,
+.actionLink {
+  min-height: 32px;
+  padding: 0 11px;
+  border-color: var(--h-line);
+  background: var(--h-bg-pane);
+}
+
+.actionButton:disabled,
+.toggleButton:disabled {
+  opacity: 0.55;
+  cursor: not-allowed;
+}
+
+.toggleButton[data-on="true"] {
+  color: var(--h-text);
+  border-color: var(--h-accent-border);
+  background: var(--h-accent-soft);
+}
+
+.toggleDot {
+  width: 7px;
+  height: 7px;
+  border-radius: 999px;
+  background: var(--h-text-3);
+}
+
+.toggleButton[data-on="true"] .toggleDot {
+  background: var(--h-ok);
+}
+
+.spinIcon {
+  animation: spin 0.9s linear infinite;
+}
+
+.metaLine {
+  display: flex;
+  flex-wrap: wrap;
+  gap: 8px 14px;
+  color: var(--h-text-3);
+  font-size: 11.5px;
+}
+
+.feedback {
+  color: var(--h-text-2);
+  font-size: 12px;
+  line-height: 1.6;
+}
+
+.feedback[data-tone="error"] {
+  color: var(--h-err);
+}
+
+.errorCard {
+  display: grid;
+  gap: 8px;
+  padding: 16px;
+  border: 1px solid color-mix(in srgb, var(--h-err) 35%, var(--h-line));
+  border-radius: var(--h-r-lg);
+  background: color-mix(in srgb, var(--h-err) 7%, var(--h-bg-pane));
+  color: var(--h-text-2);
+}
+
+.errorCard b {
+  color: var(--h-err);
+}
+
+.errorCard p {
+  margin: 0;
+  line-height: 1.65;
+}
+
+.errorActions {
+  display: flex;
+  flex-wrap: wrap;
+  gap: 8px;
+}
+
+.viewerWrap {
+  position: relative;
+  min-width: 0;
+}
+
+.newLogsButton {
+  position: absolute;
+  z-index: 2;
+  top: 10px;
+  left: 50%;
+  transform: translateX(-50%);
+  height: 30px;
+  padding: 0 12px;
+  border: 1px solid var(--h-accent-border);
+  border-radius: var(--h-r-pill);
+  background: var(--h-bg-pane);
+  color: var(--h-text);
+  box-shadow: var(--h-shadow);
+  cursor: pointer;
+}
+
+.logViewport {
+  height: calc(100vh - 330px);
+  min-height: 360px;
+  overflow: auto;
+  padding: 12px 0;
+  border: 1px solid var(--h-line-soft);
+  border-radius: var(--h-r-lg);
+  background: var(--h-bg-code);
+  font-family: var(--h-font-mono);
+  font-size: 11.5px;
+  line-height: 1.65;
+  cursor: text;
+}
+
+:global(#root) .logViewport,
+:global(#root) .logViewport .lineText,
+:global(#root) .logViewport .emptyLine {
+  -webkit-user-select: text;
+  user-select: text;
+}
+
+.logLine {
+  min-width: max-content;
+  display: grid;
+  grid-template-columns: 54px minmax(max-content, 1fr);
+  gap: 10px;
+  padding: 1px 14px;
+  color: var(--h-text-2);
+  white-space: pre;
+}
+
+.logLine:hover {
+  background: var(--h-bg-soft);
+}
+
+.lineNumber {
+  color: var(--h-text-3);
+  text-align: right;
+  -webkit-user-select: none;
+  user-select: none;
+}
+
+.lineText {
+  min-width: 0;
+}
+
+.logLine[data-tone="error"] .lineText {
+  color: var(--h-err);
+}
+
+.logLine[data-tone="warning"] .lineText {
+  color: var(--h-warn);
+}
+
+.logLine[data-tone="debug"] .lineText {
+  color: var(--h-text-3);
+}
+
+.emptyLine {
+  padding: 28px 16px;
+  color: var(--h-text-3);
+  text-align: center;
+}
+
+@keyframes spin {
+  to {
+    transform: rotate(360deg);
+  }
+}
+
+@media (max-width: 980px) {
+  .toolbar {
+    align-items: stretch;
+  }
+
+  .filterGroup {
+    width: 100%;
+    align-items: flex-start;
+    flex-direction: column;
+  }
+
+  .segmented {
+    width: 100%;
+  }
+
+  .logViewport {
+    height: calc(100vh - 390px);
+  }
+}

--- a/web/src/routes/logs.tsx
+++ b/web/src/routes/logs.tsx
@@ -1,10 +1,432 @@
+import { useCallback, useEffect, useMemo, useRef, useState, type ReactNode } from "react";
+import { Link, useSearchParams } from "react-router-dom";
+import { Copy, Download, FileJson, RefreshCw, RotateCcw, Search, ShieldCheck } from "lucide-react";
+import { CopyButton } from "@/components/ui/copy-button";
+import { useLogs } from "@/hooks/use-logs";
+import {
+  DEFAULT_LOGS_QUERY,
+  LOG_COMPONENT_OPTIONS,
+  LOG_FILE_OPTIONS,
+  LOG_LEVEL_OPTIONS,
+  LOG_LINE_COUNT_OPTIONS,
+  buildLogJsonl,
+  buildLogText,
+  classifyLogLine,
+  createLogExportFileName,
+  filterLogLines,
+  logsQueryToSearchParams,
+  parseLogsSearchParams,
+  type LogComponentOption,
+  type LogExportFormat,
+  type LogFileOption,
+  type LogLevelOption,
+  type LogsQueryState,
+} from "@/lib/logs-viewer";
 import { SectionShell } from "./section-shell";
-import { LogsSection } from "./settings";
+import s from "./logs.module.css";
+
+const LOG_FILE_LABELS: Record<LogFileOption, string> = {
+  agent: "Agent",
+  errors: "Errors",
+  gateway: "Gateway",
+};
+
+const LOG_LEVEL_LABELS: Record<LogLevelOption, string> = {
+  ALL: "全部",
+  DEBUG: "Debug",
+  INFO: "Info",
+  WARNING: "Warn",
+  ERROR: "Error",
+};
+
+const LOG_COMPONENT_LABELS: Record<LogComponentOption, string> = {
+  all: "全部",
+  gateway: "Gateway",
+  agent: "Agent",
+  tools: "Tools",
+  cli: "CLI",
+  cron: "Cron",
+  mcp: "MCP",
+  skill: "Skill",
+  task: "Task",
+};
+
+type ExportState = { tone: "normal" | "error"; message: string } | null;
+
+function isNearBottom(element: HTMLElement): boolean {
+  return element.scrollHeight - element.scrollTop - element.clientHeight < 72;
+}
+
+function formatBytes(bytes: number): string {
+  if (!Number.isFinite(bytes) || bytes <= 0) return "0 B";
+  const units = ["B", "KB", "MB", "GB"];
+  let value = bytes;
+  let index = 0;
+  while (value >= 1024 && index < units.length - 1) {
+    value /= 1024;
+    index += 1;
+  }
+  return `${value.toFixed(index === 0 ? 0 : 1)} ${units[index]}`;
+}
+
+function downloadInBrowser(fileName: string, content: string, format: LogExportFormat): void {
+  const type = format === "jsonl" ? "application/x-ndjson;charset=utf-8" : "text/plain;charset=utf-8";
+  const url = URL.createObjectURL(new Blob([content], { type }));
+  const anchor = document.createElement("a");
+  anchor.href = url;
+  anchor.download = fileName;
+  anchor.rel = "noreferrer";
+  document.body.append(anchor);
+  anchor.click();
+  anchor.remove();
+  window.setTimeout(() => URL.revokeObjectURL(url), 0);
+}
 
 export function LogsRoute() {
+  const [searchParams, setSearchParams] = useSearchParams();
+  const query = useMemo(() => parseLogsSearchParams(searchParams), [searchParams]);
+  const [searchText, setSearchText] = useState(query.q);
+  const [exportState, setExportState] = useState<ExportState>(null);
+  const [exportingFormat, setExportingFormat] = useState<LogExportFormat | null>(null);
+  const [followingTail, setFollowingTail] = useState(true);
+  const [hasNewLogs, setHasNewLogs] = useState(false);
+  const scrollRef = useRef<HTMLDivElement>(null);
+  const stickToBottomRef = useRef(true);
+  const lastVisibleSignatureRef = useRef("");
+
+  const logs = useLogs(query.file, query.lines, query.level, query.component);
+  const rawLines = logs.data?.lines ?? [];
+  const visibleLines = useMemo(() => filterLogLines(rawLines, query.q), [rawLines, query.q]);
+  const visibleSignature = useMemo(() => visibleLines.join("\n"), [visibleLines]);
+  const lastUpdated = logs.dataUpdatedAt ? new Date(logs.dataUpdatedAt).toLocaleTimeString("zh-CN") : "—";
+  const hasDesktopExport = typeof window !== "undefined" && Boolean(window.hermesDesktop?.exportLogSnapshot);
+
+  const patchQuery = useCallback((patch: Partial<LogsQueryState>, replace = false) => {
+    const current = parseLogsSearchParams(searchParams);
+    const next = { ...current, ...patch };
+    setSearchParams(logsQueryToSearchParams(next), { replace });
+  }, [searchParams, setSearchParams]);
+
+  useEffect(() => {
+    setSearchText(query.q);
+  }, [query.q]);
+
+  useEffect(() => {
+    const nextQuery = searchText.trim();
+    if (nextQuery === query.q) return;
+    const timer = window.setTimeout(() => {
+      patchQuery({ q: nextQuery }, true);
+    }, 300);
+    return () => window.clearTimeout(timer);
+  }, [patchQuery, query.q, searchText]);
+
+  useEffect(() => {
+    if (!query.live) return;
+    const timer = window.setInterval(() => {
+      void logs.refetch();
+    }, 5_000);
+    return () => window.clearInterval(timer);
+  }, [logs.refetch, query.live]);
+
+  useEffect(() => {
+    stickToBottomRef.current = true;
+    setFollowingTail(true);
+    setHasNewLogs(false);
+  }, [query.file, query.level, query.component, query.lines, query.q]);
+
+  useEffect(() => {
+    if (lastVisibleSignatureRef.current === visibleSignature) return;
+    lastVisibleSignatureRef.current = visibleSignature;
+    const element = scrollRef.current;
+    if (!element) return;
+    if (stickToBottomRef.current) {
+      const frame = window.requestAnimationFrame(() => {
+        element.scrollTop = element.scrollHeight;
+        setHasNewLogs(false);
+      });
+      return () => window.cancelAnimationFrame(frame);
+    }
+    setHasNewLogs(true);
+  }, [visibleSignature]);
+
+  const handleScroll = useCallback(() => {
+    const element = scrollRef.current;
+    if (!element) return;
+    const nextFollowing = isNearBottom(element);
+    stickToBottomRef.current = nextFollowing;
+    setFollowingTail(nextFollowing);
+    if (nextFollowing) setHasNewLogs(false);
+  }, []);
+
+  const scrollToBottom = useCallback(() => {
+    const element = scrollRef.current;
+    if (!element) return;
+    element.scrollTo({ top: element.scrollHeight, behavior: "smooth" });
+    stickToBottomRef.current = true;
+    setFollowingTail(true);
+    setHasNewLogs(false);
+  }, []);
+
+  const copyVisibleLogs = useCallback(() => buildLogText(visibleLines, { redact: query.redact }), [query.redact, visibleLines]);
+
+  const handleExport = useCallback(async (format: LogExportFormat) => {
+    const content = format === "jsonl"
+      ? buildLogJsonl(visibleLines, { file: query.file, redact: query.redact })
+      : buildLogText(visibleLines, { redact: query.redact });
+
+    if (!content) {
+      setExportState({ tone: "error", message: "当前没有可导出的日志。" });
+      return;
+    }
+
+    const fileName = createLogExportFileName({ file: query.file, format });
+    setExportingFormat(format);
+    setExportState(null);
+
+    try {
+      if (window.hermesDesktop?.exportLogSnapshot) {
+        const result = await window.hermesDesktop.exportLogSnapshot({ fileName, content, format });
+        if (result.canceled) {
+          setExportState({ tone: "normal", message: "已取消导出。" });
+        } else if (!result.ok) {
+          throw new Error(result.error ?? "导出日志失败");
+        } else {
+          setExportState({
+            tone: "normal",
+            message: `已导出 ${formatBytes(result.bytes)}：${result.path ?? fileName}`,
+          });
+        }
+      } else {
+        downloadInBrowser(fileName, content, format);
+        setExportState({
+          tone: "normal",
+          message: `已生成 ${formatBytes(new Blob([content]).size)} 的 ${format.toUpperCase()} 下载文件：${fileName}`,
+        });
+      }
+    } catch (error) {
+      setExportState({
+        tone: "error",
+        message: `导出日志失败：${error instanceof Error ? error.message : String(error)}`,
+      });
+    } finally {
+      setExportingFormat(null);
+    }
+  }, [query.file, query.redact, visibleLines]);
+
+  const clearFilters = useCallback(() => {
+    patchQuery(DEFAULT_LOGS_QUERY);
+  }, [patchQuery]);
+
+  const errorMessage = logs.error instanceof Error ? logs.error.message : logs.error ? String(logs.error) : "";
+  const showBlockingError = logs.isError && !logs.data;
+
   return (
-    <SectionShell title="日志">
-      <LogsSection />
+    <SectionShell
+      title="日志"
+      sub="查看桌面端 managed runtime 的 Agent、Gateway 与错误日志；支持选中复制、批量复制和导出当前结果。"
+    >
+      <div className={s.page}>
+        <section className={s.toolbar} aria-label="日志筛选">
+          <FilterGroup label="文件">
+            {LOG_FILE_OPTIONS.map((file) => (
+              <button
+                key={file}
+                type="button"
+                className={s.segmentButton}
+                data-active={file === query.file}
+                aria-pressed={file === query.file}
+                onClick={() => patchQuery({ file })}
+              >
+                {LOG_FILE_LABELS[file]}
+              </button>
+            ))}
+          </FilterGroup>
+
+          <FilterGroup label="级别">
+            {LOG_LEVEL_OPTIONS.map((level) => (
+              <button
+                key={level}
+                type="button"
+                className={s.segmentButton}
+                data-active={level === query.level}
+                aria-pressed={level === query.level}
+                onClick={() => patchQuery({ level })}
+              >
+                {LOG_LEVEL_LABELS[level]}
+              </button>
+            ))}
+          </FilterGroup>
+
+          <FilterGroup label="来源">
+            {LOG_COMPONENT_OPTIONS.map((component) => (
+              <button
+                key={component}
+                type="button"
+                className={s.segmentButton}
+                data-active={component === query.component}
+                aria-pressed={component === query.component}
+                onClick={() => patchQuery({ component })}
+              >
+                {LOG_COMPONENT_LABELS[component]}
+              </button>
+            ))}
+          </FilterGroup>
+
+          <FilterGroup label="行数">
+            {LOG_LINE_COUNT_OPTIONS.map((lines) => (
+              <button
+                key={lines}
+                type="button"
+                className={s.segmentButton}
+                data-active={lines === query.lines}
+                aria-pressed={lines === query.lines}
+                onClick={() => patchQuery({ lines })}
+              >
+                {lines}
+              </button>
+            ))}
+          </FilterGroup>
+
+          <label className={s.searchBox}>
+            <Search size={14} aria-hidden="true" />
+            <input
+              value={searchText}
+              onChange={(event) => setSearchText(event.target.value)}
+              placeholder="搜索当前拉取的日志…"
+              aria-label="搜索日志"
+            />
+          </label>
+        </section>
+
+        <section className={s.actions} aria-label="日志操作">
+          <button
+            type="button"
+            className={s.toggleButton}
+            data-on={query.live}
+            onClick={() => patchQuery({ live: !query.live }, true)}
+          >
+            <span className={s.toggleDot} />
+            {query.live ? "自动刷新开启" : "自动刷新关闭"}
+          </button>
+          <button
+            type="button"
+            className={s.toggleButton}
+            data-on={query.redact}
+            onClick={() => patchQuery({ redact: !query.redact }, true)}
+            title="影响一键复制和导出文件；手动框选复制仍按屏幕所见复制。"
+          >
+            <ShieldCheck size={13} />
+            {query.redact ? "复制/导出自动脱敏" : "复制/导出保留原文"}
+          </button>
+          <button type="button" className={s.actionButton} onClick={() => void logs.refetch()} disabled={logs.isFetching}>
+            <RefreshCw size={13} className={logs.isFetching ? s.spinIcon : undefined} />
+            {logs.isFetching ? "刷新中…" : "刷新"}
+          </button>
+          <CopyButton className={s.actionButton} text={copyVisibleLogs} disabled={visibleLines.length === 0}>
+            <Copy size={13} />
+            复制可见日志
+          </CopyButton>
+          <button
+            type="button"
+            className={s.actionButton}
+            onClick={() => void handleExport("log")}
+            disabled={visibleLines.length === 0 || exportingFormat !== null}
+          >
+            <Download size={13} />
+            {exportingFormat === "log" ? "导出中…" : "导出 .log"}
+          </button>
+          <button
+            type="button"
+            className={s.actionButton}
+            onClick={() => void handleExport("jsonl")}
+            disabled={visibleLines.length === 0 || exportingFormat !== null}
+          >
+            <FileJson size={13} />
+            {exportingFormat === "jsonl" ? "导出中…" : "导出 JSONL"}
+          </button>
+          <button type="button" className={s.actionButton} onClick={clearFilters}>
+            <RotateCcw size={13} />
+            清空筛选
+          </button>
+        </section>
+
+        <div className={s.metaLine}>
+          <span>显示 {visibleLines.length}/{rawLines.length} 行</span>
+          <span>最后更新 {lastUpdated}</span>
+          <span>{followingTail ? "正在跟随最新日志" : "已暂停跟随，便于查看历史"}</span>
+          <span>{hasDesktopExport ? "桌面保存对话框可用" : "浏览器下载模式"}</span>
+          {query.q && <span>搜索仅覆盖当前拉取的 {rawLines.length} 行</span>}
+        </div>
+
+        {exportState && (
+          <div className={s.feedback} data-tone={exportState.tone === "error" ? "error" : undefined}>
+            {exportState.message}
+          </div>
+        )}
+        {logs.isError && logs.data && (
+          <div className={s.feedback} data-tone="error">
+            刷新失败，已保留上次成功读取的日志：{errorMessage || "未知错误"}
+          </div>
+        )}
+
+        {showBlockingError ? (
+          <div className={s.errorCard}>
+            <b>日志加载失败</b>
+            <p>{errorMessage || "未知错误"}</p>
+            <div className={s.errorActions}>
+              <button type="button" className={s.actionButton} onClick={() => void logs.refetch()}>
+                重试
+              </button>
+              <Link className={s.actionLink} to="/debug">
+                去 Debug 导出排障包
+              </Link>
+            </div>
+          </div>
+        ) : (
+          <div className={s.viewerWrap}>
+            {hasNewLogs && (
+              <button type="button" className={s.newLogsButton} onClick={scrollToBottom}>
+                有新日志，回到底部
+              </button>
+            )}
+            <div
+              ref={scrollRef}
+              className={s.logViewport}
+              onScroll={handleScroll}
+              role="log"
+              aria-live={query.live && followingTail ? "polite" : "off"}
+            >
+              {visibleLines.map((line, index) => {
+                const tone = classifyLogLine(line);
+                return (
+                  <div key={`${index}-${line}`} className={s.logLine} data-tone={tone}>
+                    <span className={s.lineNumber}>{index + 1}</span>
+                    <span className={s.lineText}>{line}</span>
+                  </div>
+                );
+              })}
+              {logs.isLoading && visibleLines.length === 0 && <EmptyLine>日志加载中…</EmptyLine>}
+              {!logs.isLoading && rawLines.length === 0 && <EmptyLine>Hermes 还没产生日志，可能是刚启动。</EmptyLine>}
+              {!logs.isLoading && rawLines.length > 0 && visibleLines.length === 0 && (
+                <EmptyLine>没有匹配的日志，请调整关键词或清空筛选。</EmptyLine>
+              )}
+            </div>
+          </div>
+        )}
+      </div>
     </SectionShell>
   );
+}
+
+function FilterGroup({ label, children }: { label: string; children: ReactNode }) {
+  return (
+    <div className={s.filterGroup}>
+      <span className={s.filterLabel}>{label}</span>
+      <div className={s.segmented}>{children}</div>
+    </div>
+  );
+}
+
+function EmptyLine({ children }: { children: ReactNode }) {
+  return <div className={s.emptyLine}>{children}</div>;
 }


### PR DESCRIPTION
## 变更内容

本 PR 将桌面端 `/logs` 从设置页复用区块升级为独立日志中心，补齐日志选中复制、一键复制、`.log` 导出、JSONL 导出、URL 可恢复筛选、关键词搜索与更清晰的空态/错误态。

## 用户影响

用户可以直接拖选日志内容复制，也可以一键复制当前可见日志或导出当前筛选结果。复制和导出默认走前端脱敏逻辑，降低排障时误发 token、API Key 等敏感信息的风险。桌面端环境会使用 Tauri 保存对话框，Web/dev 环境回退为浏览器下载。

## 实现说明

新增日志视图工具模块负责 query 解析、批次内搜索、日志行分类、脱敏文本生成和 JSONL 生成；新增 `export_log_snapshot` Tauri command 只保存前端传入的当前结果，不直接读取任意本地日志文件。日志正文样式显式覆盖全局 `user-select: none`，允许用户选中文本。

## 验证

- `pnpm typecheck`
- `pnpm --filter @hermes/web exec vitest run src/lib/logs-viewer.test.ts src/lib/debug-redact.test.ts src/lib/tauri-bridge.test.ts`
- `cargo check`
- `cargo test --all-features`
- 本地 Vite + Browser 打开 `/logs`，确认复制/导出按钮存在，日志区域 `user-select: text` 生效

备注：仓库现有 `pnpm test:unit` 仍会在 `web/src/routes/im-onboarding.test.ts` 的飞书 scope 断言失败；该失败与本次 `/logs` 改造无关，本 PR 未改动相关文件。
