### PR TITLE
[codex] 修复火山方舟模型测试连接

### DIFF
--- a/web/src/lib/provider-catalog.test.ts
+++ b/web/src/lib/provider-catalog.test.ts
@@ -211,6 +211,8 @@ describe("provider catalog config updates", () => {
     expect(byId.get("volcengine-ark")).toMatchObject({
       name: "火山方舟 · API 按量付费",
       baseUrl: "https://ark.cn-beijing.volces.com/api/v3",
+      defaultModel: "doubao-seed-2-0-lite-260428",
+      supportsModelListing: false,
     });
     expect(byId.get("volcengine-ark-coding")).toMatchObject({
       name: "火山方舟 · Coding Plan",

--- a/web/src/lib/provider-catalog.ts
+++ b/web/src/lib/provider-catalog.ts
@@ -79,7 +79,7 @@ export interface ProviderConfigInput {
   model: string;
 }
 
-export const BUILTIN_PROVIDER_CATALOG_VERSION = "2026.06.05";
+export const BUILTIN_PROVIDER_CATALOG_VERSION = "2026.06.07";
 
 export const BUILTIN_PROVIDER_CATALOG: ProviderCatalog = {
   version: BUILTIN_PROVIDER_CATALOG_VERSION,
@@ -268,14 +268,22 @@ export const BUILTIN_PROVIDER_CATALOG: ProviderCatalog = {
       apiMode: "chat_completions",
       transport: "openai_chat",
       apiKeyLabel: "ARK_API_KEY",
-      docsUrl: "https://www.volcengine.com/docs/82379",
-      defaultModel: "doubao-seed-1-6",
+      docsUrl: "https://www.volcengine.com/docs/82379/1554709",
+      defaultModel: "doubao-seed-2-0-lite-260428",
       models: [
-        { id: "doubao-seed-1-6", supportsTools: true },
-        { id: "doubao-1-5-pro-32k", supportsTools: true },
-        { id: "deepseek-v3-1", supportsTools: true },
-        { id: "deepseek-r1", supportsReasoning: true },
+        { id: "doubao-seed-2-0-lite-260428", supportsTools: true, supportsVision: true, supportsReasoning: true },
+        { id: "doubao-seed-2-0-mini-260428", supportsTools: true, supportsVision: true, supportsReasoning: true },
+        { id: "doubao-seed-2-0-pro-260215", supportsTools: true, supportsVision: true, supportsReasoning: true },
+        { id: "doubao-seed-2-0-lite-260215", supportsTools: true, supportsVision: true, supportsReasoning: true },
+        { id: "doubao-seed-1-8-251228", supportsTools: true, supportsVision: true, supportsReasoning: true },
+        { id: "doubao-seed-1-6-251015", supportsTools: true, supportsVision: true, supportsReasoning: true },
+        { id: "doubao-seed-1-6-flash-250828", supportsTools: true, supportsVision: true, supportsReasoning: true },
+        { id: "doubao-1-5-pro-32k-250115", supportsTools: true },
+        { id: "deepseek-v4-pro-260425", supportsTools: true, supportsReasoning: true },
+        { id: "deepseek-v4-flash-260425", supportsTools: true, supportsReasoning: true },
+        { id: "deepseek-v3-2-251201", supportsTools: true, supportsReasoning: true },
       ],
+      supportsModelListing: false,
     },
     {
       id: "volcengine-ark-coding",

--- a/web/src/routes/settings-models-section.tsx
+++ b/web/src/routes/settings-models-section.tsx
@@ -21,6 +21,7 @@ import { useProviderCatalog } from "@/hooks/use-provider-catalog";
 import { ModelCombobox } from "@/components/settings/model-combobox";
 import { translateEnvCategory, translateEnvVar } from "@/lib/env-translations";
 import { rememberLastUsedModel } from "@/lib/last-used-model";
+import { fetchExternalJSON } from "@/lib/transport";
 import type { EnvVarInfo } from "@hermes/protocol";
 import { OAuthProvidersSection } from "./settings-oauth-section";
 import s from "./settings.module.css";
@@ -55,6 +56,7 @@ const PROVIDER_SWITCH_LOADING_MIN_MS = 280;
 
 type ModelSettingsTab = "main" | "auxiliary";
 type CustomProviderMode = "custom" | "local";
+type ProbeErrorKind = NonNullable<ProviderProbeResult["error_kind"]>;
 
 type AuxiliaryTaskId =
   | "vision"
@@ -93,6 +95,97 @@ interface LocalProviderPreset {
   baseUrl: string;
   model: string;
   tutorial: string;
+}
+
+function buildChatCompletionsUrl(baseUrl: string): string {
+  return `${baseUrl.replace(/\/+$/, "")}/chat/completions`;
+}
+
+function statusCodeFromErrorMessage(message: string): number | null {
+  const match = message.match(/\bHTTP\s+(\d{3})\b/i);
+  return match ? Number(match[1]) : null;
+}
+
+function probeErrorKind(statusCode: number | null, message: string): ProbeErrorKind {
+  const lower = message.toLowerCase();
+  if (statusCode === 401 || statusCode === 403 || /unauthor|api key|token|credential/.test(lower)) {
+    return "auth";
+  }
+  if (/timeout|timed out/.test(lower)) return "timeout";
+  if (statusCode != null) return "http";
+  if (/network|failed to fetch|cors|connection/.test(lower)) return "network";
+  return "unknown";
+}
+
+async function probeChatCompletionsProvider(input: {
+  apiKey: string;
+  baseUrl: string;
+  model: string;
+}): Promise<ProviderProbeResult> {
+  const apiKey = input.apiKey.trim();
+  const baseUrl = input.baseUrl.trim();
+  const model = input.model.trim();
+  if (!apiKey) {
+    return {
+      ok: false,
+      latency_ms: 0,
+      model_count: 0,
+      sample_models: [],
+      status_code: null,
+      error: "no API key (param empty, env vars unset)",
+      error_kind: "auth",
+    };
+  }
+  if (!baseUrl || !model) {
+    return {
+      ok: false,
+      latency_ms: 0,
+      model_count: 0,
+      sample_models: [],
+      status_code: null,
+      error: !baseUrl ? "base_url is required" : "model is required",
+      error_kind: "unknown",
+    };
+  }
+
+  const start = performance.now();
+  try {
+    await fetchExternalJSON<unknown>(buildChatCompletionsUrl(baseUrl), {
+      method: "POST",
+      headers: {
+        "Authorization": `Bearer ${apiKey}`,
+        "Content-Type": "application/json",
+        "Accept": "application/json",
+      },
+      body: JSON.stringify({
+        model,
+        messages: [{ role: "user", content: "ping" }],
+        max_tokens: 1,
+        stream: false,
+      }),
+    });
+    return {
+      ok: true,
+      latency_ms: Math.max(0, Math.round(performance.now() - start)),
+      model_count: 1,
+      sample_models: [model],
+      status_code: 200,
+      error: null,
+      error_kind: null,
+    };
+  } catch (error) {
+    const message = error instanceof Error ? error.message : String(error);
+    const statusCode = statusCodeFromErrorMessage(message);
+    return {
+      ok: false,
+      latency_ms: Math.max(0, Math.round(performance.now() - start)),
+      model_count: 0,
+      sample_models: [],
+      status_code: statusCode,
+      error: message,
+      error_kind: probeErrorKind(statusCode, message),
+    };
+  }
 }
 
 const AUXILIARY_TASKS: AuxiliaryTaskDefinition[] = [
@@ -773,12 +866,21 @@ export function ModelsSection() {
       // tencent-hunyuan — not in CANONICAL_PROVIDERS), we pass the catalog
       // id; the backend handler tolerates unknown slugs as long as api_key
       // + base_url are supplied explicitly.
-      const result = await probeProvider({
-        provider: selectedProvider.id,
-        api_key: apiKey || undefined,
-        base_url: baseUrl || undefined,
-        timeout_ms: 8000,
-      });
+      const shouldProbeChatCompletions =
+        selectedProvider.apiMode === "chat_completions" &&
+        selectedProvider.supportsModelListing === false;
+      const result = shouldProbeChatCompletions
+        ? await probeChatCompletionsProvider({
+          apiKey,
+          baseUrl,
+          model: providerForm.model.trim() || selectedProvider.defaultModel,
+        })
+        : await probeProvider({
+          provider: selectedProvider.id,
+          api_key: apiKey || undefined,
+          base_url: baseUrl || undefined,
+          timeout_ms: 8000,
+        });
       setProbeState({
         providerId: selectedProvider.id,
         status: result.ok ? "ok" : "error",
@@ -791,7 +893,7 @@ export function ModelsSection() {
         message: error instanceof Error ? error.message : String(error),
       });
     }
-  }, [probeProvider, providerForm.apiKey, providerForm.baseUrl, selectedProvider, selectedProviderEntry.api_key]);
+  }, [probeProvider, providerForm.apiKey, providerForm.baseUrl, providerForm.model, selectedProvider, selectedProviderEntry.api_key]);
 
   const probeForSelected = probeState && selectedProvider && probeState.providerId === selectedProvider.id
     ? probeState
@@ -1348,7 +1450,11 @@ export function ModelsSection() {
                           (!selectedHasCredentials && !providerForm.apiKey.trim())
                         }
                         onClick={() => void handleProbe()}
-                        title="向 /models 端点发一次 GET，验证 API Key + 网络通"
+                        title={
+                          selectedProvider?.apiMode === "chat_completions" && selectedProvider.supportsModelListing === false
+                            ? "向 /chat/completions 发一次极小请求，验证 API Key + Base URL + 模型"
+                            : "向 /models 端点发一次 GET，验证 API Key + 网络通"
+                        }
                       >
                         {probeForSelected?.status === "pending" ? "测试中…" : "测试连接"}
                       </button>


### PR DESCRIPTION
## 变更内容

修复模型设置页中火山方舟按量 API 的连接测试逻辑。火山方舟不再通过 `/models` 探测，而是对不支持模型列表发现的 Chat Completions 供应商发起一次极小的 `/chat/completions` 请求，以同时验证 API Key、Base URL 和模型 ID。

同时更新火山方舟按量预设，改用官方版本化模型 ID，并将默认模型调整为 `doubao-seed-2-0-lite-260428`。

## 原因

原实现依赖 `/models` 端点做轻量探测，但火山方舟按量 API 的实际调用入口是 `/chat/completions` 或 `/responses`，用户点击测试连接时会遇到误导性的 HTTP 404。旧预设中的部分模型 ID 也不是当前官方推荐的版本化 ID。

## 影响

用户在桌面端配置火山方舟 API Key 后，可以通过测试连接验证真实调用链路，不会因为 `/models` 探测失败而被误判为连接异常。

## 验证

已执行并通过：

- `pnpm typecheck`
- `pnpm test:unit`
- `cargo check`
