### PR TITLE
[codex] 统一顶部栏 profile 控件样式

### DIFF
--- a/web/src/components/app-shell/app-top-bar.module.css
+++ b/web/src/components/app-shell/app-top-bar.module.css
@@ -2,6 +2,16 @@
    Inspired by prototypes/.topbar */
 
 .topbar {
+  --h-topbar-control-h: 28px;
+  --h-topbar-control-radius: var(--h-r-sm);
+  --h-topbar-control-bg: var(--h-bg-soft);
+  --h-topbar-control-hover-bg: var(--h-bg-chip);
+  --h-topbar-control-border: var(--h-line);
+  --h-topbar-control-hover-border: var(--h-line);
+  --h-topbar-control-color: var(--h-text-2);
+  --h-topbar-control-hover-color: var(--h-text);
+  --h-topbar-control-transition: color 0.12s, background 0.12s, border-color 0.12s;
+
   height: calc(var(--h-topbar-h) + var(--h-window-control-safe-top, 0px));
   display: flex;
   align-items: center;
@@ -172,19 +182,27 @@
   width: clamp(220px, 28vw, 360px);
   max-width: 360px;
   margin-left: auto;
-  height: 28px;
-  background: var(--h-bg-soft);
-  border: 1px solid var(--h-line);
-  border-radius: 3px;
+  height: var(--h-topbar-control-h);
+  background: var(--h-topbar-control-bg);
+  border: 1px solid var(--h-topbar-control-border);
+  border-radius: var(--h-topbar-control-radius);
   display: flex;
   align-items: center;
   padding: 0 10px;
   gap: 8px;
-  color: var(--h-text-2);
+  color: var(--h-topbar-control-color);
   font-family: var(--h-font-mono);
   font-size: 11px;
+  cursor: pointer;
   -webkit-app-region: no-drag;
   user-select: none;
+  transition: var(--h-topbar-control-transition);
+}
+
+.search:hover {
+  color: var(--h-topbar-control-hover-color);
+  background: var(--h-topbar-control-hover-bg);
+  border-color: var(--h-topbar-control-hover-border);
 }
 
 .searchKbd {
@@ -195,7 +213,7 @@
   border: 1px solid var(--h-line);
   background: var(--h-bg-pane);
   padding: 1px 4px;
-  border-radius: 2px;
+  border-radius: var(--h-r-sm);
   letter-spacing: 0.04em;
 }
 
@@ -208,28 +226,29 @@
 }
 
 .iconBtn {
-  width: 28px;
-  height: 28px;
+  width: var(--h-topbar-control-h);
+  height: var(--h-topbar-control-h);
   display: inline-flex;
   align-items: center;
   justify-content: center;
-  border-radius: 3px;
-  color: var(--h-text-2);
-  border: 1px solid transparent;
-  background: transparent;
+  border-radius: var(--h-topbar-control-radius);
+  color: var(--h-topbar-control-color);
+  border: 1px solid var(--h-topbar-control-border);
+  background: var(--h-topbar-control-bg);
   cursor: pointer;
+  transition: var(--h-topbar-control-transition);
 }
 
 .iconBtn:hover {
-  color: var(--h-text);
-  background: var(--h-bg-soft);
-  border-color: var(--h-line);
+  color: var(--h-topbar-control-hover-color);
+  background: var(--h-topbar-control-hover-bg);
+  border-color: var(--h-topbar-control-hover-border);
 }
 
 .iconBtn[data-active="true"] {
-  color: var(--h-text);
-  background: var(--h-bg-soft);
-  border-color: var(--h-line);
+  color: var(--h-topbar-control-hover-color);
+  background: var(--h-topbar-control-hover-bg);
+  border-color: var(--h-topbar-control-hover-border);
 }
 
 .iconBtn[data-theme-mode="dark"] {

--- a/web/src/components/app-shell/app-top-bar.tsx
+++ b/web/src/components/app-shell/app-top-bar.tsx
@@ -84,7 +84,7 @@ export function AppTopBar() {
       </button>
 
       <div className={s.actions}>
-        <ProfileSelector />
+        <ProfileSelector variant="topbar" />
         <button
           type="button"
           className={s.iconBtn}

--- a/web/src/components/sidebar/profile-selector.module.css
+++ b/web/src/components/sidebar/profile-selector.module.css
@@ -2,12 +2,7 @@
   display: flex;
   align-items: center;
   gap: 8px;
-  width: calc(100% - 12px);
-  margin: 4px 6px 2px;
-  padding: 8px 10px;
-  border-radius: 8px;
   border: 1px solid var(--h-line);
-  background: var(--h-bg-pane);
   color: var(--h-text);
   font-family: var(--h-font-cn);
   font-size: 12.5px;
@@ -16,13 +11,49 @@
   transition: background 0.12s, border-color 0.12s;
 }
 
+.trigger[data-variant="sidebar"] {
+  width: calc(100% - 12px);
+  margin: 4px 6px 2px;
+  padding: 8px 10px;
+  border-radius: var(--h-r-md);
+  background: var(--h-bg-pane);
+}
+
+.trigger[data-variant="topbar"] {
+  flex: 0 0 auto;
+  width: auto;
+  min-width: 132px;
+  max-width: 220px;
+  height: var(--h-topbar-control-h, 28px);
+  margin: 0;
+  padding: 0 10px;
+  border-color: var(--h-topbar-control-border, var(--h-line));
+  border-radius: var(--h-topbar-control-radius, var(--h-r-sm));
+  background: var(--h-topbar-control-bg, var(--h-bg-soft));
+  color: var(--h-topbar-control-color, var(--h-text-2));
+  font-size: 11px;
+  transition: var(--h-topbar-control-transition, background 0.12s, border-color 0.12s);
+}
+
 .trigger:hover {
   background: var(--h-bg-soft);
+}
+
+.trigger[data-variant="topbar"]:hover {
+  border-color: var(--h-topbar-control-hover-border, var(--h-line));
+  background: var(--h-topbar-control-hover-bg, var(--h-bg-soft));
+  color: var(--h-topbar-control-hover-color, var(--h-text));
 }
 
 .trigger[data-state="open"] {
   border-color: var(--h-text-3);
   background: var(--h-bg-soft);
+}
+
+.trigger[data-variant="topbar"][data-state="open"] {
+  border-color: var(--h-topbar-control-hover-border, var(--h-line));
+  background: var(--h-topbar-control-hover-bg, var(--h-bg-soft));
+  color: var(--h-topbar-control-hover-color, var(--h-text));
 }
 
 .trigger:disabled {
@@ -49,19 +80,41 @@
   white-space: nowrap;
 }
 
+.trigger[data-variant="topbar"] .triggerLabel {
+  color: var(--h-topbar-control-color, var(--h-text-2));
+  font-size: 11px;
+  letter-spacing: 0;
+  text-transform: none;
+}
+
+.trigger[data-variant="topbar"] .triggerName {
+  font-size: 12px;
+}
+
 .triggerChevron {
   color: var(--h-text-3);
   flex-shrink: 0;
+}
+
+.trigger[data-variant="topbar"]:hover .triggerLabel,
+.trigger[data-variant="topbar"][data-state="open"] .triggerLabel,
+.trigger[data-variant="topbar"]:hover .triggerChevron,
+.trigger[data-variant="topbar"][data-state="open"] .triggerChevron {
+  color: var(--h-topbar-control-hover-color, var(--h-text));
 }
 
 .menu {
   width: 230px;
   padding: 4px;
   background: var(--h-bg-pane);
-  border-radius: 8px;
+  border-radius: var(--h-r-md);
   border: 1px solid var(--h-line);
-  box-shadow: 0 8px 24px rgba(0, 0, 0, 0.08);
+  box-shadow: var(--h-shadow-l);
   font-family: var(--h-font-cn);
+}
+
+.menu[data-variant="topbar"] {
+  width: 220px;
 }
 
 .menuTitle {
@@ -81,7 +134,7 @@
   padding: 7px 10px;
   border: none;
   background: transparent;
-  border-radius: 5px;
+  border-radius: var(--h-r-sm);
   text-align: left;
   font-family: var(--h-font-mono);
   font-size: 12px;
@@ -151,7 +204,7 @@
   padding: 6px 10px;
   background: var(--h-bg-soft);
   border: 1px solid var(--h-line);
-  border-radius: 6px;
+  border-radius: var(--h-r-sm);
   color: var(--h-text-2);
   font-size: 11px;
   font-family: var(--h-font-cn);
@@ -159,6 +212,16 @@
   display: flex;
   gap: 6px;
   align-items: flex-start;
+}
+
+.restartHint[data-variant="topbar"] {
+  position: absolute;
+  top: calc(var(--h-window-control-safe-top, 0px) + var(--h-topbar-h) - 4px);
+  right: 14px;
+  z-index: 55;
+  width: 280px;
+  margin: 0;
+  box-shadow: var(--h-shadow-l);
 }
 
 .restartHintBody {

--- a/web/src/components/sidebar/profile-selector.tsx
+++ b/web/src/components/sidebar/profile-selector.tsx
@@ -9,7 +9,13 @@ import {
 } from "@/hooks/use-profiles";
 import s from "./profile-selector.module.css";
 
-export function ProfileSelector() {
+type ProfileSelectorVariant = "sidebar" | "topbar";
+
+interface ProfileSelectorProps {
+  variant?: ProfileSelectorVariant;
+}
+
+export function ProfileSelector({ variant = "sidebar" }: ProfileSelectorProps) {
   const navigate = useNavigate();
   const profilesQuery = useProfiles();
   const active = useActiveProfileName();
@@ -50,8 +56,10 @@ export function ProfileSelector() {
           <button
             type="button"
             className={s.trigger}
+            data-variant={variant}
             disabled={isError}
             data-state={open ? "open" : undefined}
+            data-no-drag={variant === "topbar" ? true : undefined}
             title={
               isError
                 ? "无法读取档案（dashboard 离线或没装 hermes-agent-cn fork）"
@@ -66,7 +74,12 @@ export function ProfileSelector() {
           </button>
         </Popover.Trigger>
         <Popover.Portal>
-          <Popover.Content className={s.menu} side="bottom" align="start">
+          <Popover.Content
+            className={s.menu}
+            side="bottom"
+            align={variant === "topbar" ? "end" : "start"}
+            data-variant={variant}
+          >
             <div className={s.menuTitle}>切换档案</div>
             {isLoading ? (
               <div className={s.menuEmpty}>加载中…</div>
@@ -106,7 +119,7 @@ export function ProfileSelector() {
         </Popover.Portal>
       </Popover.Root>
       {restartHint && (
-        <div className={s.restartHint}>
+        <div className={s.restartHint} data-variant={variant}>
           <div className={s.restartHintBody}>
             已切到 <strong>{restartHint}</strong>。
             重启 dashboard 后才会真正加载新档案的 config / sessions。


### PR DESCRIPTION
## 变更说明

这次统一了顶部栏相关控件的视觉样式，让右上角 profile 按钮不再沿用侧边栏卡片式样式，而是与顶部栏搜索框、主题按钮保持一致的高度、圆角、边框和 hover 反馈。

## 影响

- `ProfileSelector` 新增 `variant` 入口，默认仍为侧边栏样式，避免影响原侧边栏布局。
- 顶部栏使用 `variant="topbar"`，并共享顶部栏控件 CSS 变量。
- profile 下拉菜单在顶部栏场景下改为右对齐，切换提示改为浮层定位，避免挤压顶部栏操作区。

## 验证

- `pnpm typecheck`
- `pnpm test:unit`
- `cargo check`
- 本地启动 Vite 后检查顶部栏，确认搜索、profile、主题按钮均为 28px 高、4px 圆角，边框和背景规则一致。