### PR TITLE
[codex] 修复单美元 LaTeX 公式渲染

### DIFF
--- a/web/src/components/chat/markdown-renderer.tsx
+++ b/web/src/components/chat/markdown-renderer.tsx
@@ -1,5 +1,5 @@
 import { cjk } from "@streamdown/cjk";
-import { math } from "@streamdown/math";
+import { createMathPlugin } from "@streamdown/math";
 import type { ComponentProps } from "react";
 import { Streamdown } from "streamdown";
 import { MessageImage } from "./message-image";
@@ -9,7 +9,10 @@ interface MarkdownTextProps {
   streaming?: boolean;
 }
 
-const streamdownPlugins = { cjk, math };
+const streamdownPlugins = {
+  cjk,
+  math: createMathPlugin({ singleDollarTextMath: true }),
+};
 
 const streamdownLinkSafety: ComponentProps<typeof Streamdown>["linkSafety"] = {
   enabled: false,

--- a/web/src/components/chat/message-timeline.test.tsx
+++ b/web/src/components/chat/message-timeline.test.tsx
@@ -68,6 +68,15 @@ describe("MessageTimeline", () => {
     expect(html).toContain("alt=\"趋势图\"");
   });
 
+  it("renders single-dollar inline LaTeX formulas", () => {
+    const html = ReactDOMServer.renderToStaticMarkup(
+      <MarkdownText text={String.raw`设 $\boldsymbol{v}_i \in \mathbb{R}^n$ 且 $A\boldsymbol{v}_i = \boldsymbol{0}$。`} />,
+    );
+
+    expect(html).toContain("katex");
+    expect(html).not.toContain("$\\boldsymbol");
+  });
+
   it("shows a readable fallback for unsupported local image URLs", () => {
     const messages: ChatMessage[] = [
       {

--- a/web/src/hooks/use-create-and-send-session.ts
+++ b/web/src/hooks/use-create-and-send-session.ts
@@ -18,7 +18,7 @@ import {
 } from "@/lib/workspaces";
 
 interface CreateAndSendOptions {
-  createSession?: () => Promise<string>;
+  createSession?: (options?: { cwd?: string }) => Promise<string>;
 }
 
 export function useCreateAndSendSession() {
@@ -42,7 +42,8 @@ export function useCreateAndSendSession() {
     options?: CreateAndSendOptions,
   ) => {
     const submittedAt = Date.now();
-    const sessionId = await (options?.createSession ?? createSession)();
+    const workspacePath = payload.workspacePath?.trim() || undefined;
+    const sessionId = await (options?.createSession ?? createSession)({ cwd: workspacePath });
     const title = titleFromPrompt(payload.text || payload.attachments[0]?.name || "");
     const optimisticDisplayText = buildComposerDisplayText(payload);
     const optimisticDisplayImages = payload.attachments
@@ -60,9 +61,9 @@ export function useCreateAndSendSession() {
     if (payload.modelSelection?.model) {
       rememberSessionModelOverride(sessionId, payload.modelSelection);
     }
-    if (payload.workspacePath) {
-      rememberWorkspaceProject(payload.workspacePath);
-      rememberSessionWorkspace(sessionId, payload.workspacePath);
+    if (workspacePath) {
+      rememberWorkspaceProject(workspacePath);
+      rememberSessionWorkspace(sessionId, workspacePath);
     }
 
     beginPrompt(sessionId, optimisticDisplayText, submittedAt, optimisticDisplayImages);

--- a/web/src/hooks/use-gateway.ts
+++ b/web/src/hooks/use-gateway.ts
@@ -148,6 +148,7 @@ async function rememberPersistentSessionKey(gatewaySessionId: string) {
 
 interface CreateSessionOptions {
   activate?: boolean;
+  cwd?: string;
 }
 
 export function useGateway() {
@@ -185,7 +186,9 @@ export function useGateway() {
     ensureSubscribed();
     const result = parseGatewayResult(
       SessionCreateResult,
-      await getGatewayClient().request("session.create", {}),
+      await getGatewayClient().request("session.create",
+        options?.cwd?.trim() ? { cwd: options.cwd.trim() } : {},
+      ),
       "session.create",
     );
     if (options?.activate !== false) {


### PR DESCRIPTION
## 变更内容

修复聊天 Markdown 渲染器中单美元内联 LaTeX 公式没有被 KaTeX 识别的问题，并修复新任务创建时未把用户选择的工作区路径传给 gateway 的问题。

## 原因

`@streamdown/math` 默认关闭 `$...$` 形式的内联数学解析，而用户反馈截图里的公式大量使用单美元分隔符，导致部分公式按普通文本显示。

新任务创建时，桌面端前端只把工作区写入 prompt 和本地映射，没有作为 `cwd` 传给 `session.create`。当 dashboard 进程的当前工作目录已失效时，后端回退到 `os.getcwd()` 会抛出 `FileNotFoundError`，前端显示 `dispatch crashed`。

## 影响

聊天消息中的 `$...$` 内联公式现在会正常进入 KaTeX 渲染链路，双美元和现有 Markdown 渲染能力保持不变。

新任务会把当前选择的工作区作为 gateway session 的 cwd，后端返回的 session info 也会带上正确工作区和 git branch。

## 验证

已运行并通过：

```bash
pnpm typecheck
pnpm test:unit
cargo check
```

另外已用本地 `dev-local-0.16.0` dashboard 直接验证 `session.create` 携带 cwd 返回 200，结果中的 `cwd` 为 `/Users/enzo/Documents/GithubProjects/hermes/hermes-agent-cn-desktop`。
