### PR TITLE
feat: 新增新任务 Skill 选择

### DIFF
--- a/packages/protocol/src/hermes-api.ts
+++ b/packages/protocol/src/hermes-api.ts
@@ -645,6 +645,28 @@ export const PromptSubmitParams = z.object({
 });
 export type PromptSubmitParams = z.infer<typeof PromptSubmitParams>;
 
+export const SlashCompletionItem = z.object({
+  text: z.string(),
+  display: z.string().optional(),
+  meta: z.string().optional(),
+}).passthrough();
+export type SlashCompletionItem = z.infer<typeof SlashCompletionItem>;
+
+export const SlashCompletionResult = z.object({
+  items: z.array(SlashCompletionItem).default([]),
+  replace_from: z.number().optional(),
+}).passthrough();
+export type SlashCompletionResult = z.infer<typeof SlashCompletionResult>;
+
+export const CommandDispatchResult = z.object({
+  type: z.string().optional(),
+  message: z.string().optional(),
+  name: z.string().optional(),
+  output: z.string().optional(),
+  target: z.string().optional(),
+}).passthrough();
+export type CommandDispatchResult = z.infer<typeof CommandDispatchResult>;
+
 export const SessionUsageResult = z.object({
   model: z.string().optional(),
   input: z.number().optional(),

--- a/web/src/components/chat/composer-types.ts
+++ b/web/src/components/chat/composer-types.ts
@@ -1,4 +1,4 @@
-import type { ModelOptionsResult } from "@hermes/protocol";
+import type { ModelOptionsResult, SkillInfo } from "@hermes/protocol";
 
 export type ComposerAttachmentKind = "image" | "file" | "directory";
 export type ComposerAttachmentSource = "browser" | "path" | "uploaded";
@@ -42,6 +42,7 @@ export interface ComposerSubmitPayload {
   attachments: ComposerAttachment[];
   workspacePath?: string;
   modelSelection?: ComposerModelSelection;
+  skillCommandNames?: string[];
 }
 
 export interface ComposerSubmitControls {
@@ -63,6 +64,13 @@ export interface ComposerModelPickerProps {
   /** Called when the user clicks "去设置" on an unconfigured provider card.
    * Host routes wire this to React Router navigation (/models#<provider>). */
   onConfigureProvider?: (providerId: string) => void;
+  disabled?: boolean;
+}
+
+export interface ComposerSkillPickerProps {
+  skills: SkillInfo[];
+  loading?: boolean;
+  error?: string;
   disabled?: boolean;
 }
 

--- a/web/src/components/chat/goose-composer.module.css
+++ b/web/src/components/chat/goose-composer.module.css
@@ -294,6 +294,137 @@
   line-height: 1.3;
 }
 
+.skillPanel {
+  margin: 8px 2px 0;
+  border: 1px solid var(--h-line);
+  border-radius: var(--h-r-md);
+  background: var(--h-bg-pane);
+  box-shadow: var(--h-shadow);
+  color: var(--h-text);
+  overflow: hidden;
+}
+
+.box[data-variant="big"] .skillPanel {
+  margin: 0 18px 12px;
+}
+
+.skillPanelHead {
+  display: flex;
+  align-items: center;
+  justify-content: space-between;
+  gap: 12px;
+  border-bottom: 1px solid var(--h-line-soft);
+  padding: 8px 10px;
+  color: var(--h-text-3);
+  font-size: 11px;
+}
+
+.skillPanelHead span {
+  display: inline-flex;
+  align-items: center;
+  gap: 6px;
+  color: var(--h-text-2);
+  font-weight: 600;
+}
+
+.skillPanelHead svg {
+  width: 13px;
+  height: 13px;
+  stroke-width: 2;
+  color: var(--h-accent);
+}
+
+.skillPanelHead small {
+  min-width: 0;
+  overflow: hidden;
+  text-overflow: ellipsis;
+  white-space: nowrap;
+  font-size: 11px;
+  color: var(--h-text-3);
+}
+
+.skillList {
+  display: grid;
+  max-height: 260px;
+  overflow-y: auto;
+  padding: 5px;
+}
+
+.skillOption {
+  display: grid;
+  grid-template-columns: minmax(128px, 0.35fr) minmax(0, 1fr) auto;
+  align-items: center;
+  gap: 10px;
+  width: 100%;
+  min-width: 0;
+  min-height: 44px;
+  border: 0;
+  border-radius: 8px;
+  background: transparent;
+  color: var(--h-text-2);
+  cursor: pointer;
+  font-family: var(--h-font-cn);
+  padding: 7px 9px;
+  text-align: left;
+}
+
+.skillOption:hover,
+.skillOption[data-active="true"] {
+  background: var(--h-bg-soft);
+  color: var(--h-text);
+}
+
+.skillCommand {
+  min-width: 0;
+  overflow: hidden;
+  color: var(--h-accent);
+  font-family: var(--h-font-mono);
+  font-size: 12px;
+  text-overflow: ellipsis;
+  white-space: nowrap;
+}
+
+.skillMain {
+  display: grid;
+  min-width: 0;
+  gap: 2px;
+}
+
+.skillName,
+.skillDesc,
+.skillMeta {
+  min-width: 0;
+  overflow: hidden;
+  text-overflow: ellipsis;
+  white-space: nowrap;
+}
+
+.skillName {
+  color: var(--h-text);
+  font-size: 12.5px;
+  font-weight: 600;
+}
+
+.skillDesc,
+.skillMeta {
+  color: var(--h-text-3);
+  font-size: 11px;
+}
+
+.skillMeta {
+  justify-self: end;
+}
+
+.skillPanelState {
+  padding: 12px;
+  color: var(--h-text-3);
+  font-size: 12px;
+}
+
+.skillPanelState[data-tone="error"] {
+  color: var(--h-err);
+}
+
 .box[data-variant="big"] .toolbar {
   padding: 10px 14px 10px;
   border-top: 1px solid var(--h-line-soft);
@@ -1240,6 +1371,15 @@
 
   .leftTools {
     flex-wrap: wrap;
+  }
+
+  .skillOption {
+    grid-template-columns: 1fr;
+    align-items: start;
+  }
+
+  .skillMeta {
+    justify-self: start;
   }
 
   .modelGrid {

--- a/web/src/components/chat/goose-composer.module.css
+++ b/web/src/components/chat/goose-composer.module.css
@@ -224,6 +224,11 @@
   padding: 18px 18px 8px;
 }
 
+.box[data-variant="big"] .selectedSkillRow + .textarea {
+  min-height: 96px;
+  padding-top: 12px;
+}
+
 .box[data-variant="big"] .textarea::placeholder {
   font-style: normal;
 }
@@ -292,6 +297,120 @@
   padding: 1px 5px;
   border-radius: 4px;
   line-height: 1.3;
+}
+
+.selectedSkillRow {
+  display: flex;
+  flex-wrap: wrap;
+  align-items: center;
+  gap: 8px;
+  margin: 0 2px 10px;
+}
+
+.box[data-variant="big"] .selectedSkillRow {
+  margin: 0;
+  padding: 14px 18px 0;
+}
+
+.selectedSkillChip {
+  display: inline-flex;
+  align-items: center;
+  min-width: 0;
+  max-width: min(100%, 460px);
+  gap: 7px;
+  border: 1px solid color-mix(in srgb, var(--h-accent) 36%, var(--h-line));
+  border-radius: 999px;
+  background:
+    linear-gradient(135deg,
+      color-mix(in srgb, var(--h-accent-soft) 74%, var(--h-bg-input)),
+      color-mix(in srgb, var(--h-bg-chip) 82%, var(--h-accent-soft)));
+  color: var(--h-text);
+  box-shadow: 0 8px 22px color-mix(in srgb, var(--h-accent) 12%, transparent);
+  font-size: 12px;
+  line-height: 1;
+  padding: 5px 5px 5px 8px;
+}
+
+.selectedSkillChip svg {
+  width: 13px;
+  height: 13px;
+  flex: 0 0 auto;
+  color: var(--h-accent);
+  stroke-width: 2.2;
+}
+
+.selectedSkillKicker {
+  flex: 0 0 auto;
+  border-radius: 999px;
+  background: color-mix(in srgb, var(--h-accent) 14%, transparent);
+  color: var(--h-accent);
+  font-size: 10px;
+  font-weight: 700;
+  letter-spacing: 0.04em;
+  padding: 3px 6px;
+  text-transform: uppercase;
+}
+
+.selectedSkillName {
+  min-width: 0;
+  overflow: hidden;
+  color: var(--h-text);
+  font-size: 12.5px;
+  font-weight: 650;
+  text-overflow: ellipsis;
+  white-space: nowrap;
+}
+
+.selectedSkillCommand {
+  flex: 0 1 auto;
+  min-width: 0;
+  overflow: hidden;
+  color: var(--h-text-3);
+  font-family: var(--h-font-mono);
+  font-size: 11px;
+  text-overflow: ellipsis;
+  white-space: nowrap;
+}
+
+.selectedSkillRemove {
+  display: inline-flex;
+  align-items: center;
+  justify-content: center;
+  width: 20px;
+  height: 20px;
+  flex: 0 0 auto;
+  border: 0;
+  border-radius: 999px;
+  background: transparent;
+  color: var(--h-text-3);
+  cursor: pointer;
+  padding: 0;
+}
+
+.selectedSkillRemove:hover {
+  background: color-mix(in srgb, var(--h-accent) 13%, transparent);
+  color: var(--h-text);
+}
+
+.selectedSkillRemove:disabled {
+  cursor: default;
+  opacity: 0.45;
+}
+
+.selectedSkillRemove svg {
+  width: 13px;
+  height: 13px;
+  color: currentColor;
+}
+
+.selectedSkillHint {
+  min-width: 0;
+  overflow: hidden;
+  color: var(--h-text-3);
+  font-size: 11px;
+  line-height: 1.4;
+  text-overflow: ellipsis;
+  white-space: nowrap;
 }
 
 .skillPanel {

--- a/web/src/components/chat/goose-composer.tsx
+++ b/web/src/components/chat/goose-composer.tsx
@@ -10,13 +10,14 @@ import {
   type KeyboardEvent,
 } from "react";
 import { useAtomValue } from "jotai";
-import { Cpu, Folder, Plus, Sparkles } from "lucide-react";
+import { Cpu, Folder, Plus, Sparkles, X } from "lucide-react";
 import type { ModelOptionsResult } from "@hermes/protocol";
 import { fileNameFromPath } from "@/lib/composer-prompt";
 import {
+  buildSkillCommandText,
+  extractBodyAfterLeadingSlashToken,
   filterComposerSkills,
   getLeadingSlashToken,
-  replaceLeadingSlashToken,
   type ComposerSkillCandidate,
 } from "@/lib/composer-skills";
 import { contextUsageRisk } from "@/lib/context-usage";
@@ -121,6 +122,7 @@ export function GooseComposer({
 }: GooseComposerProps) {
   const configuredSubmitShortcut = useAtomValue(composerSubmitShortcutAtom);
   const effectiveSubmitShortcut = submitShortcut ?? configuredSubmitShortcut;
+  const submitHint = composerSubmitShortcutHint(effectiveSubmitShortcut);
   const isBig = variant === "big";
   const [value, setValue] = useState(initial);
   const [attachments, setAttachments] = useState<ComposerAttachment[]>([]);
@@ -139,6 +141,7 @@ export function GooseComposer({
   const [modelError, setModelError] = useState("");
   const [modelSearch, setModelSearch] = useState("");
   const [switchingModel, setSwitchingModel] = useState(false);
+  const [selectedSkill, setSelectedSkill] = useState<ComposerSkillCandidate | null>(null);
   const [skillActiveIndex, setSkillActiveIndex] = useState(0);
   const [dismissedSlashToken, setDismissedSlashToken] = useState("");
   const [dragActive, setDragActive] = useState(false);
@@ -153,13 +156,17 @@ export function GooseComposer({
   const contextWarning = contextRiskText(contextRisk, loading);
   const controlsDisabled = disabled || loading;
   const modelPickerDisabled = controlsDisabled || Boolean(modelPicker?.disabled);
+  const submitText = selectedSkill
+    ? buildSkillCommandText(selectedSkill.skill.name, value)
+    : value.trim();
+  const displayedTextLength = value.length;
   const canSend =
-    (value.trim().length > 0 || attachments.length > 0) &&
+    (submitText.length > 0 || attachments.length > 0) &&
     !controlsDisabled &&
     !hasProcessingAttachment;
   const slashToken = useMemo(
-    () => getLeadingSlashToken(value, selectionStart, selectionEnd),
-    [selectionEnd, selectionStart, value],
+    () => selectedSkill ? null : getLeadingSlashToken(value, selectionStart, selectionEnd),
+    [selectionEnd, selectionStart, selectedSkill, value],
   );
   const skillCandidates = useMemo(
     () => slashToken && skillPicker
@@ -174,12 +181,16 @@ export function GooseComposer({
     !skillPicker.disabled &&
     dismissedSlashToken !== slashToken.token,
   );
+  const resolvedPlaceholder = selectedSkill
+    ? `继续描述给 ${selectedSkill.displayName} 的任务…`
+    : placeholder ?? `发送消息，${submitHint}…`;
 
   // Make `initial` reactive so external prefill (e.g. quick-start recipes) takes
   // effect after mount. We focus the textarea on non-empty external pushes so
   // the user can keep typing without an extra click.
   useEffect(() => {
     setValue(initial);
+    setSelectedSkill(null);
     setSelectionStart(initial.length);
     setSelectionEnd(initial.length);
     if (initial) {
@@ -392,7 +403,8 @@ export function GooseComposer({
 
   const commitSkillSelection = (candidate: ComposerSkillCandidate) => {
     if (!slashToken) return;
-    const next = replaceLeadingSlashToken(value, slashToken, candidate.skill.name);
+    const next = extractBodyAfterLeadingSlashToken(value, slashToken);
+    setSelectedSkill(candidate);
     setValue(next.text);
     setSelectionStart(next.cursor);
     setSelectionEnd(next.cursor);
@@ -407,11 +419,21 @@ export function GooseComposer({
     });
   };
 
+  const clearSelectedSkill = () => {
+    setSelectedSkill(null);
+    window.requestAnimationFrame(() => {
+      const textarea = textareaRef.current;
+      if (!textarea) return;
+      textarea.focus();
+      setSelectionStart(textarea.selectionStart);
+      setSelectionEnd(textarea.selectionEnd);
+    });
+  };
+
   const send = async () => {
     if (!canSend) return;
-    const text = value.trim();
     const payload: ComposerSubmitPayload = {
-      text,
+      text: submitText,
       attachments,
       workspacePath: workspacePath.trim() || undefined,
       modelSelection: selectedModelRef.current ?? undefined,
@@ -423,6 +445,7 @@ export function GooseComposer({
     try {
       await onSend?.(payload, { updateAttachment });
       setValue("");
+      setSelectedSkill(null);
       setSelectionStart(0);
       setSelectionEnd(0);
       setDismissedSlashToken("");
@@ -436,6 +459,18 @@ export function GooseComposer({
   };
 
   const handleKeyDown = (event: KeyboardEvent<HTMLTextAreaElement>) => {
+    if (
+      selectedSkill &&
+      event.key === "Backspace" &&
+      selectionStart === 0 &&
+      selectionEnd === 0 &&
+      !event.nativeEvent.isComposing
+    ) {
+      event.preventDefault();
+      clearSelectedSkill();
+      return;
+    }
+
     if (skillPanelOpen && !event.nativeEvent.isComposing) {
       if (event.key === "Escape") {
         event.preventDefault();
@@ -476,9 +511,6 @@ export function GooseComposer({
       void send();
     }
   };
-
-  const submitHint = composerSubmitShortcutHint(effectiveSubmitShortcut);
-  const resolvedPlaceholder = placeholder ?? `发送消息，${submitHint}…`;
 
   const handlePaste = (event: ClipboardEvent<HTMLTextAreaElement>) => {
     if (controlsDisabled) return;
@@ -651,7 +683,7 @@ export function GooseComposer({
               {headerLabel}
             </span>
             <span className={s.bigHeaderRight}>
-              <span className={s.bigHeaderChars}>{value.length} 字</span>
+              <span className={s.bigHeaderChars}>{displayedTextLength} 字</span>
               {contextUsage ? (
                 <ContextIndicator
                   usage={contextUsage}
@@ -663,6 +695,32 @@ export function GooseComposer({
         ) : null}
 
         <AttachmentTray attachments={attachments} onRemove={removeAttachment} />
+
+        {selectedSkill ? (
+          <div className={s.selectedSkillRow}>
+            <div
+              className={s.selectedSkillChip}
+              title={`${selectedSkill.displayName} · ${selectedSkill.command}`}
+            >
+              <Sparkles aria-hidden="true" />
+              <span className={s.selectedSkillKicker}>Skill</span>
+              <span className={s.selectedSkillName}>{selectedSkill.displayName}</span>
+              <span className={s.selectedSkillCommand}>{selectedSkill.command}</span>
+              <button
+                type="button"
+                className={s.selectedSkillRemove}
+                onMouseDown={(event) => event.preventDefault()}
+                onClick={clearSelectedSkill}
+                disabled={controlsDisabled}
+                aria-label={`移除 Skill ${selectedSkill.displayName}`}
+                title="移除 Skill"
+              >
+                <X aria-hidden="true" />
+              </button>
+            </div>
+            <span className={s.selectedSkillHint}>继续输入任务描述，Backspace 可移除</span>
+          </div>
+        ) : null}
 
         <textarea
           ref={textareaRef}
@@ -731,7 +789,7 @@ export function GooseComposer({
           </div>
         ) : null}
 
-        {isBig && hints && hints.length > 0 && value.length === 0 ? (
+        {isBig && !selectedSkill && hints && hints.length > 0 && value.length === 0 ? (
           <div className={s.hintRow}>
             {hints.map((hint, idx) => (
               <span key={`${hint.label}-${idx}`} className={s.hintItem}>

--- a/web/src/components/chat/goose-composer.tsx
+++ b/web/src/components/chat/goose-composer.tsx
@@ -10,9 +10,15 @@ import {
   type KeyboardEvent,
 } from "react";
 import { useAtomValue } from "jotai";
-import { Cpu, Folder, Plus } from "lucide-react";
+import { Cpu, Folder, Plus, Sparkles } from "lucide-react";
 import type { ModelOptionsResult } from "@hermes/protocol";
 import { fileNameFromPath } from "@/lib/composer-prompt";
+import {
+  filterComposerSkills,
+  getLeadingSlashToken,
+  replaceLeadingSlashToken,
+  type ComposerSkillCandidate,
+} from "@/lib/composer-skills";
 import { contextUsageRisk } from "@/lib/context-usage";
 import {
   composerSubmitShortcutHint,
@@ -32,6 +38,7 @@ import {
   type ComposerContextUsage,
   type ComposerModelPickerProps,
   type ComposerModelSelection,
+  type ComposerSkillPickerProps,
   type ComposerSubmitControls,
   type ComposerSubmitPayload,
 } from "./composer-types";
@@ -83,6 +90,7 @@ interface GooseComposerProps {
   submitShortcut?: ComposerSubmitShortcut;
   loadingPlaceholder?: string;
   modelPicker?: ComposerModelPickerProps;
+  skillPicker?: ComposerSkillPickerProps;
   contextUsage?: ComposerContextUsage | null;
   initialWorkspacePath?: string;
 }
@@ -107,6 +115,7 @@ export function GooseComposer({
   hints,
   submitShortcut,
   modelPicker,
+  skillPicker,
   contextUsage,
   initialWorkspacePath = "",
 }: GooseComposerProps) {
@@ -115,6 +124,8 @@ export function GooseComposer({
   const isBig = variant === "big";
   const [value, setValue] = useState(initial);
   const [attachments, setAttachments] = useState<ComposerAttachment[]>([]);
+  const [selectionStart, setSelectionStart] = useState(initial.length);
+  const [selectionEnd, setSelectionEnd] = useState(initial.length);
   const [workspacePath, setWorkspacePath] = useState(
     () => normalizeWorkspacePath(initialWorkspacePath) || readWorkspacePath(),
   );
@@ -128,6 +139,8 @@ export function GooseComposer({
   const [modelError, setModelError] = useState("");
   const [modelSearch, setModelSearch] = useState("");
   const [switchingModel, setSwitchingModel] = useState(false);
+  const [skillActiveIndex, setSkillActiveIndex] = useState(0);
+  const [dismissedSlashToken, setDismissedSlashToken] = useState("");
   const [dragActive, setDragActive] = useState(false);
   const textareaRef = useRef<HTMLTextAreaElement>(null);
   const fileInputRef = useRef<HTMLInputElement>(null);
@@ -144,12 +157,31 @@ export function GooseComposer({
     (value.trim().length > 0 || attachments.length > 0) &&
     !controlsDisabled &&
     !hasProcessingAttachment;
+  const slashToken = useMemo(
+    () => getLeadingSlashToken(value, selectionStart, selectionEnd),
+    [selectionEnd, selectionStart, value],
+  );
+  const skillCandidates = useMemo(
+    () => slashToken && skillPicker
+      ? filterComposerSkills(skillPicker.skills, slashToken.query)
+      : [],
+    [skillPicker, slashToken],
+  );
+  const skillPanelOpen = Boolean(
+    slashToken &&
+    skillPicker &&
+    !controlsDisabled &&
+    !skillPicker.disabled &&
+    dismissedSlashToken !== slashToken.token,
+  );
 
   // Make `initial` reactive so external prefill (e.g. quick-start recipes) takes
   // effect after mount. We focus the textarea on non-empty external pushes so
   // the user can keep typing without an extra click.
   useEffect(() => {
     setValue(initial);
+    setSelectionStart(initial.length);
+    setSelectionEnd(initial.length);
     if (initial) {
       window.requestAnimationFrame(() => {
         const ta = textareaRef.current;
@@ -200,9 +232,14 @@ export function GooseComposer({
     if (!controlsDisabled) return;
     setWorkspacePickerOpen(false);
     setModelOpen(false);
+    setDismissedSlashToken("");
     setDragActive(false);
     dragDepthRef.current = 0;
   }, [controlsDisabled]);
+
+  useEffect(() => {
+    setSkillActiveIndex(0);
+  }, [slashToken?.token, skillCandidates.length]);
 
   // Picker now groups candidates internally (recent / configured /
   // recommended / more) from the catalog + usage log. Composer just hands it
@@ -346,6 +383,30 @@ export function GooseComposer({
     );
   };
 
+  const syncTextareaSelection = () => {
+    const textarea = textareaRef.current;
+    if (!textarea) return;
+    setSelectionStart(textarea.selectionStart);
+    setSelectionEnd(textarea.selectionEnd);
+  };
+
+  const commitSkillSelection = (candidate: ComposerSkillCandidate) => {
+    if (!slashToken) return;
+    const next = replaceLeadingSlashToken(value, slashToken, candidate.skill.name);
+    setValue(next.text);
+    setSelectionStart(next.cursor);
+    setSelectionEnd(next.cursor);
+    setDismissedSlashToken("");
+    window.requestAnimationFrame(() => {
+      const textarea = textareaRef.current;
+      if (!textarea) return;
+      textarea.focus();
+      textarea.setSelectionRange(next.cursor, next.cursor);
+      setSelectionStart(next.cursor);
+      setSelectionEnd(next.cursor);
+    });
+  };
+
   const send = async () => {
     if (!canSend) return;
     const text = value.trim();
@@ -354,6 +415,7 @@ export function GooseComposer({
       attachments,
       workspacePath: workspacePath.trim() || undefined,
       modelSelection: selectedModelRef.current ?? undefined,
+      skillCommandNames: skillPicker?.skills.map((skill) => skill.name),
     };
 
     setSubmitError("");
@@ -361,6 +423,9 @@ export function GooseComposer({
     try {
       await onSend?.(payload, { updateAttachment });
       setValue("");
+      setSelectionStart(0);
+      setSelectionEnd(0);
+      setDismissedSlashToken("");
       setAttachments((current) => {
         current.forEach(revokeAttachmentPreview);
         return [];
@@ -371,6 +436,33 @@ export function GooseComposer({
   };
 
   const handleKeyDown = (event: KeyboardEvent<HTMLTextAreaElement>) => {
+    if (skillPanelOpen && !event.nativeEvent.isComposing) {
+      if (event.key === "Escape") {
+        event.preventDefault();
+        setDismissedSlashToken(slashToken?.token ?? "");
+        return;
+      }
+      if (event.key === "ArrowDown") {
+        event.preventDefault();
+        setSkillActiveIndex((current) =>
+          skillCandidates.length ? (current + 1) % skillCandidates.length : 0);
+        return;
+      }
+      if (event.key === "ArrowUp") {
+        event.preventDefault();
+        setSkillActiveIndex((current) =>
+          skillCandidates.length
+            ? (current - 1 + skillCandidates.length) % skillCandidates.length
+            : 0);
+        return;
+      }
+      if ((event.key === "Enter" || event.key === "Tab") && skillCandidates.length > 0) {
+        event.preventDefault();
+        commitSkillSelection(skillCandidates[Math.min(skillActiveIndex, skillCandidates.length - 1)]!);
+        return;
+      }
+    }
+
     const shouldSubmit = shouldSubmitComposerKey({
       key: event.key,
       shiftKey: event.shiftKey,
@@ -575,8 +667,16 @@ export function GooseComposer({
         <textarea
           ref={textareaRef}
           value={value}
-          onChange={(event) => setValue(event.target.value)}
+          onChange={(event) => {
+            setValue(event.target.value);
+            setSelectionStart(event.target.selectionStart);
+            setSelectionEnd(event.target.selectionEnd);
+            setDismissedSlashToken("");
+          }}
           onKeyDown={handleKeyDown}
+          onKeyUp={syncTextareaSelection}
+          onClick={syncTextareaSelection}
+          onSelect={syncTextareaSelection}
           onPaste={handlePaste}
           placeholder={loading ? (loadingPlaceholder || "Hermes 正在响应...") : resolvedPlaceholder}
           rows={1}
@@ -584,6 +684,52 @@ export function GooseComposer({
           disabled={disabled}
           aria-label="输入消息"
         />
+
+        {skillPanelOpen ? (
+          <div className={s.skillPanel} role="listbox" aria-label="选择 Skill">
+            <div className={s.skillPanelHead}>
+              <span>
+                <Sparkles aria-hidden="true" />
+                选择 Skill
+              </span>
+              <small>Enter / Tab 选择，Esc 关闭</small>
+            </div>
+            {skillPicker?.loading && skillCandidates.length === 0 ? (
+              <div className={s.skillPanelState}>正在读取已启用 Skill…</div>
+            ) : skillPicker?.error && skillCandidates.length === 0 ? (
+              <div className={s.skillPanelState} data-tone="error">
+                {skillPicker.error}
+              </div>
+            ) : skillCandidates.length === 0 ? (
+              <div className={s.skillPanelState}>没有匹配的 Skill</div>
+            ) : (
+              <div className={s.skillList}>
+                {skillCandidates.map((candidate, index) => (
+                  <button
+                    key={candidate.skill.name}
+                    type="button"
+                    className={s.skillOption}
+                    data-active={index === skillActiveIndex}
+                    role="option"
+                    aria-selected={index === skillActiveIndex}
+                    onMouseEnter={() => setSkillActiveIndex(index)}
+                    onMouseDown={(event) => event.preventDefault()}
+                    onClick={() => commitSkillSelection(candidate)}
+                  >
+                    <span className={s.skillCommand}>{candidate.command}</span>
+                    <span className={s.skillMain}>
+                      <span className={s.skillName}>{candidate.displayName}</span>
+                      <span className={s.skillDesc}>{candidate.description}</span>
+                    </span>
+                    <span className={s.skillMeta}>
+                      {candidate.originLabel} · {candidate.categoryLabel}
+                    </span>
+                  </button>
+                ))}
+              </div>
+            )}
+          </div>
+        ) : null}
 
         {isBig && hints && hints.length > 0 && value.length === 0 ? (
           <div className={s.hintRow}>

--- a/web/src/components/panel/panel-composer.tsx
+++ b/web/src/components/panel/panel-composer.tsx
@@ -5,6 +5,7 @@ import { useGateway } from "@/hooks/use-gateway";
 import { useCreateAndSendSession } from "@/hooks/use-create-and-send-session";
 import { useConfig, useModelInfo, useSaveConfig } from "@/hooks/use-config";
 import { useModelOptions } from "@/hooks/use-model-options";
+import { useSkills } from "@/hooks/use-skills";
 import { resolveModelContextWindow } from "@/lib/model-context";
 import { readLastUsedModel, rememberLastUsedModel } from "@/lib/last-used-model";
 import { recordModelUsage } from "@/lib/model-usage-log";
@@ -34,6 +35,7 @@ export function PanelComposer() {
   const { data: config } = useConfig();
   const { data: modelInfo } = useModelInfo();
   const { data: modelOptionsCache } = useModelOptions();
+  const skillsQuery = useSkills();
   const saveConfig = useSaveConfig();
   const [sending, setSending] = useState(false);
   const [selectedModel, setSelectedModel] = useState<ComposerModelSelection | null>(
@@ -45,6 +47,10 @@ export function PanelComposer() {
   const wrapperRef = useRef<HTMLDivElement>(null);
   const initialWorkspacePath = normalizeWorkspacePath(searchParams.get("workspace"));
   const submitShortcutHint = composerSubmitShortcutHint(composerSubmitShortcut);
+  const enabledSkills = useMemo(
+    () => (skillsQuery.data ?? []).filter((skill) => skill.enabled),
+    [skillsQuery.data],
+  );
 
   useEffect(() => {
     if (!initialWorkspacePath) return;
@@ -156,6 +162,14 @@ export function PanelComposer() {
           onSelect: onModelSelect,
           onSelectAndSetDefault,
           onConfigureProvider,
+          disabled: sending,
+        }}
+        skillPicker={{
+          skills: enabledSkills,
+          loading: skillsQuery.isLoading || skillsQuery.isFetching,
+          error: skillsQuery.isError
+            ? (skillsQuery.error instanceof Error ? skillsQuery.error.message : "Skill 加载失败")
+            : undefined,
           disabled: sending,
         }}
         contextUsage={

--- a/web/src/components/panel/panel-composer.tsx
+++ b/web/src/components/panel/panel-composer.tsx
@@ -148,7 +148,6 @@ export function PanelComposer() {
         variant="big"
         headerLabel="新任务"
         hints={[
-          { kbd: "@", label: "引用文件" },
           { kbd: "/", label: "选择 Skill" },
           { label: "把文件拖入此处直接附加" },
         ]}

--- a/web/src/hooks/use-create-and-send-session.ts
+++ b/web/src/hooks/use-create-and-send-session.ts
@@ -8,6 +8,7 @@ import type {
 } from "@/components/chat/composer-types";
 import { activeSessionIdAtom } from "@/stores/ui";
 import { buildComposerDisplayText, prepareComposerPrompt } from "@/lib/composer-prompt";
+import { resolveComposerSkillCommand } from "@/lib/composer-skills";
 import { rememberSessionModelOverride } from "@/lib/session-model-override";
 import { titleFromPrompt, titleWithSessionSuffix } from "@/lib/session-title";
 import { uploadAttachmentFile } from "@/lib/transport";
@@ -29,6 +30,7 @@ export function useCreateAndSendSession() {
     sendPrompt,
     setSessionTitle,
     setSessionModel,
+    dispatchCommand,
     attachImage,
     detectDroppedPath,
   } = useGateway();
@@ -81,12 +83,27 @@ export function useCreateAndSendSession() {
             payload.modelSelection.provider,
           );
         }
+        let transportText: string | undefined;
+        const skillCommand = resolveComposerSkillCommand(
+          payload.text,
+          payload.skillCommandNames,
+        );
+        if (skillCommand) {
+          const dispatched = await dispatchCommand(
+            sessionId,
+            skillCommand.name,
+            skillCommand.arg,
+          );
+          if (dispatched.type === "skill" && dispatched.message?.trim()) {
+            transportText = dispatched.message;
+          }
+        }
         const prepared = await prepareComposerPrompt(sessionId, payload, {
           attachImage,
           detectDroppedPath,
           uploadFile: uploadAttachmentFile,
           onAttachmentUpdate: controls.updateAttachment,
-        });
+        }, { transportText });
         await sendPrompt(sessionId, prepared.promptText, {
           displayText: prepared.displayText,
           displayImages: prepared.displayImages,
@@ -117,6 +134,7 @@ export function useCreateAndSendSession() {
     beginPrompt,
     createSession,
     detectDroppedPath,
+    dispatchCommand,
     failPrompt,
     navigate,
     sendPrompt,

--- a/web/src/hooks/use-gateway.ts
+++ b/web/src/hooks/use-gateway.ts
@@ -3,6 +3,7 @@ import { useQueryClient } from "@tanstack/react-query";
 import { useAtomValue, useSetAtom } from "jotai";
 import {
   ConfigSetResult,
+  CommandDispatchResult,
   ImageAttachResult,
   InputDetectDropResult,
   ModelOptionsResult,
@@ -11,6 +12,7 @@ import {
   SessionCreateResult,
   SessionResumeResult,
   SessionTitleResult,
+  SlashCompletionResult,
   SessionUsageResult,
   type GatewayEvent,
 } from "@hermes/protocol";
@@ -319,6 +321,38 @@ export function useGateway() {
     [ensureSubscribed],
   );
 
+  const completeSlash = useCallback(
+    async (text: string): Promise<SlashCompletionResult> => {
+      ensureSubscribed();
+      return parseGatewayResult(
+        SlashCompletionResult,
+        await getGatewayClient().request("complete.slash", { text }),
+        "complete.slash",
+      );
+    },
+    [ensureSubscribed],
+  );
+
+  const dispatchCommand = useCallback(
+    async (
+      sessionId: string,
+      name: string,
+      arg = "",
+    ): Promise<CommandDispatchResult> => {
+      ensureSubscribed();
+      return parseGatewayResult(
+        CommandDispatchResult,
+        await getGatewayClient().request("command.dispatch", {
+          session_id: sessionId,
+          name,
+          arg,
+        }),
+        "command.dispatch",
+      );
+    },
+    [ensureSubscribed],
+  );
+
   const probeProvider = useCallback(
     async (params: {
       provider: string;
@@ -483,6 +517,8 @@ export function useGateway() {
     sendPrompt,
     getSessionUsage,
     getModelOptions,
+    completeSlash,
+    dispatchCommand,
     probeProvider,
     setSessionModel,
     setRuntimeModel,

--- a/web/src/lib/composer-prompt.test.ts
+++ b/web/src/lib/composer-prompt.test.ts
@@ -64,4 +64,24 @@ describe("composer prompt preparation", () => {
 
     expect(stripHermesUiWorkspaceContext(storedPrompt)).toBe("看一下这张图里面是什么内容\n\n附件：ga.png");
   });
+
+  it("uses a dispatched skill invocation as transport text without changing display text", async () => {
+    const result = await prepareComposerPrompt(
+      "s1",
+      {
+        text: "/codex 修复类型错误",
+        attachments: [],
+      },
+      {
+        attachImage: vi.fn(),
+        detectDroppedPath: vi.fn(),
+      },
+      {
+        transportText: "[Skill: codex]\n修复类型错误",
+      },
+    );
+
+    expect(result.promptText).toBe("[Skill: codex]\n修复类型错误");
+    expect(result.displayText).toBe("/codex 修复类型错误");
+  });
 });

--- a/web/src/lib/composer-prompt.ts
+++ b/web/src/lib/composer-prompt.ts
@@ -141,6 +141,9 @@ export async function prepareComposerPrompt(
     detectDroppedPath(sessionId: string, path: string): Promise<InputDetectDropResult>;
     onAttachmentUpdate?(id: string, patch: Partial<ComposerAttachment>): void;
   },
+  options: {
+    transportText?: string;
+  } = {},
 ): Promise<{
   promptText: string;
   displayText: string;
@@ -250,7 +253,7 @@ export async function prepareComposerPrompt(
     }
   }
 
-  const text = payload.text.trim();
+  const text = (options.transportText ?? payload.text).trim();
   if (text) parts.push(text);
 
   const workspace = buildWorkspaceContext(payload.workspacePath);

--- a/web/src/lib/composer-skills.test.ts
+++ b/web/src/lib/composer-skills.test.ts
@@ -1,6 +1,8 @@
 import { describe, expect, it } from "vitest";
 import type { SkillInfo } from "@hermes/protocol";
 import {
+  buildSkillCommandText,
+  extractBodyAfterLeadingSlashToken,
   filterComposerSkills,
   getLeadingSlashToken,
   parseLeadingSlashCommand,
@@ -44,6 +46,18 @@ describe("composer skill slash helpers", () => {
     expect(result.cursor).toBe("/github-pr-workflow ".length);
   });
 
+  it("extracts the visible body after turning a slash command into a skill chip", () => {
+    const token = getLeadingSlashToken("/cod 修复类型错误", 4);
+    expect(token).not.toBeNull();
+
+    expect(extractBodyAfterLeadingSlashToken("/cod 修复类型错误", token!)).toEqual({
+      text: "修复类型错误",
+      cursor: 0,
+    });
+    expect(buildSkillCommandText("codex", " 修复类型错误 ")).toBe("/codex 修复类型错误");
+    expect(buildSkillCommandText("codex", "")).toBe("/codex");
+  });
+
   it("filters enabled skills by command, translation and description", () => {
     const skills = [
       skill({
@@ -84,6 +98,10 @@ describe("composer skill slash helpers", () => {
     expect(resolveComposerSkillCommand("/CODEX 修复", ["codex"])).toEqual({
       name: "codex",
       arg: "修复",
+    });
+    expect(resolveComposerSkillCommand("/user/review 总结代码", ["user/review"])).toEqual({
+      name: "user/review",
+      arg: "总结代码",
     });
     expect(resolveComposerSkillCommand("/unknown 修复", ["codex"])).toBeNull();
   });

--- a/web/src/lib/composer-skills.test.ts
+++ b/web/src/lib/composer-skills.test.ts
@@ -1,0 +1,90 @@
+import { describe, expect, it } from "vitest";
+import type { SkillInfo } from "@hermes/protocol";
+import {
+  filterComposerSkills,
+  getLeadingSlashToken,
+  parseLeadingSlashCommand,
+  replaceLeadingSlashToken,
+  resolveComposerSkillCommand,
+} from "./composer-skills";
+
+function skill(overrides: Partial<SkillInfo>): SkillInfo {
+  return {
+    name: "demo",
+    description: "Demo skill.",
+    category: "other",
+    enabled: true,
+    ...overrides,
+  };
+}
+
+describe("composer skill slash helpers", () => {
+  it("detects only the leading slash token while the caret is inside it", () => {
+    expect(getLeadingSlashToken("/", 1)).toMatchObject({ token: "/", query: "" });
+    expect(getLeadingSlashToken("  /cod", 6)).toMatchObject({
+      start: 2,
+      end: 6,
+      token: "/cod",
+      query: "cod",
+    });
+    expect(getLeadingSlashToken("帮我 /cod", 7)).toBeNull();
+    expect(getLeadingSlashToken("/cod 继续写任务", 6)).toBeNull();
+  });
+
+  it("replaces the current slash token and preserves the rest of the task", () => {
+    const token = getLeadingSlashToken("/git 审查这个 PR", 4);
+    expect(token).not.toBeNull();
+    const result = replaceLeadingSlashToken(
+      "/git 审查这个 PR",
+      token!,
+      "github-pr-workflow",
+    );
+
+    expect(result.text).toBe("/github-pr-workflow 审查这个 PR");
+    expect(result.cursor).toBe("/github-pr-workflow ".length);
+  });
+
+  it("filters enabled skills by command, translation and description", () => {
+    const skills = [
+      skill({
+        name: "github-pr-workflow",
+        description: "Pull request workflow.",
+        category: "github",
+      }),
+      skill({
+        name: "codex",
+        description: "Delegate code changes.",
+        category: "autonomous-ai-agents",
+      }),
+      skill({
+        name: "disabled-skill",
+        description: "Should not show.",
+        enabled: false,
+      }),
+    ];
+
+    expect(filterComposerSkills(skills, "github-pr").map((item) => item.skill.name)).toEqual([
+      "github-pr-workflow",
+    ]);
+    expect(filterComposerSkills(skills, "代写").map((item) => item.skill.name)).toEqual([
+      "codex",
+    ]);
+    expect(filterComposerSkills(skills, "").map((item) => item.skill.name)).toEqual([
+      "github-pr-workflow",
+      "codex",
+    ]);
+  });
+
+  it("parses and resolves only known skill commands", () => {
+    expect(parseLeadingSlashCommand("/codex 修复类型错误")).toEqual({
+      name: "codex",
+      arg: "修复类型错误",
+    });
+    expect(parseLeadingSlashCommand("请用 /codex")).toBeNull();
+    expect(resolveComposerSkillCommand("/CODEX 修复", ["codex"])).toEqual({
+      name: "codex",
+      arg: "修复",
+    });
+    expect(resolveComposerSkillCommand("/unknown 修复", ["codex"])).toBeNull();
+  });
+});

--- a/web/src/lib/composer-skills.ts
+++ b/web/src/lib/composer-skills.ts
@@ -1,0 +1,155 @@
+import type { SkillInfo } from "@hermes/protocol";
+import { translateCategory, translateSkill } from "@/lib/skill-translations";
+
+export interface LeadingSlashToken {
+  start: number;
+  end: number;
+  token: string;
+  query: string;
+}
+
+export interface SlashReplacement {
+  text: string;
+  cursor: number;
+}
+
+export interface ComposerSkillCandidate {
+  skill: SkillInfo;
+  command: string;
+  displayName: string;
+  description: string;
+  categoryLabel: string;
+  originLabel: string;
+}
+
+export interface ParsedSlashCommand {
+  name: string;
+  arg: string;
+}
+
+function lower(value: string): string {
+  return value.trim().toLowerCase();
+}
+
+function skillOriginLabel(skill: SkillInfo): string {
+  const origin = skill.origin ?? (skill.name.startsWith("user/") ? "user" : "builtin");
+  if (origin === "external") return "外部";
+  if (origin === "user") return "自建";
+  return "内置";
+}
+
+export function getLeadingSlashToken(
+  text: string,
+  selectionStart: number,
+  selectionEnd = selectionStart,
+): LeadingSlashToken | null {
+  if (selectionStart !== selectionEnd) return null;
+  const leadingWhitespace = text.match(/^\s*/)?.[0].length ?? 0;
+  if (text[leadingWhitespace] !== "/") return null;
+
+  let end = text.length;
+  for (let i = leadingWhitespace; i < text.length; i += 1) {
+    if (/\s/.test(text[i] ?? "")) {
+      end = i;
+      break;
+    }
+  }
+
+  if (selectionStart < leadingWhitespace + 1 || selectionStart > end) return null;
+  const token = text.slice(leadingWhitespace, end);
+  return {
+    start: leadingWhitespace,
+    end,
+    token,
+    query: token.slice(1),
+  };
+}
+
+export function replaceLeadingSlashToken(
+  text: string,
+  range: LeadingSlashToken,
+  skillName: string,
+): SlashReplacement {
+  const prefix = text.slice(0, range.start);
+  const suffix = text.slice(range.end).replace(/^\s+/, "");
+  const insertion = `/${skillName} `;
+  return {
+    text: `${prefix}${insertion}${suffix}`,
+    cursor: prefix.length + insertion.length,
+  };
+}
+
+export function parseLeadingSlashCommand(text: string): ParsedSlashCommand | null {
+  const trimmed = text.trimStart();
+  if (!trimmed.startsWith("/")) return null;
+  const match = trimmed.match(/^\/([^\s/]+)(?:\s+([\s\S]*))?$/);
+  if (!match?.[1]) return null;
+  return {
+    name: match[1],
+    arg: match[2]?.trim() ?? "",
+  };
+}
+
+export function resolveComposerSkillCommand(
+  text: string,
+  skillNames: readonly string[] | null | undefined,
+): ParsedSlashCommand | null {
+  const parsed = parseLeadingSlashCommand(text);
+  if (!parsed || !skillNames?.length) return null;
+
+  const canonicalByLower = new Map(skillNames.map((name) => [name.toLowerCase(), name]));
+  const canonical = canonicalByLower.get(parsed.name.toLowerCase());
+  if (!canonical) return null;
+  return { ...parsed, name: canonical };
+}
+
+function candidateRank(skill: SkillInfo, query: string, index: number): number | null {
+  if (!skill.enabled) return null;
+  const q = lower(query);
+  const translated = translateSkill(skill.name, skill.description);
+  const categoryLabel = translateCategory(skill.category);
+  if (!q) return 1000 + index;
+
+  const command = `/${skill.name}`.toLowerCase();
+  const rawName = skill.name.toLowerCase();
+  const displayName = translated.displayName.toLowerCase();
+  const description = translated.description.toLowerCase();
+  const rawDescription = skill.description.toLowerCase();
+  const category = `${skill.category ?? ""} ${categoryLabel}`.toLowerCase();
+
+  if (rawName === q || command === `/${q}`) return 0;
+  if (rawName.startsWith(q) || command.startsWith(`/${q}`)) return 10;
+  if (displayName === q) return 20;
+  if (displayName.includes(q)) return 30;
+  if (rawName.includes(q) || command.includes(q)) return 40;
+  if (category.includes(q)) return 60;
+  if (description.includes(q) || rawDescription.includes(q)) return 80;
+  return null;
+}
+
+export function filterComposerSkills(
+  skills: readonly SkillInfo[] | null | undefined,
+  query: string,
+  limit = 30,
+): ComposerSkillCandidate[] {
+  const ranked = (skills ?? [])
+    .map((skill, index) => {
+      const rank = candidateRank(skill, query, index);
+      return rank === null ? null : { skill, index, rank };
+    })
+    .filter((item): item is { skill: SkillInfo; index: number; rank: number } => Boolean(item))
+    .sort((a, b) => a.rank - b.rank || a.index - b.index)
+    .slice(0, limit);
+
+  return ranked.map(({ skill }) => {
+    const translated = translateSkill(skill.name, skill.description);
+    return {
+      skill,
+      command: `/${skill.name}`,
+      displayName: translated.displayName,
+      description: translated.description,
+      categoryLabel: translateCategory(skill.category),
+      originLabel: skillOriginLabel(skill),
+    };
+  });
+}

--- a/web/src/lib/composer-skills.ts
+++ b/web/src/lib/composer-skills.ts
@@ -13,6 +13,11 @@ export interface SlashReplacement {
   cursor: number;
 }
 
+export interface SlashCommandBody {
+  text: string;
+  cursor: number;
+}
+
 export interface ComposerSkillCandidate {
   skill: SkillInfo;
   command: string;
@@ -79,10 +84,26 @@ export function replaceLeadingSlashToken(
   };
 }
 
+export function extractBodyAfterLeadingSlashToken(
+  text: string,
+  range: LeadingSlashToken,
+): SlashCommandBody {
+  const body = text.slice(range.end).replace(/^\s+/, "");
+  return {
+    text: body,
+    cursor: 0,
+  };
+}
+
+export function buildSkillCommandText(skillName: string, body: string): string {
+  const trimmedBody = body.trim();
+  return trimmedBody ? `/${skillName} ${trimmedBody}` : `/${skillName}`;
+}
+
 export function parseLeadingSlashCommand(text: string): ParsedSlashCommand | null {
   const trimmed = text.trimStart();
   if (!trimmed.startsWith("/")) return null;
-  const match = trimmed.match(/^\/([^\s/]+)(?:\s+([\s\S]*))?$/);
+  const match = trimmed.match(/^\/(\S+)(?:\s+([\s\S]*))?$/);
   if (!match?.[1]) return null;
   return {
     name: match[1],


### PR DESCRIPTION
## 变更
- 在新任务 Composer 中输入 / 时展示已启用 Skill 选择面板。
- 选中 Skill 后替换 slash token，并在提交时通过 Gateway command.dispatch 注入 Skill invocation message。
- 补齐 Gateway 协议类型与相关单元测试。

## 验证
- pnpm typecheck
- pnpm test:unit
- cargo check