### PR TITLE
[codex] 修复自检模型设置跳转

### DIFF
--- a/web/src/components/panel/health-grid.module.css
+++ b/web/src/components/panel/health-grid.module.css
@@ -62,6 +62,10 @@
   flex-direction: column;
   gap: 6px;
   min-width: 0;
+  appearance: none;
+  color: inherit;
+  font: inherit;
+  text-align: left;
 }
 
 .cell[data-size="wide"] {
@@ -76,6 +80,32 @@
 .cell[data-err="true"] {
   background: color-mix(in srgb, var(--h-err) 8%, var(--h-bg-pane));
   border-color: color-mix(in srgb, var(--h-err) 30%, var(--h-line));
+}
+
+.cell[data-action="true"] {
+  cursor: pointer;
+  transition: background 0.12s, border-color 0.12s, transform 0.12s;
+}
+
+.cell[data-action="true"]:hover {
+  background: var(--h-bg-soft);
+  border-color: color-mix(in srgb, var(--h-accent) 35%, var(--h-line));
+  transform: translateY(-1px);
+}
+
+.cell[data-action="true"]:focus-visible {
+  outline: 2px solid color-mix(in srgb, var(--h-accent) 70%, transparent);
+  outline-offset: 2px;
+}
+
+.cell[data-action="true"][data-warn="true"]:hover {
+  background: color-mix(in srgb, var(--h-warn-soft) 55%, var(--h-bg-pane));
+  border-color: color-mix(in srgb, var(--h-warn) 45%, var(--h-line));
+}
+
+.cell[data-action="true"][data-err="true"]:hover {
+  background: color-mix(in srgb, var(--h-err) 12%, var(--h-bg-pane));
+  border-color: color-mix(in srgb, var(--h-err) 45%, var(--h-line));
 }
 
 .label {

--- a/web/src/components/panel/health-grid.tsx
+++ b/web/src/components/panel/health-grid.tsx
@@ -1,4 +1,5 @@
 import { useEffect, useMemo, useState } from "react";
+import { useNavigate } from "react-router-dom";
 import { useStatus } from "@/hooks/use-status";
 import { useConfig, useModelInfo } from "@/hooks/use-config";
 import { useEnvVars } from "@/hooks/use-env";
@@ -22,6 +23,7 @@ interface CellData {
   mono?: boolean;
   title?: string;
   wide?: boolean;
+  actionTo?: string;
 }
 
 function formatContextLength(n: number | undefined | null): string {
@@ -48,26 +50,53 @@ function originFromHealthUrl(url: string | null | undefined): string {
   }
 }
 
-function Cell({ cell }: { cell: CellData }) {
-  return (
-    <div
-      className={s.cell}
-      data-size={cell.wide ? "wide" : undefined}
-      data-warn={cell.tone === "warn" ? "true" : undefined}
-      data-err={cell.tone === "err" ? "true" : undefined}
-      title={cell.title ?? [cell.value, cell.sub].filter(Boolean).join(" · ")}
-    >
+function Cell({ cell, onNavigate }: { cell: CellData; onNavigate: (to: string) => void }) {
+  const title = cell.title ?? [cell.value, cell.sub].filter(Boolean).join(" · ");
+  const content = (
+    <>
       <div className={s.label}>
         <Dot tone={cell.tone} />
         <span>{cell.label}</span>
       </div>
       <div className={s.value} data-mono={cell.mono ? "true" : undefined}>{cell.value}</div>
       {cell.sub && <div className={s.sub}>{cell.sub}</div>}
+    </>
+  );
+
+  if (cell.actionTo) {
+    const actionTo = cell.actionTo;
+    return (
+      <button
+        type="button"
+        className={s.cell}
+        data-size={cell.wide ? "wide" : undefined}
+        data-warn={cell.tone === "warn" ? "true" : undefined}
+        data-err={cell.tone === "err" ? "true" : undefined}
+        data-action="true"
+        title={title}
+        aria-label={`${cell.label}: ${cell.value}${cell.sub ? `，${cell.sub}` : ""}`}
+        onClick={() => onNavigate(actionTo)}
+      >
+        {content}
+      </button>
+    );
+  }
+
+  return (
+    <div
+      className={s.cell}
+      data-size={cell.wide ? "wide" : undefined}
+      data-warn={cell.tone === "warn" ? "true" : undefined}
+      data-err={cell.tone === "err" ? "true" : undefined}
+      title={title}
+    >
+      {content}
     </div>
   );
 }
 
 export function HealthGrid() {
+  const navigate = useNavigate();
   const { data: status } = useStatus();
   const { data: modelInfo } = useModelInfo();
   const { data: config } = useConfig();
@@ -156,9 +185,10 @@ export function HealthGrid() {
         label: "模型",
         tone: modelName !== "—" ? "ok" : "warn",
         value: modelName,
-        sub: ctxLabel,
+        sub: modelName !== "—" ? ctxLabel : "前往模型设置",
         mono: true,
         wide: true,
+        actionTo: modelName === "—" ? "/models" : undefined,
       },
       {
         label: "Token",
@@ -166,7 +196,8 @@ export function HealthGrid() {
         value: anyTokenSet ? "已配置" : "未配置",
         sub: anyTokenSet
           ? setTokens.join(" · ").toLowerCase().replace(/_api_key/g, "")
-          : "前往设置",
+          : "前往模型设置",
+        actionTo: anyTokenSet ? undefined : "/models",
       },
       {
         label: "Skills",
@@ -192,11 +223,14 @@ export function HealthGrid() {
         sub: invalidProviders.length > 0
           ? `api_key 是 URL: ${invalidProviders.join(", ")}`
           : providerTotal === 0
-            ? "config.yaml 缺 providers"
+            ? "前往模型设置"
             : "api_key 字段健康",
         title: invalidProviders.length > 0
           ? `这些 provider 的 api_key 字段填的是 URL 不是真 key，会让 dashboard 发请求时把 URL 当 Bearer token，必定 401。请到 ~/.hermes/config.yaml 修正。`
-          : undefined,
+          : providerTotal === 0
+            ? "config.yaml 缺 providers。点击进入模型页选择服务商，填写 API Key，并设为当前模型。"
+            : undefined,
+        actionTo: providerTotal === 0 || invalidProviders.length > 0 ? "/models" : undefined,
       },
     ];
   }, [config, env, lastUsedModel, mcp, mcpError, modelInfo, skills, status]);
@@ -244,7 +278,7 @@ export function HealthGrid() {
       {open && (
         <div className={s.grid}>
           {cells.map((cell) => (
-            <Cell key={cell.label} cell={cell} />
+            <Cell key={cell.label} cell={cell} onNavigate={navigate} />
           ))}
         </div>
       )}


### PR DESCRIPTION
## 变更内容

修复健康自检卡片在模型或 Token 未配置时只显示“前往设置”文案、点击却不会跳转的问题。

具体调整：

- 为健康自检卡片增加可选的路由动作，模型未配置、Token 未配置、Provider 未配置或异常时点击卡片会进入 `/models`。
- 将相关提示统一为“前往模型设置”。
- 为可点击自检卡片补充 hover 和 focus 样式，保持原有健康状态视觉。

## 根因

原来的“前往设置”只是 `sub` 文本文案，卡片组件渲染为普通 `div`，没有绑定 `onClick` 或 React Router 跳转逻辑。

## 验证

- `pnpm typecheck`
- `pnpm test:unit`
- `cargo check`

备注：尝试用内置 Browser 做可视化点击验证时，当前环境没有可用的 `iab` 浏览器实例，因此未做浏览器端实测。