### PR TITLE
[codex] 增加桌面端托盘常驻

### DIFF
--- a/Cargo.toml
+++ b/Cargo.toml
@@ -10,7 +10,7 @@ homepage = "https://hermesagent.org.cn"
 name = "hermes_agent_cn"
 
 [dependencies]
-tauri = { version = "2", features = [] }
+tauri = { version = "2", features = ["tray-icon"] }
 tauri-plugin-dialog = "2"
 serde = { version = "1", features = ["derive"] }
 serde_json = "1"

--- a/src/lib.rs
+++ b/src/lib.rs
@@ -6,6 +6,7 @@ pub mod process;
 pub mod session_archive;
 pub mod session_log;
 pub mod state;
+pub mod tray;
 pub mod ui_store;
 pub mod update_stage;
 pub mod util;

--- a/src/main.rs
+++ b/src/main.rs
@@ -8,13 +8,15 @@
 
 use std::fs;
 use std::path::{Path, PathBuf};
-use std::sync::atomic::Ordering;
+use std::sync::atomic::{AtomicBool, Ordering};
+use std::sync::Arc;
 
 use hermes_agent_cn::commands;
 use hermes_agent_cn::commands::profiles::read_active_profile_sticky;
 use hermes_agent_cn::environment;
 use hermes_agent_cn::process::{dashboard, runtime};
 use hermes_agent_cn::state::{AppState, DashboardHandle};
+use hermes_agent_cn::tray;
 use tauri::Emitter;
 
 /// Emit a "runtime-status" event for the frontend overlay to consume.
@@ -266,14 +268,28 @@ fn main() {
     env_logger::init();
 
     let app_state = AppState::new();
+    let quit_requested = Arc::new(AtomicBool::new(false));
+    let close_quit_requested = Arc::clone(&quit_requested);
+    let tray_available = Arc::new(AtomicBool::new(false));
+    let setup_tray_available = Arc::clone(&tray_available);
+    let close_tray_available = Arc::clone(&tray_available);
 
     let app = tauri::Builder::default()
         .plugin(tauri_plugin_dialog::init())
         .manage(app_state)
-        .setup(|app| {
+        .setup(move |app| {
             use tauri::Manager;
             let state = app.state::<AppState>();
             let bundled_resource_dir = app.path().resource_dir().ok();
+
+            match tray::install(app) {
+                Ok(()) => {
+                    setup_tray_available.store(true, Ordering::Relaxed);
+                }
+                Err(err) => {
+                    log::warn!("Failed to install system tray: {}", err);
+                }
+            }
 
             // 1. Resolve HERMES_HOME
             let hermes_home_base = resolve_hermes_home();
@@ -507,17 +523,34 @@ fn main() {
             commands::terminal::terminal_resize,
             commands::terminal::terminal_close,
         ])
-        .on_window_event(|_window, event| {
-            if let tauri::WindowEvent::Destroyed = event {
+        .on_window_event(move |window, event| match event {
+            tauri::WindowEvent::CloseRequested { api, .. }
+                if window.label() == tray::MAIN_WINDOW_LABEL
+                    && close_tray_available.load(Ordering::Relaxed)
+                    && !close_quit_requested.load(Ordering::Relaxed) =>
+            {
+                api.prevent_close();
+                tray::hide_main_window_to_tray(window);
+            }
+            tauri::WindowEvent::Destroyed if window.label() == tray::MAIN_WINDOW_LABEL => {
                 log::info!("Main window destroyed");
             }
+            _ => {}
         })
         .build(tauri::generate_context!())
         .expect("error while building Hermes Agent 中文社区桌面版");
 
-    app.run(|app_handle, event| {
-        if let tauri::RunEvent::Exit = event {
+    app.run(move |app_handle, event| match event {
+        tauri::RunEvent::ExitRequested { .. } => {
+            quit_requested.store(true, Ordering::Relaxed);
+        }
+        tauri::RunEvent::Exit => {
             shutdown_owned_runtime(app_handle, "app exit");
         }
+        #[cfg(target_os = "macos")]
+        tauri::RunEvent::Reopen { .. } => {
+            tray::show_main_window(app_handle);
+        }
+        _ => {}
     });
 }

--- a/src/tray.rs
+++ b/src/tray.rs
@@ -1,0 +1,142 @@
+//! System tray integration for the desktop app.
+//!
+//! Closing the main window should keep the managed runtime alive. The tray is
+//! the visible affordance for bringing the UI back or explicitly quitting the
+//! whole desktop runtime.
+
+use tauri::menu::MenuBuilder;
+use tauri::tray::{MouseButton, MouseButtonState, TrayIconBuilder, TrayIconEvent};
+use tauri::{App, AppHandle, Manager, Runtime, Window};
+
+pub const MAIN_WINDOW_LABEL: &str = "main";
+
+const TRAY_ID: &str = "hermes-main-tray";
+const MENU_OPEN_MAIN: &str = "hermes-tray-open-main";
+const MENU_QUIT: &str = "hermes-tray-quit";
+
+#[derive(Debug, Clone, Copy, PartialEq, Eq)]
+enum TrayMenuAction {
+    OpenMainWindow,
+    Quit,
+}
+
+fn action_for_menu_id(id: &str) -> Option<TrayMenuAction> {
+    match id {
+        MENU_OPEN_MAIN => Some(TrayMenuAction::OpenMainWindow),
+        MENU_QUIT => Some(TrayMenuAction::Quit),
+        _ => None,
+    }
+}
+
+fn click_should_open_main(button: MouseButton, button_state: Option<MouseButtonState>) -> bool {
+    button == MouseButton::Left
+        && button_state
+            .map(|state| state == MouseButtonState::Up)
+            .unwrap_or(true)
+}
+
+fn tray_event_should_open_main(event: &TrayIconEvent) -> bool {
+    match event {
+        TrayIconEvent::Click {
+            button,
+            button_state,
+            ..
+        } => click_should_open_main(*button, Some(*button_state)),
+        TrayIconEvent::DoubleClick { button, .. } => click_should_open_main(*button, None),
+        _ => false,
+    }
+}
+
+pub fn install(app: &App) -> tauri::Result<()> {
+    let menu = MenuBuilder::new(app)
+        .text(MENU_OPEN_MAIN, "打开主窗口")
+        .separator()
+        .text(MENU_QUIT, "退出 Hermes")
+        .build()?;
+
+    let mut builder = TrayIconBuilder::with_id(TRAY_ID)
+        .menu(&menu)
+        .tooltip("Hermes Agent 中文社区桌面版")
+        .show_menu_on_left_click(false)
+        .on_menu_event(|app, event| match action_for_menu_id(event.id().as_ref()) {
+            Some(TrayMenuAction::OpenMainWindow) => show_main_window(app),
+            Some(TrayMenuAction::Quit) => app.exit(0),
+            None => {}
+        })
+        .on_tray_icon_event(|tray, event| {
+            if tray_event_should_open_main(&event) {
+                show_main_window(tray.app_handle());
+            }
+        });
+
+    if let Some(icon) = app.default_window_icon().cloned() {
+        builder = builder.icon(icon);
+    } else {
+        log::warn!("No default window icon available for system tray");
+    }
+
+    builder.build(app)?;
+    Ok(())
+}
+
+pub fn hide_main_window_to_tray<R: Runtime>(window: &Window<R>) {
+    if let Err(err) = window.hide() {
+        log::warn!("Failed to hide main window to tray: {}", err);
+    } else {
+        log::info!("Main window hidden to system tray");
+    }
+}
+
+pub fn show_main_window<R: Runtime>(app: &AppHandle<R>) {
+    let Some(window) = app.get_webview_window(MAIN_WINDOW_LABEL) else {
+        log::warn!("Main window not found while restoring from tray");
+        return;
+    };
+
+    if let Err(err) = window.unminimize() {
+        log::debug!(
+            "Failed to unminimize main window while restoring from tray: {}",
+            err
+        );
+    }
+    if let Err(err) = window.show() {
+        log::warn!("Failed to show main window from tray: {}", err);
+        return;
+    }
+    if let Err(err) = window.set_focus() {
+        log::debug!("Failed to focus main window after tray restore: {}", err);
+    }
+}
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+
+    #[test]
+    fn maps_known_tray_menu_ids() {
+        assert_eq!(
+            action_for_menu_id(MENU_OPEN_MAIN),
+            Some(TrayMenuAction::OpenMainWindow)
+        );
+        assert_eq!(action_for_menu_id(MENU_QUIT), Some(TrayMenuAction::Quit));
+        assert_eq!(action_for_menu_id("unrelated"), None);
+    }
+
+    #[test]
+    fn only_left_button_release_opens_main_window() {
+        assert!(click_should_open_main(
+            MouseButton::Left,
+            Some(MouseButtonState::Up)
+        ));
+        assert!(click_should_open_main(MouseButton::Left, None));
+        assert!(!click_should_open_main(
+            MouseButton::Left,
+            Some(MouseButtonState::Down)
+        ));
+        assert!(!click_should_open_main(
+            MouseButton::Right,
+            Some(MouseButtonState::Up)
+        ));
+        assert!(!click_should_open_main(MouseButton::Middle, None));
+    }
+}


### PR DESCRIPTION
## 变更

- 增加 Tauri 系统托盘入口，托盘菜单支持打开主窗口和退出 Hermes。
- 将主窗口关闭按钮改为隐藏到托盘，保持 desktop-owned dashboard、gateway 和内核运行。
- 保留显式退出时的现有 runtime 清理流程，并在 macOS Dock 重新打开时恢复主窗口。

## 影响

关闭 UI 不再直接关闭后台能力；用户需要通过托盘“退出 Hermes”或系统退出才会停止桌面端托管 runtime。

## 验证

- `git diff --check`
- `cargo check`
- `pnpm typecheck`
- `pnpm test:unit`
- `cargo test --all-features`
