### PR TITLE
[codex] 增强消息平台接入诊断与微信小白流程

### DIFF
--- a/src/commands/im_onboarding.rs
+++ b/src/commands/im_onboarding.rs
@@ -1169,8 +1169,16 @@ fn state_snapshot(
     })
 }
 
+#[cfg(test)]
 fn apply_patch_from_input(
     input: &ImOnboardingApplyInput,
+) -> Result<BTreeMap<String, String>, AppError> {
+    apply_patch_from_input_with_existing(input, None)
+}
+
+fn apply_patch_from_input_with_existing(
+    input: &ImOnboardingApplyInput,
+    existing_env: Option<&BTreeMap<String, String>>,
 ) -> Result<BTreeMap<String, String>, AppError> {
     let mut patch = input.settings.clone();
     match input.platform {
@@ -1313,8 +1321,34 @@ fn apply_patch_from_input(
             }
         }
     }
+    merge_existing_platform_values(input.platform, &mut patch, existing_env);
     validate_required(input.platform, &patch)?;
     Ok(patch)
+}
+
+fn merge_existing_platform_values(
+    platform: ImPlatform,
+    patch: &mut BTreeMap<String, String>,
+    existing_env: Option<&BTreeMap<String, String>>,
+) {
+    let Some(existing_env) = existing_env else {
+        return;
+    };
+    for key in platform.allowed_keys() {
+        let patch_is_missing = patch
+            .get(*key)
+            .map(|value| value.trim().is_empty())
+            .unwrap_or(true);
+        if !patch_is_missing {
+            continue;
+        }
+        if let Some(value) = existing_env
+            .get(*key)
+            .filter(|value| !value.trim().is_empty())
+        {
+            patch.insert((*key).to_string(), value.clone());
+        }
+    }
 }
 
 fn validate_required(
@@ -1687,8 +1721,9 @@ pub async fn im_onboarding_apply(
         let inner = state.inner.lock()?;
         (inner.hermes_home.clone(), inner.current_profile.clone())
     };
-    let patch = apply_patch_from_input(&input)?;
     let path = env_path(&hermes_home);
+    let existing_env = parse_env(&path)?;
+    let patch = apply_patch_from_input_with_existing(&input, Some(&existing_env))?;
     let backup = write_env_patch(&path, input.platform, &patch)?;
     if input.platform == ImPlatform::Weixin {
         write_weixin_account_store(&hermes_home, &patch)?;
@@ -2038,6 +2073,38 @@ mod tests {
         assert_eq!(
             patch.get("WEIXIN_ACCOUNT_ID").map(String::as_str),
             Some("wx_bot_123456")
+        );
+    }
+
+    #[test]
+    fn weixin_apply_can_reuse_existing_saved_credentials() {
+        let input = ImOnboardingApplyInput {
+            platform: ImPlatform::Weixin,
+            flow_id: None,
+            manual_credentials: None,
+            settings: BTreeMap::new(),
+            restart_gateway: Some(false),
+        };
+        let existing = BTreeMap::from([
+            ("WEIXIN_ACCOUNT_ID".to_string(), "wx_bot_saved".to_string()),
+            ("WEIXIN_TOKEN".to_string(), "token-saved".to_string()),
+            ("WEIXIN_DM_POLICY".to_string(), "open".to_string()),
+            ("WEIXIN_ALLOW_ALL_USERS".to_string(), "true".to_string()),
+        ]);
+
+        let patch = apply_patch_from_input_with_existing(&input, Some(&existing)).unwrap();
+
+        assert_eq!(
+            patch.get("WEIXIN_ACCOUNT_ID").map(String::as_str),
+            Some("wx_bot_saved")
+        );
+        assert_eq!(
+            patch.get("WEIXIN_TOKEN").map(String::as_str),
+            Some("token-saved")
+        );
+        assert_eq!(
+            patch.get("WEIXIN_DM_POLICY").map(String::as_str),
+            Some("open")
         );
     }
 

--- a/src/commands/im_onboarding.rs
+++ b/src/commands/im_onboarding.rs
@@ -1380,9 +1380,12 @@ fn validate_required(
                 .get("WEIXIN_DM_POLICY")
                 .map(|v| v.trim().to_lowercase())
                 .unwrap_or_else(|| "open".to_string());
-            if !matches!(dm_policy.as_str(), "open" | "allowlist" | "disabled") {
+            if !matches!(
+                dm_policy.as_str(),
+                "open" | "allowlist" | "pairing" | "disabled"
+            ) {
                 return Err(AppError::InvalidRequest(
-                    "WEIXIN_DM_POLICY must be open, allowlist, or disabled".to_string(),
+                    "WEIXIN_DM_POLICY must be open, allowlist, pairing, or disabled".to_string(),
                 ));
             }
         }
@@ -2010,7 +2013,7 @@ mod tests {
     }
 
     #[test]
-    fn weixin_apply_rejects_unsupported_pairing_policy() {
+    fn weixin_apply_accepts_pairing_policy() {
         let input = ImOnboardingApplyInput {
             platform: ImPlatform::Weixin,
             flow_id: None,
@@ -2026,8 +2029,16 @@ mod tests {
             restart_gateway: Some(false),
         };
 
-        let err = apply_patch_from_input(&input).unwrap_err();
-        assert!(err.to_string().contains("WEIXIN_DM_POLICY"));
+        let patch = apply_patch_from_input(&input).unwrap();
+
+        assert_eq!(
+            patch.get("WEIXIN_DM_POLICY").map(String::as_str),
+            Some("pairing")
+        );
+        assert_eq!(
+            patch.get("WEIXIN_ACCOUNT_ID").map(String::as_str),
+            Some("wx_bot_123456")
+        );
     }
 
     #[test]

--- a/src/commands/im_onboarding.rs
+++ b/src/commands/im_onboarding.rs
@@ -36,6 +36,7 @@ const WEIXIN_CDN_BASE_URL: &str = "https://novac2c.cdn.weixin.qq.com/c2c";
 const WEIXIN_CLIENT_VERSION: &str = "131584";
 const WEIXIN_QR_REFRESH_LIMIT: u8 = 3;
 const FEISHU_SCANNED_OPEN_ID_TOKEN: &str = "__HERMES_SCANNED_FEISHU_OPEN_ID__";
+const WEIXIN_SCANNED_USER_ID_TOKEN: &str = "__HERMES_SCANNED_WEIXIN_USER_ID__";
 
 const FEISHU_SECRET_KEYS: &[&str] = &[
     "FEISHU_APP_SECRET",
@@ -583,6 +584,45 @@ fn normalize_feishu_allowed_users(
     {
         let resolved =
             resolve_feishu_scanned_open_id_token(item, scanned_open_id, "FEISHU_ALLOWED_USERS")?;
+        if !result.iter().any(|existing| existing == &resolved) {
+            result.push(resolved);
+        }
+    }
+    Ok(result.join(","))
+}
+
+fn resolve_weixin_scanned_user_id_token(
+    raw: &str,
+    scanned_user_id: Option<&str>,
+    key: &str,
+) -> Result<String, AppError> {
+    let trimmed = raw.trim();
+    if trimmed != WEIXIN_SCANNED_USER_ID_TOKEN {
+        return Ok(trimmed.to_string());
+    }
+    scanned_user_id
+        .map(str::trim)
+        .filter(|value| !value.is_empty())
+        .map(str::to_string)
+        .ok_or_else(|| {
+            AppError::InvalidRequest(format!(
+                "Scanned Weixin user_id is not available; enter {key} manually"
+            ))
+        })
+}
+
+fn normalize_weixin_allowed_users(
+    raw: &str,
+    scanned_user_id: Option<&str>,
+) -> Result<String, AppError> {
+    let mut result: Vec<String> = Vec::new();
+    for item in raw
+        .split([',', '，', '\n', '\r', '\t', ' '])
+        .map(str::trim)
+        .filter(|value| !value.is_empty())
+    {
+        let resolved =
+            resolve_weixin_scanned_user_id_token(item, scanned_user_id, "WEIXIN_ALLOWED_USERS")?;
         if !result.iter().any(|existing| existing == &resolved) {
             result.push(resolved);
         }
@@ -1188,6 +1228,7 @@ fn apply_patch_from_input(
             }
         }
         ImPlatform::Weixin => {
+            let mut scanned_user_id: Option<String> = None;
             let credential = if let Some(flow_id) = &input.flow_id {
                 let flows = FLOWS.lock()?;
                 match flows.get(flow_id) {
@@ -1198,13 +1239,18 @@ fn apply_patch_from_input(
                 None
             };
             if let Some(credential) = credential {
+                scanned_user_id = credential.user_id.clone();
                 patch.insert("WEIXIN_ACCOUNT_ID".to_string(), credential.account_id);
                 patch.insert("WEIXIN_TOKEN".to_string(), credential.token);
                 patch.insert("WEIXIN_BASE_URL".to_string(), credential.base_url);
                 if let Some(user_id) = credential.user_id {
-                    patch
-                        .entry("WEIXIN_HOME_CHANNEL".to_string())
-                        .or_insert(user_id);
+                    if patch
+                        .get("WEIXIN_HOME_CHANNEL")
+                        .map(|value| value.trim().is_empty())
+                        .unwrap_or(true)
+                    {
+                        patch.insert("WEIXIN_HOME_CHANNEL".to_string(), user_id);
+                    }
                 }
             } else if let Some(manual) = &input.manual_credentials {
                 if let Some(account_id) =
@@ -1225,9 +1271,16 @@ fn apply_patch_from_input(
                     );
                 }
                 if let Some(user_id) = manual.user_id.as_ref().filter(|v| !v.trim().is_empty()) {
-                    patch
-                        .entry("WEIXIN_HOME_CHANNEL".to_string())
-                        .or_insert(user_id.trim().to_string());
+                    if patch
+                        .get("WEIXIN_HOME_CHANNEL")
+                        .map(|value| value.trim().is_empty())
+                        .unwrap_or(true)
+                    {
+                        patch.insert(
+                            "WEIXIN_HOME_CHANNEL".to_string(),
+                            user_id.trim().to_string(),
+                        );
+                    }
                 }
             }
             patch
@@ -1236,6 +1289,28 @@ fn apply_patch_from_input(
             patch
                 .entry("WEIXIN_CDN_BASE_URL".to_string())
                 .or_insert_with(|| WEIXIN_CDN_BASE_URL.to_string());
+            if let Some(dm_policy) = patch.get("WEIXIN_DM_POLICY").cloned() {
+                patch.insert(
+                    "WEIXIN_DM_POLICY".to_string(),
+                    dm_policy.trim().to_lowercase(),
+                );
+            }
+            if let Some(allowed_users) = patch.get("WEIXIN_ALLOWED_USERS").cloned() {
+                patch.insert(
+                    "WEIXIN_ALLOWED_USERS".to_string(),
+                    normalize_weixin_allowed_users(&allowed_users, scanned_user_id.as_deref())?,
+                );
+            }
+            if let Some(home_channel) = patch.get("WEIXIN_HOME_CHANNEL").cloned() {
+                patch.insert(
+                    "WEIXIN_HOME_CHANNEL".to_string(),
+                    resolve_weixin_scanned_user_id_token(
+                        &home_channel,
+                        scanned_user_id.as_deref(),
+                        "WEIXIN_HOME_CHANNEL",
+                    )?,
+                );
+            }
         }
     }
     validate_required(input.platform, &patch)?;
@@ -1299,6 +1374,15 @@ fn validate_required(
             {
                 return Err(AppError::InvalidRequest(
                     "WEIXIN_ACCOUNT_ID and WEIXIN_TOKEN are required".to_string(),
+                ));
+            }
+            let dm_policy = patch
+                .get("WEIXIN_DM_POLICY")
+                .map(|v| v.trim().to_lowercase())
+                .unwrap_or_else(|| "open".to_string());
+            if !matches!(dm_policy.as_str(), "open" | "allowlist" | "disabled") {
+                return Err(AppError::InvalidRequest(
+                    "WEIXIN_DM_POLICY must be open, allowlist, or disabled".to_string(),
                 ));
             }
         }
@@ -1866,6 +1950,84 @@ mod tests {
             patch.get("FEISHU_CONNECTION_MODE").map(String::as_str),
             Some("webhook")
         );
+    }
+
+    #[test]
+    fn weixin_apply_expands_scanned_user_tokens() {
+        let flow_id = "weixin-test-allowlist-token".to_string();
+        {
+            let mut flows = FLOWS.lock().unwrap();
+            flows.insert(
+                flow_id.clone(),
+                FlowState::Weixin(WeixinFlow {
+                    qrcode_value: "qr-test".to_string(),
+                    qrcode_url: Some("https://example.test/qr.png".to_string()),
+                    current_base_url: WEIXIN_BASE_URL.to_string(),
+                    refresh_count: 0,
+                    interval_seconds: 1,
+                    expires_at: Instant::now() + Duration::from_secs(60),
+                    expires_at_ms: now_ms() + 60_000,
+                    credential: Some(WeixinCredential {
+                        account_id: "wx_bot_123456".to_string(),
+                        token: "token-test".to_string(),
+                        base_url: "https://mock.weixin.test".to_string(),
+                        user_id: Some("wxid_scanner_123456".to_string()),
+                    }),
+                }),
+            );
+        }
+        let input = ImOnboardingApplyInput {
+            platform: ImPlatform::Weixin,
+            flow_id: Some(flow_id.clone()),
+            manual_credentials: None,
+            settings: BTreeMap::from([
+                ("WEIXIN_DM_POLICY".to_string(), "allowlist".to_string()),
+                (
+                    "WEIXIN_ALLOWED_USERS".to_string(),
+                    format!(
+                        "{WEIXIN_SCANNED_USER_ID_TOKEN}, wxid_extra_1, {WEIXIN_SCANNED_USER_ID_TOKEN}"
+                    ),
+                ),
+                (
+                    "WEIXIN_HOME_CHANNEL".to_string(),
+                    WEIXIN_SCANNED_USER_ID_TOKEN.to_string(),
+                ),
+            ]),
+            restart_gateway: Some(false),
+        };
+
+        let patch = apply_patch_from_input(&input).unwrap();
+
+        assert_eq!(
+            patch.get("WEIXIN_ALLOWED_USERS").map(String::as_str),
+            Some("wxid_scanner_123456,wxid_extra_1")
+        );
+        assert_eq!(
+            patch.get("WEIXIN_HOME_CHANNEL").map(String::as_str),
+            Some("wxid_scanner_123456")
+        );
+        FLOWS.lock().unwrap().remove(&flow_id);
+    }
+
+    #[test]
+    fn weixin_apply_rejects_unsupported_pairing_policy() {
+        let input = ImOnboardingApplyInput {
+            platform: ImPlatform::Weixin,
+            flow_id: None,
+            manual_credentials: Some(ImManualCredentials {
+                app_id: None,
+                app_secret: None,
+                account_id: Some("wx_bot_123456".to_string()),
+                token: Some("token-test".to_string()),
+                base_url: Some(WEIXIN_BASE_URL.to_string()),
+                user_id: None,
+            }),
+            settings: BTreeMap::from([("WEIXIN_DM_POLICY".to_string(), "pairing".to_string())]),
+            restart_gateway: Some(false),
+        };
+
+        let err = apply_patch_from_input(&input).unwrap_err();
+        assert!(err.to_string().contains("WEIXIN_DM_POLICY"));
     }
 
     #[test]

--- a/web/src/lib/im-onboarding-diagnostics.ts
+++ b/web/src/lib/im-onboarding-diagnostics.ts
@@ -265,13 +265,16 @@ export function buildImDiagnosticBundle(input: BuildImDiagnosticInput): ImDiagno
   const configured = input.configured ?? {};
   const statusPlatform = input.statusData?.gateway_platforms?.[input.platform];
   const testMessage = input.testResult?.message ?? textFromUnknownError(input.testError);
+  const testFailureMessage = input.testResult?.ok === false
+    ? input.testResult.message
+    : textFromUnknownError(input.testError);
   const errorMessages = [
     textFromUnknownError(input.beginError),
     textFromUnknownError(input.pollError),
     textFromUnknownError(input.applyError),
     textFromUnknownError(input.stateError),
-    input.platformInfo?.error_message ?? null,
-    testMessage,
+    input.platformInfo?.state === "connected" ? null : input.platformInfo?.error_message ?? null,
+    testFailureMessage,
   ].filter(Boolean) as string[];
   const issues: ImDiagnosticIssue[] = [];
 

--- a/web/src/lib/im-onboarding-diagnostics.ts
+++ b/web/src/lib/im-onboarding-diagnostics.ts
@@ -1,0 +1,447 @@
+import type {
+  ImCredentialSummary,
+  ImOnboardingApplyResult,
+  ImPlatform,
+  ImRedactedValue,
+  MessagingPlatformInfo,
+  MessagingPlatformTestResponse,
+  StatusResponse,
+} from "@hermes/protocol";
+
+const FEISHU_RECEIVE_EVENT = "im.message.receive_v1";
+
+type ImDiagnosticLevel = "ok" | "warn" | "error";
+
+export interface ImDiagnosticIssue {
+  level: ImDiagnosticLevel;
+  title: string;
+  detail: string;
+  nextStep: string;
+  evidence?: string | null;
+}
+
+interface ImDiagnosticConfigKey {
+  key: string;
+  isSet: boolean;
+  redactedValue?: string | null;
+  fingerprint?: string | null;
+}
+
+export interface ImDiagnosticBundle {
+  kind: "hermes-im-onboarding-diagnosis";
+  version: 1;
+  generatedAt: string;
+  platform: ImPlatform;
+  platformLabel: string;
+  currentProfile: string;
+  hermesHome?: string | null;
+  envPath?: string | null;
+  gateway: {
+    running?: boolean;
+    state?: string | null;
+    platformState?: string | null;
+    platformErrorCode?: string | null;
+    platformErrorMessage?: string | null;
+    updatedAt?: string | null;
+  };
+  officialPlatform: {
+    available: boolean;
+    enabled?: boolean;
+    configured?: boolean;
+    gatewayRunning?: boolean;
+    state?: string | null;
+    errorCode?: string | null;
+    errorMessage?: string | null;
+    homeChannel?: string | null;
+    envVars?: Array<{
+      key: string;
+      required?: boolean;
+      isSet?: boolean;
+      redactedValue?: string | null;
+      advanced?: boolean;
+    }>;
+  };
+  onboarding: {
+    qrStatus?: string | null;
+    qrMessage?: string | null;
+    credentialReturned?: boolean;
+    lastApplyOk?: boolean | null;
+    restartOk?: boolean | null;
+    restartMessage?: string | null;
+  };
+  configuration: {
+    requiredKeys: ImDiagnosticConfigKey[];
+    policyKeys: ImDiagnosticConfigKey[];
+  };
+  test: {
+    ran: boolean;
+    ok?: boolean | null;
+    state?: string | null;
+    message?: string | null;
+  };
+  issues: ImDiagnosticIssue[];
+}
+
+export interface BuildImDiagnosticInput {
+  platform: ImPlatform;
+  currentProfile?: string | null;
+  hermesHome?: string | null;
+  envPath?: string | null;
+  configured?: Record<string, ImRedactedValue>;
+  statusData?: StatusResponse;
+  platformInfo?: MessagingPlatformInfo | null;
+  testResult?: MessagingPlatformTestResponse | null;
+  testError?: unknown;
+  applyResult?: ImOnboardingApplyResult | null;
+  beginError?: unknown;
+  pollError?: unknown;
+  applyError?: unknown;
+  stateError?: unknown;
+  qrStatus?: string | null;
+  qrMessage?: string | null;
+  credential?: ImCredentialSummary | null;
+}
+
+const DIAGNOSTIC_REQUIRED_KEYS: Record<ImPlatform, string[]> = {
+  feishu: ["FEISHU_APP_ID", "FEISHU_APP_SECRET"],
+  weixin: ["WEIXIN_ACCOUNT_ID", "WEIXIN_TOKEN"],
+};
+
+const DIAGNOSTIC_POLICY_KEYS: Record<ImPlatform, string[]> = {
+  feishu: ["FEISHU_DM_POLICY", "FEISHU_ALLOWED_USERS", "FEISHU_HOME_CHANNEL", "FEISHU_GROUP_POLICY"],
+  weixin: ["WEIXIN_DM_POLICY", "WEIXIN_ALLOWED_USERS", "WEIXIN_HOME_CHANNEL", "WEIXIN_ALLOW_ALL_USERS"],
+};
+
+function textFromUnknownError(error: unknown): string | null {
+  if (!error) return null;
+  return error instanceof Error ? error.message : String(error);
+}
+
+function platformStateLabel(state?: string | null): string {
+  switch (state) {
+    case "connected": return "已连接";
+    case "disabled": return "未启用";
+    case "not_configured": return "配置不完整";
+    case "pending_restart": return "等待重启";
+    case "gateway_stopped": return "接收服务未运行";
+    case "error": return "连接错误";
+    default: return state || "暂无状态";
+  }
+}
+
+function safeDiagnosticValue(key: string, value?: string | null): string | null {
+  if (!value) return null;
+  if (!/(SECRET|TOKEN|PASSWORD|COOKIE|PRIVATE)/i.test(key)) return value;
+  if (/[•*…]/.test(value) || value.length <= 8) return value;
+  return "已设置（已隐藏）";
+}
+
+function configuredKey(configured: Record<string, ImRedactedValue> | undefined, key: string): ImDiagnosticConfigKey {
+  const value = configured?.[key];
+  return {
+    key,
+    isSet: Boolean(value?.isSet),
+    redactedValue: safeDiagnosticValue(key, value?.redactedValue),
+    fingerprint: value?.fingerprint ?? null,
+  };
+}
+
+function isConfigured(configured: Record<string, ImRedactedValue> | undefined, key: string): boolean {
+  return Boolean(configured?.[key]?.isSet);
+}
+
+function addIssue(issues: ImDiagnosticIssue[], issue: ImDiagnosticIssue | null | undefined) {
+  if (!issue) return;
+  const id = `${issue.level}:${issue.title}:${issue.nextStep}`;
+  if (issues.some((item) => `${item.level}:${item.title}:${item.nextStep}` === id)) return;
+  issues.push(issue);
+}
+
+export function explainMessagingFailure(platform: ImPlatform, rawMessage?: string | null): ImDiagnosticIssue | null {
+  const raw = rawMessage?.trim();
+  if (!raw) return null;
+  const message = raw.toLowerCase();
+
+  if (/address already in use|eaddrinuse|\bport\b|端口|占用/.test(message)) {
+    return {
+      level: "error",
+      title: "接收服务端口被占用",
+      detail: "Hermes 的接收服务没有成功启动，通常是已有网关进程占用了端口。",
+      nextStep: "先关闭另一个 Hermes/Gateway，再回到本页点击保存并重启。",
+      evidence: raw,
+    };
+  }
+
+  if (/gateway|接收服务|not running|stopped|未运行|停止/.test(message)) {
+    return {
+      level: "error",
+      title: "接收服务未运行",
+      detail: "消息平台无法把消息交给 Hermes，当前阻断点在本机接收服务。",
+      nextStep: "点击“保存并启动接收服务”，再点一次平台检测。",
+      evidence: raw,
+    };
+  }
+
+  if (platform === "feishu") {
+    if (/permission|scope|forbidden|unauthori[sz]ed|401|403|权限|授权|scope/.test(message)) {
+      return {
+        level: "error",
+        title: "飞书权限或版本发布未完成",
+        detail: "飞书后台缺少收消息/发消息权限，或者权限加完后还没有创建版本并发布。",
+        nextStep: "打开飞书开发者后台，确认机器人能力、私聊消息权限、发送消息权限都已勾选，并创建版本发布。",
+        evidence: raw,
+      };
+    }
+    if (/event|subscribe|subscription|callback|websocket|receive|事件|订阅|回调|长连接/.test(message)) {
+      return {
+        level: "error",
+        title: "飞书消息事件没有正确订阅",
+        detail: "机器人可能能发消息，但飞书没有把用户消息投递到桌面端。",
+        nextStep: `在飞书后台「事件与回调」里选择长连接，并订阅 ${FEISHU_RECEIVE_EVENT} 后发布版本。`,
+        evidence: raw,
+      };
+    }
+    if (/bot|机器人|bot disabled|not enabled|未启用/.test(message)) {
+      return {
+        level: "error",
+        title: "飞书机器人能力未启用",
+        detail: "应用凭据存在，但机器人能力没有打开时，用户私聊看起来会没有响应。",
+        nextStep: "在飞书开发者后台打开「机器人」能力，然后重新发布应用。",
+        evidence: raw,
+      };
+    }
+  }
+
+  if (platform === "weixin") {
+    if (/expired|expire|过期|timeout waiting qr|二维码/.test(message)) {
+      return {
+        level: "warn",
+        title: "微信二维码已过期或未确认",
+        detail: "微信扫码凭据没有在有效期内确认，桌面端拿不到账号和口令。",
+        nextStep: "重新生成二维码，用微信扫码后在手机上确认，再回到桌面端保存。",
+        evidence: raw,
+      };
+    }
+    if (/aiohttp|cryptography|module|importerror|dependency|依赖|模块/.test(message)) {
+      return {
+        level: "error",
+        title: "微信接入运行依赖缺失",
+        detail: "iLink 拉消息需要的 Python 依赖没有安装完整。",
+        nextStep: "按错误提示安装缺失依赖，或重新安装/更新桌面端后再检测微信连接。",
+        evidence: raw,
+      };
+    }
+    if (/token|account|unauthori[sz]ed|401|403|认证|口令|账号/.test(message)) {
+      return {
+        level: "error",
+        title: "微信账号或口令不可用",
+        detail: "当前保存的 iLink 账号、Token 可能已经失效，或者不是同一次扫码得到的组合。",
+        nextStep: "重新扫码绑定微信，不要手动混用旧账号和旧 Token。",
+        evidence: raw,
+      };
+    }
+    if (/ilink|base url|network|econn|fetch|connect|连接|网络|拉取|轮询/.test(message)) {
+      return {
+        level: "warn",
+        title: "微信 iLink 服务暂时不可达",
+        detail: "桌面端已经尝试连接微信 iLink，但网络、服务地址或服务状态可能异常。",
+        nextStep: "确认网络可用；如果你改过高级接口地址，先恢复默认地址后重新检测。",
+        evidence: raw,
+      };
+    }
+  }
+
+  return {
+    level: "warn",
+    title: `${platform === "feishu" ? "飞书" : "微信"}检测返回异常`,
+    detail: "检测接口返回了错误，但当前无法自动归类。",
+    nextStep: "复制诊断包让 Hermes Agent 根据上下文继续排查。",
+    evidence: raw,
+  };
+}
+
+export function buildImDiagnosticBundle(input: BuildImDiagnosticInput): ImDiagnosticBundle {
+  const platformLabel = input.platform === "feishu" ? "飞书" : "微信";
+  const configured = input.configured ?? {};
+  const statusPlatform = input.statusData?.gateway_platforms?.[input.platform];
+  const testMessage = input.testResult?.message ?? textFromUnknownError(input.testError);
+  const errorMessages = [
+    textFromUnknownError(input.beginError),
+    textFromUnknownError(input.pollError),
+    textFromUnknownError(input.applyError),
+    textFromUnknownError(input.stateError),
+    input.platformInfo?.error_message ?? null,
+    testMessage,
+  ].filter(Boolean) as string[];
+  const issues: ImDiagnosticIssue[] = [];
+
+  const hasRequiredCredential = DIAGNOSTIC_REQUIRED_KEYS[input.platform].every((key) => isConfigured(configured, key));
+  if (!hasRequiredCredential) {
+    addIssue(issues, {
+      level: "warn",
+      title: `${platformLabel}凭据还没保存完整`,
+      detail: input.platform === "feishu"
+        ? "还没有完整的 App ID 和 App Secret，飞书无法建立长连接。"
+        : "还没有完整的 iLink 账号和 Token，微信消息轮询无法启动。",
+      nextStep: input.platform === "feishu" ? "先扫码绑定飞书应用，或在高级配置里恢复已有应用密钥。" : "优先重新扫码绑定微信，不建议小白手填账号和 Token。",
+    });
+  }
+
+  if (input.statusData && !input.statusData.gateway_running) {
+    addIssue(issues, {
+      level: "error",
+      title: "接收服务未运行",
+      detail: "Hermes Gateway 当前没有运行，消息平台无法投递消息。",
+      nextStep: "点击保存并启动接收服务；如果仍失败，再复制诊断包让 Hermes 排查端口和日志。",
+      evidence: input.statusData.gateway_exit_reason ?? input.statusData.gateway_state ?? null,
+    });
+  }
+
+  if (input.applyResult && !input.applyResult.restart.ok) {
+    addIssue(issues, {
+      level: "error",
+      title: "保存后重启接收服务失败",
+      detail: "配置已经写入，但新配置没有被正在运行的接收服务加载。",
+      nextStep: "根据重启消息处理后再次点击保存；常见原因是端口占用或已有 Gateway 进程未退出。",
+      evidence: input.applyResult.restart.message ?? null,
+    });
+  }
+
+  const officialState = input.platformInfo?.state ?? statusPlatform?.state ?? null;
+  if (officialState && officialState !== "connected") {
+    const stateLabel = platformStateLabel(officialState);
+    addIssue(issues, {
+      level: officialState === "pending_restart" ? "warn" : "error",
+      title: `${platformLabel}平台状态：${stateLabel}`,
+      detail: officialState === "not_configured"
+        ? "运行时认为这个平台的必填配置还不完整。"
+        : officialState === "gateway_stopped"
+          ? "运行时提示接收服务没有启动。"
+          : officialState === "disabled"
+            ? "运行时认为这个平台尚未启用。"
+            : "运行时没有进入已连接状态。",
+      nextStep: officialState === "pending_restart"
+        ? "先保存并重启接收服务，再重新检测。"
+        : `按照本页 ${platformLabel} 接入步骤补齐配置后重新检测。`,
+      evidence: input.platformInfo?.error_message ?? statusPlatform?.error_message ?? officialState,
+    });
+  }
+
+  if (input.testResult && !input.testResult.ok) {
+    addIssue(issues, explainMessagingFailure(input.platform, input.testResult.message));
+  }
+  for (const message of errorMessages) {
+    addIssue(issues, explainMessagingFailure(input.platform, message));
+  }
+
+  if (input.platform === "feishu") {
+    if (hasRequiredCredential && !isConfigured(configured, "FEISHU_ALLOWED_USERS") && configured.FEISHU_DM_POLICY?.redactedValue !== "open") {
+      addIssue(issues, {
+        level: "warn",
+        title: "飞书允许用户列表为空",
+        detail: "如果私聊策略不是开放模式，允许用户为空会导致用户发消息后无法使用。",
+        nextStep: "推荐使用扫码用户作为默认允许用户，或手动补充 open_id 后保存。",
+      });
+    }
+    if (input.applyResult?.restart.ok && !input.testResult?.ok) {
+      addIssue(issues, {
+        level: "warn",
+        title: "还需要确认飞书后台发布",
+        detail: "桌面端保存成功只代表本机配置完成，飞书后台权限和事件订阅仍需要发布后才生效。",
+        nextStep: `确认已订阅 ${FEISHU_RECEIVE_EVENT}，并在飞书开发者后台创建版本发布。`,
+      });
+    }
+  } else {
+    if (input.qrStatus === "expired" || input.qrStatus === "denied") {
+      addIssue(issues, explainMessagingFailure("weixin", input.qrStatus === "expired" ? "二维码已过期" : "二维码已拒绝"));
+    }
+    if (hasRequiredCredential && configured.WEIXIN_DM_POLICY?.redactedValue === "allowlist" && !isConfigured(configured, "WEIXIN_ALLOWED_USERS")) {
+      addIssue(issues, {
+        level: "warn",
+        title: "微信允许用户列表为空",
+        detail: "白名单模式下如果没有写入扫码用户，私聊消息会被过滤。",
+        nextStep: "重新扫码后保存，或在额外允许用户里补充微信 user_id。",
+      });
+    }
+  }
+
+  if (issues.length === 0) {
+    addIssue(issues, {
+      level: "ok",
+      title: "暂未发现明显阻断点",
+      detail: "本页可见状态没有显示配置缺失或运行错误。",
+      nextStep: `点击“检测${platformLabel}连接”，再去${platformLabel}私聊机器人发送 hi 验证。`,
+    });
+  }
+
+  return {
+    kind: "hermes-im-onboarding-diagnosis",
+    version: 1,
+    generatedAt: new Date().toISOString(),
+    platform: input.platform,
+    platformLabel,
+    currentProfile: input.currentProfile || "default",
+    hermesHome: input.hermesHome ?? input.statusData?.hermes_home ?? null,
+    envPath: input.envPath ?? input.statusData?.env_path ?? null,
+    gateway: {
+      running: input.statusData?.gateway_running,
+      state: input.statusData?.gateway_state ?? null,
+      platformState: statusPlatform?.state ?? null,
+      platformErrorCode: statusPlatform?.error_code ?? null,
+      platformErrorMessage: statusPlatform?.error_message ?? null,
+      updatedAt: statusPlatform?.updated_at ?? null,
+    },
+    officialPlatform: {
+      available: input.platformInfo !== undefined && input.platformInfo !== null,
+      enabled: input.platformInfo?.enabled,
+      configured: input.platformInfo?.configured,
+      gatewayRunning: input.platformInfo?.gateway_running,
+      state: input.platformInfo?.state ?? null,
+      errorCode: input.platformInfo?.error_code ?? null,
+      errorMessage: input.platformInfo?.error_message ?? null,
+      homeChannel: input.platformInfo?.home_channel?.chat_id ? "已设置" : null,
+      envVars: input.platformInfo?.env_vars?.map((item) => ({
+        key: item.key,
+        required: item.required,
+        isSet: item.is_set,
+        redactedValue: safeDiagnosticValue(item.key, item.redacted_value),
+        advanced: item.advanced,
+      })),
+    },
+    onboarding: {
+      qrStatus: input.qrStatus ?? null,
+      qrMessage: input.qrMessage ?? null,
+      credentialReturned: Boolean(input.credential),
+      lastApplyOk: input.applyResult?.ok ?? null,
+      restartOk: input.applyResult?.restart.ok ?? null,
+      restartMessage: input.applyResult?.restart.message ?? null,
+    },
+    configuration: {
+      requiredKeys: DIAGNOSTIC_REQUIRED_KEYS[input.platform].map((key) => configuredKey(configured, key)),
+      policyKeys: DIAGNOSTIC_POLICY_KEYS[input.platform].map((key) => configuredKey(configured, key)),
+    },
+    test: {
+      ran: Boolean(input.testResult || input.testError),
+      ok: input.testResult?.ok ?? null,
+      state: input.testResult?.state ?? null,
+      message: testMessage ?? null,
+    },
+    issues,
+  };
+}
+
+export function buildImDiagnosticPrompt(bundle: ImDiagnosticBundle): string {
+  return `你是 Hermes Agent 的消息平台接入排障助手。请根据下面的诊断包，帮助小白用户排查 ${bundle.platformLabel} 接入失败问题。
+
+要求：
+1. 不要展示、索要或还原 token、secret、cookie、完整 user_id/open_id 等敏感信息。
+2. 先判断最可能的阻断点，再给出最多 3 个下一步操作，每一步都要能在桌面端或平台后台完成。
+3. 如果是飞书，优先检查应用发布、机器人能力、消息事件订阅、收发消息权限和允许用户列表。
+4. 如果是微信，优先检查二维码是否过期、扫码是否确认、iLink 服务是否可用、扫码用户是否写入允许列表、接收服务是否已重启。
+5. 如果证据不足，请让用户回到接入页点击“检测连接”或“重新扫码”，不要让小白执行复杂命令。
+
+诊断包 JSON：
+\`\`\`json
+${JSON.stringify(bundle, null, 2)}
+\`\`\``;
+}

--- a/web/src/routes/im-onboarding.module.css
+++ b/web/src/routes/im-onboarding.module.css
@@ -147,6 +147,20 @@
 .statusItem[data-tone="ok"] { border-color: color-mix(in srgb, var(--h-ok) 32%, var(--h-line)); background: color-mix(in srgb, var(--h-ok) 6%, var(--h-bg-pane)); }
 .statusItem[data-tone="warn"] { border-color: color-mix(in srgb, var(--h-warn) 34%, var(--h-line)); background: color-mix(in srgb, var(--h-warn) 6%, var(--h-bg-pane)); }
 .testActions { display: flex; justify-content: flex-end; padding-top: 2px; }
+.diagnosticAssistant { display: grid; gap: 12px; border: 1px solid color-mix(in srgb, var(--h-accent) 28%, var(--h-line)); border-radius: var(--h-r-lg); background: color-mix(in srgb, var(--h-accent) 5%, var(--h-bg-pane)); padding: 14px; }
+.diagnosticHead { display: flex; align-items: flex-start; justify-content: space-between; gap: 14px; }
+.diagnosticHead h4 { margin: 5px 0 7px; color: var(--h-text); font-size: 15px; }
+.diagnosticHead p { margin: 0; color: var(--h-text-2); line-height: 1.7; font-size: 12px; }
+.diagnosticActions { display: flex; flex-wrap: wrap; justify-content: flex-end; gap: 8px; flex: 0 0 auto; }
+.issueGrid { display: grid; grid-template-columns: repeat(auto-fit, minmax(220px, 1fr)); gap: 10px; }
+.issueCard { display: grid; gap: 6px; align-content: start; border: 1px solid var(--h-line-soft); border-radius: var(--h-r-md); background: var(--h-bg-soft); padding: 11px 12px; }
+.issueCard b { color: var(--h-text); font-size: 12px; }
+.issueCard span { color: var(--h-text-2); line-height: 1.55; font-size: 12px; }
+.issueCard em { color: var(--h-text-3); line-height: 1.55; font-style: normal; font-size: 11px; }
+.issueCard[data-tone="ok"] { border-color: color-mix(in srgb, var(--h-ok) 34%, var(--h-line)); background: color-mix(in srgb, var(--h-ok) 6%, var(--h-bg-soft)); }
+.issueCard[data-tone="warn"] { border-color: color-mix(in srgb, var(--h-warn) 38%, var(--h-line)); background: color-mix(in srgb, var(--h-warn) 6%, var(--h-bg-soft)); }
+.issueCard[data-tone="error"] { border-color: color-mix(in srgb, var(--h-err) 42%, var(--h-line)); background: color-mix(in srgb, var(--h-err) 6%, var(--h-bg-soft)); }
+.inlineError { display: inline-flex; align-items: center; gap: 7px; color: var(--h-err); font-size: 12px; line-height: 1.5; }
 .summaryLine { color: var(--h-text-2); background: var(--h-bg-soft); border: 1px solid var(--h-line); border-radius: var(--h-r-md); padding: 10px 12px; font-size: 12px; }
 .reviewTable { width: 100%; border-collapse: collapse; font-size: 12px; }
 .reviewTable th, .reviewTable td { text-align: left; border-bottom: 1px solid var(--h-line-soft); padding: 9px; color: var(--h-text-2); }
@@ -406,6 +420,8 @@
   .testGuide { grid-template-columns: 1fr; }
   .testIntro { border-right: 0; border-bottom: 1px solid var(--h-line-soft); padding: 0 0 12px; }
   .testActions { justify-content: flex-start; }
+  .diagnosticHead { flex-direction: column; }
+  .diagnosticActions { justify-content: flex-start; }
   .testCards { min-width: 0; width: 100%; }
   .field { grid-template-columns: 1fr; }
   .heroActions { align-items: flex-start; }

--- a/web/src/routes/im-onboarding.test.ts
+++ b/web/src/routes/im-onboarding.test.ts
@@ -1,5 +1,10 @@
 import { describe, expect, it } from "vitest";
 import {
+  buildImDiagnosticBundle,
+  buildImDiagnosticPrompt,
+  explainMessagingFailure,
+} from "@/lib/im-onboarding-diagnostics";
+import {
   FEISHU_GROUP_SCOPE,
   FEISHU_RECOMMENDED_SCOPES,
   FEISHU_REQUIRED_SCOPES,
@@ -49,5 +54,54 @@ describe("im onboarding routing helpers", () => {
     expect(feishuRailCopy).toContain("im.message.receive_v1");
     expect(feishuRailCopy).toContain(FEISHU_GROUP_SCOPE);
     expect(feishuRailCopy).toContain("创建版本并发布");
+  });
+
+  it("maps platform failures to beginner-friendly next steps", () => {
+    expect(explainMessagingFailure("feishu", "403 permission denied")?.title).toContain("权限");
+    expect(explainMessagingFailure("feishu", "event subscription missing")?.nextStep).toContain("im.message.receive_v1");
+    expect(explainMessagingFailure("weixin", "ImportError: No module named aiohttp")?.title).toContain("依赖");
+    expect(explainMessagingFailure("weixin", "QR code expired")?.nextStep).toContain("重新生成二维码");
+  });
+
+  it("builds a secret-safe diagnostic prompt for Hermes Agent", () => {
+    const bundle = buildImDiagnosticBundle({
+      platform: "weixin",
+      currentProfile: "default",
+      configured: {
+        WEIXIN_ACCOUNT_ID: { isSet: true, redactedValue: "wxid…demo" },
+        WEIXIN_TOKEN: { isSet: true, redactedValue: "raw-token-that-should-not-leak" },
+        WEIXIN_DM_POLICY: { isSet: true, redactedValue: "allowlist" },
+      },
+      statusData: {
+        version: "dev",
+        release_date: "today",
+        gateway_running: false,
+        gateway_pid: null,
+        gateway_health_url: null,
+        gateway_state: "stopped",
+        gateway_platforms: {
+          weixin: {
+            state: "gateway_stopped",
+            error_code: null,
+            error_message: "gateway stopped",
+            updated_at: null,
+          },
+        },
+        gateway_exit_reason: "port already in use",
+        gateway_updated_at: null,
+        active_sessions: 0,
+      },
+      testResult: {
+        ok: false,
+        state: "gateway_stopped",
+        message: "gateway stopped",
+      },
+    });
+    const prompt = buildImDiagnosticPrompt(bundle);
+
+    expect(prompt).toContain("消息平台接入排障助手");
+    expect(prompt).toContain("接收服务未运行");
+    expect(prompt).not.toContain("raw-token-that-should-not-leak");
+    expect(JSON.stringify(bundle)).toContain("已设置（已隐藏）");
   });
 });

--- a/web/src/routes/im-onboarding.test.ts
+++ b/web/src/routes/im-onboarding.test.ts
@@ -104,4 +104,64 @@ describe("im onboarding routing helpers", () => {
     expect(prompt).not.toContain("raw-token-that-should-not-leak");
     expect(JSON.stringify(bundle)).toContain("已设置（已隐藏）");
   });
+
+  it("does not classify a successful WeChat Official Account check as an account failure", () => {
+    const bundle = buildImDiagnosticBundle({
+      platform: "weixin",
+      currentProfile: "default",
+      configured: {
+        WEIXIN_ACCOUNT_ID: { isSet: true, redactedValue: "9c5fd2…im.bot" },
+        WEIXIN_TOKEN: { isSet: true, redactedValue: "••••6a21" },
+        WEIXIN_DM_POLICY: { isSet: true, redactedValue: "open" },
+        WEIXIN_ALLOW_ALL_USERS: { isSet: true, redactedValue: "true" },
+      },
+      statusData: {
+        version: "dev",
+        release_date: "today",
+        gateway_running: true,
+        gateway_pid: 123,
+        gateway_health_url: null,
+        gateway_state: "running",
+        gateway_platforms: {
+          weixin: {
+            state: "connected",
+            error_code: null,
+            error_message: null,
+            updated_at: "today",
+          },
+        },
+        gateway_exit_reason: null,
+        gateway_updated_at: "today",
+        active_sessions: 0,
+      },
+      platformInfo: {
+        id: "weixin",
+        name: "WeChat (Official Account)",
+        description: "Connect WeChat.",
+        docs_url: "",
+        enabled: true,
+        configured: true,
+        gateway_running: true,
+        state: "connected",
+        error_code: null,
+        error_message: "stale token warning should be ignored once connected",
+        updated_at: "today",
+        home_channel: null,
+        env_vars: [],
+      },
+      testResult: {
+        ok: true,
+        state: "connected",
+        message: "WeChat (Official Account) is connected.",
+      },
+    });
+
+    expect(bundle.issues).toEqual([
+      expect.objectContaining({
+        level: "ok",
+        title: "暂未发现明显阻断点",
+      }),
+    ]);
+    expect(JSON.stringify(bundle.issues)).not.toContain("微信账号或口令不可用");
+  });
 });

--- a/web/src/routes/im-onboarding.tsx
+++ b/web/src/routes/im-onboarding.tsx
@@ -1057,6 +1057,7 @@ function WeixinRoute() {
   const busy = begin.isPending || poll.isPending || apply.isPending;
   const canApplyQr = Boolean(credential && pollResult?.status === "confirmed");
   const canApplyManual = Boolean(accountId.trim() && token.trim());
+  const canApplySaved = Boolean(configured.WEIXIN_ACCOUNT_ID?.isSet && configured.WEIXIN_TOKEN?.isSet);
   const jumpToQr = () => qrAnchorRef.current?.scrollIntoView({ behavior: "smooth", block: "start" });
 
   const start = () => {
@@ -1114,13 +1115,16 @@ function WeixinRoute() {
     }
     return patch;
   };
-  const save = () => apply.mutate({
-    platform: "weixin",
-    flowId: flow?.flowId,
-    manualCredentials: canApplyQr ? undefined : { accountId, token, baseUrl },
-    settings: settings(),
-    restartGateway: true,
-  }, { onSuccess: setResult });
+  const save = () => {
+    const useSavedCredentials = !canApplyQr && !canApplyManual && canApplySaved;
+    apply.mutate({
+      platform: "weixin",
+      flowId: flow?.flowId,
+      manualCredentials: canApplyQr || useSavedCredentials ? undefined : { accountId, token, baseUrl },
+      settings: useSavedCredentials ? {} : settings(),
+      restartGateway: true,
+    }, { onSuccess: setResult });
+  };
   const allowedUsersReview = dmPolicy === "open"
     ? "未限制"
     : dmPolicy === "pairing"
@@ -1269,7 +1273,7 @@ function WeixinRoute() {
           </section>
           <SectionTitle num="[ REVIEW ]" title="保存前看一眼" meta="口令会自动打码" />
           <ReviewTable rows={rows} />
-          <div className={s.sectionActions}><button className={`${s.btn} ${s.primary}`} onClick={save} disabled={busy || !(canApplyQr || canApplyManual) || !allowPolicyReady}><Save size={14} />保存并启动接收服务</button></div>
+          <div className={s.sectionActions}><button className={`${s.btn} ${s.primary}`} onClick={save} disabled={busy || !(canApplyQr || canApplyManual || canApplySaved) || !allowPolicyReady}><Save size={14} />{canApplyQr || canApplyManual ? "保存并启动接收服务" : "重新启动接收服务"}</button></div>
           <ApplyResult result={result} />
           <SectionTitle num="[ STEP 05 ]" title="发一条消息试试" meta="私聊微信机器人，确认真的能回复" />
           <MessagingTestGuide

--- a/web/src/routes/im-onboarding.tsx
+++ b/web/src/routes/im-onboarding.tsx
@@ -420,13 +420,14 @@ function DiagnosticAssistant({
   askError?: string | null;
 }) {
   const shownIssues = bundle.issues.slice(0, 3);
+  const hasIssue = bundle.issues.some((issue) => issue.level !== "ok");
   return (
     <div className={s.diagnosticAssistant}>
       <div className={s.diagnosticHead}>
         <div>
           <div className={s.miniEyebrow}>HERMES CHECK</div>
-          <h4>接入失败时，让 Hermes 帮你排查</h4>
-          <p>这里会打包当前配置状态、接收服务状态、官方检测结果和最近一次扫码/保存结果，不包含密钥明文。</p>
+          <h4>{hasIssue ? "接入失败时，让 Hermes 帮你排查" : "接入已就绪，可按需继续检查"}</h4>
+          <p>{hasIssue ? "这里会打包当前配置状态、接收服务状态、官方检测结果和最近一次扫码/保存结果，不包含密钥明文。" : "当前可见状态没有明显阻断点；如果后续收不到回复，也可以复制诊断信息继续排查。"}</p>
         </div>
         <div className={s.diagnosticActions}>
           <CopyButton className={s.btn} text={() => JSON.stringify(bundle, null, 2)}>

--- a/web/src/routes/im-onboarding.tsx
+++ b/web/src/routes/im-onboarding.tsx
@@ -1,4 +1,4 @@
-import { useEffect, useRef, useState, type ReactNode } from "react";
+import { useEffect, useMemo, useRef, useState, type ReactNode } from "react";
 import { Navigate, useLocation } from "react-router-dom";
 import QRCode from "qrcode";
 import {
@@ -21,7 +21,6 @@ import {
   type LucideIcon,
 } from "lucide-react";
 import type {
-  ImCredentialSummary,
   ImOnboardingApplyResult,
   ImOnboardingBeginResult,
   ImOnboardingPollResult,
@@ -31,6 +30,7 @@ import type {
   MessagingPlatformTestResponse,
 } from "@hermes/protocol";
 import { useStatus } from "@/hooks/use-status";
+import { CopyButton } from "@/components/ui/copy-button";
 import {
   useApplyImOnboarding,
   useBeginImOnboarding,
@@ -39,7 +39,13 @@ import {
   usePollImOnboarding,
   useTestMessagingPlatform,
 } from "@/hooks/use-im-onboarding";
+import { useCreateAndSendSession } from "@/hooks/use-create-and-send-session";
 import { openExternalUrl } from "@/lib/external-links";
+import {
+  buildImDiagnosticBundle,
+  buildImDiagnosticPrompt,
+  type ImDiagnosticBundle,
+} from "@/lib/im-onboarding-diagnostics";
 import { SectionShell } from "./section-shell";
 import s from "./im-onboarding.module.css";
 
@@ -48,6 +54,7 @@ type DmPolicy = "scanned" | "pairing" | "allowlist" | "open" | "disabled";
 
 const FEISHU_DEVELOPER_URL = "https://open.feishu.cn/app";
 const FEISHU_SCANNED_OPEN_ID_TOKEN = "__HERMES_SCANNED_FEISHU_OPEN_ID__";
+const WEIXIN_SCANNED_USER_ID_TOKEN = "__HERMES_SCANNED_WEIXIN_USER_ID__";
 export const FEISHU_REQUIRED_SCOPES = [
   "im:message.p2p_msg:readonly",
   "im:message:send_as_bot",
@@ -400,7 +407,54 @@ function platformStateText(state?: string | null): string {
   }
 }
 
-function FeishuTestGuide({
+
+function DiagnosticAssistant({
+  bundle,
+  onAskHermes,
+  asking,
+  askError,
+}: {
+  bundle: ImDiagnosticBundle;
+  onAskHermes: () => void;
+  asking: boolean;
+  askError?: string | null;
+}) {
+  const shownIssues = bundle.issues.slice(0, 3);
+  return (
+    <div className={s.diagnosticAssistant}>
+      <div className={s.diagnosticHead}>
+        <div>
+          <div className={s.miniEyebrow}>HERMES CHECK</div>
+          <h4>接入失败时，让 Hermes 帮你排查</h4>
+          <p>这里会打包当前配置状态、接收服务状态、官方检测结果和最近一次扫码/保存结果，不包含密钥明文。</p>
+        </div>
+        <div className={s.diagnosticActions}>
+          <CopyButton className={s.btn} text={() => JSON.stringify(bundle, null, 2)}>
+            <ClipboardList size={14} />复制诊断包
+          </CopyButton>
+          <CopyButton className={s.btn} text={() => buildImDiagnosticPrompt(bundle)}>
+            <ClipboardList size={14} />复制排查提示
+          </CopyButton>
+          <button className={`${s.btn} ${s.primary}`} type="button" onClick={onAskHermes} disabled={asking}>
+            <MessageSquareText size={14} />{asking ? "正在打开…" : "让 Hermes 排查"}
+          </button>
+        </div>
+      </div>
+      <div className={s.issueGrid}>
+        {shownIssues.map((issue) => (
+          <div className={s.issueCard} data-tone={issue.level} key={`${issue.level}-${issue.title}`}>
+            <b>{issue.title}</b>
+            <span>{issue.detail}</span>
+            <em>{issue.nextStep}</em>
+          </div>
+        ))}
+      </div>
+      {askError ? <div className={s.inlineError}><XCircle size={14} />{askError}</div> : null}
+    </div>
+  );
+}
+
+function MessagingTestGuide({
   result,
   platform,
   platformLoading,
@@ -408,6 +462,9 @@ function FeishuTestGuide({
   testError,
   testPending,
   onTest,
+  platformLabel,
+  readyCopy,
+  notReadyCopy,
 }: {
   result: ImOnboardingApplyResult | null;
   platform?: MessagingPlatformInfo | null;
@@ -416,6 +473,9 @@ function FeishuTestGuide({
   testError?: unknown;
   testPending: boolean;
   onTest: () => void;
+  platformLabel: string;
+  readyCopy?: string;
+  notReadyCopy?: string;
 }) {
   const restartOk = Boolean(result?.restart.ok);
   const connected = platform?.state === "connected";
@@ -427,8 +487,8 @@ function FeishuTestGuide({
         <div className={s.miniEyebrow}>LIVE TEST</div>
         <h3>最后发消息试一下</h3>
         <p>{restartOk
-          ? "接收服务已经按当前档案重启。先点一次检测确认链路，再去飞书里私聊机器人发送 hi。"
-          : "先保存、完成飞书后台设置并发布，再回来私聊机器人验证。"}</p>
+          ? readyCopy ?? `接收服务已经按当前档案重启。先点一次检测确认链路，再去${platformLabel}里私聊机器人发送 hi。`
+          : notReadyCopy ?? `先保存、完成${platformLabel}后台设置，再回来私聊机器人验证。`}</p>
       </div>
 
       <div className={s.testPanel}>
@@ -449,7 +509,7 @@ function FeishuTestGuide({
 
         <div className={s.testActions}>
           <button className={s.btn} type="button" onClick={onTest} disabled={platformLoading || testPending}>
-            <RotateCw size={14} />{testPending ? "检测中…" : "检测飞书连接"}
+            <RotateCw size={14} />{testPending ? "检测中…" : `检测${platformLabel}连接`}
           </button>
         </div>
       </div>
@@ -687,6 +747,7 @@ function FeishuRoute() {
   const apply = useApplyImOnboarding("feishu");
   const messagingPlatformQuery = useMessagingPlatform("feishu");
   const testPlatform = useTestMessagingPlatform("feishu");
+  const createAndSendSession = useCreateAndSendSession();
   const domain = "feishu";
   const connectionMode = "websocket";
   const [dmPolicy, setDmPolicy] = useState<DmPolicy>("pairing");
@@ -698,6 +759,8 @@ function FeishuRoute() {
   const [flow, setFlow] = useState<ImOnboardingBeginResult | null>(null);
   const [pollResult, setPollResult] = useState<ImOnboardingPollResult | null>(null);
   const [result, setResult] = useState<ImOnboardingApplyResult | null>(null);
+  const [diagnosticPending, setDiagnosticPending] = useState(false);
+  const [diagnosticError, setDiagnosticError] = useState<string | null>(null);
   const qrAnchorRef = useRef<HTMLDivElement>(null);
 
   const configured = stateQuery.data?.configured ?? {};
@@ -797,6 +860,57 @@ function FeishuRoute() {
     ["群聊入口", `FEISHU_GROUP_POLICY=${groupEnabled ? "open" : "disabled"}`, groupEnabled ? "高级：仅 @ 响应" : "默认关闭"],
     ["默认通知会话", `FEISHU_HOME_CHANNEL=${homeChannelReview}`, homeChannelStatus],
   ];
+  const diagnosticBundle = useMemo(() => buildImDiagnosticBundle({
+    platform: "feishu",
+    currentProfile: stateQuery.data?.currentProfile,
+    hermesHome: stateQuery.data?.hermesHome,
+    envPath: stateQuery.data?.envPath,
+    configured,
+    statusData: statusQuery.data,
+    platformInfo: messagingPlatformQuery.data,
+    testResult: testPlatform.data,
+    testError: testPlatform.error,
+    applyResult: result,
+    beginError: begin.error,
+    pollError: poll.error,
+    applyError: apply.error,
+    stateError: stateQuery.error,
+    qrStatus: status,
+    qrMessage: pollResult?.message ?? flow?.message,
+    credential,
+  }), [
+    apply.error,
+    begin.error,
+    configured,
+    credential,
+    flow?.message,
+    messagingPlatformQuery.data,
+    poll.error,
+    pollResult?.message,
+    result,
+    stateQuery.data?.currentProfile,
+    stateQuery.data?.envPath,
+    stateQuery.data?.hermesHome,
+    stateQuery.error,
+    status,
+    statusQuery.data,
+    testPlatform.data,
+    testPlatform.error,
+  ]);
+  const askHermesToDiagnose = async () => {
+    setDiagnosticError(null);
+    setDiagnosticPending(true);
+    try {
+      await createAndSendSession({
+        text: buildImDiagnosticPrompt(diagnosticBundle),
+        attachments: [],
+      }, { updateAttachment: () => undefined });
+    } catch (error) {
+      setDiagnosticError(textFromError(error) ?? "无法打开 Hermes 排查会话");
+    } finally {
+      setDiagnosticPending(false);
+    }
+  };
 
   return (
     <SectionShell title="消息平台接入 · 飞书" sub="02 配置 / 023 消息平台接入" rail={<Rail platform="feishu" />} railLabel="飞书接入诊断边栏">
@@ -875,7 +989,7 @@ function FeishuRoute() {
           <SectionTitle num="[ STEP 03 ]" title="打开飞书后台完成权限" meta="按清单勾选权限、订阅消息并发布版本" />
           <FeishuBackendChecklist groupEnabled={groupEnabled} />
           <SectionTitle num="[ STEP 04 ]" title="发一条消息试试" meta="私聊机器人，确认真的能回复" />
-          <FeishuTestGuide
+          <MessagingTestGuide
             result={result}
             platform={messagingPlatformQuery.data}
             platformLoading={messagingPlatformQuery.isLoading}
@@ -883,6 +997,15 @@ function FeishuRoute() {
             testError={testPlatform.error}
             testPending={testPlatform.isPending}
             onTest={() => testPlatform.mutate()}
+            platformLabel="飞书"
+            readyCopy="接收服务已经按当前档案重启。先点一次检测确认链路，再去飞书里私聊机器人发送 hi。"
+            notReadyCopy="先保存、完成飞书后台设置并发布，再回来私聊机器人验证。"
+          />
+          <DiagnosticAssistant
+            bundle={diagnosticBundle}
+            onAskHermes={askHermesToDiagnose}
+            asking={diagnosticPending}
+            askError={diagnosticError}
           />
           {(begin.error || poll.error || apply.error || stateQuery.error) && <div className={s.errorBox}><XCircle size={16} />{textFromError(begin.error || poll.error || apply.error || stateQuery.error)}</div>}
         </main>
@@ -897,9 +1020,13 @@ function WeixinRoute() {
   const begin = useBeginImOnboarding();
   const poll = usePollImOnboarding();
   const apply = useApplyImOnboarding("weixin");
-  const [dmPolicy, setDmPolicy] = useState<DmPolicy>("pairing");
+  const messagingPlatformQuery = useMessagingPlatform("weixin");
+  const testPlatform = useTestMessagingPlatform("weixin");
+  const createAndSendSession = useCreateAndSendSession();
+  const [dmPolicy, setDmPolicy] = useState<DmPolicy>("allowlist");
   const [allowedUsers, setAllowedUsers] = useState("");
   const [homeChannel, setHomeChannel] = useState("");
+  const [showAdvanced, setShowAdvanced] = useState(false);
   const [accountId, setAccountId] = useState("");
   const [token, setToken] = useState("");
   const [baseUrl, setBaseUrl] = useState("https://ilinkai.weixin.qq.com");
@@ -907,10 +1034,13 @@ function WeixinRoute() {
   const [flow, setFlow] = useState<ImOnboardingBeginResult | null>(null);
   const [pollResult, setPollResult] = useState<ImOnboardingPollResult | null>(null);
   const [result, setResult] = useState<ImOnboardingApplyResult | null>(null);
+  const [diagnosticPending, setDiagnosticPending] = useState(false);
+  const [diagnosticError, setDiagnosticError] = useState<string | null>(null);
   const qrAnchorRef = useRef<HTMLDivElement>(null);
   const configured = stateQuery.data?.configured ?? {};
   const status = pollResult?.status ?? flow?.status;
   const credential = pollResult?.credentialSummary;
+  const scannedUserId = isSet(credential?.userId) ? credential.userId : null;
   const busy = begin.isPending || poll.isPending || apply.isPending;
   const canApplyQr = credential && pollResult?.status === "confirmed";
   const canApplyManual = accountId.trim() && token.trim();
@@ -919,6 +1049,7 @@ function WeixinRoute() {
   const start = () => {
     begin.reset();
     poll.reset();
+    testPlatform.reset();
     begin.mutate({ platform: "weixin" }, {
       onSuccess: (next) => {
         setFlow(next);
@@ -938,16 +1069,32 @@ function WeixinRoute() {
     return () => window.clearInterval(id);
   }, [flow?.flowId, pollResult?.status]);
 
-  const settings = () => ({
-    WEIXIN_BASE_URL: baseUrl.trim().replace(/\/$/, ""),
-    WEIXIN_CDN_BASE_URL: cdnBaseUrl.trim().replace(/\/$/, ""),
-    WEIXIN_DM_POLICY: dmPolicy,
-    WEIXIN_ALLOW_ALL_USERS: dmPolicy === "open" ? "true" : "false",
-    WEIXIN_ALLOWED_USERS: dmPolicy === "allowlist" ? allowedUsers.replaceAll(" ", "") : "",
-    WEIXIN_GROUP_POLICY: "disabled",
-    WEIXIN_GROUP_ALLOWED_USERS: "",
-    WEIXIN_HOME_CHANNEL: homeChannel.trim(),
-  });
+  const shouldAutoWeixinHomeChannel = Boolean(scannedUserId) && !homeChannel.trim();
+  const useScannedUserId = Boolean(scannedUserId) && dmPolicy === "allowlist";
+  const manualAllowedCount = splitAllowedUsers(allowedUsers).length;
+  const allowPolicyReady = dmPolicy === "open" || Boolean(useScannedUserId || manualAllowedCount > 0);
+  const settings = () => {
+    const patch: Record<string, string> = {
+      WEIXIN_BASE_URL: baseUrl.trim().replace(/\/$/, ""),
+      WEIXIN_CDN_BASE_URL: cdnBaseUrl.trim().replace(/\/$/, ""),
+      WEIXIN_DM_POLICY: dmPolicy === "open" ? "open" : "allowlist",
+      WEIXIN_ALLOW_ALL_USERS: dmPolicy === "open" ? "true" : "false",
+      WEIXIN_GROUP_POLICY: "disabled",
+      WEIXIN_GROUP_ALLOWED_USERS: "",
+    };
+    if (dmPolicy === "allowlist") {
+      patch.WEIXIN_ALLOWED_USERS = compactList([
+        ...(useScannedUserId ? [WEIXIN_SCANNED_USER_ID_TOKEN] : []),
+        ...splitAllowedUsers(allowedUsers),
+      ]);
+    } else {
+      patch.WEIXIN_ALLOWED_USERS = "";
+    }
+    if (shouldAutoWeixinHomeChannel || homeChannel.trim()) {
+      patch.WEIXIN_HOME_CHANNEL = shouldAutoWeixinHomeChannel ? WEIXIN_SCANNED_USER_ID_TOKEN : homeChannel.trim();
+    }
+    return patch;
+  };
   const save = () => apply.mutate({
     platform: "weixin",
     flowId: flow?.flowId,
@@ -955,12 +1102,72 @@ function WeixinRoute() {
     settings: settings(),
     restartGateway: true,
   }, { onSuccess: setResult });
+  const allowedUsersReview = dmPolicy === "open"
+    ? "未限制"
+    : compactList([
+      ...(useScannedUserId ? [`扫码用户 ${last(scannedUserId)}`] : []),
+      ...(manualAllowedCount > 0 ? [`手动 ${manualAllowedCount} 个`] : []),
+    ]) || "缺少用户 ID";
+  const homeChannelReview = shouldAutoWeixinHomeChannel ? `扫码用户 ${last(scannedUserId)}` : homeChannel.trim() || "保持原配置";
   const rows: Array<[string, string, string]> = [
     ["账号 ID", `WEIXIN_ACCOUNT_ID=${credential?.accountId?.redactedValue ?? accountId}`, credential ? "扫码返回" : "手动"],
     ["认证 Token", `WEIXIN_TOKEN=${credential?.token?.redactedValue ?? (token ? "••••" : "")}`, "敏感"],
-    ["私聊策略", `WEIXIN_DM_POLICY=${dmPolicy}`, dmPolicy === "pairing" ? "推荐：先确认" : dmPolicy],
+    ["私聊策略", `WEIXIN_DM_POLICY=${dmPolicy === "open" ? "open" : "allowlist"}`, dmPolicy === "open" ? "试用开放" : "只允许白名单"],
+    ["允许用户", `WEIXIN_ALLOWED_USERS=${allowedUsersReview}`, allowPolicyReady ? "可保存" : "缺少用户 ID"],
     ["允许所有用户", `WEIXIN_ALLOW_ALL_USERS=${dmPolicy === "open" ? "true" : "false"}`, "安全默认"],
+    ["默认通知会话", `WEIXIN_HOME_CHANNEL=${homeChannelReview}`, shouldAutoWeixinHomeChannel ? "自动设置" : homeChannel.trim() ? "已填写" : "不改动"],
   ];
+  const diagnosticBundle = useMemo(() => buildImDiagnosticBundle({
+    platform: "weixin",
+    currentProfile: stateQuery.data?.currentProfile,
+    hermesHome: stateQuery.data?.hermesHome,
+    envPath: stateQuery.data?.envPath,
+    configured,
+    statusData: statusQuery.data,
+    platformInfo: messagingPlatformQuery.data,
+    testResult: testPlatform.data,
+    testError: testPlatform.error,
+    applyResult: result,
+    beginError: begin.error,
+    pollError: poll.error,
+    applyError: apply.error,
+    stateError: stateQuery.error,
+    qrStatus: status,
+    qrMessage: pollResult?.message ?? flow?.message,
+    credential,
+  }), [
+    apply.error,
+    begin.error,
+    configured,
+    credential,
+    flow?.message,
+    messagingPlatformQuery.data,
+    poll.error,
+    pollResult?.message,
+    result,
+    stateQuery.data?.currentProfile,
+    stateQuery.data?.envPath,
+    stateQuery.data?.hermesHome,
+    stateQuery.error,
+    status,
+    statusQuery.data,
+    testPlatform.data,
+    testPlatform.error,
+  ]);
+  const askHermesToDiagnose = async () => {
+    setDiagnosticError(null);
+    setDiagnosticPending(true);
+    try {
+      await createAndSendSession({
+        text: buildImDiagnosticPrompt(diagnosticBundle),
+        attachments: [],
+      }, { updateAttachment: () => undefined });
+    } catch (error) {
+      setDiagnosticError(textFromError(error) ?? "无法打开 Hermes 排查会话");
+    } finally {
+      setDiagnosticPending(false);
+    }
+  };
 
   return (
     <SectionShell title="消息平台接入 · 微信" sub="02 配置 / 023 消息平台接入" rail={<Rail platform="weixin" />} railLabel="微信接入诊断边栏">
@@ -988,27 +1195,79 @@ function WeixinRoute() {
             />
           </div>
           <div className={s.sectionActions}><button className={`${s.btn} ${s.primary}`} onClick={start} disabled={busy}><ScanLine size={14} />生成二维码</button><button className={s.btn} onClick={pollOnce} disabled={!flow || busy}><RotateCw size={14} />立即检查</button></div>
-          <SectionTitle num="[ STEP 03 ]" title="账号信息和连接地址" meta="新手不用手填，扫码成功后会自动保存" />
+          <SectionTitle num="[ STEP 03 ]" title="确认扫码结果" meta="新手不用手填账号、口令或接口地址" />
           <section className={s.section}>
-            <Field label="微信接入账号" desc="扫码成功后自动带出；恢复旧配置时才需要手动填。" meta="WEIXIN_ACCOUNT_ID"><input value={accountId} onChange={(e) => setAccountId(e.target.value)} placeholder={last(credential?.accountId)} /></Field>
-            <Field label="微信接入口令" desc="敏感信息，只保存在当前配置档案。" meta="WEIXIN_TOKEN"><input type="password" value={token} onChange={(e) => setToken(e.target.value)} placeholder={last(credential?.token)} /></Field>
-            <Field label="消息接口地址" desc="默认值即可，不知道就不要改。" meta="WEIXIN_BASE_URL"><input value={credential?.baseUrl ?? baseUrl} onChange={(e) => setBaseUrl(e.target.value)} /></Field>
-            <Field label="媒体接口地址" desc="用于图片、文件等媒体内容，默认即可。" meta="WEIXIN_CDN_BASE_URL"><input value={cdnBaseUrl} onChange={(e) => setCdnBaseUrl(e.target.value)} /></Field>
+            {credential ? (
+              <div className={s.identityNote}>
+                <b>已拿到微信扫码凭据</b>
+                <span>账号 <code>{last(credential.accountId)}</code> 和口令会自动保存；如果扫码返回了用户 ID，桌面端会自动写入 <code>WEIXIN_ALLOWED_USERS</code> 和 <code>WEIXIN_HOME_CHANNEL</code>。</span>
+              </div>
+            ) : (
+              <div className={s.identityNote}>
+                <b>等待微信扫码</b>
+                <span>推荐直接扫码完成绑定。只有恢复旧配置，或者 iLink 默认地址不可用时，才需要展开下面的高级设置手动填写。</span>
+              </div>
+            )}
+            <div className={s.advancedPanel} data-open={showAdvanced ? "true" : undefined}>
+              <button className={s.advancedHeader} type="button" onClick={() => setShowAdvanced((value) => !value)} aria-expanded={showAdvanced}>
+                <span>
+                  <b>高级设置 / 恢复旧配置</b>
+                  <small>默认不用动；这里主要给已有账号、Token 或自定义 iLink 地址的用户使用。</small>
+                </span>
+                <em>{showAdvanced ? "收起" : "展开"}</em>
+              </button>
+              {showAdvanced ? (
+                <div className={s.advancedBody}>
+                  <Field label="微信接入账号" desc="扫码成功后自动带出；恢复旧配置时才需要手动填。" meta="WEIXIN_ACCOUNT_ID"><input value={accountId} onChange={(e) => setAccountId(e.target.value)} placeholder={last(credential?.accountId)} /></Field>
+                  <Field label="微信接入口令" desc="敏感信息，只保存在当前配置档案。" meta="WEIXIN_TOKEN"><input type="password" value={token} onChange={(e) => setToken(e.target.value)} placeholder={last(credential?.token)} /></Field>
+                  <Field label="消息接口地址" desc="默认值即可，不知道就不要改。" meta="WEIXIN_BASE_URL"><input value={baseUrl} onChange={(e) => setBaseUrl(e.target.value)} /></Field>
+                  <Field label="媒体接口地址" desc="用于图片、文件等媒体内容，默认即可。" meta="WEIXIN_CDN_BASE_URL"><input value={cdnBaseUrl} onChange={(e) => setCdnBaseUrl(e.target.value)} /></Field>
+                </div>
+              ) : null}
+            </div>
           </section>
-          <SectionTitle num="[ STEP 04 ]" title="设置谁可以使用" meta="默认需要先确认，避免陌生用户直接使用" />
+          <SectionTitle num="[ STEP 04 ]" title="设置谁可以使用" meta="默认只允许扫码用户，避免陌生用户直接使用" />
           <section className={s.section}>
             <div className={s.policyGrid}>
-              <PolicyCard active={dmPolicy === "pairing"} title="需要确认再放行" desc="陌生用户私聊时先生成确认码。" onClick={() => setDmPolicy("pairing")} />
-              <PolicyCard active={dmPolicy === "allowlist"} title="只允许指定用户" desc="只有列表里的微信用户 ID 可用。" onClick={() => setDmPolicy("allowlist")} />
+              <PolicyCard active={dmPolicy === "allowlist"} title="只允许扫码用户" desc={scannedUserId ? `默认加入本次扫码用户（${last(scannedUserId)}）。` : "扫码完成后会自动加入本次微信用户。"} onClick={() => setDmPolicy("allowlist")} />
               <PolicyCard active={dmPolicy === "open"} warning title="所有私聊都可用" desc="方便试用，但不建议长期开放。" onClick={() => setDmPolicy("open")} />
             </div>
-            {dmPolicy === "allowlist" && <Field label="允许用户" desc="多个用户 ID 用英文逗号分隔；不确定可先跳过。" meta="WEIXIN_ALLOWED_USERS"><input value={allowedUsers} onChange={(e) => setAllowedUsers(e.target.value)} /></Field>}
-            <Field label="默认通知会话" desc="用于定时任务和通知；可以先留空。" meta="WEIXIN_HOME_CHANNEL"><input value={homeChannel} onChange={(e) => setHomeChannel(e.target.value)} placeholder="wxid_xxx / filehelper / user_id" /></Field>
+            {dmPolicy === "allowlist" && (
+              <>
+                {scannedUserId ? (
+                  <div className={s.identityNote}>
+                    <b>已自动选择扫码用户</b>
+                    <span>保存时会把完整用户 ID 写入允许列表，界面只展示打码值 <code>{last(scannedUserId)}</code>。</span>
+                  </div>
+                ) : null}
+                <Field label="额外允许用户" desc="可选。多个微信用户 ID 用英文逗号分隔；不确定就留空。" meta="WEIXIN_ALLOWED_USERS"><input value={allowedUsers} onChange={(e) => setAllowedUsers(e.target.value)} placeholder="wxid_xxx,wxid_yyy" /></Field>
+              </>
+            )}
+            <Field label="默认通知会话" desc={scannedUserId ? "留空会自动使用本次扫码用户；也可以手动指定 filehelper 或微信 user_id。" : "用于定时任务和通知；扫码成功后可自动填，也可以手动填。"} meta="WEIXIN_HOME_CHANNEL"><input value={homeChannel} onChange={(e) => setHomeChannel(e.target.value)} placeholder={scannedUserId ? "留空自动使用扫码用户" : "wxid_xxx / filehelper / user_id"} /></Field>
           </section>
           <SectionTitle num="[ REVIEW ]" title="保存前看一眼" meta="口令会自动打码" />
           <ReviewTable rows={rows} />
-          <div className={s.sectionActions}><button className={`${s.btn} ${s.primary}`} onClick={save} disabled={busy || !(canApplyQr || canApplyManual)}><Save size={14} />保存并启动接收服务</button></div>
+          <div className={s.sectionActions}><button className={`${s.btn} ${s.primary}`} onClick={save} disabled={busy || !(canApplyQr || canApplyManual) || !allowPolicyReady}><Save size={14} />保存并启动接收服务</button></div>
           <ApplyResult result={result} />
+          <SectionTitle num="[ STEP 05 ]" title="发一条消息试试" meta="私聊微信机器人，确认真的能回复" />
+          <MessagingTestGuide
+            result={result}
+            platform={messagingPlatformQuery.data}
+            platformLoading={messagingPlatformQuery.isLoading}
+            testResult={testPlatform.data}
+            testError={testPlatform.error}
+            testPending={testPlatform.isPending}
+            onTest={() => testPlatform.mutate()}
+            platformLabel="微信"
+            readyCopy="接收服务已经按当前档案重启。先点一次检测确认链路，再去微信里私聊机器人发送 hi。"
+            notReadyCopy="先扫码保存并启动接收服务，再回来私聊机器人验证。"
+          />
+          <DiagnosticAssistant
+            bundle={diagnosticBundle}
+            onAskHermes={askHermesToDiagnose}
+            asking={diagnosticPending}
+            askError={diagnosticError}
+          />
           {(begin.error || poll.error || apply.error || stateQuery.error) && <div className={s.errorBox}><XCircle size={16} />{textFromError(begin.error || poll.error || apply.error || stateQuery.error)}</div>}
         </main>
       </div>

--- a/web/src/routes/im-onboarding.tsx
+++ b/web/src/routes/im-onboarding.tsx
@@ -480,18 +480,12 @@ function MessagingTestGuide({
   const restartOk = Boolean(result?.restart.ok);
   const connected = platform?.state === "connected";
   const officialAvailable = platform !== null && platform !== undefined;
-  const canRunTest = restartOk || connected || Boolean(platform?.configured);
-  const testBlocked = !canRunTest;
-  const testMessage = testBlocked
-    ? `先完成保存并启动接收服务；未保存时${platformLabel}不会回复。`
-    : testResult?.message ?? textFromError(testError);
+  const testMessage = testResult?.message ?? textFromError(testError);
   const platformStatus = platformLoading
     ? "读取中…"
-    : testBlocked
-      ? "未保存"
-      : officialAvailable
-        ? platformStateText(platform?.state)
-        : "旧 runtime 未提供";
+    : officialAvailable
+      ? platformStateText(platform?.state)
+      : "旧 runtime 未提供";
   return (
     <section className={`${s.section} ${s.testGuide}`} data-ready={restartOk || connected ? "true" : undefined}>
       <div className={s.testIntro}>
@@ -507,8 +501,6 @@ function MessagingTestGuide({
           <div><MessageSquareText size={15} /><b>私聊测试</b><span>给机器人发送 <code>hi</code>，应收到回复或配对提示。</span></div>
           <div><Stethoscope size={15} /><b>官方检测</b><span>{platformLoading
             ? "正在读取官方消息平台状态。"
-            : testBlocked
-              ? `还没有把扫码结果保存到当前档案，${platformLabel}接收服务不会启动。`
             : officialAvailable
               ? `当前状态：${platformStateText(platform?.state)}${platform?.error_message ? `，${platform.error_message}` : ""}`
               : "当前 runtime 暂无官方消息平台检测接口，已使用接收服务状态兜底。"}</span></div>
@@ -516,13 +508,13 @@ function MessagingTestGuide({
 
         <div className={s.statusGrid}>
           <div className={s.statusItem} data-tone={restartOk ? "ok" : "warn"}><b>保存重启</b><span>{restartOk ? result?.restart.message || "已完成" : "还没有成功保存并重启"}</span></div>
-          <div className={s.statusItem} data-tone={connected ? "ok" : testBlocked ? "warn" : undefined}><b>平台状态</b><span>{platformStatus}</span></div>
-          <div className={s.statusItem} data-tone={testResult?.ok ? "ok" : testResult || testBlocked ? "warn" : undefined}><b>检测结果</b><span>{testPending ? "检测中…" : testMessage || "可点击检测缺口"}</span></div>
+          <div className={s.statusItem} data-tone={connected ? "ok" : undefined}><b>平台状态</b><span>{platformStatus}</span></div>
+          <div className={s.statusItem} data-tone={testResult?.ok ? "ok" : testResult ? "warn" : undefined}><b>检测结果</b><span>{testPending ? "检测中…" : testMessage || "可点击检测缺口"}</span></div>
         </div>
 
         <div className={s.testActions}>
-          <button className={s.btn} type="button" onClick={onTest} disabled={platformLoading || testPending || testBlocked}>
-            <RotateCw size={14} />{testPending ? "检测中…" : testBlocked ? "先保存再检测" : `检测${platformLabel}连接`}
+          <button className={s.btn} type="button" onClick={onTest} disabled={platformLoading || testPending}>
+            <RotateCw size={14} />{testPending ? "检测中…" : `检测${platformLabel}连接`}
           </button>
         </div>
       </div>

--- a/web/src/routes/im-onboarding.tsx
+++ b/web/src/routes/im-onboarding.tsx
@@ -480,7 +480,18 @@ function MessagingTestGuide({
   const restartOk = Boolean(result?.restart.ok);
   const connected = platform?.state === "connected";
   const officialAvailable = platform !== null && platform !== undefined;
-  const testMessage = testResult?.message ?? textFromError(testError);
+  const canRunTest = restartOk || connected || Boolean(platform?.configured);
+  const testBlocked = !canRunTest;
+  const testMessage = testBlocked
+    ? `先完成保存并启动接收服务；未保存时${platformLabel}不会回复。`
+    : testResult?.message ?? textFromError(testError);
+  const platformStatus = platformLoading
+    ? "读取中…"
+    : testBlocked
+      ? "未保存"
+      : officialAvailable
+        ? platformStateText(platform?.state)
+        : "旧 runtime 未提供";
   return (
     <section className={`${s.section} ${s.testGuide}`} data-ready={restartOk || connected ? "true" : undefined}>
       <div className={s.testIntro}>
@@ -496,6 +507,8 @@ function MessagingTestGuide({
           <div><MessageSquareText size={15} /><b>私聊测试</b><span>给机器人发送 <code>hi</code>，应收到回复或配对提示。</span></div>
           <div><Stethoscope size={15} /><b>官方检测</b><span>{platformLoading
             ? "正在读取官方消息平台状态。"
+            : testBlocked
+              ? `还没有把扫码结果保存到当前档案，${platformLabel}接收服务不会启动。`
             : officialAvailable
               ? `当前状态：${platformStateText(platform?.state)}${platform?.error_message ? `，${platform.error_message}` : ""}`
               : "当前 runtime 暂无官方消息平台检测接口，已使用接收服务状态兜底。"}</span></div>
@@ -503,13 +516,13 @@ function MessagingTestGuide({
 
         <div className={s.statusGrid}>
           <div className={s.statusItem} data-tone={restartOk ? "ok" : "warn"}><b>保存重启</b><span>{restartOk ? result?.restart.message || "已完成" : "还没有成功保存并重启"}</span></div>
-          <div className={s.statusItem} data-tone={connected ? "ok" : undefined}><b>平台状态</b><span>{platformLoading ? "读取中…" : officialAvailable ? platformStateText(platform?.state) : "旧 runtime 未提供"}</span></div>
-          <div className={s.statusItem} data-tone={testResult?.ok ? "ok" : testResult ? "warn" : undefined}><b>检测结果</b><span>{testPending ? "检测中…" : testMessage || "可点击检测缺口"}</span></div>
+          <div className={s.statusItem} data-tone={connected ? "ok" : testBlocked ? "warn" : undefined}><b>平台状态</b><span>{platformStatus}</span></div>
+          <div className={s.statusItem} data-tone={testResult?.ok ? "ok" : testResult || testBlocked ? "warn" : undefined}><b>检测结果</b><span>{testPending ? "检测中…" : testMessage || "可点击检测缺口"}</span></div>
         </div>
 
         <div className={s.testActions}>
-          <button className={s.btn} type="button" onClick={onTest} disabled={platformLoading || testPending}>
-            <RotateCw size={14} />{testPending ? "检测中…" : `检测${platformLabel}连接`}
+          <button className={s.btn} type="button" onClick={onTest} disabled={platformLoading || testPending || testBlocked}>
+            <RotateCw size={14} />{testPending ? "检测中…" : testBlocked ? "先保存再检测" : `检测${platformLabel}连接`}
           </button>
         </div>
       </div>
@@ -1023,7 +1036,7 @@ function WeixinRoute() {
   const messagingPlatformQuery = useMessagingPlatform("weixin");
   const testPlatform = useTestMessagingPlatform("weixin");
   const createAndSendSession = useCreateAndSendSession();
-  const [dmPolicy, setDmPolicy] = useState<DmPolicy>("allowlist");
+  const [dmPolicy, setDmPolicy] = useState<DmPolicy>("pairing");
   const [allowedUsers, setAllowedUsers] = useState("");
   const [homeChannel, setHomeChannel] = useState("");
   const [showAdvanced, setShowAdvanced] = useState(false);
@@ -1042,8 +1055,8 @@ function WeixinRoute() {
   const credential = pollResult?.credentialSummary;
   const scannedUserId = isSet(credential?.userId) ? credential.userId : null;
   const busy = begin.isPending || poll.isPending || apply.isPending;
-  const canApplyQr = credential && pollResult?.status === "confirmed";
-  const canApplyManual = accountId.trim() && token.trim();
+  const canApplyQr = Boolean(credential && pollResult?.status === "confirmed");
+  const canApplyManual = Boolean(accountId.trim() && token.trim());
   const jumpToQr = () => qrAnchorRef.current?.scrollIntoView({ behavior: "smooth", block: "start" });
 
   const start = () => {
@@ -1068,16 +1081,22 @@ function WeixinRoute() {
     const id = window.setInterval(pollOnce, 1500);
     return () => window.clearInterval(id);
   }, [flow?.flowId, pollResult?.status]);
+  useEffect(() => {
+    if (pollResult?.status === "confirmed" && scannedUserId && dmPolicy === "pairing") {
+      setDmPolicy("allowlist");
+    }
+  }, [pollResult?.status, scannedUserId?.fingerprint, dmPolicy]);
 
   const shouldAutoWeixinHomeChannel = Boolean(scannedUserId) && !homeChannel.trim();
   const useScannedUserId = Boolean(scannedUserId) && dmPolicy === "allowlist";
   const manualAllowedCount = splitAllowedUsers(allowedUsers).length;
-  const allowPolicyReady = dmPolicy === "open" || Boolean(useScannedUserId || manualAllowedCount > 0);
+  const allowPolicyReady = dmPolicy === "open" || dmPolicy === "pairing" || Boolean(useScannedUserId || manualAllowedCount > 0);
+  const dmPolicyValue = dmPolicy === "open" ? "open" : dmPolicy === "pairing" ? "pairing" : "allowlist";
   const settings = () => {
     const patch: Record<string, string> = {
       WEIXIN_BASE_URL: baseUrl.trim().replace(/\/$/, ""),
       WEIXIN_CDN_BASE_URL: cdnBaseUrl.trim().replace(/\/$/, ""),
-      WEIXIN_DM_POLICY: dmPolicy === "open" ? "open" : "allowlist",
+      WEIXIN_DM_POLICY: dmPolicyValue,
       WEIXIN_ALLOW_ALL_USERS: dmPolicy === "open" ? "true" : "false",
       WEIXIN_GROUP_POLICY: "disabled",
       WEIXIN_GROUP_ALLOWED_USERS: "",
@@ -1104,6 +1123,8 @@ function WeixinRoute() {
   }, { onSuccess: setResult });
   const allowedUsersReview = dmPolicy === "open"
     ? "未限制"
+    : dmPolicy === "pairing"
+      ? "走配对确认"
     : compactList([
       ...(useScannedUserId ? [`扫码用户 ${last(scannedUserId)}`] : []),
       ...(manualAllowedCount > 0 ? [`手动 ${manualAllowedCount} 个`] : []),
@@ -1112,8 +1133,8 @@ function WeixinRoute() {
   const rows: Array<[string, string, string]> = [
     ["账号 ID", `WEIXIN_ACCOUNT_ID=${credential?.accountId?.redactedValue ?? accountId}`, credential ? "扫码返回" : "手动"],
     ["认证 Token", `WEIXIN_TOKEN=${credential?.token?.redactedValue ?? (token ? "••••" : "")}`, "敏感"],
-    ["私聊策略", `WEIXIN_DM_POLICY=${dmPolicy === "open" ? "open" : "allowlist"}`, dmPolicy === "open" ? "试用开放" : "只允许白名单"],
-    ["允许用户", `WEIXIN_ALLOWED_USERS=${allowedUsersReview}`, allowPolicyReady ? "可保存" : "缺少用户 ID"],
+    ["私聊策略", `WEIXIN_DM_POLICY=${dmPolicyValue}`, dmPolicy === "open" ? "试用开放" : dmPolicy === "pairing" ? "需要确认" : "只允许白名单"],
+    ["允许用户", `WEIXIN_ALLOWED_USERS=${allowedUsersReview}`, dmPolicy === "pairing" ? "无需预填" : allowPolicyReady ? "可保存" : "缺少用户 ID"],
     ["允许所有用户", `WEIXIN_ALLOW_ALL_USERS=${dmPolicy === "open" ? "true" : "false"}`, "安全默认"],
     ["默认通知会话", `WEIXIN_HOME_CHANNEL=${homeChannelReview}`, shouldAutoWeixinHomeChannel ? "自动设置" : homeChannel.trim() ? "已填写" : "不改动"],
   ];
@@ -1230,6 +1251,7 @@ function WeixinRoute() {
           <section className={s.section}>
             <div className={s.policyGrid}>
               <PolicyCard active={dmPolicy === "allowlist"} title="只允许扫码用户" desc={scannedUserId ? `默认加入本次扫码用户（${last(scannedUserId)}）。` : "扫码完成后会自动加入本次微信用户。"} onClick={() => setDmPolicy("allowlist")} />
+              <PolicyCard active={dmPolicy === "pairing"} title="需要确认再放行" desc="没有拿到用户 ID 时也能先保存；陌生用户发 hi 会收到配对提示。" onClick={() => setDmPolicy("pairing")} />
               <PolicyCard active={dmPolicy === "open"} warning title="所有私聊都可用" desc="方便试用，但不建议长期开放。" onClick={() => setDmPolicy("open")} />
             </div>
             {dmPolicy === "allowlist" && (


### PR DESCRIPTION
## 变更内容

这次把飞书和微信接入补齐为统一的小白排障闭环：接入页会生成脱敏诊断包，展示最可能的阻断点，并提供“复制诊断包”“复制排查提示”“让 Hermes 排查”三个入口。

同时继续修复微信扫码接入流程，让扫码用户自动写入允许列表和默认通知会话，并拒绝 runtime 不支持的微信 `pairing` 策略，避免用户以为是确认放行但实际近似开放私聊。

## 用户影响

小白用户接入失败后，不再只能看到模糊检测结果，可以直接把当前平台状态、接收服务状态、扫码/保存状态和官方检测结果交给 Hermes Agent 排查。诊断包会隐藏 token、secret 等敏感信息。

## 验证

- `pnpm --filter @hermes/web typecheck`
- `pnpm --filter @hermes/web exec vitest run src/routes/im-onboarding.test.ts`
- `cargo test im_onboarding`
- `pnpm --filter @hermes/web build`
- `git diff --check`
