### PR TITLE
[codex] 优化飞书接入检测和扫码界面

### DIFF
--- a/packages/protocol/src/hermes-api.ts
+++ b/packages/protocol/src/hermes-api.ts
@@ -41,6 +41,68 @@ export const StatusResponse = z.object({
 });
 export type StatusResponse = z.infer<typeof StatusResponse>;
 
+// ── Messaging platforms (/api/messaging/platforms) ────────────────────
+
+export const MessagingEnvVarInfo = z
+  .object({
+    key: z.string(),
+    required: z.boolean().optional().default(false),
+    is_set: z.boolean().optional().default(false),
+    redacted_value: z.string().nullable().optional(),
+    prompt: z.string().optional().default(""),
+    description: z.string().optional().default(""),
+    advanced: z.boolean().optional().default(false),
+    is_password: z.boolean().optional().default(false),
+    url: z.string().nullable().optional(),
+  })
+  .passthrough();
+export type MessagingEnvVarInfo = z.infer<typeof MessagingEnvVarInfo>;
+
+export const MessagingHomeChannel = z
+  .object({
+    chat_id: z.string(),
+    name: z.string(),
+    platform: z.string(),
+    thread_id: z.string().optional(),
+  })
+  .passthrough();
+export type MessagingHomeChannel = z.infer<typeof MessagingHomeChannel>;
+
+export const MessagingPlatformInfo = z
+  .object({
+    id: z.string(),
+    name: z.string(),
+    description: z.string().optional().default(""),
+    docs_url: z.string().optional().default(""),
+    enabled: z.boolean().optional().default(false),
+    configured: z.boolean().optional().default(false),
+    gateway_running: z.boolean().optional().default(false),
+    state: z.string().nullable().optional(),
+    error_code: z.string().nullable().optional(),
+    error_message: z.string().nullable().optional(),
+    updated_at: z.string().nullable().optional(),
+    home_channel: MessagingHomeChannel.nullable().optional(),
+    env_vars: z.array(MessagingEnvVarInfo).optional().default([]),
+  })
+  .passthrough();
+export type MessagingPlatformInfo = z.infer<typeof MessagingPlatformInfo>;
+
+export const MessagingPlatformsResponse = z
+  .object({
+    platforms: z.array(MessagingPlatformInfo),
+  })
+  .passthrough();
+export type MessagingPlatformsResponse = z.infer<typeof MessagingPlatformsResponse>;
+
+export const MessagingPlatformTestResponse = z
+  .object({
+    ok: z.boolean(),
+    message: z.string(),
+    state: z.string().nullable().optional(),
+  })
+  .passthrough();
+export type MessagingPlatformTestResponse = z.infer<typeof MessagingPlatformTestResponse>;
+
 // ── Sessions (/api/sessions) ──────────────────────────────────────────
 
 export const SessionSummary = z.object({

--- a/src/commands/im_onboarding.rs
+++ b/src/commands/im_onboarding.rs
@@ -1164,6 +1164,12 @@ fn apply_patch_from_input(
             patch
                 .entry("FEISHU_CONNECTION_MODE".to_string())
                 .or_insert_with(|| "websocket".to_string());
+            if let Some(connection_mode) = patch.get("FEISHU_CONNECTION_MODE").cloned() {
+                patch.insert(
+                    "FEISHU_CONNECTION_MODE".to_string(),
+                    connection_mode.trim().to_lowercase(),
+                );
+            }
             if let Some(allowed_users) = patch.get("FEISHU_ALLOWED_USERS").cloned() {
                 patch.insert(
                     "FEISHU_ALLOWED_USERS".to_string(),
@@ -1254,6 +1260,31 @@ fn validate_required(
                 return Err(AppError::InvalidRequest(
                     "FEISHU_APP_ID and FEISHU_APP_SECRET are required".to_string(),
                 ));
+            }
+            let mode = patch
+                .get("FEISHU_CONNECTION_MODE")
+                .map(|v| v.trim().to_lowercase())
+                .unwrap_or_else(|| "websocket".to_string());
+            if !matches!(mode.as_str(), "websocket" | "webhook") {
+                return Err(AppError::InvalidRequest(
+                    "FEISHU_CONNECTION_MODE must be websocket or webhook".to_string(),
+                ));
+            }
+            if mode == "webhook" {
+                let has_verification_token = patch
+                    .get("FEISHU_VERIFICATION_TOKEN")
+                    .map(|v| !v.trim().is_empty())
+                    .unwrap_or(false);
+                let has_encrypt_key = patch
+                    .get("FEISHU_ENCRYPT_KEY")
+                    .map(|v| !v.trim().is_empty())
+                    .unwrap_or(false);
+                if !has_verification_token && !has_encrypt_key {
+                    return Err(AppError::InvalidRequest(
+                        "FEISHU_VERIFICATION_TOKEN or FEISHU_ENCRYPT_KEY is required for webhook mode"
+                            .to_string(),
+                    ));
+                }
             }
         }
         ImPlatform::Weixin => {
@@ -1743,6 +1774,98 @@ mod tests {
             Some("ou_scanner_123456")
         );
         FLOWS.lock().unwrap().remove(&flow_id);
+    }
+
+    #[test]
+    fn feishu_apply_rejects_scanned_token_without_open_id() {
+        let flow_id = "feishu-test-missing-open-id".to_string();
+        {
+            let mut flows = FLOWS.lock().unwrap();
+            flows.insert(
+                flow_id.clone(),
+                FlowState::Feishu(FeishuFlow {
+                    device_code: "device-test".to_string(),
+                    domain: "feishu".to_string(),
+                    interval_seconds: 5,
+                    expires_at: Instant::now() + Duration::from_secs(60),
+                    expires_at_ms: now_ms() + 60_000,
+                    credential: Some(FeishuCredential {
+                        app_id: "cli_test".to_string(),
+                        app_secret: "secret-test".to_string(),
+                        domain: "feishu".to_string(),
+                        open_id: None,
+                        bot_name: None,
+                        bot_open_id: None,
+                    }),
+                }),
+            );
+        }
+        let input = ImOnboardingApplyInput {
+            platform: ImPlatform::Feishu,
+            flow_id: Some(flow_id.clone()),
+            manual_credentials: None,
+            settings: BTreeMap::from([(
+                "FEISHU_ALLOWED_USERS".to_string(),
+                FEISHU_SCANNED_OPEN_ID_TOKEN.to_string(),
+            )]),
+            restart_gateway: Some(false),
+        };
+
+        let err = apply_patch_from_input(&input).unwrap_err();
+
+        assert!(err.to_string().contains("Scanned Feishu open_id"));
+        FLOWS.lock().unwrap().remove(&flow_id);
+    }
+
+    #[test]
+    fn feishu_webhook_mode_requires_callback_secret() {
+        let base = ImManualCredentials {
+            app_id: Some("cli_test".to_string()),
+            app_secret: Some("secret-test".to_string()),
+            account_id: None,
+            token: None,
+            base_url: None,
+            user_id: None,
+        };
+        let input = ImOnboardingApplyInput {
+            platform: ImPlatform::Feishu,
+            flow_id: None,
+            manual_credentials: Some(base),
+            settings: BTreeMap::from([(
+                "FEISHU_CONNECTION_MODE".to_string(),
+                "webhook".to_string(),
+            )]),
+            restart_gateway: Some(false),
+        };
+
+        let err = apply_patch_from_input(&input).unwrap_err();
+        assert!(err.to_string().contains("FEISHU_VERIFICATION_TOKEN"));
+
+        let ok_input = ImOnboardingApplyInput {
+            platform: ImPlatform::Feishu,
+            flow_id: None,
+            manual_credentials: Some(ImManualCredentials {
+                app_id: Some("cli_test".to_string()),
+                app_secret: Some("secret-test".to_string()),
+                account_id: None,
+                token: None,
+                base_url: None,
+                user_id: None,
+            }),
+            settings: BTreeMap::from([
+                ("FEISHU_CONNECTION_MODE".to_string(), "Webhook".to_string()),
+                (
+                    "FEISHU_VERIFICATION_TOKEN".to_string(),
+                    "verify-token".to_string(),
+                ),
+            ]),
+            restart_gateway: Some(false),
+        };
+        let patch = apply_patch_from_input(&ok_input).unwrap();
+        assert_eq!(
+            patch.get("FEISHU_CONNECTION_MODE").map(String::as_str),
+            Some("webhook")
+        );
     }
 
     #[test]

--- a/web/src/hooks/use-im-onboarding.ts
+++ b/web/src/hooks/use-im-onboarding.ts
@@ -1,5 +1,6 @@
 import { useMutation, useQuery, useQueryClient } from "@tanstack/react-query";
 import { useActiveProfileName } from "@/hooks/use-profiles";
+import { fetchJSON, postJSON } from "@/lib/transport";
 import type {
   ImOnboardingApplyInput,
   ImOnboardingApplyResult,
@@ -9,6 +10,12 @@ import type {
   ImOnboardingPollResult,
   ImOnboardingStateResult,
   ImPlatform,
+  MessagingPlatformInfo,
+  MessagingPlatformTestResponse as MessagingPlatformTestResponseType,
+} from "@hermes/protocol";
+import {
+  MessagingPlatformTestResponse,
+  MessagingPlatformsResponse,
 } from "@hermes/protocol";
 
 function requireDesktop() {
@@ -47,7 +54,57 @@ export function useApplyImOnboarding(platform: ImPlatform) {
     mutationFn: (input) => requireDesktop().imOnboardingApply!(input),
     onSuccess: () => {
       qc.invalidateQueries({ queryKey: ["im-onboarding", platform] });
+      qc.invalidateQueries({ queryKey: ["messaging-platform", platform] });
+      qc.invalidateQueries({ queryKey: ["messaging-platforms"] });
       qc.invalidateQueries({ queryKey: ["env"] });
+      qc.invalidateQueries({ queryKey: ["status"] });
+    },
+  });
+}
+
+function messageFromError(error: unknown): string {
+  return error instanceof Error ? error.message : String(error || "未知错误");
+}
+
+export function useMessagingPlatform(platform: ImPlatform) {
+  const profile = useActiveProfileName();
+  return useQuery<MessagingPlatformInfo | null>({
+    queryKey: ["messaging-platform", platform, profile],
+    queryFn: async () => {
+      try {
+        const result = await fetchJSON("/api/messaging/platforms", undefined, MessagingPlatformsResponse);
+        return result.platforms.find((item) => item.id === platform) ?? null;
+      } catch {
+        // 旧版 runtime 可能还没有官方消息平台接口。接入向导仍然可以用
+        // /api/status 和桌面端扫码命令完成主流程，所以这里降级为 null。
+        return null;
+      }
+    },
+    staleTime: 10_000,
+    refetchInterval: 15_000,
+  });
+}
+
+export function useTestMessagingPlatform(platform: ImPlatform) {
+  const qc = useQueryClient();
+  return useMutation<MessagingPlatformTestResponseType, Error, void>({
+    mutationFn: async () => {
+      try {
+        return await postJSON(
+          `/api/messaging/platforms/${encodeURIComponent(platform)}/test`,
+          {},
+          MessagingPlatformTestResponse,
+        );
+      } catch (error) {
+        return MessagingPlatformTestResponse.parse({
+          ok: false,
+          state: null,
+          message: `当前运行时暂不能执行官方检测：${messageFromError(error)}`,
+        });
+      }
+    },
+    onSuccess: () => {
+      qc.invalidateQueries({ queryKey: ["messaging-platform", platform] });
       qc.invalidateQueries({ queryKey: ["status"] });
     },
   });

--- a/web/src/routes/im-onboarding.module.css
+++ b/web/src/routes/im-onboarding.module.css
@@ -78,21 +78,34 @@
 .identityNote code, .checkToggle code { color: var(--h-accent); font-family: var(--h-font-mono); font-size: 11px; }
 .checkToggle { display: flex; align-items: center; gap: 9px; border: 1px solid var(--h-line-soft); border-radius: var(--h-r-md); background: var(--h-bg-soft); padding: 10px 12px; color: var(--h-text-2); font-size: 12px; cursor: pointer; }
 .checkToggle input { width: 14px; height: 14px; accent-color: var(--h-accent); }
-.qrSection { grid-template-columns: 256px 1fr; align-items: center; }
+.advancedPanel { border: 1px solid var(--h-line-soft); border-radius: var(--h-r-md); background: color-mix(in srgb, var(--h-bg-soft) 78%, transparent); overflow: hidden; }
+.advancedPanel[data-open="true"] { border-color: color-mix(in srgb, var(--h-accent) 28%, var(--h-line)); }
+.advancedHeader { width: 100%; display: flex; align-items: center; justify-content: space-between; gap: 12px; border: 0; background: transparent; color: var(--h-text); padding: 12px; text-align: left; cursor: pointer; }
+.advancedHeader b, .advancedHeader small { display: block; }
+.advancedHeader b { font-size: 13px; }
+.advancedHeader small { color: var(--h-text-3); margin-top: 3px; line-height: 1.55; }
+.advancedHeader em { flex: none; color: var(--h-accent); font-style: normal; font-size: 12px; }
+.advancedBody { display: grid; gap: 10px; padding: 0 12px 12px; }
+.advancedHint { display: grid; gap: 4px; border: 1px dashed color-mix(in srgb, var(--h-warn) 38%, var(--h-line)); border-radius: var(--h-r-md); padding: 10px 12px; color: var(--h-text-2); background: color-mix(in srgb, var(--h-warn) 6%, transparent); }
+.advancedHint b { color: var(--h-text); font-size: 12px; }
+.advancedHint span { line-height: 1.65; font-size: 12px; }
+.qrSection { grid-template-columns: 256px minmax(0, 1fr); align-items: center; gap: 18px; }
 .qrBox { width: 240px; height: 240px; display: grid; place-items: center; border-radius: var(--h-r-lg); border: 1px solid var(--h-line); background: var(--bone-100); overflow: hidden; }
 .qrBox img { width: 232px; height: 232px; display: block; }
 .qrPlaceholder { display: grid; place-items: center; gap: 14px; color: var(--ink-700); font-family: var(--h-font-mono); letter-spacing: .2em; }
 .qrPlaceholder span { opacity: .55; }
 .qrStartBtn { font-family: var(--h-font-ui); letter-spacing: 0; }
-.qrCopy h3 { margin: 6px 0; font-size: 18px; color: var(--h-text); }
-.qrCopy p { margin: 0 0 12px; color: var(--h-text-2); line-height: 1.7; }
+.qrCopy { min-width: 0; display: grid; align-content: center; gap: 10px; }
+.qrCopy h3 { margin: 0; font-size: 18px; color: var(--h-text); }
+.qrCopy p { margin: 0; color: var(--h-text-2); line-height: 1.7; }
 .miniEyebrow { color: var(--h-accent); font-family: var(--h-font-mono); font-size: 10px; letter-spacing: .12em; }
-.traceRow { display: grid; grid-template-columns: 60px minmax(0, 1fr); gap: 2px 10px; align-items: center; padding: 10px; border-radius: var(--h-r-md); background: var(--h-bg-soft); }
+.traceRow { display: grid; grid-template-columns: auto minmax(0, 1fr); gap: 6px 12px; align-items: center; padding: 12px; border: 1px solid var(--h-line-soft); border-radius: var(--h-r-md); background: var(--h-bg-soft); }
 .traceRow span { color: var(--h-text-3); font-size: 11px; }
-.traceRow b { color: var(--h-text); }
-.traceRow em { grid-column: 2; color: var(--h-text-3); font-style: normal; font-size: 11px; }
+.traceRow b { justify-self: start; min-height: 22px; display: inline-flex; align-items: center; border-radius: var(--h-r-pill); padding: 0 9px; color: var(--h-text); background: var(--h-bg-pane); font-size: 12px; }
+.traceRow em { grid-column: 1 / -1; color: var(--h-text-3); font-style: normal; font-size: 11px; line-height: 1.55; }
 .urlPreview { display: block; color: var(--h-text-2); background: var(--h-bg-code); border: 1px solid var(--h-line); border-radius: var(--h-r-sm); padding: 8px; word-break: break-all; }
 .buttonRow, .sectionActions { display: flex; flex-wrap: wrap; gap: 8px; }
+.buttonRow { margin-top: 2px; align-items: center; }
 .verifyGrid { display: grid; gap: 8px; }
 .verifyRow { display: flex; gap: 10px; align-items: flex-start; padding: 10px; border: 1px solid var(--h-line-soft); background: var(--h-bg-soft); border-radius: var(--h-r-md); }
 .verifyRow svg { color: var(--h-accent); flex-shrink: 0; margin-top: 2px; }
@@ -100,7 +113,7 @@
 .verifyRow small { color: var(--h-text-3); margin-top: 3px; }
 .backendChecklist { gap: 14px; }
 .checkIntro { display: flex; align-items: flex-start; justify-content: space-between; gap: 16px; }
-.checkIntro h3, .testGuide h3 { margin: 5px 0 6px; color: var(--h-text); font-size: 16px; }
+.checkIntro h3, .testGuide h3 { margin: 5px 0 8px; color: var(--h-text); font-size: 16px; }
 .checkIntro p, .testGuide p { margin: 0; color: var(--h-text-2); line-height: 1.7; font-size: 12px; }
 .consoleSteps { display: grid; grid-template-columns: repeat(3, minmax(0, 1fr)); gap: 10px; }
 .consoleStep { display: grid; gap: 7px; align-content: start; border: 1px solid var(--h-line-soft); border-radius: var(--h-r-md); background: var(--h-bg-soft); padding: 12px; }
@@ -115,15 +128,25 @@
 .scopeHead button { height: 24px; border: 1px solid var(--h-line); border-radius: var(--h-r-pill); color: var(--h-text-2); background: var(--h-bg-soft); padding: 0 9px; font-size: 11px; cursor: pointer; }
 .scopeHead button:hover { color: var(--h-text); border-color: color-mix(in srgb, var(--h-accent) 40%, var(--h-line)); }
 .scopeBox code { display: block; color: var(--h-text-2); font-family: var(--h-font-mono); font-size: 11px; word-break: break-all; }
+.scopeNote { color: var(--h-text-3); line-height: 1.6; font-size: 11px; }
 .importBox pre { max-height: 220px; overflow: auto; margin: 0; border: 1px solid var(--h-line-soft); border-radius: var(--h-r-sm); background: var(--h-bg-code); color: var(--h-text-2); padding: 10px; font-family: var(--h-font-mono); font-size: 10.5px; line-height: 1.55; }
-.testGuide { display: flex; align-items: flex-start; justify-content: space-between; gap: 16px; }
+.testGuide { display: grid; grid-template-columns: minmax(180px, 260px) minmax(0, 1fr); gap: 18px 24px; align-items: stretch; }
 .testGuide[data-ready="true"] { border-color: color-mix(in srgb, var(--h-ok) 34%, var(--h-line)); }
-.testCards { display: grid; grid-template-columns: repeat(2, minmax(150px, 1fr)); gap: 10px; min-width: min(420px, 48%); }
-.testCards div { display: grid; gap: 6px; border: 1px solid var(--h-line-soft); border-radius: var(--h-r-md); background: var(--h-bg-soft); padding: 12px; }
+.testIntro { display: grid; align-content: start; padding: 4px 10px 4px 0; border-right: 1px solid var(--h-line-soft); }
+.testPanel { min-width: 0; display: grid; gap: 12px; }
+.testCards { display: grid; grid-template-columns: repeat(auto-fit, minmax(260px, 1fr)); gap: 12px; min-width: 0; }
+.testCards div { display: grid; gap: 8px; align-content: start; min-height: 116px; border: 1px solid var(--h-line-soft); border-radius: var(--h-r-md); background: var(--h-bg-soft); padding: 14px 16px; }
 .testCards svg { color: var(--h-accent); }
 .testCards b { color: var(--h-text); font-size: 13px; }
 .testCards span { color: var(--h-text-2); line-height: 1.6; font-size: 12px; }
 .testCards code { color: var(--h-accent); font-family: var(--h-font-mono); }
+.statusGrid { width: 100%; display: grid; grid-template-columns: repeat(auto-fit, minmax(190px, 1fr)); gap: 10px; }
+.statusItem { display: grid; gap: 5px; align-content: start; min-height: 78px; border: 1px solid var(--h-line-soft); border-radius: var(--h-r-md); background: var(--h-bg-pane); padding: 11px 12px; }
+.statusItem b { color: var(--h-text); font-size: 12px; }
+.statusItem span { color: var(--h-text-2); line-height: 1.55; font-size: 12px; }
+.statusItem[data-tone="ok"] { border-color: color-mix(in srgb, var(--h-ok) 32%, var(--h-line)); background: color-mix(in srgb, var(--h-ok) 6%, var(--h-bg-pane)); }
+.statusItem[data-tone="warn"] { border-color: color-mix(in srgb, var(--h-warn) 34%, var(--h-line)); background: color-mix(in srgb, var(--h-warn) 6%, var(--h-bg-pane)); }
+.testActions { display: flex; justify-content: flex-end; padding-top: 2px; }
 .summaryLine { color: var(--h-text-2); background: var(--h-bg-soft); border: 1px solid var(--h-line); border-radius: var(--h-r-md); padding: 10px 12px; font-size: 12px; }
 .reviewTable { width: 100%; border-collapse: collapse; font-size: 12px; }
 .reviewTable th, .reviewTable td { text-align: left; border-bottom: 1px solid var(--h-line-soft); padding: 9px; color: var(--h-text-2); }
@@ -378,8 +401,11 @@
 
 @media (max-width: 760px) {
   .headBand, .qrSection { grid-template-columns: 1fr; display: grid; }
-  .metaStrip, .flowSteps, .choiceGrid, .policyGrid, .consoleSteps, .scopeGrid, .testCards { grid-template-columns: 1fr; }
-  .actionFeedback, .checkIntro, .testGuide { align-items: flex-start; flex-direction: column; }
+  .metaStrip, .flowSteps, .choiceGrid, .policyGrid, .consoleSteps, .scopeGrid, .testCards, .statusGrid { grid-template-columns: 1fr; }
+  .actionFeedback, .checkIntro { align-items: flex-start; flex-direction: column; }
+  .testGuide { grid-template-columns: 1fr; }
+  .testIntro { border-right: 0; border-bottom: 1px solid var(--h-line-soft); padding: 0 0 12px; }
+  .testActions { justify-content: flex-start; }
   .testCards { min-width: 0; width: 100%; }
   .field { grid-template-columns: 1fr; }
   .heroActions { align-items: flex-start; }

--- a/web/src/routes/im-onboarding.test.ts
+++ b/web/src/routes/im-onboarding.test.ts
@@ -1,5 +1,6 @@
 import { describe, expect, it } from "vitest";
 import {
+  FEISHU_GROUP_SCOPE,
   FEISHU_RECOMMENDED_SCOPES,
   FEISHU_REQUIRED_SCOPES,
   railPanels,
@@ -40,10 +41,13 @@ describe("im onboarding routing helpers", () => {
       "im:message.p2p_msg:readonly",
       "im:message:send_as_bot",
     ]);
+    expect(FEISHU_REQUIRED_SCOPES).not.toContain(FEISHU_GROUP_SCOPE);
+    expect(FEISHU_GROUP_SCOPE).toBe("im:message.group_at_msg:readonly");
     expect(FEISHU_RECOMMENDED_SCOPES).toContain("im:resource");
 
     const feishuRailCopy = JSON.stringify(railPanels("feishu"));
     expect(feishuRailCopy).toContain("im.message.receive_v1");
+    expect(feishuRailCopy).toContain(FEISHU_GROUP_SCOPE);
     expect(feishuRailCopy).toContain("创建版本并发布");
   });
 });

--- a/web/src/routes/im-onboarding.tsx
+++ b/web/src/routes/im-onboarding.tsx
@@ -27,13 +27,17 @@ import type {
   ImOnboardingPollResult,
   ImPlatform,
   ImRedactedValue,
+  MessagingPlatformInfo,
+  MessagingPlatformTestResponse,
 } from "@hermes/protocol";
 import { useStatus } from "@/hooks/use-status";
 import {
   useApplyImOnboarding,
   useBeginImOnboarding,
   useImOnboardingState,
+  useMessagingPlatform,
   usePollImOnboarding,
+  useTestMessagingPlatform,
 } from "@/hooks/use-im-onboarding";
 import { openExternalUrl } from "@/lib/external-links";
 import { SectionShell } from "./section-shell";
@@ -48,6 +52,7 @@ export const FEISHU_REQUIRED_SCOPES = [
   "im:message.p2p_msg:readonly",
   "im:message:send_as_bot",
 ] as const;
+export const FEISHU_GROUP_SCOPE = "im:message.group_at_msg:readonly";
 export const FEISHU_RECOMMENDED_SCOPES = [
   "im:resource",
   "cardkit:card:write",
@@ -233,7 +238,7 @@ function MetaStrip({ platform, profile, statusData, configured }: {
 }) {
   const runtime = platformState(statusData, platform);
   const connectionLabel = platform === "feishu"
-    ? (configured.FEISHU_CONNECTION_MODE?.redactedValue === "webhook" ? "回调模式" : "长连接")
+    ? "长连接"
     : "自动轮询";
   const credentialSet = platform === "feishu"
     ? Boolean(configured.FEISHU_APP_ID?.isSet && configured.FEISHU_APP_SECRET?.isSet)
@@ -316,12 +321,16 @@ function copyText(value: string) {
   void navigator.clipboard?.writeText(value);
 }
 
-function FeishuBackendChecklist() {
-  const requiredScopes = FEISHU_REQUIRED_SCOPES.join("\n");
+function FeishuBackendChecklist({ groupEnabled }: { groupEnabled: boolean }) {
+  const requiredScopeList = [
+    ...FEISHU_REQUIRED_SCOPES,
+    ...(groupEnabled ? [FEISHU_GROUP_SCOPE] : []),
+  ];
+  const requiredScopes = requiredScopeList.join("\n");
   const recommendedScopes = FEISHU_RECOMMENDED_SCOPES.join("\n");
   const importJson = JSON.stringify({
     scopes: {
-      tenant: [...FEISHU_REQUIRED_SCOPES, ...FEISHU_RECOMMENDED_SCOPES],
+      tenant: [...requiredScopeList, ...FEISHU_RECOMMENDED_SCOPES],
     },
   }, null, 2);
 
@@ -331,7 +340,9 @@ function FeishuBackendChecklist() {
         <div>
           <div className={s.miniEyebrow}>FEISHU CONSOLE</div>
           <h3>飞书后台还要点几下</h3>
-          <p>扫码只是把应用信息带回来。想让桌面端真的收到消息，需要在飞书开放平台打开机器人能力、消息事件和发送权限，最后发布一次版本。</p>
+          <p>{groupEnabled
+            ? "扫码只是把应用信息带回来。你已打开群聊高级选项，所以除了私聊权限，还要补上群聊 @ 消息权限，最后发布一次版本。"
+            : "扫码只是把应用信息带回来。先完成私聊最小闭环：打开机器人能力、消息事件和发送权限，最后发布一次版本。"}</p>
         </div>
         <button className={`${s.btn} ${s.externalBtn}`} type="button" onClick={() => openExternal(FEISHU_DEVELOPER_URL)}>
           <ExternalLink size={14} />打开飞书开发者后台
@@ -347,7 +358,7 @@ function FeishuBackendChecklist() {
         <div className={s.consoleStep}>
           <span>2</span>
           <b>订阅接收消息</b>
-          <p>在「事件与回调」里选择长连接接收事件，然后添加「接收消息 v2.0」。</p>
+          <p>在「事件与回调」里选择长连接接收事件，然后添加「接收消息 v2.0」。{groupEnabled ? "群聊场景也需要在消息权限里勾选群聊 @ 消息。" : ""}</p>
           <code>{FEISHU_RECEIVE_EVENT}</code>
         </div>
         <div className={s.consoleStep}>
@@ -359,8 +370,9 @@ function FeishuBackendChecklist() {
 
       <div className={s.scopeGrid}>
         <div className={s.scopeBox}>
-          <div className={s.scopeHead}><b>必须权限</b><button type="button" onClick={() => copyText(requiredScopes)}>复制</button></div>
-          {FEISHU_REQUIRED_SCOPES.map((scope) => <code key={scope}>{scope}</code>)}
+          <div className={s.scopeHead}><b>当前必须权限</b><button type="button" onClick={() => copyText(requiredScopes)}>复制</button></div>
+          {requiredScopeList.map((scope) => <code key={scope}>{scope}</code>)}
+          {!groupEnabled ? <small className={s.scopeNote}>默认只做私聊闭环；需要群聊时再到高级设置打开。</small> : null}
         </div>
         <div className={s.scopeBox}>
           <div className={s.scopeHead}><b>按需推荐</b><button type="button" onClick={() => copyText(recommendedScopes)}>复制</button></div>
@@ -376,18 +388,70 @@ function FeishuBackendChecklist() {
   );
 }
 
-function FeishuTestGuide({ result }: { result: ImOnboardingApplyResult | null }) {
+function platformStateText(state?: string | null): string {
+  switch (state) {
+    case "connected": return "已连接";
+    case "disabled": return "未启用";
+    case "not_configured": return "配置不完整";
+    case "pending_restart": return "等待重启";
+    case "gateway_stopped": return "接收服务未运行";
+    case "error": return "连接错误";
+    default: return state || "暂无状态";
+  }
+}
+
+function FeishuTestGuide({
+  result,
+  platform,
+  platformLoading,
+  testResult,
+  testError,
+  testPending,
+  onTest,
+}: {
+  result: ImOnboardingApplyResult | null;
+  platform?: MessagingPlatformInfo | null;
+  platformLoading: boolean;
+  testResult?: MessagingPlatformTestResponse | null;
+  testError?: unknown;
+  testPending: boolean;
+  onTest: () => void;
+}) {
+  const restartOk = Boolean(result?.restart.ok);
+  const connected = platform?.state === "connected";
+  const officialAvailable = platform !== null && platform !== undefined;
+  const testMessage = testResult?.message ?? textFromError(testError);
   return (
-    <section className={`${s.section} ${s.testGuide}`} data-ready={result?.ok ? "true" : undefined}>
-      <div>
+    <section className={`${s.section} ${s.testGuide}`} data-ready={restartOk || connected ? "true" : undefined}>
+      <div className={s.testIntro}>
         <div className={s.miniEyebrow}>LIVE TEST</div>
         <h3>最后发消息试一下</h3>
-        <p>{result?.ok
-          ? "接收服务已经启动。现在去飞书里私聊机器人发送 hi，确认能收到回复。"
+        <p>{restartOk
+          ? "接收服务已经按当前档案重启。先点一次检测确认链路，再去飞书里私聊机器人发送 hi。"
           : "先保存、完成飞书后台设置并发布，再回来私聊机器人验证。"}</p>
       </div>
-      <div className={s.testCards}>
-        <div><MessageSquareText size={15} /><b>私聊测试</b><span>给机器人发送 <code>hi</code>，应收到回复或配对提示。</span></div>
+
+      <div className={s.testPanel}>
+        <div className={s.testCards}>
+          <div><MessageSquareText size={15} /><b>私聊测试</b><span>给机器人发送 <code>hi</code>，应收到回复或配对提示。</span></div>
+          <div><Stethoscope size={15} /><b>官方检测</b><span>{platformLoading
+            ? "正在读取官方消息平台状态。"
+            : officialAvailable
+              ? `当前状态：${platformStateText(platform?.state)}${platform?.error_message ? `，${platform.error_message}` : ""}`
+              : "当前 runtime 暂无官方消息平台检测接口，已使用接收服务状态兜底。"}</span></div>
+        </div>
+
+        <div className={s.statusGrid}>
+          <div className={s.statusItem} data-tone={restartOk ? "ok" : "warn"}><b>保存重启</b><span>{restartOk ? result?.restart.message || "已完成" : "还没有成功保存并重启"}</span></div>
+          <div className={s.statusItem} data-tone={connected ? "ok" : undefined}><b>平台状态</b><span>{platformLoading ? "读取中…" : officialAvailable ? platformStateText(platform?.state) : "旧 runtime 未提供"}</span></div>
+          <div className={s.statusItem} data-tone={testResult?.ok ? "ok" : testResult ? "warn" : undefined}><b>检测结果</b><span>{testPending ? "检测中…" : testMessage || "可点击检测缺口"}</span></div>
+        </div>
+
+        <div className={s.testActions}>
+          <button className={s.btn} type="button" onClick={onTest} disabled={platformLoading || testPending}>
+            <RotateCw size={14} />{testPending ? "检测中…" : "检测飞书连接"}
+          </button>
+        </div>
       </div>
     </section>
   );
@@ -434,6 +498,10 @@ export function railPanels(platform: ImPlatform): RailPanelConfig[] {
             title: "必须权限",
             items: Array.from(FEISHU_REQUIRED_SCOPES),
             chips: ["单聊可收", "机器人可发"],
+          },
+          {
+            title: "群聊可选",
+            items: [`需要群聊 @ 回复时，再打开高级设置并补充 ${FEISHU_GROUP_SCOPE}`, "默认先完成私聊闭环，少申请一个权限，小白更容易排错"],
           },
         ],
       },
@@ -617,11 +685,15 @@ function FeishuRoute() {
   const begin = useBeginImOnboarding();
   const poll = usePollImOnboarding();
   const apply = useApplyImOnboarding("feishu");
+  const messagingPlatformQuery = useMessagingPlatform("feishu");
+  const testPlatform = useTestMessagingPlatform("feishu");
   const domain = "feishu";
   const connectionMode = "websocket";
   const [dmPolicy, setDmPolicy] = useState<DmPolicy>("pairing");
   const [allowedUsers, setAllowedUsers] = useState("");
   const [includeScannedOpenId, setIncludeScannedOpenId] = useState(true);
+  const [groupEnabled, setGroupEnabled] = useState(false);
+  const [showAdvanced, setShowAdvanced] = useState(false);
   const [homeChannel, setHomeChannel] = useState("");
   const [flow, setFlow] = useState<ImOnboardingBeginResult | null>(null);
   const [pollResult, setPollResult] = useState<ImOnboardingPollResult | null>(null);
@@ -639,6 +711,7 @@ function FeishuRoute() {
   const start = () => {
     begin.reset();
     poll.reset();
+    testPlatform.reset();
     setResult(null);
     begin.mutate({ platform: "feishu", domain }, {
       onSuccess: (next) => {
@@ -676,15 +749,18 @@ function FeishuRoute() {
         ...splitAllowedUsers(allowedUsers),
       ])
       : "";
-    return {
+    const patch: Record<string, string> = {
       FEISHU_DOMAIN: domain,
       FEISHU_CONNECTION_MODE: connectionMode,
       FEISHU_ALLOW_ALL_USERS: allowAll,
       FEISHU_ALLOWED_USERS: allowedList,
-      FEISHU_GROUP_POLICY: "disabled",
+      FEISHU_GROUP_POLICY: groupEnabled ? "open" : "disabled",
       FEISHU_REQUIRE_MENTION: "true",
-      FEISHU_HOME_CHANNEL: shouldAutoHomeChannel ? FEISHU_SCANNED_OPEN_ID_TOKEN : homeChannel.trim(),
     };
+    if (shouldAutoHomeChannel || homeChannel.trim()) {
+      patch.FEISHU_HOME_CHANNEL = shouldAutoHomeChannel ? FEISHU_SCANNED_OPEN_ID_TOKEN : homeChannel.trim();
+    }
+    return patch;
   };
   const save = () => {
     apply.mutate({
@@ -711,13 +787,14 @@ function FeishuRoute() {
       ]) || "未填写"
       : "";
   const allowlistStatus = dmPolicy === "open" ? "未限制" : dmPolicy === "pairing" ? "走配对确认" : allowPolicyReady ? "可保存" : "缺少 open_id";
-  const homeChannelReview = shouldAutoHomeChannel ? `扫码用户 ${last(scannedOpenId)}` : homeChannel.trim();
-  const homeChannelStatus = shouldAutoHomeChannel ? "自动设置" : homeChannel.trim() ? "已填写" : "稍后设置";
+  const homeChannelReview = shouldAutoHomeChannel ? `扫码用户 ${last(scannedOpenId)}` : homeChannel.trim() || "保持原配置";
+  const homeChannelStatus = shouldAutoHomeChannel ? "自动设置" : homeChannel.trim() ? "已填写" : "不改动";
   const rows: Array<[string, string, string]> = [
     ["连接模式", `FEISHU_CONNECTION_MODE=${connectionMode}`, connectionMode === "websocket" ? "推荐" : "高级"],
     ["区域", `FEISHU_DOMAIN=${domain}`, "已选择"],
     ["私聊策略", `FEISHU_ALLOW_ALL_USERS=${dmPolicy === "open" ? "true" : "false"}`, dmPolicy === "scanned" ? "只允许扫码用户" : dmPolicy === "pairing" ? "需要确认" : dmPolicy],
     ["允许对话用户", `FEISHU_ALLOWED_USERS=${allowlistReview}`, allowlistStatus],
+    ["群聊入口", `FEISHU_GROUP_POLICY=${groupEnabled ? "open" : "disabled"}`, groupEnabled ? "高级：仅 @ 响应" : "默认关闭"],
     ["默认通知会话", `FEISHU_HOME_CHANNEL=${homeChannelReview}`, homeChannelStatus],
   ];
 
@@ -728,7 +805,7 @@ function FeishuRoute() {
           <Hero platform="feishu" stateSub={`当前档案：${stateQuery.data?.currentProfile ?? "default"}`} onPrimary={start} primaryBusy={busy} />
           <ActionFeedback busy={begin.isPending} error={begin.error} flow={flow} status={status} onJump={jumpToQr} />
           <MetaStrip platform="feishu" profile={stateQuery.data?.currentProfile ?? "default"} statusData={statusQuery.data} configured={configured} />
-          <FlowSteps platform="feishu" status={status} saved={Boolean(result?.ok)} />
+          <FlowSteps platform="feishu" status={status} saved={Boolean(result?.restart.ok)} />
           <div ref={qrAnchorRef} className={s.anchorBlock}>
             <SectionTitle num="[ STEP 01 ]" title="用飞书扫码确认" meta={flow ? `每 ${flow.intervalSeconds} 秒自动检查一次；成功后继续下一步` : "二维码只在当前页面临时使用"} />
             <QrPanel
@@ -767,6 +844,27 @@ function FeishuRoute() {
               <Field label="允许对话用户 open_id" desc={scannedOpenId ? "可继续添加其他飞书用户 open_id；多个值用英文逗号分隔。" : "多个飞书 open_id 用英文逗号分隔；可从飞书消息事件 sender_id.open_id 获取。"} meta="FEISHU_ALLOWED_USERS"><input value={allowedUsers} onChange={(e) => setAllowedUsers(e.target.value)} placeholder="ou_xxx,ou_yyy" /></Field>
             </>}
             <Field label="默认通知会话" desc={scannedOpenId ? "用于定时任务和跨平台通知；留空会自动使用本次扫码用户的私聊。" : "用于定时任务和跨平台通知；扫码成功后会自动填到当前用户，也可以手动填 chat_id。"} meta="FEISHU_HOME_CHANNEL"><input value={homeChannel} onChange={(e) => setHomeChannel(e.target.value)} placeholder={scannedOpenId ? "留空自动使用扫码用户" : "oc_xxx 或留空"} /></Field>
+            <div className={s.advancedPanel} data-open={showAdvanced ? "true" : undefined}>
+              <button className={s.advancedHeader} type="button" onClick={() => setShowAdvanced((value) => !value)} aria-expanded={showAdvanced}>
+                <span>
+                  <b>高级设置</b>
+                  <small>默认不需要动；只有要群聊、Lark 国际版或公司统一回调时才展开。</small>
+                </span>
+                <em>{showAdvanced ? "收起" : "展开"}</em>
+              </button>
+              {showAdvanced ? (
+                <div className={s.advancedBody}>
+                  <label className={s.checkToggle}>
+                    <input type="checkbox" checked={groupEnabled} onChange={(e) => setGroupEnabled(e.target.checked)} />
+                    <span>启用群聊 @ 机器人入口。打开后会写入 <code>FEISHU_GROUP_POLICY=open</code>，并在权限清单里补充 <code>{FEISHU_GROUP_SCOPE}</code>；关闭时保持 <code>disabled</code>。</span>
+                  </label>
+                  <div className={s.advancedHint}>
+                    <b>先别急着开高级项</b>
+                    <span>新手建议先跑通私聊。Webhook、Lark 国际版和已有企业应用的手动密钥仍可在环境变量页配置；这个向导默认采用飞书中国区长连接，避免准备公网回调地址。</span>
+                  </div>
+                </div>
+              ) : null}
+            </div>
           </section>
 
           <SectionTitle num="[ REVIEW ]" title="保存前看一眼" meta="密钥会自动打码；保存后继续去飞书后台确认" />
@@ -775,9 +873,17 @@ function FeishuRoute() {
           <div className={s.sectionActions}><button className={`${s.btn} ${s.primary}`} onClick={save} disabled={busy || !canApplyQr || !allowPolicyReady}><Save size={14} />保存并启动接收服务</button></div>
           <ApplyResult result={result} />
           <SectionTitle num="[ STEP 03 ]" title="打开飞书后台完成权限" meta="按清单勾选权限、订阅消息并发布版本" />
-          <FeishuBackendChecklist />
+          <FeishuBackendChecklist groupEnabled={groupEnabled} />
           <SectionTitle num="[ STEP 04 ]" title="发一条消息试试" meta="私聊机器人，确认真的能回复" />
-          <FeishuTestGuide result={result} />
+          <FeishuTestGuide
+            result={result}
+            platform={messagingPlatformQuery.data}
+            platformLoading={messagingPlatformQuery.isLoading}
+            testResult={testPlatform.data}
+            testError={testPlatform.error}
+            testPending={testPlatform.isPending}
+            onTest={() => testPlatform.mutate()}
+          />
           {(begin.error || poll.error || apply.error || stateQuery.error) && <div className={s.errorBox}><XCircle size={16} />{textFromError(begin.error || poll.error || apply.error || stateQuery.error)}</div>}
         </main>
       </div>


### PR DESCRIPTION
## 变更内容

本 PR 优化飞书接入向导的小白使用体验，主要包括：

- 扩展消息平台 API schema，并在飞书接入页展示官方平台状态与检测结果。
- 将飞书扫码接入默认保持长连接，私聊作为最小闭环，群聊权限改为高级按需项。
- 调整二维码确认区域 UI，让状态、说明和操作按钮之间有更清晰的间距。
- 增加飞书配置校验，规范连接模式，并补充扫码 open_id 缺失、webhook 回调密钥等测试。

## 原因

飞书接入流程之前对新手暴露了过多高级配置，且二维码状态区域布局拥挤，容易造成“下一步应该点哪里”的困惑。本次改动把默认路径收敛为扫码、保存、完成后台私聊权限、发消息验证，同时保留检测能力帮助定位缺口。

## 验证

已在 rebase 到 `origin/main` 后执行：

- `pnpm typecheck`
- `pnpm test:unit`
- `cargo fmt --check && cargo check`
- `cargo test --all-features`
