### PR TITLE
需求：增强对话流 Markdown 渲染与 Obsidian 链接

### DIFF
--- a/pnpm-lock.yaml
+++ b/pnpm-lock.yaml
@@ -88,6 +88,9 @@ importers:
       '@streamdown/math':
         specifier: ^1.0.2
         version: 1.0.2(react@19.2.6)
+      '@streamdown/mermaid':
+        specifier: ^1.0.2
+        version: 1.0.2(react@19.2.6)
       '@tanstack/react-query':
         specifier: ^5.100.5
         version: 5.100.10(react@19.2.6)
@@ -949,6 +952,11 @@ packages:
 
   '@streamdown/math@1.0.2':
     resolution: {integrity: sha512-r8Ur9/lBuFnzZAFdEWrLUF2s/gRwRRRwruqltdZibyjbCBnuW7SJbFm26nXqvpJPW/gzpBUMrBVBzd88z05D5g==}
+    peerDependencies:
+      react: ^18.0.0 || ^19.0.0
+
+  '@streamdown/mermaid@1.0.2':
+    resolution: {integrity: sha512-Fr/4sBWnAeSnxM3PcrV/+DiZe5oPMq9gOkUIAH7ZauJeuwrZ/DVzD4g0zlav6AH0axh2m/sOfrfLtY5aLT7niw==}
     peerDependencies:
       react: ^18.0.0 || ^19.0.0
 
@@ -3179,6 +3187,11 @@ snapshots:
       remark-math: 6.0.0
     transitivePeerDependencies:
       - supports-color
+
+  '@streamdown/mermaid@1.0.2(react@19.2.6)':
+    dependencies:
+      mermaid: 11.15.0
+      react: 19.2.6
 
   '@tanstack/query-core@5.100.10': {}
 

--- a/pnpm-lock.yaml
+++ b/pnpm-lock.yaml
@@ -136,6 +136,15 @@ importers:
       recharts:
         specifier: ^3.8.1
         version: 3.8.1(@types/react@19.2.14)(react-dom@19.2.6(react@19.2.6))(react-is@19.2.7)(react@19.2.6)(redux@5.0.1)
+      rehype-harden:
+        specifier: ^1.1.8
+        version: 1.1.8
+      rehype-raw:
+        specifier: ^7.0.0
+        version: 7.0.0
+      rehype-sanitize:
+        specifier: ^6.0.0
+        version: 6.0.0
       streamdown:
         specifier: ^2.5.0
         version: 2.5.0(react-dom@19.2.6(react@19.2.6))(react@19.2.6)

--- a/src/commands/file_dialogs.rs
+++ b/src/commands/file_dialogs.rs
@@ -188,6 +188,13 @@ fn validate_external_url(raw: &str) -> AppResult<String> {
                 ));
             }
         }
+        "obsidian" => {
+            if parsed.host_str().is_none() {
+                return Err(AppError::InvalidRequest(
+                    "obsidian URL must include an action".to_string(),
+                ));
+            }
+        }
         scheme => {
             return Err(AppError::InvalidRequest(format!(
                 "Refusing to open unsupported URL scheme: {scheme}"
@@ -284,6 +291,13 @@ mod tests {
             validate_external_url("mailto:hello@example.com").unwrap(),
             "mailto:hello@example.com"
         );
+        assert_eq!(
+            validate_external_url(
+                "obsidian://open?vault=Hermes&file=Twitter%20%E6%97%B6%E9%97%B4%E7%BA%BF"
+            )
+            .unwrap(),
+            "obsidian://open?vault=Hermes&file=Twitter%20%E6%97%B6%E9%97%B4%E7%BA%BF"
+        );
     }
 
     #[test]
@@ -296,6 +310,7 @@ mod tests {
             "tauri://localhost",
             "ftp://example.com/file",
             "mailto:",
+            "obsidian:open",
         ] {
             assert!(
                 matches!(validate_external_url(raw), Err(AppError::InvalidRequest(_))),

--- a/web/package.json
+++ b/web/package.json
@@ -20,6 +20,7 @@
     "@hermes/shared-ui": "workspace:*",
     "@streamdown/cjk": "^1.0.3",
     "@streamdown/math": "^1.0.2",
+    "@streamdown/mermaid": "^1.0.2",
     "@tanstack/react-query": "^5.100.5",
     "@xterm/addon-fit": "^0.11.0",
     "@xterm/addon-web-links": "^0.12.0",

--- a/web/package.json
+++ b/web/package.json
@@ -36,6 +36,9 @@
     "react-router": "^7.6.0",
     "react-router-dom": "^7.6.0",
     "recharts": "^3.8.1",
+    "rehype-harden": "^1.1.8",
+    "rehype-raw": "^7.0.0",
+    "rehype-sanitize": "^6.0.0",
     "streamdown": "^2.5.0"
   },
   "devDependencies": {

--- a/web/src/components/chat/markdown-renderer.module.css
+++ b/web/src/components/chat/markdown-renderer.module.css
@@ -1,0 +1,32 @@
+.richInline {
+  color: inherit;
+  font-size: inherit;
+  line-height: inherit;
+}
+
+.toneMuted {
+  color: var(--h-text-3);
+}
+
+.toneSubtle {
+  color: var(--h-text-4);
+}
+
+.toneAccent {
+  color: var(--h-accent);
+}
+
+.sizeSmall {
+  font-size: 0.86em;
+}
+
+.sizeTiny {
+  font-size: 0.78em;
+}
+
+.mark {
+  border-radius: 4px;
+  background: var(--h-accent-soft);
+  color: var(--h-accent);
+  padding: 0 0.25em;
+}

--- a/web/src/components/chat/markdown-renderer.tsx
+++ b/web/src/components/chat/markdown-renderer.tsx
@@ -1,6 +1,6 @@
 import { cjk } from "@streamdown/cjk";
 import { createMathPlugin } from "@streamdown/math";
-import type { CSSProperties, ComponentProps } from "react";
+import type { CSSProperties, ComponentProps, MouseEvent } from "react";
 import rehypeRaw from "rehype-raw";
 import rehypeSanitize, { defaultSchema, type Options as SanitizeSchema } from "rehype-sanitize";
 import { harden } from "rehype-harden";
@@ -96,6 +96,50 @@ function isExternalHref(value: string): boolean {
   }
 }
 
+function decodeHashId(value: string): string {
+  try {
+    return decodeURIComponent(value);
+  } catch {
+    return value;
+  }
+}
+
+function footnoteTargetCandidates(id: string): string[] {
+  const decoded = decodeHashId(id);
+  const candidates = new Set([id, decoded]);
+
+  for (const candidate of Array.from(candidates)) {
+    if (candidate.startsWith("user-content-")) {
+      candidates.add(`user-content-${candidate}`);
+    } else {
+      candidates.add(`user-content-${candidate}`);
+    }
+  }
+
+  return Array.from(candidates).filter(Boolean);
+}
+
+function scrollToHashTarget(hash: string): boolean {
+  if (typeof document === "undefined" || !hash.startsWith("#")) return false;
+  const id = hash.slice(1);
+  if (!id) return false;
+
+  for (const candidate of footnoteTargetCandidates(id)) {
+    const target = document.getElementById(candidate);
+    if (!target) continue;
+    target.scrollIntoView({ block: "start", behavior: "smooth" });
+    return true;
+  }
+
+  return false;
+}
+
+function handleHashAnchorClick(event: MouseEvent<HTMLAnchorElement>, href: string) {
+  if (event.defaultPrevented || event.button !== 0) return;
+  event.preventDefault();
+  scrollToHashTarget(href);
+}
+
 function MarkdownAnchor({
   href,
   children,
@@ -105,10 +149,12 @@ function MarkdownAnchor({
   const safe = safeHref(href);
   if (!safe) return <span>{children}</span>;
   const external = isExternalHref(safe);
+  const isHashAnchor = safe.startsWith("#");
   return (
     <a
       {...props}
       href={safe}
+      onClick={isHashAnchor ? (event) => handleHashAnchorClick(event, safe) : props.onClick}
       rel={external ? "noreferrer" : undefined}
       target={external && /^https?:\/\//i.test(safe) ? "_blank" : undefined}
     >

--- a/web/src/components/chat/markdown-renderer.tsx
+++ b/web/src/components/chat/markdown-renderer.tsx
@@ -1,5 +1,6 @@
 import { cjk } from "@streamdown/cjk";
 import { createMathPlugin } from "@streamdown/math";
+import { mermaid } from "@streamdown/mermaid";
 import type { CSSProperties, ComponentProps, MouseEvent } from "react";
 import rehypeRaw from "rehype-raw";
 import rehypeSanitize, { defaultSchema, type Options as SanitizeSchema } from "rehype-sanitize";
@@ -29,6 +30,7 @@ const BLOCKED_EXTERNAL_PROTOCOLS = /^(?:javascript|data|file|vbscript|tauri):/i;
 const streamdownPlugins = {
   cjk,
   math: createMathPlugin({ singleDollarTextMath: true }),
+  mermaid,
 };
 
 const streamdownLinkSafety: ComponentProps<typeof Streamdown>["linkSafety"] = {

--- a/web/src/components/chat/markdown-renderer.tsx
+++ b/web/src/components/chat/markdown-renderer.tsx
@@ -1,13 +1,30 @@
 import { cjk } from "@streamdown/cjk";
 import { createMathPlugin } from "@streamdown/math";
-import type { ComponentProps } from "react";
+import type { CSSProperties, ComponentProps } from "react";
+import rehypeRaw from "rehype-raw";
+import rehypeSanitize, { defaultSchema, type Options as SanitizeSchema } from "rehype-sanitize";
+import { harden } from "rehype-harden";
 import { Streamdown } from "streamdown";
 import { MessageImage } from "./message-image";
+import s from "./markdown-renderer.module.css";
 
 interface MarkdownTextProps {
   text: string;
   streaming?: boolean;
 }
+
+type RichInlineProps<T extends "span" | "small" | "time" | "mark"> = Omit<
+  ComponentProps<T>,
+  "className" | "style"
+> & {
+  className?: string;
+  node?: unknown;
+  style?: unknown;
+};
+
+const ALLOWED_LINK_PROTOCOLS = ["http", "https", "irc", "ircs", "mailto", "xmpp", "tel", "obsidian"];
+const ALLOWED_EXTERNAL_PROTOCOLS = new Set(["http:", "https:", "mailto:", "tel:", "obsidian:"]);
+const BLOCKED_EXTERNAL_PROTOCOLS = /^(?:javascript|data|file|vbscript|tauri):/i;
 
 const streamdownPlugins = {
   cjk,
@@ -18,11 +35,65 @@ const streamdownLinkSafety: ComponentProps<typeof Streamdown>["linkSafety"] = {
   enabled: false,
 };
 
+const markdownSanitizeSchema: SanitizeSchema = {
+  ...defaultSchema,
+  protocols: {
+    ...defaultSchema.protocols,
+    href: Array.from(new Set([...(defaultSchema.protocols?.href ?? []), ...ALLOWED_LINK_PROTOCOLS])),
+  },
+  tagNames: Array.from(new Set([...(defaultSchema.tagNames ?? []), "small", "time", "mark"])),
+  attributes: {
+    ...defaultSchema.attributes,
+    a: Array.from(new Set([...(defaultSchema.attributes?.a ?? []), "title"])),
+    span: ["dataTone", "dataSize", "data-tone", "data-size", "style", "title"],
+    small: ["dataTone", "dataSize", "data-tone", "data-size", "style", "title"],
+    time: ["dateTime", "datetime", "dataTone", "dataSize", "data-tone", "data-size", "style", "title"],
+    mark: ["dataTone", "dataSize", "data-tone", "data-size", "style", "title"],
+  },
+};
+
+const streamdownRehypePlugins: ComponentProps<typeof Streamdown>["rehypePlugins"] = [
+  rehypeRaw,
+  [rehypeSanitize, markdownSanitizeSchema],
+  [
+    harden,
+    {
+      allowedImagePrefixes: ["*"],
+      allowedLinkPrefixes: ["*"],
+      allowedProtocols: ["tel:", "obsidian:"],
+      allowDataImages: true,
+    },
+  ],
+];
+
 function safeHref(value: unknown): string | undefined {
   if (typeof value !== "string") return undefined;
   const trimmed = value.trim();
-  if (/^(?:javascript|data|vbscript):/i.test(trimmed)) return undefined;
-  return trimmed;
+  if (!trimmed || BLOCKED_EXTERNAL_PROTOCOLS.test(trimmed)) return undefined;
+
+  try {
+    const url = new URL(trimmed);
+    if (!ALLOWED_EXTERNAL_PROTOCOLS.has(url.protocol)) return undefined;
+    if ((url.protocol === "http:" || url.protocol === "https:") && !url.hostname) return undefined;
+    if (url.protocol === "mailto:" && !url.pathname.trim()) return undefined;
+    if (url.protocol === "obsidian:" && !url.hostname) return undefined;
+    return url.href;
+  } catch {
+    if (trimmed.startsWith("#")) return trimmed;
+    if ((trimmed.startsWith("/") && !trimmed.startsWith("//")) || trimmed.startsWith("./") || trimmed.startsWith("../")) {
+      return trimmed;
+    }
+    return undefined;
+  }
+}
+
+function isExternalHref(value: string): boolean {
+  try {
+    const url = new URL(value);
+    return ALLOWED_EXTERNAL_PROTOCOLS.has(url.protocol);
+  } catch {
+    return false;
+  }
 }
 
 function MarkdownAnchor({
@@ -33,13 +104,13 @@ function MarkdownAnchor({
 }: ComponentProps<"a"> & { node?: unknown }) {
   const safe = safeHref(href);
   if (!safe) return <span>{children}</span>;
-  const external = /^https?:\/\//i.test(safe);
+  const external = isExternalHref(safe);
   return (
     <a
       {...props}
       href={safe}
       rel={external ? "noreferrer" : undefined}
-      target={external ? "_blank" : undefined}
+      target={external && /^https?:\/\//i.test(safe) ? "_blank" : undefined}
     >
       {children}
     </a>
@@ -65,7 +136,218 @@ function MarkdownImage({
   );
 }
 
-const streamdownComponents = { a: MarkdownAnchor, img: MarkdownImage };
+function classNames(...values: Array<string | false | null | undefined>): string | undefined {
+  const joined = values.filter(Boolean).join(" ");
+  return joined || undefined;
+}
+
+function dataValue(props: Record<string, unknown>, dashed: string, camel: string): string | undefined {
+  const value = props[dashed] ?? props[camel];
+  return typeof value === "string" ? value.trim().toLowerCase() : undefined;
+}
+
+function toneClass(tone: string | undefined, fallback?: "muted" | "accent" | "subtle") {
+  const value = tone || fallback;
+  switch (value) {
+    case "muted":
+    case "secondary":
+      return s.toneMuted;
+    case "subtle":
+    case "faint":
+      return s.toneSubtle;
+    case "accent":
+    case "primary":
+      return s.toneAccent;
+    default:
+      return undefined;
+  }
+}
+
+function sizeClass(size: string | undefined, fallback?: "small" | "tiny") {
+  const value = size || fallback;
+  switch (value) {
+    case "small":
+    case "sm":
+      return s.sizeSmall;
+    case "tiny":
+    case "xs":
+      return s.sizeTiny;
+    default:
+      return undefined;
+  }
+}
+
+function sanitizeStyleValue(name: string, value: unknown): string | undefined {
+  if (typeof value !== "string" && typeof value !== "number") return undefined;
+  const raw = String(value).trim();
+  if (!raw || /url\s*\(|expression\s*\(|[<>]/i.test(raw)) return undefined;
+
+  switch (name) {
+    case "color": {
+      if (/^#(?:[\da-f]{3,4}|[\da-f]{6}|[\da-f]{8})$/i.test(raw)) return raw;
+      if (/^rgba?\(\s*\d{1,3}\s*,\s*\d{1,3}\s*,\s*\d{1,3}(?:\s*,\s*(?:0|1|0?\.\d+))?\s*\)$/i.test(raw)) return raw;
+      if (/^hsla?\(\s*\d{1,3}\s*,\s*\d{1,3}%\s*,\s*\d{1,3}%(?:\s*,\s*(?:0|1|0?\.\d+))?\s*\)$/i.test(raw)) return raw;
+      if (/^var\(--[a-z0-9-]+\)$/i.test(raw)) return raw;
+      if (/^(?:currentcolor|inherit|initial|unset)$/i.test(raw)) return raw;
+      return undefined;
+    }
+    case "fontSize": {
+      const px = raw.match(/^(\d+(?:\.\d+)?)px$/i);
+      if (px) {
+        const valuePx = Number(px[1]);
+        return valuePx >= 10 && valuePx <= 18 ? raw : undefined;
+      }
+      const relative = raw.match(/^(\d+(?:\.\d+)?)(em|rem)$/i);
+      if (relative) {
+        const valueRelative = Number(relative[1]);
+        return valueRelative >= 0.65 && valueRelative <= 1.2 ? raw : undefined;
+      }
+      const percent = raw.match(/^(\d+(?:\.\d+)?)%$/);
+      if (percent) {
+        const valuePercent = Number(percent[1]);
+        return valuePercent >= 65 && valuePercent <= 120 ? raw : undefined;
+      }
+      return undefined;
+    }
+    case "opacity": {
+      const opacity = Number(raw);
+      return Number.isFinite(opacity) && opacity >= 0.35 && opacity <= 1 ? String(opacity) : undefined;
+    }
+    case "fontWeight": {
+      if (/^(?:normal|bold|lighter|bolder)$/i.test(raw)) return raw;
+      const weight = Number(raw);
+      return Number.isInteger(weight) && weight >= 300 && weight <= 800 ? String(weight) : undefined;
+    }
+    case "fontStyle": {
+      return /^(?:normal|italic)$/i.test(raw) ? raw : undefined;
+    }
+    case "lineHeight": {
+      const lineHeight = Number(raw);
+      return Number.isFinite(lineHeight) && lineHeight >= 1 && lineHeight <= 2 ? String(lineHeight) : undefined;
+    }
+    default:
+      return undefined;
+  }
+}
+
+function toCamelStyleName(name: string): keyof CSSProperties | null {
+  switch (name.trim().toLowerCase()) {
+    case "color":
+      return "color";
+    case "font-size":
+    case "fontsize":
+      return "fontSize";
+    case "opacity":
+      return "opacity";
+    case "font-weight":
+    case "fontweight":
+      return "fontWeight";
+    case "font-style":
+    case "fontstyle":
+      return "fontStyle";
+    case "line-height":
+    case "lineheight":
+      return "lineHeight";
+    default:
+      return null;
+  }
+}
+
+function sanitizeInlineStyle(style: unknown): CSSProperties | undefined {
+  const entries: Array<[string, unknown]> = [];
+
+  if (typeof style === "string") {
+    for (const declaration of style.split(";")) {
+      const separator = declaration.indexOf(":");
+      if (separator === -1) continue;
+      entries.push([declaration.slice(0, separator), declaration.slice(separator + 1)]);
+    }
+  } else if (style && typeof style === "object") {
+    entries.push(...Object.entries(style as Record<string, unknown>));
+  }
+
+  const sanitized: CSSProperties = {};
+  for (const [rawName, rawValue] of entries) {
+    const name = toCamelStyleName(rawName);
+    if (!name) continue;
+    const value = sanitizeStyleValue(name, rawValue);
+    if (value) {
+      (sanitized as Record<string, string>)[name] = value;
+    }
+  }
+
+  return Object.keys(sanitized).length > 0 ? sanitized : undefined;
+}
+
+function richInlineClassName(
+  props: Record<string, unknown>,
+  className: string | undefined,
+  defaults: { size?: "small" | "tiny"; tone?: "muted" | "accent" | "subtle" } = {},
+) {
+  return classNames(
+    s.richInline,
+    toneClass(dataValue(props, "data-tone", "dataTone"), defaults.tone),
+    sizeClass(dataValue(props, "data-size", "dataSize"), defaults.size),
+    className,
+  );
+}
+
+function MarkdownSpan({ children, className, node: _node, style, ...props }: RichInlineProps<"span">) {
+  return (
+    <span
+      {...props}
+      className={richInlineClassName(props as Record<string, unknown>, className)}
+      style={sanitizeInlineStyle(style)}
+    >
+      {children}
+    </span>
+  );
+}
+
+function MarkdownSmall({ children, className, node: _node, style, ...props }: RichInlineProps<"small">) {
+  return (
+    <small
+      {...props}
+      className={richInlineClassName(props as Record<string, unknown>, className, { size: "small", tone: "muted" })}
+      style={sanitizeInlineStyle(style)}
+    >
+      {children}
+    </small>
+  );
+}
+
+function MarkdownTime({ children, className, node: _node, style, ...props }: RichInlineProps<"time">) {
+  return (
+    <time
+      {...props}
+      className={richInlineClassName(props as Record<string, unknown>, className, { size: "small", tone: "muted" })}
+      style={sanitizeInlineStyle(style)}
+    >
+      {children}
+    </time>
+  );
+}
+
+function MarkdownMark({ children, className, node: _node, style, ...props }: RichInlineProps<"mark">) {
+  return (
+    <mark
+      {...props}
+      className={classNames(s.mark, toneClass(dataValue(props as Record<string, unknown>, "data-tone", "dataTone"), "accent"), className)}
+      style={sanitizeInlineStyle(style)}
+    >
+      {children}
+    </mark>
+  );
+}
+
+const streamdownComponents = {
+  a: MarkdownAnchor,
+  img: MarkdownImage,
+  mark: MarkdownMark,
+  small: MarkdownSmall,
+  span: MarkdownSpan,
+  time: MarkdownTime,
+};
 
 export function MarkdownText({ text, streaming = false }: MarkdownTextProps) {
   return (
@@ -78,6 +360,7 @@ export function MarkdownText({ text, streaming = false }: MarkdownTextProps) {
       linkSafety={streamdownLinkSafety}
       mode="streaming"
       plugins={streamdownPlugins}
+      rehypePlugins={streamdownRehypePlugins}
     >
       {text}
     </Streamdown>

--- a/web/src/components/chat/message-timeline.module.css
+++ b/web/src/components/chat/message-timeline.module.css
@@ -493,6 +493,42 @@
   margin: 0;
 }
 
+.messageText :global([data-streamdown="mermaid-block"]) {
+  overflow: hidden;
+  margin: 10px 0;
+  border: 1px solid var(--h-line-soft);
+  border-radius: 10px;
+  background: var(--h-bg-code);
+}
+
+.messageText :global([data-streamdown="mermaid-block"] > div:first-child) {
+  border-bottom: 1px solid var(--h-line-soft);
+  padding: 6px 10px;
+  color: var(--h-text-3);
+  font-family: var(--h-font-mono);
+  font-size: 11px;
+  line-height: 1.4;
+}
+
+.messageText :global([data-streamdown="mermaid-block"] > div:last-child) {
+  overflow-x: auto;
+  background: var(--h-bg-pane);
+  padding: 12px;
+}
+
+.messageText :global([data-streamdown="mermaid"]) {
+  min-width: max-content;
+}
+
+.messageText :global([data-streamdown="mermaid"] svg) {
+  max-width: 100%;
+  height: auto;
+}
+
+:global([data-theme="dark"]) .messageText :global([data-streamdown="mermaid"] svg) {
+  color-scheme: light;
+}
+
 .codeBlock,
 .toolBody pre {
   overflow-x: auto;

--- a/web/src/components/chat/message-timeline.test.tsx
+++ b/web/src/components/chat/message-timeline.test.tsx
@@ -114,6 +114,16 @@ describe("MessageTimeline", () => {
     expect(html).not.toContain("200px");
   });
 
+
+  it("routes Mermaid fences away from the plain code block renderer", () => {
+    const html = ReactDOMServer.renderToStaticMarkup(
+      <MarkdownText text={"```mermaid\ngraph TD\n  A[开始] --> B{条件判断}\n  B -->|是| C[处理]\n```"} />,
+    );
+
+    expect(html).not.toContain('data-language="mermaid"');
+    expect(html).not.toContain('data-streamdown="code-block"');
+  });
+
   it("renders Markdown image syntax as an image preview", () => {
     const html = ReactDOMServer.renderToStaticMarkup(
       <MarkdownText text="结果图：![趋势图](https://example.test/chart.png)" />,

--- a/web/src/components/chat/message-timeline.test.tsx
+++ b/web/src/components/chat/message-timeline.test.tsx
@@ -71,6 +71,18 @@ describe("MessageTimeline", () => {
   });
 
 
+
+  it("renders footnote anchors as in-page links", () => {
+    const html = ReactDOMServer.renderToStaticMarkup(
+      <MarkdownText text={"正文引用[^1]\n\n[^1]: 这里是脚注内容"} />,
+    );
+
+    expect(html).toContain('href="#user-content-fn-1"');
+    expect(html).toContain('href="#user-content-fnref-1"');
+    expect(html).toContain("这里是脚注内容");
+    expect(html).not.toContain('target="_blank"');
+  });
+
   it("keeps safe relative Markdown links renderable", () => {
     const html = ReactDOMServer.renderToStaticMarkup(
       <MarkdownText text="[内部帮助](/advanced/about)" />,

--- a/web/src/components/chat/message-timeline.test.tsx
+++ b/web/src/components/chat/message-timeline.test.tsx
@@ -59,6 +59,49 @@ describe("MessageTimeline", () => {
     expect(html).not.toContain("1.0M tokens");
   });
 
+
+  it("renders Obsidian deep links without the blocked indicator", () => {
+    const html = ReactDOMServer.renderToStaticMarkup(
+      <MarkdownText text="[Twitter 时间线](obsidian://open?vault=Hermes&file=Twitter%20%E6%97%B6%E9%97%B4%E7%BA%BF)" />,
+    );
+
+    expect(html).toContain("href=\"obsidian://open?vault=Hermes&amp;file=Twitter%20%E6%97%B6%E9%97%B4%E7%BA%BF\"");
+    expect(html).toContain("Twitter 时间线");
+    expect(html).not.toContain("[blocked]");
+  });
+
+
+  it("keeps safe relative Markdown links renderable", () => {
+    const html = ReactDOMServer.renderToStaticMarkup(
+      <MarkdownText text="[内部帮助](/advanced/about)" />,
+    );
+
+    expect(html).toContain("href=\"/advanced/about\"");
+    expect(html).toContain("内部帮助");
+  });
+
+  it("renders controlled rich inline Markdown formatting", () => {
+    const html = ReactDOMServer.renderToStaticMarkup(
+      <MarkdownText text={'<small style="font-size: 12px; color: #999">06 月 07 日 05:30</small> · <span data-tone="muted" data-size="small">浏览 152</span>'} />,
+    );
+
+    expect(html).toContain("06 月 07 日 05:30");
+    expect(html).toContain("浏览 152");
+    expect(html).toContain("font-size:12px");
+    expect(html).toContain("color:#999");
+  });
+
+  it("drops unsafe inline styles from rich formatting tags", () => {
+    const html = ReactDOMServer.renderToStaticMarkup(
+      <MarkdownText text={'<span style="background-image: url(javascript:alert(1)); font-size: 200px">日期</span>'} />,
+    );
+
+    expect(html).toContain("日期");
+    expect(html).not.toContain("javascript");
+    expect(html).not.toContain("background-image");
+    expect(html).not.toContain("200px");
+  });
+
   it("renders Markdown image syntax as an image preview", () => {
     const html = ReactDOMServer.renderToStaticMarkup(
       <MarkdownText text="结果图：![趋势图](https://example.test/chart.png)" />,

--- a/web/src/lib/external-links.test.ts
+++ b/web/src/lib/external-links.test.ts
@@ -12,12 +12,16 @@ describe("external-links", () => {
     );
     expect(normalizeExternalUrl("http://example.com")).toBe("http://example.com/");
     expect(normalizeExternalUrl("mailto:hello@example.com")).toBe("mailto:hello@example.com");
+    expect(normalizeExternalUrl("obsidian://open?vault=Hermes&file=Twitter%20%E6%97%B6%E9%97%B4%E7%BA%BF")).toBe(
+      "obsidian://open?vault=Hermes&file=Twitter%20%E6%97%B6%E9%97%B4%E7%BA%BF",
+    );
   });
 
   it("rejects non-browser schemes", () => {
     expect(normalizeExternalUrl("file:///etc/passwd")).toBeNull();
     expect(normalizeExternalUrl("javascript:alert(1)")).toBeNull();
     expect(normalizeExternalUrl("tauri://localhost")).toBeNull();
+    expect(normalizeExternalUrl("obsidian:open")).toBeNull();
     expect(normalizeExternalUrl("/advanced/about")).toBeNull();
   });
 

--- a/web/src/lib/external-links.ts
+++ b/web/src/lib/external-links.ts
@@ -1,6 +1,6 @@
 type NativeWindowOpen = typeof window.open;
 
-const SAFE_EXTERNAL_PROTOCOLS = new Set(["http:", "https:", "mailto:"]);
+const SAFE_EXTERNAL_PROTOCOLS = new Set(["http:", "https:", "mailto:", "obsidian:"]);
 let nativeWindowOpen: NativeWindowOpen | null = null;
 let installed = false;
 
@@ -19,6 +19,7 @@ export function normalizeExternalUrl(raw: string | URL | null | undefined): stri
     if (!SAFE_EXTERNAL_PROTOCOLS.has(url.protocol)) return null;
     if ((url.protocol === "http:" || url.protocol === "https:") && !url.hostname) return null;
     if (url.protocol === "mailto:" && !url.pathname.trim()) return null;
+    if (url.protocol === "obsidian:" && !url.hostname) return null;
     return url.href;
   } catch {
     return null;


### PR DESCRIPTION
## 变更内容

- 增强对话流 Markdown 渲染，允许受控 HTML inline 标签用于弱化日期、来源和统计信息。
- 支持 `obsidian://` 深链接通过 Markdown 正常渲染，不再显示 `[blocked]`。
- 扩展桌面端外部链接打开白名单，允许 Obsidian 协议交给系统处理。
- 增加链接、富文本样式和危险样式过滤测试。

## 背景

修复 #150。用户希望 Hermes 在刷推等信息流场景中能按指定模板输出，并能让日期使用更小字号、浅色等视觉层级，同时点击对话中的 Obsidian 链接可以直接打开指定笔记。

## 验证

- `pnpm typecheck`
- `pnpm test:unit`
- `cargo check`
