### PR TITLE
[codex] 支持调整对话宽度

### DIFF
--- a/web/src/components/chat/conversation-width-control.module.css
+++ b/web/src/components/chat/conversation-width-control.module.css
@@ -1,0 +1,68 @@
+.control {
+  display: inline-flex;
+  align-items: center;
+  flex-shrink: 0;
+  gap: 2px;
+  height: 26px;
+  padding: 2px;
+  border: 1px solid var(--h-line);
+  border-radius: var(--h-r-sm);
+  background: color-mix(in srgb, var(--h-bg-input) 82%, transparent);
+  color: var(--h-text-2);
+  -webkit-app-region: no-drag;
+}
+
+.label {
+  padding: 0 5px 0 6px;
+  color: var(--h-text-3);
+  font-size: 11px;
+  line-height: 1;
+  white-space: nowrap;
+}
+
+.option {
+  display: inline-flex;
+  align-items: center;
+  justify-content: center;
+  min-width: 24px;
+  height: 20px;
+  border: 0;
+  border-radius: calc(var(--h-r-sm) - 2px);
+  background: transparent;
+  color: var(--h-text-2);
+  cursor: pointer;
+  font-size: 11px;
+  line-height: 1;
+  padding: 0 6px;
+}
+
+.option:hover {
+  background: var(--h-bg-soft);
+  color: var(--h-text);
+}
+
+.option:focus-visible {
+  outline: 2px solid color-mix(in srgb, var(--h-accent) 65%, transparent);
+  outline-offset: 1px;
+}
+
+.option[data-active="true"] {
+  background: var(--h-accent);
+  color: #fff;
+}
+
+.option[data-active="true"]:hover {
+  background: var(--h-accent);
+  color: #fff;
+}
+
+@media (max-width: 720px) {
+  .label {
+    display: none;
+  }
+
+  .option {
+    min-width: 22px;
+    padding: 0 5px;
+  }
+}

--- a/web/src/components/chat/conversation-width-control.test.tsx
+++ b/web/src/components/chat/conversation-width-control.test.tsx
@@ -1,0 +1,20 @@
+import ReactDOMServer from "react-dom/server";
+import { describe, expect, it } from "vitest";
+
+import { ConversationWidthControl } from "./conversation-width-control";
+
+describe("ConversationWidthControl", () => {
+  it("renders the four width choices and marks the current value", () => {
+    const html = ReactDOMServer.renderToStaticMarkup(
+      <ConversationWidthControl value="medium" onChange={() => {}} />,
+    );
+
+    expect(html).toContain("aria-label=\"对话宽度\"");
+    expect(html).toContain("data-width-value=\"small\"");
+    expect(html).toContain("data-width-value=\"medium\"");
+    expect(html).toContain("data-width-value=\"large\"");
+    expect(html).toContain("data-width-value=\"full\"");
+    expect(html).toContain("data-width-value=\"medium\" title=\"对话宽度：中等宽度（medium）\"");
+    expect(html).toContain("aria-checked=\"true\"");
+  });
+});

--- a/web/src/components/chat/conversation-width-control.tsx
+++ b/web/src/components/chat/conversation-width-control.tsx
@@ -1,0 +1,77 @@
+import type { KeyboardEvent } from "react";
+import {
+  CONVERSATION_WIDTH_OPTIONS,
+  type ConversationWidthMode,
+} from "@/stores/ui";
+import s from "./conversation-width-control.module.css";
+
+interface ConversationWidthControlProps {
+  value: ConversationWidthMode;
+  onChange: (value: ConversationWidthMode) => void;
+}
+
+export function ConversationWidthControl({ value, onChange }: ConversationWidthControlProps) {
+  const activeIndex = Math.max(
+    0,
+    CONVERSATION_WIDTH_OPTIONS.findIndex((option) => option.value === value),
+  );
+
+  const handleKeyDown = (event: KeyboardEvent<HTMLDivElement>) => {
+    let nextIndex: number | null = null;
+    const lastIndex = CONVERSATION_WIDTH_OPTIONS.length - 1;
+
+    if (event.key === "ArrowLeft" || event.key === "ArrowUp") {
+      nextIndex = activeIndex <= 0 ? lastIndex : activeIndex - 1;
+    } else if (event.key === "ArrowRight" || event.key === "ArrowDown") {
+      nextIndex = activeIndex >= lastIndex ? 0 : activeIndex + 1;
+    } else if (event.key === "Home") {
+      nextIndex = 0;
+    } else if (event.key === "End") {
+      nextIndex = lastIndex;
+    }
+
+    if (nextIndex === null) return;
+
+    event.preventDefault();
+    const next = CONVERSATION_WIDTH_OPTIONS[nextIndex]?.value;
+    if (!next) return;
+    onChange(next);
+
+    const root = event.currentTarget;
+    const focusNext = () => {
+      root
+        .querySelector<HTMLButtonElement>(`button[data-width-value="${next}"]`)
+        ?.focus();
+    };
+    if (typeof window === "undefined") {
+      focusNext();
+    } else {
+      window.requestAnimationFrame(focusNext);
+    }
+  };
+
+  return (
+    <div className={s.control} role="radiogroup" aria-label="对话宽度" onKeyDown={handleKeyDown}>
+      <span className={s.label}>宽度</span>
+      {CONVERSATION_WIDTH_OPTIONS.map((option) => {
+        const active = option.value === value;
+        return (
+          <button
+            key={option.value}
+            type="button"
+            role="radio"
+            aria-checked={active}
+            aria-label={`将对话宽度设为${option.title}（${option.value}）`}
+            className={s.option}
+            data-active={active ? "true" : undefined}
+            data-width-value={option.value}
+            title={`对话宽度：${option.title}（${option.value}）`}
+            onClick={() => onChange(option.value)}
+          >
+            {option.label}
+          </button>
+        );
+      })}
+    </div>
+  );
+}

--- a/web/src/components/chat/message-timeline.module.css
+++ b/web/src/components/chat/message-timeline.module.css
@@ -21,7 +21,7 @@
 
 .turnRail {
   position: absolute;
-  right: max(12px, calc((100% - 780px) / 2 - 30px));
+  right: max(12px, calc((100% - var(--conversation-max-width, 780px)) / 2 - 30px));
   display: flex;
   flex-direction: column;
   align-items: center;
@@ -70,7 +70,7 @@
 
 .messages {
   width: 100%;
-  max-width: 780px;
+  max-width: var(--conversation-max-width, 780px);
   margin: 0 auto;
   padding: 18px 28px 24px;
 }

--- a/web/src/routes/detail.module.css
+++ b/web/src/routes/detail.module.css
@@ -1,4 +1,5 @@
 .page {
+  --conversation-max-width: 780px;
   flex: 1;
   min-width: 0;
   display: flex;
@@ -10,7 +11,7 @@
 .composerArea {
   position: relative;
   width: 100%;
-  max-width: 780px;
+  max-width: var(--conversation-max-width, 780px);
   margin: 0 auto;
   padding: 10px 28px 18px;
 }

--- a/web/src/routes/detail.tsx
+++ b/web/src/routes/detail.tsx
@@ -1,8 +1,12 @@
-import { useEffect, useMemo, useCallback, useRef, useState } from "react";
+import { useEffect, useMemo, useCallback, useRef, useState, type CSSProperties } from "react";
 import { useAtom, useSetAtom } from "jotai";
 import { useNavigate, useParams } from "react-router-dom";
 import { Check, Copy } from "lucide-react";
-import { activeSessionIdAtom } from "@/stores/ui";
+import {
+  activeSessionIdAtom,
+  conversationWidthMaxWidth,
+  conversationWidthModeAtom,
+} from "@/stores/ui";
 import {
   recoverCompletedTurnFromStoredMessagesAtom,
   removeApprovalAtom,
@@ -41,6 +45,7 @@ import type {
   ComposerSubmitPayload,
 } from "@/components/chat/composer-types";
 import { MessageTimeline } from "@/components/chat/message-timeline";
+import { ConversationWidthControl } from "@/components/chat/conversation-width-control";
 import {
   hermesUIMessagesToChatMessages,
   attachTurnStatsMetadata,
@@ -58,6 +63,7 @@ export function DetailRoute() {
   const { taskId: urlTaskId } = useParams<{ taskId: string }>();
   const navigate = useNavigate();
   const [activeSessionId, setActiveId] = useAtom(activeSessionIdAtom);
+  const [conversationWidthMode, setConversationWidthMode] = useAtom(conversationWidthModeAtom);
   const taskId = activeSessionId ?? urlTaskId;
   const [turnStats, setTurnStats] = useState<UiTurnStats[]>([]);
 
@@ -347,14 +353,24 @@ export function DetailRoute() {
     selectedContextMax,
     estimatedUsed: estimatedContextUsed,
   });
+  const pageStyle = useMemo(
+    () => ({
+      "--conversation-max-width": conversationWidthMaxWidth(conversationWidthMode),
+    }) as CSSProperties,
+    [conversationWidthMode],
+  );
 
   return (
-    <div className={s.page}>
+    <div className={s.page} data-conversation-width={conversationWidthMode} style={pageStyle}>
       <TopBar
         title={title}
         sub={model ? `本会话 ${model}` : undefined}
         right={
           <>
+            <ConversationWidthControl
+              value={conversationWidthMode}
+              onChange={setConversationWidthMode}
+            />
             {copyableSessionId ? (
               <TopBarActionButton
                 onClick={copySessionId}

--- a/web/src/stores/ui.test.ts
+++ b/web/src/stores/ui.test.ts
@@ -98,6 +98,45 @@ describe("composerSubmitShortcutAtom (persisted)", () => {
   });
 });
 
+describe("conversationWidthModeAtom (persisted)", () => {
+  it("defaults to medium when nothing is stored", async () => {
+    const { conversationWidthModeAtom } = await loadUi();
+    const store = createStore();
+    expect(store.get(conversationWidthModeAtom)).toBe("medium");
+  });
+
+  it("restores a supported width from the UI store", async () => {
+    const { conversationWidthModeAtom } = await loadUi({
+      "hermes.conversation-width": "large",
+    });
+    const store = createStore();
+    expect(store.get(conversationWidthModeAtom)).toBe("large");
+  });
+
+  it("normalizes unsupported stored and written values back to medium", async () => {
+    const { conversationWidthModeAtom, uiStore } = await loadUi({
+      "hermes.conversation-width": "wide",
+    });
+    const store = createStore();
+    expect(store.get(conversationWidthModeAtom)).toBe("medium");
+
+    store.set(conversationWidthModeAtom, "full");
+    expect(uiStore.readUiValue("hermes.conversation-width", "")).toBe("full");
+
+    store.set(conversationWidthModeAtom, "tiny" as never);
+    expect(store.get(conversationWidthModeAtom)).toBe("medium");
+    expect(uiStore.readUiValue("hermes.conversation-width", "")).toBe("medium");
+  });
+
+  it("maps the four width modes to concrete CSS max-width values", async () => {
+    const { conversationWidthMaxWidth } = await loadUi();
+    expect(conversationWidthMaxWidth("small")).toBe("640px");
+    expect(conversationWidthMaxWidth("medium")).toBe("780px");
+    expect(conversationWidthMaxWidth("large")).toBe("960px");
+    expect(conversationWidthMaxWidth("full")).toBe("100%");
+  });
+});
+
 describe("profileSwitchingAtom", () => {
   it("defaults to { active: false }", async () => {
     const { profileSwitchingAtom } = await loadUi();

--- a/web/src/stores/ui.ts
+++ b/web/src/stores/ui.ts
@@ -5,6 +5,41 @@ import { readUiValue, writeUiValue } from "@/lib/ui-store";
 export const activeSessionIdAtom = atom<string | null>(null);
 export const sidebarSearchAtom = atom("");
 
+export const CONVERSATION_WIDTH_OPTIONS = [
+  { value: "small", label: "小", title: "小宽度", maxWidth: "640px" },
+  { value: "medium", label: "中", title: "中等宽度", maxWidth: "780px" },
+  { value: "large", label: "大", title: "大宽度", maxWidth: "960px" },
+  { value: "full", label: "满", title: "铺满宽度", maxWidth: "100%" },
+] as const;
+
+export type ConversationWidthMode = typeof CONVERSATION_WIDTH_OPTIONS[number]["value"];
+
+const DEFAULT_CONVERSATION_WIDTH_MODE: ConversationWidthMode = "medium";
+const CONVERSATION_WIDTH_KEY = "hermes.conversation-width";
+const CONVERSATION_WIDTH_VALUES = CONVERSATION_WIDTH_OPTIONS.map((option) => option.value);
+
+export function normalizeConversationWidthMode(value: unknown): ConversationWidthMode {
+  return CONVERSATION_WIDTH_VALUES.includes(value as ConversationWidthMode)
+    ? (value as ConversationWidthMode)
+    : DEFAULT_CONVERSATION_WIDTH_MODE;
+}
+
+export function conversationWidthMaxWidth(mode: ConversationWidthMode): string {
+  return CONVERSATION_WIDTH_OPTIONS.find((option) => option.value === mode)?.maxWidth ?? "780px";
+}
+
+const conversationWidthModeBaseAtom = atom<ConversationWidthMode>(
+  normalizeConversationWidthMode(readUiValue(CONVERSATION_WIDTH_KEY, DEFAULT_CONVERSATION_WIDTH_MODE)),
+);
+export const conversationWidthModeAtom = atom(
+  (get) => get(conversationWidthModeBaseAtom),
+  (_get, set, next: ConversationWidthMode) => {
+    const value = normalizeConversationWidthMode(next);
+    set(conversationWidthModeBaseAtom, value);
+    writeUiValue(CONVERSATION_WIDTH_KEY, value);
+  },
+);
+
 // Active profile name. Persisted in the UI SQLite store so refresh keeps
 // the user's choice. "default" is the upstream's reserved name for the root
 // HERMES_HOME (~/.hermes), so we use it both as the literal default profile


### PR DESCRIPTION
## 变更内容

- 在会话详情页顶栏增加对话宽度四档控制：small、medium、large、full。
- 将消息流、输入区和轮次导航的固定宽度改为共享 CSS 变量，确保切换后保持同一视觉轴线。
- 增加 UI store 持久化与归一化逻辑，默认保持当前 medium 宽度体验。

## 影响

用户可以根据阅读场景调整对话区域宽度；该偏好是本地 UI 设置，不影响后端接口、会话数据或运行时协议。

## 验证

- `pnpm typecheck`
- `pnpm test:unit`
- `cargo check`
- 已启动桌面端手动验证宽度控件显示与切换。