### PR TITLE
[codex] 修复小米模型密钥写入

### DIFF
--- a/web/src/lib/provider-catalog.test.ts
+++ b/web/src/lib/provider-catalog.test.ts
@@ -9,6 +9,7 @@ import {
   getProviderCredentialPreview,
   getProviderEntry,
   maskSecretPreview,
+  providerApiKeyLabels,
   providerHasSavedCredentials,
   sortProvidersForCnEdition,
   TOP5_PROVIDER_IDS,
@@ -358,6 +359,51 @@ describe("provider catalog config updates", () => {
     )).toBe(true);
   });
 
+  it("uses XIAOMI_API_KEY as the canonical Xiaomi key while keeping MIMO_API_KEY as a legacy alias", () => {
+    const preset = BUILTIN_PROVIDER_CATALOG.providers.find((provider) => provider.id === "xiaomi");
+    expect(preset).toBeTruthy();
+
+    expect(preset!.apiKeyLabel).toBe("XIAOMI_API_KEY");
+    expect(providerApiKeyLabels(preset!)).toEqual(["XIAOMI_API_KEY", "MIMO_API_KEY"]);
+  });
+
+  it("treats legacy Xiaomi MIMO_API_KEY as saved credentials", () => {
+    const preset = BUILTIN_PROVIDER_CATALOG.providers.find((provider) => provider.id === "xiaomi");
+    expect(preset).toBeTruthy();
+
+    const envVars = {
+      MIMO_API_KEY: {
+        is_set: true,
+        redacted_value: "mimo...tail",
+      },
+    };
+
+    expect(providerHasSavedCredentials({}, "xiaomi", envVars, preset!)).toBe(true);
+    expect(getProviderCredentialPreview({}, envVars, preset!)).toBe("mimo...tail");
+  });
+
+  it("prefers canonical Xiaomi XIAOMI_API_KEY over the legacy MIMO_API_KEY alias", () => {
+    const preset = BUILTIN_PROVIDER_CATALOG.providers.find((provider) => provider.id === "xiaomi");
+    expect(preset).toBeTruthy();
+
+    const preview = getProviderCredentialPreview(
+      {},
+      {
+        XIAOMI_API_KEY: {
+          is_set: true,
+          redacted_value: "xiao...tail",
+        },
+        MIMO_API_KEY: {
+          is_set: true,
+          redacted_value: "mimo...tail",
+        },
+      },
+      preset!,
+    );
+
+    expect(preview).toBe("xiao...tail");
+  });
+
   it("loads remote catalog through fetchExternalJSON timeout path", async () => {
     mockedFetchExternalJSON.mockResolvedValue({
       version: "remote-v1",
@@ -371,6 +417,7 @@ describe("provider catalog config updates", () => {
           apiMode: "chat_completions",
           transport: "openai_chat",
           apiKeyLabel: "REMOTE_API_KEY",
+          apiKeyAliases: ["REMOTE_LEGACY_KEY", "REMOTE_LEGACY_KEY", ""],
           defaultModel: "remote-model",
           models: [{ id: "remote-model" }],
         },
@@ -388,6 +435,7 @@ describe("provider catalog config updates", () => {
       providers: [
         {
           id: "remote-provider",
+          apiKeyAliases: ["REMOTE_LEGACY_KEY"],
           defaultModel: "remote-model",
         },
       ],

--- a/web/src/lib/provider-catalog.ts
+++ b/web/src/lib/provider-catalog.ts
@@ -21,6 +21,8 @@ export interface ProviderPreset {
   apiMode: ProviderApiMode;
   transport: ProviderTransport;
   apiKeyLabel: string;
+  /** Backward-compatible env names that should still be recognized as saved credentials. */
+  apiKeyAliases?: string[];
   docsUrl?: string;
   defaultModel: string;
   models: ProviderCatalogModel[];
@@ -362,7 +364,8 @@ export const BUILTIN_PROVIDER_CATALOG: ProviderCatalog = {
       baseUrl: "https://api.xiaomimimo.com/v1",
       apiMode: "chat_completions",
       transport: "openai_chat",
-      apiKeyLabel: "MIMO_API_KEY",
+      apiKeyLabel: "XIAOMI_API_KEY",
+      apiKeyAliases: ["MIMO_API_KEY"],
       docsUrl: "https://platform.xiaomimimo.com/docs/en-US/api/chat/openai-api",
       defaultModel: "mimo-v2.5-pro",
       models: [
@@ -463,14 +466,23 @@ function envPreview(envVars: EnvVarPreviewMap | undefined, key: string | undefin
   return preview || undefined;
 }
 
+export function providerApiKeyLabels(provider: ProviderPreset): string[] {
+  const labels = [provider.apiKeyLabel, ...(provider.apiKeyAliases ?? [])]
+    .map((key) => key.trim())
+    .filter(Boolean);
+  return Array.from(new Set(labels));
+}
+
 export function getProviderCredentialPreview(
   config: Record<string, any> | undefined,
   envVars: EnvVarPreviewMap | undefined,
   provider: ProviderPreset,
 ): string | undefined {
   const entry = getProviderEntry(config, provider.id);
-  const previewFromProviderEnv = envPreview(envVars, provider.apiKeyLabel);
-  if (previewFromProviderEnv) return previewFromProviderEnv;
+  for (const key of providerApiKeyLabels(provider)) {
+    const previewFromProviderEnv = envPreview(envVars, key);
+    if (previewFromProviderEnv) return previewFromProviderEnv;
+  }
 
   const previewFromEntryEnv = envPreview(envVars, String(entry.key_env || ""));
   if (previewFromEntryEnv) return previewFromEntryEnv;
@@ -486,7 +498,7 @@ export function providerHasSavedCredentials(
   provider?: ProviderPreset,
 ): boolean {
   const entry = getProviderEntry(config, providerId);
-  if (provider?.apiKeyLabel && envVars?.[provider.apiKeyLabel]?.is_set) return true;
+  if (provider && providerApiKeyLabels(provider).some((key) => envVars?.[key]?.is_set)) return true;
   const keyEnv = typeof entry.key_env === "string" ? entry.key_env : "";
   if (keyEnv && envVars?.[keyEnv]?.is_set) return true;
   return Boolean(entry.api_key || entry.key_env);
@@ -587,6 +599,14 @@ function normalizeRemoteProvider(provider: Partial<ProviderPreset> | undefined):
   const models = Array.isArray(provider.models) && provider.models.length > 0
     ? provider.models.filter((model): model is ProviderCatalogModel => Boolean(model?.id))
     : [{ id: provider.defaultModel }];
+  const apiKeyAliases = Array.isArray(provider.apiKeyAliases)
+    ? Array.from(new Set(
+      provider.apiKeyAliases
+        .filter((key): key is string => typeof key === "string")
+        .map((key) => key.trim())
+        .filter(Boolean),
+    ))
+    : [];
 
   return {
     id: provider.id,
@@ -597,6 +617,7 @@ function normalizeRemoteProvider(provider: Partial<ProviderPreset> | undefined):
     apiMode,
     transport,
     apiKeyLabel: provider.apiKeyLabel || "API Key",
+    ...(apiKeyAliases.length > 0 ? { apiKeyAliases } : {}),
     docsUrl: provider.docsUrl,
     defaultModel: provider.defaultModel,
     models,

--- a/web/src/routes/settings-models-section.tsx
+++ b/web/src/routes/settings-models-section.tsx
@@ -12,6 +12,7 @@ import {
   buildProviderSettingsUpdate,
   getProviderCredentialPreview,
   getProviderEntry,
+  providerApiKeyLabels,
   providerHasSavedCredentials,
   sortProvidersForCnEdition,
   TOP5_PROVIDER_IDS,
@@ -467,6 +468,20 @@ function isLocalProviderBaseUrl(baseUrl: string): boolean {
   }
 }
 
+function isWritableProviderEnvKey(key: string): boolean {
+  return /^[A-Z_][A-Z0-9_]*$/u.test(key);
+}
+
+function getStoredProviderApiKey(config: Record<string, any>, providerId: string): string {
+  const entryKey = getProviderEntry(config, providerId).api_key;
+  if (typeof entryKey === "string" && entryKey.trim()) return entryKey.trim();
+
+  const model = asRecord(config.model);
+  if (String(model.provider || "") !== providerId) return "";
+  const modelKey = model.api_key;
+  return typeof modelKey === "string" ? modelKey.trim() : "";
+}
+
 export function ModelsSection() {
   const { data: envVars, isLoading } = useEnvVars();
   const { data: config, isLoading: configLoading } = useConfig();
@@ -861,25 +876,56 @@ export function ModelsSection() {
     void refreshCatalog();
   };
 
+  const syncProviderApiKeyToCanonicalEnv = async (
+    provider: ProviderPreset,
+    explicitApiKey: string,
+  ) => {
+    if (provider.id.startsWith("custom:")) return;
+
+    const canonicalKey = provider.apiKeyLabel.trim();
+    if (!isWritableProviderEnvKey(canonicalKey)) return;
+
+    const newApiKey = explicitApiKey.trim();
+    if (newApiKey) {
+      await setEnv.mutateAsync({ key: canonicalKey, value: newApiKey });
+      return;
+    }
+
+    if (envVars?.[canonicalKey]?.is_set) return;
+
+    const storedApiKey = config ? getStoredProviderApiKey(config, provider.id) : "";
+    if (storedApiKey) {
+      await setEnv.mutateAsync({ key: canonicalKey, value: storedApiKey });
+      return;
+    }
+
+    for (const aliasKey of providerApiKeyLabels(provider).slice(1)) {
+      if (!isWritableProviderEnvKey(aliasKey) || !envVars?.[aliasKey]?.is_set) continue;
+      const revealed = await revealEnv.mutateAsync(aliasKey);
+      const aliasValue = revealed.value.trim();
+      if (!aliasValue) continue;
+      await setEnv.mutateAsync({ key: canonicalKey, value: aliasValue });
+      return;
+    }
+  };
+
   const handleProviderSave = async () => {
     if (!config || !selectedProvider) return;
     const pendingStartedAt = performance.now();
     const newApiKey = providerForm.apiKey.trim();
-    const isCustomProvider = selectedProvider.id.startsWith("custom:");
     // Built-in providers (alibaba, deepseek, zai, kimi, ...): hermes-agent
     // only reads their API key from environment variables / ~/.hermes/.env,
-    // never from config.yaml's providers.<id>.api_key. Mirror the key into
-    // the named env var so chat requests actually find credentials. Custom
-    // providers are read inline from config.yaml, so they don't need this.
+    // never from config.yaml's providers.<id>.api_key. Mirror the key into the
+    // canonical env var so chat requests actually find credentials. Xiaomi used
+    // to be saved as MIMO_API_KEY in the desktop catalog; keep that alias
+    // readable and migrate it to XIAOMI_API_KEY when the user saves again.
     const savedBaseUrl = providerForm.baseUrl.trim() || selectedProvider.baseUrl;
     const savedModel = providerForm.model.trim() || selectedProvider.defaultModel;
     const providerId = selectedProvider.id;
     setProviderSavePending(true);
     setProviderSaveError("");
     try {
-      if (newApiKey && !isCustomProvider && selectedProvider.apiKeyLabel) {
-        await setEnv.mutateAsync({ key: selectedProvider.apiKeyLabel, value: newApiKey });
-      }
+      await syncProviderApiKeyToCanonicalEnv(selectedProvider, newApiKey);
       await saveConfig.mutateAsync(
         buildProviderSettingsUpdate(config, selectedProvider, providerForm),
       );
@@ -909,13 +955,10 @@ export function ModelsSection() {
     const savedModel = providerForm.model.trim() || selectedProvider.defaultModel;
     const providerId = selectedProvider.id;
     const providerName = selectedProvider.name;
-    const isCustomProvider = providerId.startsWith("custom:");
     setProviderSetCurrentPending(true);
     setProviderSaveError("");
     try {
-      if (newApiKey && !isCustomProvider && selectedProvider.apiKeyLabel) {
-        await setEnv.mutateAsync({ key: selectedProvider.apiKeyLabel, value: newApiKey });
-      }
+      await syncProviderApiKeyToCanonicalEnv(selectedProvider, newApiKey);
       // Persist both providers.<id> and model.* before asking the live gateway
       // to hot-switch. First-run setups otherwise have no current provider for
       // gateway _apply_model_switch() to resolve, so it can fail before it ever


### PR DESCRIPTION
## 变更

修复桌面端 Xiaomi MiMo provider 保存 API Key 时使用错误环境变量的问题。新配置会写入后端实际读取的 `XIAOMI_API_KEY`，同时继续识别旧版桌面端写入的 `MIMO_API_KEY`。

## 原因

后端 canonical provider `xiaomi` 查找的是 `XIAOMI_API_KEY`，但桌面端 provider catalog 之前展示并保存的是 `MIMO_API_KEY`，导致用户在桌面端填完 key 后对话仍报 `Provider 'xiaomi' ... no API key was found`。

## 验证

- `pnpm --filter @hermes/web exec vitest run src/lib/provider-catalog.test.ts`
- `pnpm typecheck`
- `cargo check`
- `pnpm test:unit`