### PR TITLE
[codex] 优化会话历史管理

### DIFF
--- a/web/src/components/app-shell/app-shell.tsx
+++ b/web/src/components/app-shell/app-shell.tsx
@@ -2,7 +2,6 @@ import type { ReactNode } from "react";
 import { AppTopBar } from "./app-top-bar";
 import { AppSidebar } from "./app-sidebar";
 import { AppStatusBar } from "./app-status-bar";
-import { SidebarVersionTag } from "./sidebar-version-tag";
 import { ModelOnboardingGuard } from "./model-onboarding-guard";
 import s from "./app-shell.module.css";
 
@@ -18,7 +17,6 @@ export function AppShell({ children }: AppShellProps) {
       </div>
       <div className={s.sidebarSlot}>
         <AppSidebar />
-        <SidebarVersionTag />
       </div>
       <div className={s.mainSlot}>{children}<ModelOnboardingGuard /></div>
       <div className={s.statusbarSlot}>

--- a/web/src/components/app-shell/app-status-bar.tsx
+++ b/web/src/components/app-shell/app-status-bar.tsx
@@ -6,12 +6,14 @@ import { useModelInfo } from "@/hooks/use-config";
 import { useSessions } from "@/hooks/use-sessions";
 import { useAnalytics } from "@/hooks/use-analytics";
 import { useGatewayRestartAction } from "@/hooks/use-gateway-restart";
+import { useRuntimeInfo } from "@/hooks/use-runtime-update";
 import { chatRuntimeBySessionAtom } from "@/stores/chat";
 import { dashboardPortFromUrl, dashboardUrlFromInputs } from "@/lib/dashboard-url";
 import { openExternalUrl } from "@/lib/external-links";
 import { isSessionRunning } from "@/lib/session-activity";
 import { formatTokens } from "@/lib/format";
 import { gatewayRestartButtonLabel, gatewayRestartTitle } from "@/lib/gateway-restart";
+import { buildSidebarVersionRows } from "./sidebar-version-tag";
 import s from "./app-status-bar.module.css";
 
 function formatModelShort(model: string | null | undefined): string {
@@ -31,6 +33,7 @@ export function AppStatusBar() {
   const { data: modelInfo } = useModelInfo();
   const { data: sessions } = useSessions();
   const { data: analytics } = useAnalytics(1);
+  const { data: runtimeInfo } = useRuntimeInfo();
   const runtimeBySession = useAtomValue(chatRuntimeBySessionAtom);
   const gatewayRestart = useGatewayRestartAction();
 
@@ -46,6 +49,7 @@ export function AppStatusBar() {
   const contextLabel = formatContext(
     modelInfo?.effective_context_length ?? modelInfo?.auto_context_length,
   );
+  const versionRows = buildSidebarVersionRows({ status, runtimeInfo });
 
   const runningCount = useMemo(() => {
     if (!sessions?.sessions) return status?.active_sessions ?? 0;
@@ -109,6 +113,18 @@ export function AppStatusBar() {
       <span className={s.stat}>
         <span className={s.lbl}>上下文</span>
         <span className={s.val}>{contextLabel}</span>
+      </span>
+      <span className={s.sep} />
+      <span className={s.stat} title={versionRows.kernel}>
+        <span className={s.lbl}>内核</span>
+        <span className={s.val}>{versionRows.kernelLine.version}</span>
+        <span className={s.val}>{versionRows.kernelLine.commit}</span>
+      </span>
+      <span className={s.sep} />
+      <span className={s.stat} title={versionRows.ui}>
+        <span className={s.lbl}>界面</span>
+        <span className={s.val}>{versionRows.uiLine.version}</span>
+        <span className={s.val}>{versionRows.uiLine.commit}</span>
       </span>
 
       <div className={s.right}>

--- a/web/src/components/app-shell/capability-sidebar.tsx
+++ b/web/src/components/app-shell/capability-sidebar.tsx
@@ -19,13 +19,14 @@ interface CapabilityItem {
   label: string;
   path: string;
   icon: LucideIcon;
+  shortcut?: string;
   title?: string;
 }
 
 export const CONFIG_ITEMS: readonly CapabilityItem[] = [
   { label: "模型", path: "/models", icon: Cpu },
   { label: "备份恢复", path: "/backup", icon: Archive },
-  { label: "配置迁移", path: "/config-migration", icon: Sparkles },
+  { label: "配置迁移", path: "/config-migration", icon: Sparkles, shortcut: "/migration" },
   {
     label: "档案",
     path: "/profiles",
@@ -86,7 +87,7 @@ export function CapabilitySidebar() {
                     <Icon size={14} />
                   </span>
                   <span className={s.itemLabel}>{item.label}</span>
-                  <span className={s.itemPath}>{item.path}</span>
+                  <span className={s.itemPath}>{item.shortcut ?? item.path}</span>
                 </Link>
               );
             })}

--- a/web/src/components/app-shell/sidebar-version-tag.test.ts
+++ b/web/src/components/app-shell/sidebar-version-tag.test.ts
@@ -53,36 +53,35 @@ function runtimeInfo(overrides: Partial<RuntimeInfo> = {}): RuntimeInfo {
 }
 
 describe("buildSidebarVersionRows", () => {
-  it("shows kernel version, kernel commit and kernel commit date", () => {
+  it("shows kernel and UI versions with short commits only", () => {
     const rows = buildSidebarVersionRows({
       runtimeInfo: runtimeInfo(),
       status: { version: "0.14.0", release_date: "2026.5.29.2" },
       buildCommit: "80157e462c630803571eef1ba17c2a01edfe240f",
-      buildDate: "2026-06-03T16:00:00+08:00",
       desktopVersion: DESKTOP_VERSION,
     });
 
-    expect(rows.kernel).toBe("内核 v0.15.2 · 8820 · 05.29");
-    expect(rows.ui).toBe(`界面 ${DESKTOP_VERSION_LABEL} · 8015 · 06.03`);
-    expect(rows.title).toContain("内核 v0.15.2 · 8820 · 2026-05-29");
-    expect(rows.title).toContain(`界面 ${DESKTOP_VERSION_LABEL} · 8015 · 2026-06-03`);
+    expect(rows.kernel).toBe("内核 v0.15.2 · 8820");
+    expect(rows.ui).toBe(`界面 ${DESKTOP_VERSION_LABEL} · 8015`);
+    expect(rows.title).toBe(`内核 v0.15.2 · 8820\n界面 ${DESKTOP_VERSION_LABEL} · 8015`);
     expect(rows.kernel).not.toContain("2026.5.29.2");
+    expect(rows.title.split("\n")).toHaveLength(2);
+    expect(rows.title).not.toContain("2026-");
   });
 
   it("falls back to status version and unknown kernel metadata without runtime bridge", () => {
     const rows = buildSidebarVersionRows({
       status: { version: "0.15.2", release_date: "2026.5.29.2" },
       buildCommit: "80157e462c630803571eef1ba17c2a01edfe240f",
-      buildDate: "2026-06-03T16:00:00+08:00",
       desktopVersion: DESKTOP_VERSION,
     });
 
-    expect(rows.kernel).toBe("内核 v0.15.2 · — · 日期未知");
-    expect(rows.ui).toBe(`界面 ${DESKTOP_VERSION_LABEL} · 8015 · 06.03`);
+    expect(rows.kernel).toBe("内核 v0.15.2 · —");
+    expect(rows.ui).toBe(`界面 ${DESKTOP_VERSION_LABEL} · 8015`);
     expect(rows.kernel).not.toContain("2026.5.29.2");
   });
 
-  it("shows unknown commit date when the installed kernel commit is absent from recent commits", () => {
+  it("does not depend on recent commit dates", () => {
     const rows = buildSidebarVersionRows({
       runtimeInfo: runtimeInfo({
         source: {
@@ -94,31 +93,28 @@ describe("buildSidebarVersionRows", () => {
         },
       }),
       buildCommit: "80157e462c630803571eef1ba17c2a01edfe240f",
-      buildDate: "2026-06-03T16:00:00+08:00",
       desktopVersion: DESKTOP_VERSION,
     });
 
-    expect(rows.kernel).toBe("内核 v0.15.2 · 8820 · 日期未知");
+    expect(rows.kernel).toBe("内核 v0.15.2 · 8820");
   });
 
   it("shows a dash instead of a hard-coded kernel version when status is unavailable", () => {
     const rows = buildSidebarVersionRows({
       buildCommit: "unknown",
-      buildDate: "unknown",
       desktopVersion: DESKTOP_VERSION,
     });
 
-    expect(rows.kernel).toBe("内核 v— · — · 日期未知");
+    expect(rows.kernel).toBe("内核 v— · —");
   });
 
   it("shows a dash when the UI build commit is unknown", () => {
     const rows = buildSidebarVersionRows({
       runtimeInfo: runtimeInfo(),
       buildCommit: "unknown",
-      buildDate: "2026-06-03T16:00:00+08:00",
       desktopVersion: DESKTOP_VERSION,
     });
 
-    expect(rows.ui).toBe(`界面 ${DESKTOP_VERSION_LABEL} · — · 06.03`);
+    expect(rows.ui).toBe(`界面 ${DESKTOP_VERSION_LABEL} · —`);
   });
 });

--- a/web/src/components/app-shell/sidebar-version-tag.tsx
+++ b/web/src/components/app-shell/sidebar-version-tag.tsx
@@ -1,6 +1,6 @@
 import { useRuntimeInfo } from "@/hooks/use-runtime-update";
 import { useStatus } from "@/hooks/use-status";
-import { BUILD_COMMIT, BUILD_DATE, DESKTOP_VERSION, UNKNOWN_DATE, UNKNOWN_VALUE, versionLabel } from "@/lib/build-info";
+import { BUILD_COMMIT, DESKTOP_VERSION, UNKNOWN_VALUE, versionLabel } from "@/lib/build-info";
 import type { RuntimeInfo, StatusResponse } from "@hermes/protocol";
 import s from "./app-shell.module.css";
 
@@ -11,36 +11,10 @@ function shortCommit(commit: string | undefined): string {
   return normalized.slice(0, 4);
 }
 
-function fullCommitDate(value: string | undefined): string {
-  const normalized = value?.trim() ?? "";
-  if (!normalized || normalized === "unknown") return UNKNOWN_DATE;
-  const datePrefix = normalized.match(/^\d{4}-\d{2}-\d{2}/)?.[0];
-  if (datePrefix) return datePrefix;
-  const date = new Date(normalized);
-  if (Number.isNaN(date.getTime())) return UNKNOWN_DATE;
-  return date.toISOString().slice(0, 10);
-}
-
-function shortCommitDate(value: string | undefined): string {
-  const full = fullCommitDate(value);
-  const match = full.match(/^\d{4}-(\d{2})-(\d{2})$/);
-  return match ? `${match[1]}.${match[2]}` : full;
-}
-
-function runtimeCommitDate(runtimeInfo: RuntimeInfo | undefined, compact: boolean): string {
-  const sourceCommit = runtimeInfo?.current?.sourceCommit?.trim();
-  if (!sourceCommit) return UNKNOWN_DATE;
-  const match = runtimeInfo?.source?.recentCommits.find((commit) =>
-    commit.hash === sourceCommit || commit.hash.startsWith(sourceCommit) || sourceCommit.startsWith(commit.hash),
-  );
-  return compact ? shortCommitDate(match?.date) : fullCommitDate(match?.date);
-}
-
 export interface SidebarVersionRowsInput {
   status?: Pick<StatusResponse, "version" | "release_date">;
   runtimeInfo?: RuntimeInfo;
   buildCommit?: string;
-  buildDate?: string;
   desktopVersion?: string;
 }
 
@@ -48,7 +22,6 @@ export interface SidebarVersionLine {
   label: "内核" | "界面";
   version: string;
   commit: string;
-  date: string;
 }
 
 export interface SidebarVersionRows {
@@ -63,34 +36,27 @@ export function buildSidebarVersionRows({
   status,
   runtimeInfo,
   buildCommit = BUILD_COMMIT,
-  buildDate = BUILD_DATE,
   desktopVersion = DESKTOP_VERSION,
 }: SidebarVersionRowsInput): SidebarVersionRows {
   const kernelVersion = versionLabel(runtimeInfo?.current?.kernelVersion ?? status?.version);
   const kernelCommit = shortCommit(runtimeInfo?.current?.sourceCommit);
-  const kernelDate = runtimeCommitDate(runtimeInfo, true);
-  const kernelFullDate = runtimeCommitDate(runtimeInfo, false);
   const uiVersion = versionLabel(desktopVersion);
   const uiCommit = shortCommit(buildCommit);
-  const uiDate = shortCommitDate(buildDate);
-  const uiFullDate = fullCommitDate(buildDate);
 
   return {
-    kernel: `内核 ${kernelVersion} · ${kernelCommit} · ${kernelDate}`,
-    ui: `界面 ${uiVersion} · ${uiCommit} · ${uiDate}`,
+    kernel: `内核 ${kernelVersion} · ${kernelCommit}`,
+    ui: `界面 ${uiVersion} · ${uiCommit}`,
     kernelLine: {
       label: "内核",
       version: kernelVersion,
       commit: kernelCommit,
-      date: kernelDate,
     },
     uiLine: {
       label: "界面",
       version: uiVersion,
       commit: uiCommit,
-      date: uiDate,
     },
-    title: `内核 ${kernelVersion} · ${kernelCommit} · ${kernelFullDate}\n界面 ${uiVersion} · ${uiCommit} · ${uiFullDate}\n预览版本，不代表最终品质`,
+    title: `内核 ${kernelVersion} · ${kernelCommit}\n界面 ${uiVersion} · ${uiCommit}`,
   };
 }
 
@@ -112,8 +78,6 @@ function VersionLine({
       <span className={s.sidebarInfoCell}>{line.version}</span>
       <span className={s.sidebarInfoDot} aria-hidden="true">·</span>
       <span className={s.sidebarInfoCell}>{line.commit}</span>
-      <span className={s.sidebarInfoDot} aria-hidden="true">·</span>
-      <span className={s.sidebarInfoCell}>{line.date}</span>
     </div>
   );
 }
@@ -132,7 +96,6 @@ export function SidebarVersionTag() {
         <VersionLine accent line={rows.kernelLine} text={rows.kernel} />
         <VersionLine line={rows.uiLine} text={rows.ui} />
       </div>
-      <div className={s.sidebarInfoNote}>预览版本，不代表最终品质</div>
     </div>
   );
 }

--- a/web/src/components/app-shell/workbench-sidebar.module.css
+++ b/web/src/components/app-shell/workbench-sidebar.module.css
@@ -98,11 +98,11 @@
   margin: 0 12px 10px;
   display: flex;
   flex-direction: column;
-  gap: 6px;
+  gap: 4px;
 }
 
 .quickNavButton {
-  height: 32px;
+  height: 30px;
   width: 100%;
   display: grid;
   grid-template-columns: 20px minmax(0, 1fr);

--- a/web/src/components/app-shell/workbench-sidebar.module.css
+++ b/web/src/components/app-shell/workbench-sidebar.module.css
@@ -29,7 +29,7 @@
 }
 
 .newTask {
-  margin: 12px 12px 6px;
+  margin: 12px 12px 8px;
   height: 36px;
   background: var(--persimmon);
   color: #1a0c04;
@@ -67,45 +67,49 @@
   letter-spacing: 0.04em;
 }
 
-.searchRow {
+.quickNav {
   margin: 0 12px 10px;
-  height: 28px;
-  background: var(--h-bg-soft);
-  border: 1px solid var(--h-line);
-  border-radius: 3px;
   display: flex;
-  align-items: center;
-  justify-content: space-between;
-  padding: 0 10px;
-  color: var(--h-text-2);
-  font-family: var(--h-font-mono);
-  font-size: 11px;
-  cursor: pointer;
-  user-select: none;
+  flex-direction: column;
+  gap: 6px;
 }
 
-.searchRow:hover {
+.quickNavButton {
+  height: 32px;
+  width: 100%;
+  display: flex;
+  align-items: center;
+  gap: 8px;
+  padding: 0 11px;
+  border: 1px solid var(--h-line);
+  background: var(--h-bg-soft);
+  border-radius: 3px;
+  color: var(--h-text-2);
+  font-family: var(--h-font-cn);
+  font-size: 12.5px;
+  font-weight: 500;
+  cursor: pointer;
+  text-align: left;
+}
+
+.quickNavButton:hover {
   color: var(--h-text);
   background: var(--h-bg-chip);
 }
 
-.searchLead {
-  display: inline-flex;
-  align-items: center;
-  gap: 7px;
+.quickNavButton[data-active="true"] {
+  color: var(--h-text);
+  border-color: color-mix(in srgb, var(--h-accent) 48%, var(--h-line));
+  background: color-mix(in srgb, var(--h-accent) 12%, var(--h-bg-chip));
 }
 
-.searchKbd {
-  font-family: var(--h-font-mono);
-  font-size: 9.5px;
+.quickNavButton svg {
   color: var(--h-text-3);
-  border: 1px solid var(--h-line);
-  background: var(--h-bg-pane);
-  padding: 1px 5px;
-  border-radius: 2px;
-  letter-spacing: 0.04em;
-  min-width: 14px;
-  text-align: center;
+  flex-shrink: 0;
+}
+
+.quickNavButton[data-active="true"] svg {
+  color: var(--h-accent);
 }
 
 .scrollY {

--- a/web/src/components/app-shell/workbench-sidebar.module.css
+++ b/web/src/components/app-shell/workbench-sidebar.module.css
@@ -115,7 +115,7 @@
   color: var(--h-text-2);
   font-family: var(--h-font-cn);
   font-size: 13.5px;
-  font-weight: 600;
+  font-weight: 400;
   line-height: 1;
   letter-spacing: 0.01em;
   cursor: pointer;

--- a/web/src/components/app-shell/workbench-sidebar.module.css
+++ b/web/src/components/app-shell/workbench-sidebar.module.css
@@ -52,24 +52,34 @@
 }
 
 .newTaskLead {
-  display: inline-flex;
+  display: inline-grid;
+  grid-template-columns: 20px minmax(0, auto);
   align-items: center;
-  gap: 8px;
+  column-gap: 8px;
   min-width: 0;
 }
 
-.newTaskLead svg,
-.quickNavButton svg {
+.entryIcon {
+  width: 20px;
+  height: 20px;
+  display: inline-flex;
+  align-items: center;
+  justify-content: center;
+  line-height: 0;
+}
+
+.entryIcon svg {
   display: block;
   width: 16px;
   height: 16px;
-  flex: 0 0 16px;
 }
 
-.newTaskLead span,
-.quickNavButton span {
+.entryLabel {
   display: block;
-  line-height: 16px;
+  min-width: 0;
+  height: 20px;
+  line-height: 20px;
+  white-space: nowrap;
 }
 
 .newTaskKbd {
@@ -93,9 +103,10 @@
 .quickNavButton {
   height: 32px;
   width: 100%;
-  display: flex;
+  display: grid;
+  grid-template-columns: 20px minmax(0, 1fr);
   align-items: center;
-  gap: 8px;
+  column-gap: 8px;
   padding: 0 11px;
   border: 1px solid var(--h-line);
   background: var(--h-bg-soft);
@@ -121,11 +132,11 @@
   background: color-mix(in srgb, var(--h-accent) 12%, var(--h-bg-chip));
 }
 
-.quickNavButton svg {
+.quickNavButton .entryIcon {
   color: var(--h-text-3);
 }
 
-.quickNavButton[data-active="true"] svg {
+.quickNavButton[data-active="true"] .entryIcon {
   color: var(--h-accent);
 }
 

--- a/web/src/components/app-shell/workbench-sidebar.module.css
+++ b/web/src/components/app-shell/workbench-sidebar.module.css
@@ -213,9 +213,32 @@
   display: flex;
   align-items: center;
   gap: 8px;
+  width: 100%;
+  min-width: 0;
   font-family: var(--h-font-mono);
   font-size: 10px;
   color: var(--h-text-3);
+}
+
+.metaText {
+  min-width: 0;
+  overflow: hidden;
+  text-overflow: ellipsis;
+  white-space: nowrap;
+}
+
+.metaProject {
+  flex: 0 1 48%;
+  min-width: 0;
+  margin-left: auto;
+  overflow: hidden;
+  color: var(--h-text-3);
+  font-family: var(--h-font-cn);
+  font-size: 10px;
+  line-height: 1.25;
+  text-align: right;
+  text-overflow: ellipsis;
+  white-space: nowrap;
 }
 
 .sideItem {

--- a/web/src/components/app-shell/workbench-sidebar.module.css
+++ b/web/src/components/app-shell/workbench-sidebar.module.css
@@ -78,7 +78,26 @@
   display: block;
   min-width: 0;
   height: 20px;
+  overflow: hidden;
   line-height: 20px;
+  text-overflow: ellipsis;
+  transform: translateY(1px);
+  white-space: nowrap;
+}
+
+.entryCommand {
+  display: block;
+  min-width: 0;
+  height: 20px;
+  overflow: hidden;
+  color: var(--h-text-3);
+  font-family: var(--h-font-mono);
+  font-size: 11px;
+  font-weight: 400;
+  letter-spacing: 0.02em;
+  line-height: 20px;
+  text-align: right;
+  text-overflow: ellipsis;
   transform: translateY(1px);
   white-space: nowrap;
 }
@@ -105,7 +124,7 @@
   height: 30px;
   width: 100%;
   display: grid;
-  grid-template-columns: 20px minmax(0, 1fr);
+  grid-template-columns: 20px minmax(0, 1fr) auto;
   align-items: center;
   column-gap: 8px;
   padding: 0 11px;

--- a/web/src/components/app-shell/workbench-sidebar.module.css
+++ b/web/src/components/app-shell/workbench-sidebar.module.css
@@ -270,16 +270,16 @@
   height: 5px;
   border-radius: 50%;
   flex-shrink: 0;
-  background: var(--h-text-3);
+  background: transparent;
 }
 
 .dot[data-state="live"] {
-  background: var(--h-accent);
-  box-shadow: 0 0 0 3px rgba(255, 122, 61, 0.18);
+  background: var(--h-ok);
+  box-shadow: 0 0 0 3px color-mix(in srgb, var(--h-ok) 22%, transparent);
 }
 
 .dot[data-state="ok"] {
-  background: var(--moss);
+  background: var(--h-warn);
 }
 
 .dot[data-state="err"] {

--- a/web/src/components/app-shell/workbench-sidebar.module.css
+++ b/web/src/components/app-shell/workbench-sidebar.module.css
@@ -114,30 +114,32 @@
 }
 
 .quickNav {
-  margin: 0 12px 10px;
+  margin: 0 0 8px;
   display: flex;
   flex-direction: column;
-  gap: 4px;
 }
 
 .quickNavButton {
-  height: 30px;
+  appearance: none;
+  box-sizing: border-box;
+  min-height: 34px;
   width: 100%;
-  display: grid;
-  grid-template-columns: 20px minmax(0, 1fr) auto;
+  display: flex;
   align-items: center;
-  column-gap: 8px;
-  padding: 0 11px;
-  border: 1px solid var(--h-line);
-  background: var(--h-bg-soft);
-  border-radius: 3px;
+  gap: 8px;
+  padding: 6px 16px;
+  border-left: 2px solid transparent;
+  border-right: none;
+  border-top: none;
+  border-bottom: none;
+  background: transparent;
   color: var(--h-text-2);
   font-family: var(--h-font-cn);
-  font-size: 13.5px;
+  font-size: 12.5px;
   font-weight: 400;
-  line-height: 1;
-  letter-spacing: 0.01em;
+  line-height: var(--h-lh);
   cursor: pointer;
+  position: relative;
   text-align: left;
 }
 
@@ -146,14 +148,42 @@
   background: var(--h-bg-chip);
 }
 
+.quickNavButton:focus-visible {
+  outline: 2px solid color-mix(in srgb, var(--h-accent) 45%, transparent);
+  outline-offset: -2px;
+}
+
 .quickNavButton[data-active="true"] {
   color: var(--h-text);
-  border-color: color-mix(in srgb, var(--h-accent) 48%, var(--h-line));
-  background: color-mix(in srgb, var(--h-accent) 12%, var(--h-bg-chip));
+  background: var(--h-bg-chip);
+  border-left-color: var(--h-accent);
 }
 
 .quickNavButton .entryIcon {
+  width: 14px;
+  height: 14px;
   color: var(--h-text-3);
+  flex-shrink: 0;
+}
+
+.quickNavButton .entryIcon svg {
+  width: 14px;
+  height: 14px;
+}
+
+.quickNavButton .entryLabel {
+  flex: 1;
+  height: auto;
+  line-height: var(--h-lh);
+  transform: none;
+}
+
+.quickNavButton .entryCommand {
+  flex-shrink: 0;
+  height: auto;
+  font-size: 9.5px;
+  line-height: var(--h-lh);
+  transform: none;
 }
 
 .quickNavButton[data-active="true"] .entryIcon {

--- a/web/src/components/app-shell/workbench-sidebar.module.css
+++ b/web/src/components/app-shell/workbench-sidebar.module.css
@@ -114,7 +114,9 @@
 }
 
 .quickNav {
-  margin: 0 0 8px;
+  margin: 0 0 4px;
+  padding-bottom: 8px;
+  border-bottom: 1px solid var(--h-line-soft);
   display: flex;
   flex-direction: column;
 }

--- a/web/src/components/app-shell/workbench-sidebar.module.css
+++ b/web/src/components/app-shell/workbench-sidebar.module.css
@@ -238,6 +238,7 @@
 }
 
 .metaText {
+  flex: 0 0 auto;
   min-width: 0;
   overflow: hidden;
   text-overflow: ellipsis;
@@ -245,7 +246,7 @@
 }
 
 .metaProject {
-  flex: 0 1 48%;
+  flex: 1 1 auto;
   min-width: 0;
   margin-left: auto;
   overflow: hidden;

--- a/web/src/components/app-shell/workbench-sidebar.module.css
+++ b/web/src/components/app-shell/workbench-sidebar.module.css
@@ -79,6 +79,7 @@
   min-width: 0;
   height: 20px;
   line-height: 20px;
+  transform: translateY(1px);
   white-space: nowrap;
 }
 

--- a/web/src/components/app-shell/workbench-sidebar.module.css
+++ b/web/src/components/app-shell/workbench-sidebar.module.css
@@ -39,7 +39,8 @@
   justify-content: space-between;
   padding: 0 12px;
   font-weight: 600;
-  font-size: 12px;
+  font-size: 13.5px;
+  line-height: 1;
   letter-spacing: 0.01em;
   border: none;
   cursor: pointer;
@@ -53,7 +54,22 @@
 .newTaskLead {
   display: inline-flex;
   align-items: center;
-  gap: 7px;
+  gap: 8px;
+  min-width: 0;
+}
+
+.newTaskLead svg,
+.quickNavButton svg {
+  display: block;
+  width: 16px;
+  height: 16px;
+  flex: 0 0 16px;
+}
+
+.newTaskLead span,
+.quickNavButton span {
+  display: block;
+  line-height: 16px;
 }
 
 .newTaskKbd {
@@ -86,8 +102,10 @@
   border-radius: 3px;
   color: var(--h-text-2);
   font-family: var(--h-font-cn);
-  font-size: 12.5px;
-  font-weight: 500;
+  font-size: 13.5px;
+  font-weight: 600;
+  line-height: 1;
+  letter-spacing: 0.01em;
   cursor: pointer;
   text-align: left;
 }
@@ -105,7 +123,6 @@
 
 .quickNavButton svg {
   color: var(--h-text-3);
-  flex-shrink: 0;
 }
 
 .quickNavButton[data-active="true"] svg {

--- a/web/src/components/app-shell/workbench-sidebar.tsx
+++ b/web/src/components/app-shell/workbench-sidebar.tsx
@@ -195,8 +195,10 @@ export function WorkbenchSidebar() {
     <aside className={s.sidebar}>
       <button type="button" className={s.newTask} onClick={() => navigate("/")}>
         <span className={s.newTaskLead}>
-          <Plus size={14} strokeWidth={2.2} />
-          <span>新建对话</span>
+          <span className={s.entryIcon}>
+            <Plus size={16} strokeWidth={2.2} />
+          </span>
+          <span className={s.entryLabel}>新建对话</span>
         </span>
         <span className={s.newTaskKbd}>⌘ N</span>
       </button>
@@ -208,8 +210,10 @@ export function WorkbenchSidebar() {
           data-active={location.pathname.startsWith("/history") ? "true" : undefined}
           onClick={() => navigate("/history")}
         >
-          <MessageSquare size={14} />
-          <span>对话历史</span>
+          <span className={s.entryIcon}>
+            <MessageSquare size={16} />
+          </span>
+          <span className={s.entryLabel}>对话历史</span>
         </button>
         <button
           type="button"
@@ -217,8 +221,10 @@ export function WorkbenchSidebar() {
           data-active={location.pathname.startsWith("/projects") ? "true" : undefined}
           onClick={() => navigate("/projects")}
         >
-          <Folder size={14} />
-          <span>工作空间</span>
+          <span className={s.entryIcon}>
+            <Folder size={16} />
+          </span>
+          <span className={s.entryLabel}>工作空间</span>
         </button>
       </div>
 

--- a/web/src/components/app-shell/workbench-sidebar.tsx
+++ b/web/src/components/app-shell/workbench-sidebar.tsx
@@ -16,9 +16,11 @@ import {
 import { deriveSidebarSessionLists } from "@/lib/sidebar-session-lists";
 import {
   readPinnedWorkspaceProjectPaths,
+  readSessionWorkspaceMap,
   readWorkspaceProjects,
   subscribeWorkspaceChanges,
   unpinWorkspaceProjects,
+  workspaceNameFromPath,
   type WorkspaceProject,
 } from "@/lib/workspaces";
 import type { SessionSummary } from "@hermes/protocol";
@@ -57,10 +59,11 @@ interface SessionRowProps {
   state: "live" | "ok" | "err" | "idle";
   active: boolean;
   meta: string;
+  projectName?: string;
   onClick: () => void;
 }
 
-function SessionRow({ session, state, active, meta, onClick }: SessionRowProps) {
+function SessionRow({ session, state, active, meta, projectName, onClick }: SessionRowProps) {
   const title = sessionDisplayTitle(session);
   return (
     <button
@@ -74,7 +77,14 @@ function SessionRow({ session, state, active, meta, onClick }: SessionRowProps) 
         <span className={s.dot} data-state={state === "idle" ? undefined : state} />
         <span className={s.ttlText}>{title}</span>
       </div>
-      <div className={s.meta}>{meta}</div>
+      <div className={s.meta}>
+        <span className={s.metaText}>{meta}</span>
+        {projectName ? (
+          <span className={s.metaProject} title={projectName}>
+            {projectName}
+          </span>
+        ) : null}
+      </div>
     </button>
   );
 }
@@ -89,6 +99,7 @@ export function WorkbenchSidebar() {
   const [pinnedSessionIds, setPinnedSessionIds] = useState(readPinnedSessionIds);
   const [projects, setProjects] = useState<WorkspaceProject[]>(readWorkspaceProjects);
   const [pinnedProjectPaths, setPinnedProjectPaths] = useState(readPinnedWorkspaceProjectPaths);
+  const [sessionWorkspaceMap, setSessionWorkspaceMap] = useState(readSessionWorkspaceMap);
 
   useEffect(
     () =>
@@ -103,6 +114,7 @@ export function WorkbenchSidebar() {
       subscribeWorkspaceChanges(() => {
         setProjects(readWorkspaceProjects());
         setPinnedProjectPaths(readPinnedWorkspaceProjectPaths());
+        setSessionWorkspaceMap(readSessionWorkspaceMap());
       }),
     [],
   );
@@ -145,6 +157,16 @@ export function WorkbenchSidebar() {
     },
     [pinnedProjectPaths, projects],
   );
+
+  const projectNameBySessionId = useMemo(() => {
+    const projectNameByPath = new Map(projects.map((project) => [project.path, project.name]));
+    return new Map(
+      Object.entries(sessionWorkspaceMap).flatMap(([sessionId, workspacePath]) => {
+        const projectName = projectNameByPath.get(workspacePath) ?? workspaceNameFromPath(workspacePath);
+        return projectName ? [[sessionId, projectName]] : [];
+      }),
+    );
+  }, [projects, sessionWorkspaceMap]);
 
   useEffect(() => {
     if (pinnedProjectPaths.size === 0) return;
@@ -216,6 +238,7 @@ export function WorkbenchSidebar() {
                 state="live"
                 active={sess.id === activeSessionId}
                 meta={`${modelShort(sess.model)} · ${elapsed(sess.started_at, now)}`}
+                projectName={projectNameBySessionId.get(sess.id)}
                 onClick={() => goSession(sess)}
               />
             ))
@@ -244,6 +267,7 @@ export function WorkbenchSidebar() {
                   state={state}
                   active={sess.id === activeSessionId}
                   meta={running ? `${modelShort(sess.model)} · ${elapsed(sess.started_at, now)}` : relTime(ts, now)}
+                  projectName={projectNameBySessionId.get(sess.id)}
                   onClick={() => goSession(sess)}
                 />
               );
@@ -308,6 +332,7 @@ export function WorkbenchSidebar() {
                   state={state}
                   active={sess.id === activeSessionId}
                   meta={meta}
+                  projectName={projectNameBySessionId.get(sess.id)}
                   onClick={() => goSession(sess)}
                 />
               );

--- a/web/src/components/app-shell/workbench-sidebar.tsx
+++ b/web/src/components/app-shell/workbench-sidebar.tsx
@@ -1,7 +1,7 @@
 import { useEffect, useMemo, useState } from "react";
 import { useAtomValue, useSetAtom } from "jotai";
 import { useNavigate, useLocation } from "react-router-dom";
-import { Folder, MessageSquare, Plus, Search } from "lucide-react";
+import { Folder, MessageSquare, Plus } from "lucide-react";
 import { chatRuntimeBySessionAtom } from "@/stores/chat";
 import { activeSessionIdAtom } from "@/stores/ui";
 import { useSessions } from "@/hooks/use-sessions";
@@ -162,9 +162,10 @@ export function WorkbenchSidebar() {
     ? decodeURIComponent(location.pathname.slice("/tasks/".length))
     : null;
   const showPinned = pinned.length > 0;
-  const pinnedProjectSectionIndex = showPinned ? 4 : 3;
+  const pinnedProjectSectionIndex = showPinned ? 3 : 2;
   const recentSectionIndex = pinnedProjectSectionIndex + 1;
-  const pinnedSessionSectionLabel = sectionLabel(3, "置顶对话");
+  const activeSectionLabel = sectionLabel(1, "进行中");
+  const pinnedSessionSectionLabel = sectionLabel(2, "置顶对话");
   const pinnedProjectSectionLabel = sectionLabel(pinnedProjectSectionIndex, "置顶项目");
   const recentSectionLabel = sectionLabel(recentSectionIndex, "最近对话");
 
@@ -178,47 +179,31 @@ export function WorkbenchSidebar() {
         <span className={s.newTaskKbd}>⌘ N</span>
       </button>
 
-      <button type="button" className={s.searchRow} onClick={() => navigate("/history")}>
-        <span className={s.searchLead}>
-          <Search size={13} />
-          <span>搜索…</span>
-        </span>
-        <span className={s.searchKbd}>/</span>
-      </button>
+      <div className={s.quickNav}>
+        <button
+          type="button"
+          className={s.quickNavButton}
+          data-active={location.pathname.startsWith("/history") ? "true" : undefined}
+          onClick={() => navigate("/history")}
+        >
+          <MessageSquare size={14} />
+          <span>对话历史</span>
+        </button>
+        <button
+          type="button"
+          className={s.quickNavButton}
+          data-active={location.pathname.startsWith("/projects") ? "true" : undefined}
+          onClick={() => navigate("/projects")}
+        >
+          <Folder size={14} />
+          <span>工作空间</span>
+        </button>
+      </div>
 
       <div className={s.scrollY}>
         <section className={s.section}>
           <div className={s.label}>
-            <span>§01 · 工作台</span>
-            <span className={s.labelNum}>✕✕</span>
-          </div>
-          <button
-            type="button"
-            className={s.sideItem}
-            data-active={location.pathname.startsWith("/history") ? "true" : undefined}
-            onClick={() => navigate("/history")}
-          >
-            <span className={s.sideItemIcon}>
-              <MessageSquare size={14} />
-            </span>
-            <span className={s.sideItemLabel}>对话历史</span>
-          </button>
-          <button
-            type="button"
-            className={s.sideItem}
-            data-active={location.pathname.startsWith("/projects") ? "true" : undefined}
-            onClick={() => navigate("/projects")}
-          >
-            <span className={s.sideItemIcon}>
-              <Folder size={14} />
-            </span>
-            <span className={s.sideItemLabel}>工作空间</span>
-          </button>
-        </section>
-
-        <section className={s.section}>
-          <div className={s.label}>
-            <span>§02 · 进行中</span>
+            <span>{activeSectionLabel}</span>
             <span className={s.labelNum}>✕✕</span>
           </div>
           {active.length === 0 ? (

--- a/web/src/components/app-shell/workbench-sidebar.tsx
+++ b/web/src/components/app-shell/workbench-sidebar.tsx
@@ -65,6 +65,7 @@ interface SessionRowProps {
 
 function SessionRow({ session, state, active, meta, projectName, onClick }: SessionRowProps) {
   const title = sessionDisplayTitle(session);
+  const dotState = state === "idle" ? undefined : state;
   return (
     <button
       type="button"
@@ -74,7 +75,7 @@ function SessionRow({ session, state, active, meta, projectName, onClick }: Sess
       title={title}
     >
       <div className={s.ttl}>
-        <span className={s.dot} data-state={state === "idle" ? undefined : state} />
+        <span className={s.dot} data-state={dotState} />
         <span className={s.ttlText}>{title}</span>
       </div>
       <div className={s.meta}>

--- a/web/src/components/app-shell/workbench-sidebar.tsx
+++ b/web/src/components/app-shell/workbench-sidebar.tsx
@@ -15,14 +15,14 @@ import {
 } from "@/lib/session-ui-state";
 import { deriveSidebarSessionLists } from "@/lib/sidebar-session-lists";
 import {
+  readPinnedWorkspaceProjectPaths,
   readWorkspaceProjects,
   subscribeWorkspaceChanges,
+  unpinWorkspaceProjects,
   type WorkspaceProject,
 } from "@/lib/workspaces";
 import type { SessionSummary } from "@hermes/protocol";
 import s from "./workbench-sidebar.module.css";
-
-const PROJECT_QUICK_LIMIT = 6;
 
 function relTime(unixSec: number, now: Date) {
   const d = new Date(unixSec * 1000);
@@ -46,6 +46,10 @@ function elapsed(unixSec: number, now: Date) {
 function modelShort(model: string | null | undefined) {
   if (!model) return "—";
   return model.replace(/^claude-/, "").replace(/-\d{8}$/, "");
+}
+
+function sectionLabel(index: number, label: string): string {
+  return `§${index.toString().padStart(2, "0")} · ${label}`;
 }
 
 interface SessionRowProps {
@@ -84,6 +88,7 @@ export function WorkbenchSidebar() {
   const [titleOverrides, setTitleOverrides] = useState(readSessionTitleOverrides);
   const [pinnedSessionIds, setPinnedSessionIds] = useState(readPinnedSessionIds);
   const [projects, setProjects] = useState<WorkspaceProject[]>(readWorkspaceProjects);
+  const [pinnedProjectPaths, setPinnedProjectPaths] = useState(readPinnedWorkspaceProjectPaths);
 
   useEffect(
     () =>
@@ -93,7 +98,14 @@ export function WorkbenchSidebar() {
       }),
     [],
   );
-  useEffect(() => subscribeWorkspaceChanges(() => setProjects(readWorkspaceProjects())), []);
+  useEffect(
+    () =>
+      subscribeWorkspaceChanges(() => {
+        setProjects(readWorkspaceProjects());
+        setPinnedProjectPaths(readPinnedWorkspaceProjectPaths());
+      }),
+    [],
+  );
 
   const sessions = useMemo(
     () =>
@@ -123,10 +135,23 @@ export function WorkbenchSidebar() {
     [pinnedSessionIds, runtimeBySession, sessions],
   );
 
-  const sortedProjects = useMemo(
-    () => [...projects].sort((a, b) => b.updatedAt - a.updatedAt).slice(0, PROJECT_QUICK_LIMIT),
-    [projects],
+  const pinnedProjects = useMemo(
+    () => {
+      const projectByPath = new Map(projects.map((project) => [project.path, project]));
+      return Array.from(pinnedProjectPaths).flatMap((path) => {
+        const project = projectByPath.get(path);
+        return project ? [project] : [];
+      });
+    },
+    [pinnedProjectPaths, projects],
   );
+
+  useEffect(() => {
+    if (pinnedProjectPaths.size === 0) return;
+    const livePaths = new Set(projects.map((project) => project.path));
+    const stalePaths = Array.from(pinnedProjectPaths).filter((path) => !livePaths.has(path));
+    if (stalePaths.length > 0) setPinnedProjectPaths(unpinWorkspaceProjects(stalePaths));
+  }, [pinnedProjectPaths, projects]);
 
   const goSession = (sess: SessionSummary) => {
     setActiveId(sess.id);
@@ -137,8 +162,11 @@ export function WorkbenchSidebar() {
     ? decodeURIComponent(location.pathname.slice("/tasks/".length))
     : null;
   const showPinned = pinned.length > 0;
-  const recentSectionLabel = showPinned ? "§04 · 最近对话" : "§03 · 最近对话";
-  const projectSectionLabel = showPinned ? "§05 · 项目快捷" : "§04 · 项目快捷";
+  const pinnedProjectSectionIndex = showPinned ? 4 : 3;
+  const recentSectionIndex = pinnedProjectSectionIndex + 1;
+  const pinnedSessionSectionLabel = sectionLabel(3, "置顶对话");
+  const pinnedProjectSectionLabel = sectionLabel(pinnedProjectSectionIndex, "置顶项目");
+  const recentSectionLabel = sectionLabel(recentSectionIndex, "最近对话");
 
   return (
     <aside className={s.sidebar}>
@@ -212,7 +240,7 @@ export function WorkbenchSidebar() {
         {showPinned ? (
           <section className={s.section}>
             <div className={s.label}>
-              <span>§03 · 置顶对话</span>
+              <span>{pinnedSessionSectionLabel}</span>
               <span className={s.labelNum}>✕✕</span>
             </div>
             {pinned.map((sess) => {
@@ -240,6 +268,44 @@ export function WorkbenchSidebar() {
 
         <section className={s.section}>
           <div className={s.label}>
+            <span>{pinnedProjectSectionLabel}</span>
+            <span className={s.labelNum}>✕✕</span>
+          </div>
+          {pinnedProjects.length === 0 ? (
+            <button
+              type="button"
+              className={s.sideItem}
+              onClick={() => navigate("/projects")}
+            >
+              <span className={s.sideItemIcon}>
+                <Folder size={14} />
+              </span>
+              <span className={s.sideItemLabel}>暂无置顶项目</span>
+            </button>
+          ) : (
+            pinnedProjects.map((proj) => {
+              const target = `/projects/${encodeURIComponent(proj.path)}`;
+              return (
+                <button
+                  type="button"
+                  key={proj.path}
+                  className={s.sideItem}
+                  data-active={location.pathname === target ? "true" : undefined}
+                  onClick={() => navigate(target)}
+                  title={proj.path}
+                >
+                  <span className={s.sideItemIcon}>
+                    <Folder size={14} />
+                  </span>
+                  <span className={s.sideItemLabel}>{proj.name}</span>
+                </button>
+              );
+            })
+          )}
+        </section>
+
+        <section className={s.section}>
+          <div className={s.label}>
             <span>{recentSectionLabel}</span>
             <span className={s.labelNum}>✕✕</span>
           </div>
@@ -259,44 +325,6 @@ export function WorkbenchSidebar() {
                   meta={meta}
                   onClick={() => goSession(sess)}
                 />
-              );
-            })
-          )}
-        </section>
-
-        <section className={s.section}>
-          <div className={s.label}>
-            <span>{projectSectionLabel}</span>
-            <span className={s.labelNum}>✕✕</span>
-          </div>
-          {sortedProjects.length === 0 ? (
-            <button
-              type="button"
-              className={s.sideItem}
-              onClick={() => navigate("/projects")}
-            >
-              <span className={s.sideItemIcon}>
-                <Folder size={14} />
-              </span>
-              <span className={s.sideItemLabel}>暂无项目</span>
-            </button>
-          ) : (
-            sortedProjects.map((proj) => {
-              const target = `/projects/${encodeURIComponent(proj.path)}`;
-              return (
-                <button
-                  type="button"
-                  key={proj.path}
-                  className={s.sideItem}
-                  data-active={location.pathname === target ? "true" : undefined}
-                  onClick={() => navigate(target)}
-                  title={proj.path}
-                >
-                  <span className={s.sideItemIcon}>
-                    <Folder size={14} />
-                  </span>
-                  <span className={s.sideItemLabel}>{proj.name}</span>
-                </button>
               );
             })
           )}

--- a/web/src/components/app-shell/workbench-sidebar.tsx
+++ b/web/src/components/app-shell/workbench-sidebar.tsx
@@ -8,9 +8,12 @@ import { useSessions } from "@/hooks/use-sessions";
 import { isSessionRunning } from "@/lib/session-activity";
 import { sessionDisplayTitle } from "@/lib/session-title";
 import {
+  readPinnedSessionIds,
   readSessionTitleOverrides,
   subscribeSessionUiStateChanges,
+  unpinSessions,
 } from "@/lib/session-ui-state";
+import { deriveSidebarSessionLists } from "@/lib/sidebar-session-lists";
 import {
   readWorkspaceProjects,
   subscribeWorkspaceChanges,
@@ -20,13 +23,6 @@ import type { SessionSummary } from "@hermes/protocol";
 import s from "./workbench-sidebar.module.css";
 
 const PROJECT_QUICK_LIMIT = 6;
-const TODAY_LIMIT = 8;
-
-function todayStartSec() {
-  const d = new Date();
-  d.setHours(0, 0, 0, 0);
-  return d.getTime() / 1000;
-}
 
 function relTime(unixSec: number, now: Date) {
   const d = new Date(unixSec * 1000);
@@ -86,9 +82,17 @@ export function WorkbenchSidebar() {
   const runtimeBySession = useAtomValue(chatRuntimeBySessionAtom);
   const { data } = useSessions();
   const [titleOverrides, setTitleOverrides] = useState(readSessionTitleOverrides);
+  const [pinnedSessionIds, setPinnedSessionIds] = useState(readPinnedSessionIds);
   const [projects, setProjects] = useState<WorkspaceProject[]>(readWorkspaceProjects);
 
-  useEffect(() => subscribeSessionUiStateChanges(() => setTitleOverrides(readSessionTitleOverrides())), []);
+  useEffect(
+    () =>
+      subscribeSessionUiStateChanges(() => {
+        setTitleOverrides(readSessionTitleOverrides());
+        setPinnedSessionIds(readPinnedSessionIds());
+      }),
+    [],
+  );
   useEffect(() => subscribeWorkspaceChanges(() => setProjects(readWorkspaceProjects())), []);
 
   const sessions = useMemo(
@@ -100,22 +104,24 @@ export function WorkbenchSidebar() {
     [data?.sessions, titleOverrides],
   );
 
-  const now = new Date();
-  const todayStart = todayStartSec();
+  useEffect(() => {
+    if (!data || data.total > sessions.length || pinnedSessionIds.size === 0) return;
+    const liveIds = new Set(sessions.map((session) => session.id));
+    const staleIds = Array.from(pinnedSessionIds).filter((id) => !liveIds.has(id));
+    if (staleIds.length > 0) setPinnedSessionIds(unpinSessions(staleIds));
+  }, [data, pinnedSessionIds, sessions]);
 
-  const { active, today } = useMemo(() => {
-    const active: SessionSummary[] = [];
-    const today: SessionSummary[] = [];
-    for (const sess of sessions) {
-      if (isSessionRunning(sess, runtimeBySession)) {
-        active.push(sess);
-      } else if (sess.ended_at != null && sess.ended_at >= todayStart) {
-        today.push(sess);
-      }
-    }
-    today.sort((a, b) => (b.ended_at ?? 0) - (a.ended_at ?? 0));
-    return { active, today: today.slice(0, TODAY_LIMIT) };
-  }, [sessions, runtimeBySession, todayStart]);
+  const now = new Date();
+
+  const { active, pinned, recent } = useMemo(
+    () =>
+      deriveSidebarSessionLists(
+        sessions,
+        pinnedSessionIds,
+        (session) => isSessionRunning(session, runtimeBySession),
+      ),
+    [pinnedSessionIds, runtimeBySession, sessions],
+  );
 
   const sortedProjects = useMemo(
     () => [...projects].sort((a, b) => b.updatedAt - a.updatedAt).slice(0, PROJECT_QUICK_LIMIT),
@@ -130,6 +136,9 @@ export function WorkbenchSidebar() {
   const activeSessionId = location.pathname.startsWith("/tasks/")
     ? decodeURIComponent(location.pathname.slice("/tasks/".length))
     : null;
+  const showPinned = pinned.length > 0;
+  const recentSectionLabel = showPinned ? "§04 · 最近对话" : "§03 · 最近对话";
+  const projectSectionLabel = showPinned ? "§05 · 项目快捷" : "§04 · 项目快捷";
 
   return (
     <aside className={s.sidebar}>
@@ -200,15 +209,44 @@ export function WorkbenchSidebar() {
           )}
         </section>
 
+        {showPinned ? (
+          <section className={s.section}>
+            <div className={s.label}>
+              <span>§03 · 置顶对话</span>
+              <span className={s.labelNum}>✕✕</span>
+            </div>
+            {pinned.map((sess) => {
+              const running = isSessionRunning(sess, runtimeBySession);
+              const state: "live" | "ok" | "err" =
+                running
+                  ? "live"
+                  : sess.end_reason === "error" || sess.end_reason === "interrupted"
+                    ? "err"
+                    : "ok";
+              const ts = sess.ended_at ?? sess.started_at;
+              return (
+                <SessionRow
+                  key={sess.id}
+                  session={sess}
+                  state={state}
+                  active={sess.id === activeSessionId}
+                  meta={running ? `${modelShort(sess.model)} · ${elapsed(sess.started_at, now)}` : relTime(ts, now)}
+                  onClick={() => goSession(sess)}
+                />
+              );
+            })}
+          </section>
+        ) : null}
+
         <section className={s.section}>
           <div className={s.label}>
-            <span>§03 · 今日</span>
+            <span>{recentSectionLabel}</span>
             <span className={s.labelNum}>✕✕</span>
           </div>
-          {today.length === 0 ? (
-            <div className={s.empty}>今日暂无完成</div>
+          {recent.length === 0 ? (
+            <div className={s.empty}>暂无最近会话</div>
           ) : (
-            today.map((sess) => {
+            recent.map((sess) => {
               const state: "ok" | "err" =
                 sess.end_reason === "error" || sess.end_reason === "interrupted" ? "err" : "ok";
               const meta = relTime(sess.ended_at ?? sess.started_at, now);
@@ -228,7 +266,7 @@ export function WorkbenchSidebar() {
 
         <section className={s.section}>
           <div className={s.label}>
-            <span>§04 · 项目快捷</span>
+            <span>{projectSectionLabel}</span>
             <span className={s.labelNum}>✕✕</span>
           </div>
           {sortedProjects.length === 0 ? (

--- a/web/src/components/app-shell/workbench-sidebar.tsx
+++ b/web/src/components/app-shell/workbench-sidebar.tsx
@@ -214,6 +214,7 @@ export function WorkbenchSidebar() {
             <MessageSquare size={16} />
           </span>
           <span className={s.entryLabel}>对话历史</span>
+          <span className={s.entryCommand}>/history</span>
         </button>
         <button
           type="button"
@@ -225,6 +226,7 @@ export function WorkbenchSidebar() {
             <Folder size={16} />
           </span>
           <span className={s.entryLabel}>工作空间</span>
+          <span className={s.entryCommand}>/workspace</span>
         </button>
       </div>
 

--- a/web/src/hooks/use-sessions.test.ts
+++ b/web/src/hooks/use-sessions.test.ts
@@ -1,0 +1,83 @@
+import { describe, expect, it, vi } from "vitest";
+import type { SearchResult, SessionsResponse, SessionSummary } from "@hermes/protocol";
+import {
+  deleteSessionsInBatches,
+  withoutSearchResults,
+  withoutSessions,
+} from "./use-sessions";
+
+function session(id: string): SessionSummary {
+  return {
+    id,
+    model: "model",
+    title: id,
+    started_at: 1,
+    ended_at: 2,
+    message_count: 1,
+    input_tokens: 0,
+    output_tokens: 0,
+    estimated_cost_usd: null,
+  };
+}
+
+function sessionsResponse(ids: string[]): SessionsResponse {
+  return {
+    sessions: ids.map(session),
+    total: ids.length,
+    limit: 50,
+    offset: 0,
+  };
+}
+
+function searchResult(id: string): SearchResult {
+  return {
+    session_id: id,
+    snippet: id,
+  };
+}
+
+describe("session cache delete helpers", () => {
+  it("removes several sessions and updates total", () => {
+    const result = withoutSessions(sessionsResponse(["s1", "s2", "s3"]), ["s1", "s3"]);
+
+    expect(result?.sessions.map((item) => item.id)).toEqual(["s2"]);
+    expect(result?.total).toBe(1);
+  });
+
+  it("removes matching search results", () => {
+    const result = withoutSearchResults(
+      { results: ["s1", "s2", "s3"].map(searchResult) },
+      ["s2", "missing"],
+    );
+
+    expect(result?.results.map((item) => item.session_id)).toEqual(["s1", "s3"]);
+  });
+});
+
+describe("deleteSessionsInBatches", () => {
+  it("deduplicates ids and reports successful deletes", async () => {
+    const deleteOne = vi.fn().mockResolvedValue(undefined);
+
+    const result = await deleteSessionsInBatches(["s1", "s2", "s1", " "], deleteOne, 2);
+
+    expect(deleteOne).toHaveBeenCalledTimes(2);
+    expect(result.requestedIds).toEqual(["s1", "s2"]);
+    expect(result.succeededIds).toEqual(["s1", "s2"]);
+    expect(result.failed).toEqual([]);
+    expect(result.successCount).toBe(2);
+    expect(result.failureCount).toBe(0);
+  });
+
+  it("keeps partial failures visible to callers", async () => {
+    const deleteOne = vi.fn(async (id: string) => {
+      if (id === "s2") throw new Error("boom");
+    });
+
+    const result = await deleteSessionsInBatches(["s1", "s2", "s3"], deleteOne, 3);
+
+    expect(result.succeededIds).toEqual(["s1", "s3"]);
+    expect(result.failed).toEqual([{ id: "s2", error: "boom" }]);
+    expect(result.successCount).toBe(2);
+    expect(result.failureCount).toBe(1);
+  });
+});

--- a/web/src/hooks/use-sessions.ts
+++ b/web/src/hooks/use-sessions.ts
@@ -1,6 +1,7 @@
-import { useQuery, useMutation, useQueryClient } from "@tanstack/react-query";
+import { useQuery, useMutation, useQueryClient, type QueryClient } from "@tanstack/react-query";
 import { fetchJSON, deleteJSON, postJSON } from "@/lib/transport";
 import { useActiveProfileName } from "@/hooks/use-profiles";
+import { unpinSessions } from "@/lib/session-ui-state";
 import {
   MessagesResponse,
   MutationOkResponse,
@@ -9,6 +10,21 @@ import {
   SessionsResponse,
   type SearchResult,
 } from "@hermes/protocol";
+
+export const DELETE_SESSION_CONCURRENCY = 3;
+
+export interface DeleteSessionsFailure {
+  id: string;
+  error: string;
+}
+
+export interface DeleteSessionsResult {
+  requestedIds: string[];
+  succeededIds: string[];
+  failed: DeleteSessionsFailure[];
+  successCount: number;
+  failureCount: number;
+}
 
 function hasAnyMessages(result: MessagesResponse): boolean {
   return result.ui_messages ? result.ui_messages.length > 0 : result.messages.length > 0;
@@ -73,17 +89,75 @@ export function useSessionSearch(q: string) {
   });
 }
 
-export function useDeleteSession() {
-  const qc = useQueryClient();
-  return useMutation({
-    mutationFn: (id: string) => deleteJSON(`/api/sessions/${id}`, undefined, MutationOkResponse),
-    onSuccess: () => qc.invalidateQueries({ queryKey: ["sessions"] }),
+function normalizeSessionIds(ids: Iterable<string>): string[] {
+  const seen = new Set<string>();
+  return Array.from(ids).flatMap((raw) => {
+    const id = raw.trim();
+    if (!id || seen.has(id)) return [];
+    seen.add(id);
+    return [id];
   });
 }
 
-function withoutSession(sessions: SessionsResponse | undefined, id: string): SessionsResponse | undefined {
+async function deleteSessionRequest(id: string): Promise<void> {
+  await deleteJSON(`/api/sessions/${encodeURIComponent(id)}`, undefined, MutationOkResponse);
+}
+
+export async function deleteSessionsInBatches(
+  ids: Iterable<string>,
+  deleteOne: (id: string) => Promise<void> = deleteSessionRequest,
+  concurrency = DELETE_SESSION_CONCURRENCY,
+): Promise<DeleteSessionsResult> {
+  const requestedIds = normalizeSessionIds(ids);
+  const succeededIds: string[] = [];
+  const failed: DeleteSessionsFailure[] = [];
+  const workers = Math.max(1, Math.floor(concurrency));
+  let cursor = 0;
+
+  async function runWorker(): Promise<void> {
+    while (cursor < requestedIds.length) {
+      const id = requestedIds[cursor];
+      cursor += 1;
+      try {
+        await deleteOne(id);
+        succeededIds.push(id);
+      } catch (error) {
+        failed.push({
+          id,
+          error: error instanceof Error ? error.message : String(error),
+        });
+      }
+    }
+  }
+
+  await Promise.all(
+    Array.from({ length: Math.min(workers, requestedIds.length) }, () => runWorker()),
+  );
+  const succeededSet = new Set(succeededIds);
+  const failedById = new Map(failed.map((item) => [item.id, item]));
+  const orderedSucceededIds = requestedIds.filter((id) => succeededSet.has(id));
+  const orderedFailed = requestedIds.flatMap((id) => {
+    const item = failedById.get(id);
+    return item ? [item] : [];
+  });
+
+  return {
+    requestedIds,
+    succeededIds: orderedSucceededIds,
+    failed: orderedFailed,
+    successCount: orderedSucceededIds.length,
+    failureCount: orderedFailed.length,
+  };
+}
+
+export function withoutSessions(
+  sessions: SessionsResponse | undefined,
+  ids: Iterable<string>,
+): SessionsResponse | undefined {
   if (!sessions) return sessions;
-  const nextSessions = sessions.sessions.filter((session) => session.id !== id);
+  const idSet = new Set(normalizeSessionIds(ids));
+  if (idSet.size === 0) return sessions;
+  const nextSessions = sessions.sessions.filter((session) => !idSet.has(session.id));
   if (nextSessions.length === sessions.sessions.length) return sessions;
   return {
     ...sessions,
@@ -92,13 +166,66 @@ function withoutSession(sessions: SessionsResponse | undefined, id: string): Ses
   };
 }
 
-function withoutSearchResult(
+export function withoutSearchResults(
   results: { results: SearchResult[] } | undefined,
-  id: string,
+  ids: Iterable<string>,
 ): { results: SearchResult[] } | undefined {
   if (!results) return results;
-  const nextResults = results.results.filter((result) => result.session_id !== id);
+  const idSet = new Set(normalizeSessionIds(ids));
+  if (idSet.size === 0) return results;
+  const nextResults = results.results.filter((result) => !idSet.has(result.session_id));
   return nextResults.length === results.results.length ? results : { ...results, results: nextResults };
+}
+
+function removeDeletedSessionsFromCache(qc: QueryClient, ids: Iterable<string>): void {
+  const cleanIds = normalizeSessionIds(ids);
+  if (cleanIds.length === 0) return;
+  qc.setQueriesData<SessionsResponse>({ queryKey: ["sessions"] }, (data) =>
+    withoutSessions(data, cleanIds),
+  );
+  qc.setQueriesData<{ results: SearchResult[] }>({ queryKey: ["sessions-search"] }, (data) =>
+    withoutSearchResults(data, cleanIds),
+  );
+}
+
+function invalidateSessionLists(qc: QueryClient): void {
+  void qc.invalidateQueries({ queryKey: ["sessions"] });
+  void qc.invalidateQueries({ queryKey: ["sessions-search"] });
+}
+
+export function useDeleteSession() {
+  const qc = useQueryClient();
+  return useMutation({
+    mutationFn: async (id: string) => {
+      const cleanId = id.trim();
+      if (!cleanId) throw new Error("缺少会话 ID");
+      await deleteSessionRequest(cleanId);
+      return cleanId;
+    },
+    onSuccess: (id) => {
+      unpinSessions([id]);
+      removeDeletedSessionsFromCache(qc, [id]);
+    },
+    onSettled: () => {
+      invalidateSessionLists(qc);
+    },
+  });
+}
+
+export function useDeleteSessions() {
+  const qc = useQueryClient();
+  return useMutation({
+    mutationFn: (ids: Iterable<string>) => deleteSessionsInBatches(ids),
+    onSuccess: (result) => {
+      if (result.succeededIds.length > 0) {
+        unpinSessions(result.succeededIds);
+        removeDeletedSessionsFromCache(qc, result.succeededIds);
+      }
+    },
+    onSettled: () => {
+      invalidateSessionLists(qc);
+    },
+  });
 }
 
 export function useArchiveSession() {
@@ -117,13 +244,16 @@ export function useArchiveSession() {
       });
 
       qc.setQueriesData<SessionsResponse>({ queryKey: ["sessions"] }, (data) =>
-        withoutSession(data, id),
+        withoutSessions(data, [id]),
       );
       qc.setQueriesData<{ results: SearchResult[] }>({ queryKey: ["sessions-search"] }, (data) =>
-        withoutSearchResult(data, id),
+        withoutSearchResults(data, [id]),
       );
 
       return { sessionSnapshots, searchSnapshots };
+    },
+    onSuccess: (_result, id) => {
+      unpinSessions([id]);
     },
     onError: (_error, _id, context) => {
       for (const [queryKey, data] of context?.sessionSnapshots ?? []) {
@@ -134,8 +264,7 @@ export function useArchiveSession() {
       }
     },
     onSettled: () => {
-      void qc.invalidateQueries({ queryKey: ["sessions"] });
-      void qc.invalidateQueries({ queryKey: ["sessions-search"] });
+      invalidateSessionLists(qc);
     },
   });
 }

--- a/web/src/lib/session-ui-state.test.ts
+++ b/web/src/lib/session-ui-state.test.ts
@@ -1,0 +1,67 @@
+import { afterEach, beforeEach, describe, expect, it, vi } from "vitest";
+import {
+  isSessionPinned,
+  readPinnedSessionIds,
+  subscribeSessionUiStateChanges,
+  togglePinnedSession,
+  unpinSessions,
+  writePinnedSessionIds,
+} from "./session-ui-state";
+import { __resetUiStoreForTests } from "./ui-store";
+
+beforeEach(() => {
+  __resetUiStoreForTests();
+  vi.stubGlobal("window", {
+    dispatchEvent: vi.fn(),
+    addEventListener: vi.fn(),
+    removeEventListener: vi.fn(),
+  });
+});
+
+afterEach(() => {
+  vi.restoreAllMocks();
+  vi.unstubAllGlobals();
+});
+
+describe("pinned session UI state", () => {
+  it("persists clean pinned session ids with de-duplication", () => {
+    writePinnedSessionIds([" s1 ", "", "s2", "s1", "   ", "s3"]);
+
+    expect(Array.from(readPinnedSessionIds())).toEqual(["s1", "s2", "s3"]);
+    expect(isSessionPinned("s2")).toBe(true);
+    expect(isSessionPinned("missing")).toBe(false);
+  });
+
+  it("toggles pin and unpin for one session", () => {
+    expect(Array.from(togglePinnedSession("s1"))).toEqual(["s1"]);
+    expect(isSessionPinned("s1")).toBe(true);
+
+    expect(Array.from(togglePinnedSession("s1"))).toEqual([]);
+    expect(isSessionPinned("s1")).toBe(false);
+  });
+
+  it("ignores empty session ids", () => {
+    writePinnedSessionIds(["s1"]);
+
+    expect(Array.from(togglePinnedSession("   "))).toEqual(["s1"]);
+    expect(Array.from(readPinnedSessionIds())).toEqual(["s1"]);
+  });
+
+  it("unpinned multiple sessions without touching others", () => {
+    writePinnedSessionIds(["s1", "s2", "s3"]);
+
+    expect(Array.from(unpinSessions(["s2", "missing", "s1"]))).toEqual(["s3"]);
+    expect(Array.from(readPinnedSessionIds())).toEqual(["s3"]);
+  });
+
+  it("notifies subscribers when pinned state changes", () => {
+    const listener = vi.fn();
+    const unsubscribe = subscribeSessionUiStateChanges(listener);
+
+    writePinnedSessionIds(["s1"]);
+    unsubscribe();
+    writePinnedSessionIds(["s2"]);
+
+    expect(listener).toHaveBeenCalledTimes(1);
+  });
+});

--- a/web/src/lib/session-ui-state.ts
+++ b/web/src/lib/session-ui-state.ts
@@ -1,6 +1,7 @@
 import { readUiValue, subscribeUiStore, writeUiValue } from "@/lib/ui-store";
 
 const SESSION_TITLE_OVERRIDES_STORAGE_KEY = "hermes-cn-ui.sessionTitleOverrides";
+const PINNED_SESSION_IDS_STORAGE_KEY = "hermes-cn-ui.pinnedSessionIds";
 const SESSION_UI_STATE_CHANGED_EVENT = "hermes-cn-ui.sessionUiState.changed";
 
 function emitSessionUiStateChange(): void {
@@ -37,6 +38,52 @@ export function rememberSessionTitleOverride(sessionId: string, title: string): 
   const overrides = readSessionTitleOverrides();
   overrides[cleanSessionId] = cleanTitle;
   writeJSON(SESSION_TITLE_OVERRIDES_STORAGE_KEY, overrides);
+}
+
+function normalizeSessionIds(value: unknown): string[] {
+  if (!Array.isArray(value)) return [];
+  const seen = new Set<string>();
+  return value.flatMap((item) => {
+    if (typeof item !== "string") return [];
+    const id = item.trim();
+    if (!id || seen.has(id)) return [];
+    seen.add(id);
+    return [id];
+  });
+}
+
+export function readPinnedSessionIds(): Set<string> {
+  return new Set(normalizeSessionIds(readJSON<unknown>(PINNED_SESSION_IDS_STORAGE_KEY, [])));
+}
+
+export function writePinnedSessionIds(ids: Iterable<string>): Set<string> {
+  const cleanIds = normalizeSessionIds(Array.from(ids));
+  writeJSON(PINNED_SESSION_IDS_STORAGE_KEY, cleanIds);
+  return new Set(cleanIds);
+}
+
+export function isSessionPinned(sessionId: string): boolean {
+  const cleanSessionId = sessionId.trim();
+  return cleanSessionId ? readPinnedSessionIds().has(cleanSessionId) : false;
+}
+
+export function togglePinnedSession(sessionId: string): Set<string> {
+  const cleanSessionId = sessionId.trim();
+  const ids = readPinnedSessionIds();
+  if (!cleanSessionId) return ids;
+  if (ids.has(cleanSessionId)) ids.delete(cleanSessionId);
+  else ids.add(cleanSessionId);
+  return writePinnedSessionIds(ids);
+}
+
+export function unpinSessions(sessionIds: Iterable<string>): Set<string> {
+  const ids = readPinnedSessionIds();
+  let changed = false;
+  for (const sessionId of sessionIds) {
+    const cleanSessionId = sessionId.trim();
+    if (cleanSessionId && ids.delete(cleanSessionId)) changed = true;
+  }
+  return changed ? writePinnedSessionIds(ids) : ids;
 }
 
 export function subscribeSessionUiStateChanges(listener: () => void): () => void {

--- a/web/src/lib/sidebar-session-lists.test.ts
+++ b/web/src/lib/sidebar-session-lists.test.ts
@@ -1,0 +1,68 @@
+import { describe, expect, it } from "vitest";
+import type { SessionSummary } from "@hermes/protocol";
+import { deriveSidebarSessionLists } from "./sidebar-session-lists";
+
+function session(id: string, startedAt: number, endedAt: number | null = startedAt + 10): SessionSummary {
+  return {
+    id,
+    model: "model",
+    title: id,
+    started_at: startedAt,
+    ended_at: endedAt,
+    message_count: 1,
+    input_tokens: 0,
+    output_tokens: 0,
+    estimated_cost_usd: null,
+  };
+}
+
+describe("deriveSidebarSessionLists", () => {
+  it("keeps pinned sessions before recent and excludes them from recent", () => {
+    const lists = deriveSidebarSessionLists(
+      [session("s1", 10), session("s2", 20), session("s3", 30)],
+      ["s2"],
+      () => false,
+    );
+
+    expect(lists.pinned.map((item) => item.id)).toEqual(["s2"]);
+    expect(lists.recent.map((item) => item.id)).toEqual(["s3", "s1"]);
+  });
+
+  it("orders pinned sessions by persisted pin order", () => {
+    const lists = deriveSidebarSessionLists(
+      [session("s1", 30), session("s2", 20), session("s3", 10)],
+      ["s3", "s1"],
+      () => false,
+    );
+
+    expect(lists.pinned.map((item) => item.id)).toEqual(["s3", "s1"]);
+  });
+
+  it("limits recent sessions to five by last activity time", () => {
+    const lists = deriveSidebarSessionLists(
+      [
+        session("s1", 1),
+        session("s2", 2),
+        session("s3", 3),
+        session("s4", 4),
+        session("s5", 5),
+        session("s6", 6),
+      ],
+      [],
+      () => false,
+    );
+
+    expect(lists.recent.map((item) => item.id)).toEqual(["s6", "s5", "s4", "s3", "s2"]);
+  });
+
+  it("uses started time for active sessions and keeps running sessions out of recent", () => {
+    const lists = deriveSidebarSessionLists(
+      [session("done", 1, 3), session("running", 10, null)],
+      [],
+      (item) => item.id === "running",
+    );
+
+    expect(lists.active.map((item) => item.id)).toEqual(["running"]);
+    expect(lists.recent.map((item) => item.id)).toEqual(["done"]);
+  });
+});

--- a/web/src/lib/sidebar-session-lists.ts
+++ b/web/src/lib/sidebar-session-lists.ts
@@ -1,0 +1,44 @@
+import type { SessionSummary } from "@hermes/protocol";
+
+export const RECENT_SESSION_LIMIT = 5;
+
+export function lastActivitySec(session: SessionSummary): number {
+  return session.ended_at ?? session.started_at;
+}
+
+export interface SidebarSessionLists {
+  active: SessionSummary[];
+  pinned: SessionSummary[];
+  recent: SessionSummary[];
+}
+
+export function deriveSidebarSessionLists(
+  sessions: SessionSummary[],
+  pinnedIds: Iterable<string>,
+  isRunning: (session: SessionSummary) => boolean,
+  recentLimit = RECENT_SESSION_LIMIT,
+): SidebarSessionLists {
+  const sessionById = new Map(sessions.map((session) => [session.id, session]));
+  const pinned = Array.from(pinnedIds).flatMap((id) => {
+    const session = sessionById.get(id);
+    return session ? [session] : [];
+  });
+  const pinnedIdSet = new Set(pinned.map((session) => session.id));
+  const active: SessionSummary[] = [];
+  const recent: SessionSummary[] = [];
+
+  for (const session of sessions) {
+    if (isRunning(session)) {
+      active.push(session);
+    } else if (!pinnedIdSet.has(session.id)) {
+      recent.push(session);
+    }
+  }
+
+  recent.sort((a, b) => lastActivitySec(b) - lastActivitySec(a));
+  return {
+    active,
+    pinned,
+    recent: recent.slice(0, recentLimit),
+  };
+}

--- a/web/src/lib/tauri-bridge.ts
+++ b/web/src/lib/tauri-bridge.ts
@@ -49,7 +49,7 @@ import type {
   UiStoreSnapshot,
   UiTurnStats,
 } from "./runtime";
-import { BUILD_COMMIT, BUILD_DATE, DESKTOP_VERSION, versionLabel } from "./build-info";
+import { BUILD_COMMIT, DESKTOP_VERSION, versionLabel } from "./build-info";
 import hermesLogoSvg from "../../../icons/icon.svg?raw";
 
 let invoke: typeof import("@tauri-apps/api/core").invoke;
@@ -64,7 +64,6 @@ interface BootstrapVersionLine {
   label: "界面";
   version: string;
   commit: string;
-  date: string;
 }
 
 function shortBootstrapCommit(commit: string | undefined): string {
@@ -73,22 +72,11 @@ function shortBootstrapCommit(commit: string | undefined): string {
   return normalized.slice(0, 4);
 }
 
-function shortBootstrapCommitDate(value: string | undefined): string {
-  const normalized = value?.trim() ?? "";
-  if (!normalized || normalized === "unknown") return "日期未知";
-  const datePrefix = normalized.match(/^\d{4}-(\d{2})-(\d{2})/)?.slice(1, 3);
-  if (datePrefix) return `${datePrefix[0]}.${datePrefix[1]}`;
-  const date = new Date(normalized);
-  if (Number.isNaN(date.getTime())) return "日期未知";
-  return `${String(date.getMonth() + 1).padStart(2, "0")}.${String(date.getDate()).padStart(2, "0")}`;
-}
-
 function buildBootstrapVersionLine(): BootstrapVersionLine {
   return {
     label: "界面",
     version: versionLabel(DESKTOP_VERSION),
     commit: shortBootstrapCommit(BUILD_COMMIT),
-    date: shortBootstrapCommitDate(BUILD_DATE),
   };
 }
 
@@ -502,24 +490,17 @@ function showBootstrapOverlay(initialMessage: string): {
   );
 
   const uiVersionRow = document.createElement("div");
-  const versionNote = document.createElement("div");
 
   const applyVersionRow = (rowEl: HTMLDivElement, line: BootstrapVersionLine) => {
     rowEl.setAttribute(
       "style",
       "font-variant-numeric:tabular-nums;white-space:nowrap;color:rgba(133,126,111,0.76);",
     );
-    rowEl.textContent = `${line.label} ${line.version} · ${line.commit} · ${line.date}`;
+    rowEl.textContent = `${line.label} ${line.version} · ${line.commit}`;
   };
 
   applyVersionRow(uiVersionRow, buildBootstrapVersionLine());
-  versionNote.setAttribute(
-    "style",
-    "font-family:'Inter',-apple-system,BlinkMacSystemFont,'Segoe UI',sans-serif;" +
-      "font-size:10px;font-weight:500;letter-spacing:0.03em;color:rgba(133,126,111,0.5);",
-  );
-  versionNote.textContent = "预览版本，不代表最终品质";
-  versionPanel.append(uiVersionRow, versionNote);
+  versionPanel.append(uiVersionRow);
   panel.appendChild(versionPanel);
 
   const sub = document.createElement("div");

--- a/web/src/lib/workspaces.test.ts
+++ b/web/src/lib/workspaces.test.ts
@@ -1,12 +1,16 @@
 import { beforeEach, describe, expect, it, vi } from "vitest";
 import {
   normalizeWorkspacePath,
+  readPinnedWorkspaceProjectPaths,
   mirrorSessionWorkspaceMapping,
   readSessionWorkspaceMap,
   readWorkspaceProjects,
   rememberSessionWorkspace,
   rememberWorkspaceProject,
   removeWorkspaceProject,
+  togglePinnedWorkspaceProject,
+  unpinWorkspaceProjects,
+  writePinnedWorkspaceProjectPaths,
   workspaceNameFromPath,
 } from "./workspaces";
 import { rememberSessionMapping } from "./session-map";
@@ -64,6 +68,38 @@ describe("workspace persistence helpers", () => {
     ]);
   });
 
+  it("stores pinned workspace projects without duplicating equivalent paths", () => {
+    writePinnedWorkspaceProjectPaths([
+      "",
+      "/Users/claw/Project/",
+      "/Users/claw/Project",
+      "/Users/claw/Other",
+    ]);
+
+    expect(Array.from(readPinnedWorkspaceProjectPaths())).toEqual([
+      "/Users/claw/Project",
+      "/Users/claw/Other",
+    ]);
+  });
+
+  it("toggles and unpins workspace projects", () => {
+    expect(Array.from(togglePinnedWorkspaceProject(" /Users/claw/Project/ "))).toEqual([
+      "/Users/claw/Project",
+    ]);
+    expect(Array.from(togglePinnedWorkspaceProject("/Users/claw/Project"))).toEqual([]);
+
+    writePinnedWorkspaceProjectPaths([
+      "/Users/claw/Project",
+      "/Users/claw/Other",
+      "/Users/claw/Third",
+    ]);
+
+    expect(Array.from(unpinWorkspaceProjects(["/Users/claw/Other/"]))).toEqual([
+      "/Users/claw/Project",
+      "/Users/claw/Third",
+    ]);
+  });
+
   it("links sessions to workspaces and registers the project", () => {
     rememberSessionWorkspace("session-1", "/Users/claw/Project");
 
@@ -114,6 +150,7 @@ describe("workspace persistence helpers", () => {
   it("removes a workspace project and unlinks its sessions", () => {
     rememberSessionWorkspace("session-1", "/Users/claw/Project");
     rememberSessionWorkspace("session-2", "/Users/claw/Other");
+    writePinnedWorkspaceProjectPaths(["/Users/claw/Project", "/Users/claw/Other"]);
 
     removeWorkspaceProject("/Users/claw/Project/");
 
@@ -123,5 +160,6 @@ describe("workspace persistence helpers", () => {
     expect(readSessionWorkspaceMap()).toEqual({
       "session-2": "/Users/claw/Other",
     });
+    expect(Array.from(readPinnedWorkspaceProjectPaths())).toEqual(["/Users/claw/Other"]);
   });
 });

--- a/web/src/lib/workspaces.ts
+++ b/web/src/lib/workspaces.ts
@@ -11,6 +11,7 @@ export const WORKSPACE_STORAGE_KEY = "hermes-cn-ui.workspacePath";
 
 const WORKSPACE_PROJECTS_STORAGE_KEY = "hermes-cn-ui.workspaceProjects";
 const SESSION_WORKSPACE_STORAGE_KEY = "hermes-cn-ui.sessionWorkspaces";
+const PINNED_WORKSPACE_PROJECTS_STORAGE_KEY = "hermes-cn-ui.pinnedWorkspaceProjects";
 const WORKSPACE_CHANGED_EVENT = "hermes-cn-ui.workspaces.changed";
 
 export function normalizeWorkspacePath(path: unknown): string {
@@ -39,6 +40,17 @@ function writeJSON(key: string, value: unknown): void {
 
 function isRecord(value: unknown): value is Record<string, unknown> {
   return Boolean(value) && typeof value === "object" && !Array.isArray(value);
+}
+
+function normalizeWorkspacePathList(value: unknown): string[] {
+  if (!Array.isArray(value)) return [];
+  const seen = new Set<string>();
+  return value.flatMap((item) => {
+    const path = normalizeWorkspacePath(item);
+    if (!path || seen.has(path)) return [];
+    seen.add(path);
+    return [path];
+  });
 }
 
 export function readWorkspacePath(): string {
@@ -105,6 +117,42 @@ export function rememberWorkspaceProject(path: string, name?: string): Workspace
   return nextProject;
 }
 
+export function readPinnedWorkspaceProjectPaths(): Set<string> {
+  return new Set(
+    normalizeWorkspacePathList(readJSON<unknown>(PINNED_WORKSPACE_PROJECTS_STORAGE_KEY, [])),
+  );
+}
+
+export function writePinnedWorkspaceProjectPaths(paths: Iterable<string>): Set<string> {
+  const cleanPaths = normalizeWorkspacePathList(Array.from(paths));
+  writeJSON(PINNED_WORKSPACE_PROJECTS_STORAGE_KEY, cleanPaths);
+  return new Set(cleanPaths);
+}
+
+export function isWorkspaceProjectPinned(path: string): boolean {
+  const normalized = normalizeWorkspacePath(path);
+  return normalized ? readPinnedWorkspaceProjectPaths().has(normalized) : false;
+}
+
+export function togglePinnedWorkspaceProject(path: string): Set<string> {
+  const normalized = normalizeWorkspacePath(path);
+  const paths = readPinnedWorkspaceProjectPaths();
+  if (!normalized) return paths;
+  if (paths.has(normalized)) paths.delete(normalized);
+  else paths.add(normalized);
+  return writePinnedWorkspaceProjectPaths(paths);
+}
+
+export function unpinWorkspaceProjects(pathsToUnpin: Iterable<string>): Set<string> {
+  const paths = readPinnedWorkspaceProjectPaths();
+  let changed = false;
+  for (const path of pathsToUnpin) {
+    const normalized = normalizeWorkspacePath(path);
+    if (normalized && paths.delete(normalized)) changed = true;
+  }
+  return changed ? writePinnedWorkspaceProjectPaths(paths) : paths;
+}
+
 function readRawSessionWorkspaceMap(): Record<string, string> {
   const raw = readJSON<unknown>(SESSION_WORKSPACE_STORAGE_KEY, {});
   if (!isRecord(raw)) return {};
@@ -145,6 +193,8 @@ export function removeWorkspaceProject(path: string): void {
   if (readWorkspacePath() === normalized) {
     writeWorkspacePath("");
   }
+
+  unpinWorkspaceProjects([normalized]);
 }
 
 export function readSessionWorkspaceMap(): Record<string, string> {

--- a/web/src/routes/history.module.css
+++ b/web/src/routes/history.module.css
@@ -123,6 +123,57 @@
   color: var(--h-text-3);
 }
 
+.bulkBar {
+  display: flex;
+  align-items: center;
+  gap: 8px;
+  min-height: 38px;
+  padding: 8px 24px;
+  border-bottom: 1px solid var(--h-line-soft);
+  background: var(--h-bg-soft);
+  color: var(--h-text-3);
+  font-size: 11.5px;
+  font-family: var(--h-font-cn);
+}
+
+.bulkBar[data-active="true"] {
+  color: var(--h-text-2);
+}
+
+.bulkBar button {
+  height: 26px;
+  padding: 0 10px;
+  border: 1px solid var(--h-line);
+  border-radius: 7px;
+  background: var(--h-bg-pane);
+  color: var(--h-text-2);
+  cursor: pointer;
+  font-size: 11.5px;
+  font-family: var(--h-font-cn);
+}
+
+.bulkBar button:hover:not(:disabled) {
+  color: var(--h-text);
+  background: var(--h-bg-chip);
+}
+
+.bulkBar button:disabled {
+  cursor: default;
+  opacity: 0.52;
+}
+
+.bulkDanger {
+  display: inline-flex;
+  align-items: center;
+  gap: 6px;
+  color: var(--h-err) !important;
+  margin-left: auto;
+}
+
+.bulkFeedback {
+  color: var(--h-accent);
+}
+
 /* popover */
 .popover {
   width: 320px;
@@ -341,6 +392,7 @@
 .convRow {
   display: grid;
   grid-template-columns:
+    28px       /* select */
     64px       /* id */
     minmax(0, 1fr) /* title */
     80px       /* source chip */
@@ -378,8 +430,26 @@
   border-color: var(--h-line);
 }
 
+.convRow[data-selected="true"] {
+  background: var(--h-bg-chip);
+  border-color: var(--h-line);
+}
+
 .convRow[data-status="failed"] .titleText {
   color: var(--h-err);
+}
+
+.cellSelect {
+  display: inline-flex;
+  align-items: center;
+  justify-content: center;
+}
+
+.cellSelect input {
+  width: 14px;
+  height: 14px;
+  accent-color: var(--h-accent);
+  cursor: pointer;
 }
 
 .cellId {
@@ -420,6 +490,11 @@
   flex-shrink: 0;
 }
 
+.titlePin {
+  color: var(--h-accent);
+  flex-shrink: 0;
+}
+
 .cellMono {
   font-family: var(--h-font-mono);
   font-size: 11.5px;
@@ -453,6 +528,11 @@
   color: var(--h-text);
 }
 
+.cellMore:disabled {
+  cursor: default;
+  opacity: 0.45;
+}
+
 .rowMenu {
   min-width: 140px;
   padding: 4px;
@@ -479,6 +559,11 @@
 
 .rowMenu button:hover {
   background: var(--h-bg-soft);
+}
+
+.rowMenu button:disabled {
+  cursor: default;
+  opacity: 0.5;
 }
 
 .rowMenu button[data-tone="danger"] {
@@ -670,6 +755,103 @@
 
 .renameSubmit:disabled,
 .renameCancel:disabled {
+  cursor: default;
+  opacity: 0.55;
+}
+
+.confirmModal {
+  width: min(420px, calc(100vw - 48px));
+  padding: 18px;
+  border: 1px solid var(--h-line);
+  border-radius: 12px;
+  background: var(--h-bg-input);
+  box-shadow: var(--h-shadow-l);
+  font-family: var(--h-font-cn);
+}
+
+.confirmModal h2 {
+  margin: 0 0 10px;
+  color: var(--h-text);
+  font-size: 15px;
+  font-weight: 600;
+}
+
+.confirmText {
+  margin: 0;
+  color: var(--h-text-2);
+  font-size: 12.5px;
+  line-height: 1.6;
+}
+
+.confirmList {
+  margin-top: 12px;
+  border: 1px solid var(--h-line-soft);
+  border-radius: 8px;
+  background: var(--h-bg-app);
+  overflow: hidden;
+}
+
+.confirmListItem,
+.confirmListMore {
+  padding: 8px 10px;
+  color: var(--h-text-2);
+  font-size: 12px;
+  white-space: nowrap;
+  overflow: hidden;
+  text-overflow: ellipsis;
+}
+
+.confirmListItem + .confirmListItem,
+.confirmListMore {
+  border-top: 1px solid var(--h-line-soft);
+}
+
+.confirmListMore {
+  color: var(--h-text-3);
+  font-family: var(--h-font-mono);
+}
+
+.confirmActions {
+  display: flex;
+  justify-content: flex-end;
+  gap: 8px;
+  margin-top: 16px;
+}
+
+.confirmCancel,
+.confirmDanger {
+  min-width: 72px;
+  height: 30px;
+  padding: 0 12px;
+  border-radius: 8px;
+  cursor: pointer;
+  font-family: var(--h-font-cn);
+  font-size: 12px;
+}
+
+.confirmCancel {
+  border: 1px solid var(--h-line);
+  background: transparent;
+  color: var(--h-text-2);
+}
+
+.confirmDanger {
+  border: 1px solid var(--h-err);
+  background: var(--h-err);
+  color: white;
+}
+
+.confirmCancel:hover:not(:disabled) {
+  background: var(--h-line-soft);
+  color: var(--h-text);
+}
+
+.confirmDanger:hover:not(:disabled) {
+  filter: brightness(1.06);
+}
+
+.confirmCancel:disabled,
+.confirmDanger:disabled {
   cursor: default;
   opacity: 0.55;
 }

--- a/web/src/routes/history.module.css
+++ b/web/src/routes/history.module.css
@@ -392,7 +392,6 @@
 .convRow {
   display: grid;
   grid-template-columns:
-    28px       /* select */
     64px       /* id */
     minmax(0, 1fr) /* title */
     80px       /* source chip */
@@ -402,6 +401,19 @@
     32px;      /* more */
   gap: 12px;
   align-items: center;
+}
+
+.colHead[data-bulk="true"],
+.convRow[data-bulk="true"] {
+  grid-template-columns:
+    28px       /* select */
+    64px       /* id */
+    minmax(0, 1fr) /* title */
+    80px       /* source chip */
+    140px      /* model */
+    minmax(0, 160px) /* workspace */
+    100px      /* updated */
+    32px;      /* more */
 }
 
 .colHead {

--- a/web/src/routes/history.tsx
+++ b/web/src/routes/history.tsx
@@ -666,7 +666,6 @@ export function HistoryRoute() {
       });
       if (activeSessionId && result.succeededIds.includes(activeSessionId)) {
         setActiveSessionId(null);
-        navigate("/");
       }
     }
     if (result.failureCount > 0) {
@@ -678,7 +677,7 @@ export function HistoryRoute() {
       setSelectedSessionIds(new Set());
     }
     setDeleteTargets(null);
-  }, [activeSessionId, deleteSessions, deleteTargets, navigate, setActiveSessionId]);
+  }, [activeSessionId, deleteSessions, deleteTargets, setActiveSessionId]);
 
   const totalTokens = useMemo(
     () =>

--- a/web/src/routes/history.tsx
+++ b/web/src/routes/history.tsx
@@ -16,7 +16,7 @@ import {
 import type { SessionSummary } from "@hermes/protocol";
 import { chatRuntimeBySessionAtom } from "@/stores/chat";
 import { activeSessionIdAtom } from "@/stores/ui";
-import { useArchiveSession, useDeleteSession, useSessions } from "@/hooks/use-sessions";
+import { useArchiveSession, useDeleteSessions, useSessions } from "@/hooks/use-sessions";
 import { useGateway } from "@/hooks/use-gateway";
 import { isSessionRunning } from "@/lib/session-activity";
 import { sessionDisplayTitle } from "@/lib/session-title";
@@ -29,8 +29,11 @@ import {
   timeOfDay,
 } from "@/lib/format";
 import {
+  readPinnedSessionIds,
   readSessionTitleOverrides,
   subscribeSessionUiStateChanges,
+  togglePinnedSession,
+  unpinSessions,
 } from "@/lib/session-ui-state";
 import {
   normalizeWorkspacePath,
@@ -85,12 +88,15 @@ function classifySession(
 }
 
 interface RowMenuProps {
+  pinned: boolean;
+  disabled?: boolean;
+  onTogglePin: () => void;
   onRename: () => void;
   onArchive: () => void;
   onDelete: () => void;
 }
 
-function RowMenu({ onRename, onArchive, onDelete }: RowMenuProps) {
+function RowMenu({ pinned, disabled, onTogglePin, onRename, onArchive, onDelete }: RowMenuProps) {
   return (
     <Popover.Portal>
       <Popover.Content
@@ -102,17 +108,23 @@ function RowMenu({ onRename, onArchive, onDelete }: RowMenuProps) {
         onClick={(event) => event.stopPropagation()}
       >
         <Popover.Close asChild>
-          <button type="button" onClick={onRename} role="menuitem">
+          <button type="button" onClick={onTogglePin} role="menuitem" disabled={disabled}>
+            {pinned ? <PinOff size={13} /> : <Pin size={13} />}
+            {pinned ? "取消置顶" : "置顶"}
+          </button>
+        </Popover.Close>
+        <Popover.Close asChild>
+          <button type="button" onClick={onRename} role="menuitem" disabled={disabled}>
             <Edit3 size={13} /> 重命名
           </button>
         </Popover.Close>
         <Popover.Close asChild>
-          <button type="button" onClick={onArchive} role="menuitem">
+          <button type="button" onClick={onArchive} role="menuitem" disabled={disabled}>
             <Archive size={13} /> 归档
           </button>
         </Popover.Close>
         <Popover.Close asChild>
-          <button type="button" onClick={onDelete} role="menuitem" data-tone="danger">
+          <button type="button" onClick={onDelete} role="menuitem" data-tone="danger" disabled={disabled}>
             <Trash2 size={13} /> 删除
           </button>
         </Popover.Close>
@@ -186,6 +198,62 @@ function RenameModal({ value, saving, error, onChange, onClose, onSubmit }: Rena
               </button>
             </div>
           </form>
+        </Dialog.Content>
+      </Dialog.Portal>
+    </Dialog.Root>
+  );
+}
+
+interface DeleteConfirmModalProps {
+  sessions: SessionSummary[];
+  deleting: boolean;
+  onClose: () => void;
+  onConfirm: () => void;
+}
+
+function DeleteConfirmModal({ sessions, deleting, onClose, onConfirm }: DeleteConfirmModalProps) {
+  const count = sessions.length;
+  const preview = sessions.slice(0, 5);
+  return (
+    <Dialog.Root
+      open
+      onOpenChange={(open) => {
+        if (!open && !deleting) onClose();
+      }}
+    >
+      <Dialog.Portal>
+        <Dialog.Overlay className={s.modalBackdrop} />
+        <Dialog.Content
+          className={s.confirmModal}
+          aria-describedby="history-delete-confirm-desc"
+          onEscapeKeyDown={(event) => {
+            if (deleting) event.preventDefault();
+          }}
+        >
+          <Dialog.Title asChild>
+            <h2>{count === 1 ? "删除会话" : "批量删除会话"}</h2>
+          </Dialog.Title>
+          <Dialog.Description id="history-delete-confirm-desc" className={s.confirmText}>
+            将删除 {count} 个会话，此操作不可撤销。
+          </Dialog.Description>
+          <div className={s.confirmList}>
+            {preview.map((session) => (
+              <div key={session.id} className={s.confirmListItem}>
+                {sessionDisplayTitle(session)}
+              </div>
+            ))}
+            {count > preview.length ? (
+              <div className={s.confirmListMore}>另有 {count - preview.length} 个会话</div>
+            ) : null}
+          </div>
+          <div className={s.confirmActions}>
+            <button type="button" className={s.confirmCancel} onClick={onClose} disabled={deleting}>
+              取消
+            </button>
+            <button type="button" className={s.confirmDanger} onClick={onConfirm} disabled={deleting}>
+              {deleting ? "删除中…" : "确认删除"}
+            </button>
+          </div>
         </Dialog.Content>
       </Dialog.Portal>
     </Dialog.Root>
@@ -320,7 +388,7 @@ export function HistoryRoute() {
   const runtimeBySession = useAtomValue(chatRuntimeBySessionAtom);
   const { data, isLoading, isError } = useSessions(PAGE_SIZE, 0);
   const archiveSession = useArchiveSession();
-  const deleteSession = useDeleteSession();
+  const deleteSessions = useDeleteSessions();
   const { setSessionTitle, resumeSession } = useGateway();
 
   const [statusFilter, setStatusFilter] = useState<StatusFilter>("all");
@@ -332,16 +400,21 @@ export function HistoryRoute() {
   const [renameValue, setRenameValue] = useState("");
   const [renameError, setRenameError] = useState("");
   const [renameSaving, setRenameSaving] = useState(false);
+  const [selectedSessionIds, setSelectedSessionIds] = useState<Set<string>>(() => new Set());
+  const [deleteTargets, setDeleteTargets] = useState<SessionSummary[] | null>(null);
+  const [deleteFeedback, setDeleteFeedback] = useState<string | null>(null);
 
   const [titleOverrides, setTitleOverrides] = useState(readSessionTitleOverrides);
   const [workspaceMap, setWorkspaceMap] = useState(readSessionWorkspaceMap);
   const [pinnedSources, setPinnedSources] = useState<Set<string>>(readPinnedSources);
+  const [pinnedSessionIds, setPinnedSessionIds] = useState<Set<string>>(readPinnedSessionIds);
 
   useEffect(
     () =>
-      subscribeSessionUiStateChanges(() =>
-        setTitleOverrides(readSessionTitleOverrides()),
-      ),
+      subscribeSessionUiStateChanges(() => {
+        setTitleOverrides(readSessionTitleOverrides());
+        setPinnedSessionIds(readPinnedSessionIds());
+      }),
     [],
   );
   useEffect(
@@ -361,6 +434,13 @@ export function HistoryRoute() {
       }),
     [data?.sessions, titleOverrides],
   );
+
+  useEffect(() => {
+    if (!data || data.total > sessions.length || pinnedSessionIds.size === 0) return;
+    const liveIds = new Set(sessions.map((session) => session.id));
+    const staleIds = Array.from(pinnedSessionIds).filter((id) => !liveIds.has(id));
+    if (staleIds.length > 0) setPinnedSessionIds(unpinSessions(staleIds));
+  }, [data, pinnedSessionIds, sessions]);
 
   // status counts (across all sessions, ignoring source/search filters)
   const statusCounts = useMemo(() => {
@@ -446,10 +526,47 @@ export function HistoryRoute() {
     return Array.from(groups.values()).sort((a, b) => b.sortKey - a.sortKey);
   }, [filtered]);
 
+  const visibleSessionIds = useMemo(() => filtered.map((session) => session.id), [filtered]);
+  const visibleSessionIdSet = useMemo(() => new Set(visibleSessionIds), [visibleSessionIds]);
+  const selectedSessions = useMemo(
+    () => filtered.filter((session) => selectedSessionIds.has(session.id)),
+    [filtered, selectedSessionIds],
+  );
+  const allVisibleSelected = visibleSessionIds.length > 0 && visibleSessionIds.every((id) => selectedSessionIds.has(id));
+
+  useEffect(() => {
+    setSelectedSessionIds((prev) => {
+      const next = new Set(Array.from(prev).filter((id) => visibleSessionIdSet.has(id)));
+      return next.size === prev.size ? prev : next;
+    });
+  }, [visibleSessionIdSet]);
+
   const onTogglePinSource = useCallback((key: string) => {
     setPinnedSources(togglePinnedSource(key));
   }, []);
 
+  const onTogglePinSession = useCallback((sessionId: string) => {
+    setPinnedSessionIds(togglePinnedSession(sessionId));
+  }, []);
+
+  const toggleSelectedSession = useCallback((sessionId: string, checked: boolean) => {
+    setSelectedSessionIds((prev) => {
+      const next = new Set(prev);
+      if (checked) next.add(sessionId);
+      else next.delete(sessionId);
+      return next;
+    });
+  }, []);
+
+  const clearSelectedSessions = useCallback(() => {
+    setSelectedSessionIds(new Set());
+  }, []);
+
+  const selectVisibleSessions = useCallback(() => {
+    setSelectedSessionIds(new Set(visibleSessionIds));
+  }, [visibleSessionIds]);
+
+  const activeSessionId = useAtomValue(activeSessionIdAtom);
   const setActiveSessionId = useSetAtom(activeSessionIdAtom);
   const goSession = useCallback(
     (session: SessionSummary) => {
@@ -503,17 +620,43 @@ export function HistoryRoute() {
     [archiveSession],
   );
 
-  const handleDelete = useCallback(
-    (session: SessionSummary) => {
-      setOpenMenuId(null);
-      const confirmed = window.confirm(
-        `确认删除会话「${sessionDisplayTitle(session)}」？此操作不可撤销。`,
-      );
-      if (!confirmed) return;
-      deleteSession.mutate(session.id);
-    },
-    [deleteSession],
-  );
+  const openDeleteDialog = useCallback((targets: SessionSummary[]) => {
+    const uniqueTargets = Array.from(new Map(targets.map((session) => [session.id, session])).values());
+    if (uniqueTargets.length === 0) return;
+    setOpenMenuId(null);
+    setDeleteFeedback(null);
+    setDeleteTargets(uniqueTargets);
+  }, []);
+
+  const closeDeleteDialog = useCallback(() => {
+    if (!deleteSessions.isPending) setDeleteTargets(null);
+  }, [deleteSessions.isPending]);
+
+  const confirmDelete = useCallback(async () => {
+    if (!deleteTargets?.length) return;
+    const targetIds = deleteTargets.map((session) => session.id);
+    const result = await deleteSessions.mutateAsync(targetIds);
+    if (result.succeededIds.length > 0) {
+      unpinSessions(result.succeededIds);
+      setPinnedSessionIds(readPinnedSessionIds());
+      setSelectedSessionIds((prev) => {
+        const next = new Set(prev);
+        for (const id of result.succeededIds) next.delete(id);
+        return next;
+      });
+      if (activeSessionId && result.succeededIds.includes(activeSessionId)) {
+        setActiveSessionId(null);
+        navigate("/");
+      }
+    }
+    if (result.failureCount > 0) {
+      const sample = result.failed[0]?.error ? `：${result.failed[0].error}` : "";
+      setDeleteFeedback(`已删除 ${result.successCount} 个会话，${result.failureCount} 个删除失败${sample}`);
+    } else {
+      setDeleteFeedback(result.successCount > 0 ? `已删除 ${result.successCount} 个会话` : null);
+    }
+    setDeleteTargets(null);
+  }, [activeSessionId, deleteSessions, deleteTargets, navigate, setActiveSessionId]);
 
   const totalTokens = useMemo(
     () =>
@@ -636,6 +779,29 @@ export function HistoryRoute() {
         </div>
       </div>
 
+      <div className={s.bulkBar} data-active={selectedSessionIds.size > 0 ? "true" : undefined}>
+        {deleteFeedback ? <span className={s.bulkFeedback}>{deleteFeedback}</span> : null}
+        <span>
+          已选择 {selectedSessionIds.size} 个会话
+          {filtered.length > 0 ? ` · 当前筛选 ${filtered.length} 个` : ""}
+        </span>
+        <button type="button" onClick={selectVisibleSessions} disabled={visibleSessionIds.length === 0 || allVisibleSelected || deleteSessions.isPending}>
+          选择当前筛选结果
+        </button>
+        <button type="button" onClick={clearSelectedSessions} disabled={selectedSessionIds.size === 0 || deleteSessions.isPending}>
+          清空选择
+        </button>
+        <button
+          type="button"
+          className={s.bulkDanger}
+          onClick={() => openDeleteDialog(selectedSessions)}
+          disabled={selectedSessions.length === 0 || deleteSessions.isPending}
+        >
+          <Trash2 size={13} />
+          删除所选
+        </button>
+      </div>
+
       <div className={s.scroll}>
         {isError ? (
           <div className={s.errorState}>无法加载会话列表，请检查 Dashboard 服务。</div>
@@ -664,6 +830,7 @@ export function HistoryRoute() {
 
                 {groupIdx === 0 ? (
                   <div className={s.colHead} aria-hidden="true">
+                    <span />
                     <span>ID</span>
                     <span>标题</span>
                     <span>来源</span>
@@ -678,6 +845,8 @@ export function HistoryRoute() {
                   const live = isSessionRunning(session, runtimeBySession);
                   const status = classifySession(session, live);
                   const meta = getSourceMeta(session.source);
+                  const selected = selectedSessionIds.has(session.id);
+                  const pinned = pinnedSessionIds.has(session.id);
                   const workspacePath = normalizeWorkspacePath(workspaceMap[session.id]);
                   const workspaceName = workspacePath
                     ? workspaceNameFromPath(workspacePath)
@@ -694,8 +863,19 @@ export function HistoryRoute() {
                       key={session.id}
                       className={s.convRow}
                       data-status={status.kind}
+                      data-selected={selected ? "true" : undefined}
                       onClick={() => goSession(session)}
                     >
+                      <span className={s.cellSelect}>
+                        <input
+                          type="checkbox"
+                          checked={selected}
+                          disabled={deleteSessions.isPending}
+                          aria-label={`选择会话 ${sessionDisplayTitle(session)}`}
+                          onChange={(event) => toggleSelectedSession(session.id, event.currentTarget.checked)}
+                          onClick={(event) => event.stopPropagation()}
+                        />
+                      </span>
                       <span className={s.cellId}>{shortId(session.id)}</span>
                       <span className={s.cellTitle}>
                         {status.kind === "running" ? (
@@ -703,6 +883,7 @@ export function HistoryRoute() {
                         ) : status.kind === "failed" ? (
                           <span className={s.dotFail} aria-hidden />
                         ) : null}
+                        {pinned ? <Pin size={12} className={s.titlePin} aria-hidden /> : null}
                         <span className={s.titleText}>{sessionDisplayTitle(session)}</span>
                       </span>
                       <SourceBadge meta={meta} />
@@ -720,15 +901,19 @@ export function HistoryRoute() {
                             type="button"
                             className={s.cellMore}
                             aria-label="会话操作"
+                            disabled={deleteSessions.isPending}
                             onClick={(event) => event.stopPropagation()}
                           >
                             <MoreHorizontal size={14} />
                           </button>
                         </Popover.Trigger>
                         <RowMenu
+                          pinned={pinned}
+                          disabled={deleteSessions.isPending}
+                          onTogglePin={() => onTogglePinSession(session.id)}
                           onRename={() => startRename(session)}
                           onArchive={() => handleArchive(session)}
-                          onDelete={() => handleDelete(session)}
+                          onDelete={() => openDeleteDialog([session])}
                         />
                       </Popover.Root>
                     </div>
@@ -760,6 +945,15 @@ export function HistoryRoute() {
           }}
           onClose={closeRename}
           onSubmit={submitRename}
+        />
+      ) : null}
+
+      {deleteTargets ? (
+        <DeleteConfirmModal
+          sessions={deleteTargets}
+          deleting={deleteSessions.isPending}
+          onClose={closeDeleteDialog}
+          onConfirm={confirmDelete}
         />
       ) : null}
     </main>

--- a/web/src/routes/history.tsx
+++ b/web/src/routes/history.tsx
@@ -400,6 +400,7 @@ export function HistoryRoute() {
   const [renameValue, setRenameValue] = useState("");
   const [renameError, setRenameError] = useState("");
   const [renameSaving, setRenameSaving] = useState(false);
+  const [bulkDeleteMode, setBulkDeleteMode] = useState(false);
   const [selectedSessionIds, setSelectedSessionIds] = useState<Set<string>>(() => new Set());
   const [deleteTargets, setDeleteTargets] = useState<SessionSummary[] | null>(null);
   const [deleteFeedback, setDeleteFeedback] = useState<string | null>(null);
@@ -535,11 +536,12 @@ export function HistoryRoute() {
   const allVisibleSelected = visibleSessionIds.length > 0 && visibleSessionIds.every((id) => selectedSessionIds.has(id));
 
   useEffect(() => {
+    if (!bulkDeleteMode) return;
     setSelectedSessionIds((prev) => {
       const next = new Set(Array.from(prev).filter((id) => visibleSessionIdSet.has(id)));
       return next.size === prev.size ? prev : next;
     });
-  }, [visibleSessionIdSet]);
+  }, [bulkDeleteMode, visibleSessionIdSet]);
 
   const onTogglePinSource = useCallback((key: string) => {
     setPinnedSources(togglePinnedSource(key));
@@ -566,17 +568,35 @@ export function HistoryRoute() {
     setSelectedSessionIds(new Set(visibleSessionIds));
   }, [visibleSessionIds]);
 
+  const startBulkDeleteMode = useCallback(() => {
+    setOpenMenuId(null);
+    setDeleteFeedback(null);
+    setSelectedSessionIds(new Set());
+    setBulkDeleteMode(true);
+  }, []);
+
+  const stopBulkDeleteMode = useCallback(() => {
+    if (deleteSessions.isPending) return;
+    setBulkDeleteMode(false);
+    setSelectedSessionIds(new Set());
+    setDeleteFeedback(null);
+  }, [deleteSessions.isPending]);
+
   const activeSessionId = useAtomValue(activeSessionIdAtom);
   const setActiveSessionId = useSetAtom(activeSessionIdAtom);
   const goSession = useCallback(
     (session: SessionSummary) => {
+      if (bulkDeleteMode) {
+        toggleSelectedSession(session.id, !selectedSessionIds.has(session.id));
+        return;
+      }
       // Atom is the source of truth (#53). Set synchronously *before*
       // navigate so any async work that mounts as part of the detail
       // route reads the post-click value, not the previous one.
       setActiveSessionId(session.id);
       navigate(`/tasks/${session.id}`);
     },
-    [navigate, setActiveSessionId],
+    [bulkDeleteMode, navigate, selectedSessionIds, setActiveSessionId, toggleSelectedSession],
   );
 
   const startRename = useCallback((session: SessionSummary) => {
@@ -653,7 +673,9 @@ export function HistoryRoute() {
       const sample = result.failed[0]?.error ? `：${result.failed[0].error}` : "";
       setDeleteFeedback(`已删除 ${result.successCount} 个会话，${result.failureCount} 个删除失败${sample}`);
     } else {
-      setDeleteFeedback(result.successCount > 0 ? `已删除 ${result.successCount} 个会话` : null);
+      setDeleteFeedback(null);
+      setBulkDeleteMode(false);
+      setSelectedSessionIds(new Set());
     }
     setDeleteTargets(null);
   }, [activeSessionId, deleteSessions, deleteTargets, navigate, setActiveSessionId]);
@@ -686,6 +708,13 @@ export function HistoryRoute() {
             <span className={s.headerStat}>
               今日 <span className={s.headerStatValue}>{formatTokens(todayTokens)} tokens</span>
             </span>
+            <TopBarActionButton
+              onClick={startBulkDeleteMode}
+              disabled={bulkDeleteMode || deleteSessions.isPending || filtered.length === 0}
+            >
+              <Trash2 size={13} />
+              批量删除
+            </TopBarActionButton>
             <TopBarActionButton onClick={() => navigate("/")}>
               <Plus size={13} />
               新对话
@@ -779,28 +808,33 @@ export function HistoryRoute() {
         </div>
       </div>
 
-      <div className={s.bulkBar} data-active={selectedSessionIds.size > 0 ? "true" : undefined}>
-        {deleteFeedback ? <span className={s.bulkFeedback}>{deleteFeedback}</span> : null}
-        <span>
-          已选择 {selectedSessionIds.size} 个会话
-          {filtered.length > 0 ? ` · 当前筛选 ${filtered.length} 个` : ""}
-        </span>
-        <button type="button" onClick={selectVisibleSessions} disabled={visibleSessionIds.length === 0 || allVisibleSelected || deleteSessions.isPending}>
-          选择当前筛选结果
-        </button>
-        <button type="button" onClick={clearSelectedSessions} disabled={selectedSessionIds.size === 0 || deleteSessions.isPending}>
-          清空选择
-        </button>
-        <button
-          type="button"
-          className={s.bulkDanger}
-          onClick={() => openDeleteDialog(selectedSessions)}
-          disabled={selectedSessions.length === 0 || deleteSessions.isPending}
-        >
-          <Trash2 size={13} />
-          删除所选
-        </button>
-      </div>
+      {bulkDeleteMode ? (
+        <div className={s.bulkBar} data-active={selectedSessionIds.size > 0 ? "true" : undefined}>
+          {deleteFeedback ? <span className={s.bulkFeedback}>{deleteFeedback}</span> : null}
+          <span>
+            已选择 {selectedSessionIds.size} 个会话
+            {filtered.length > 0 ? ` · 当前筛选 ${filtered.length} 个` : ""}
+          </span>
+          <button type="button" onClick={selectVisibleSessions} disabled={visibleSessionIds.length === 0 || allVisibleSelected || deleteSessions.isPending}>
+            选择当前筛选结果
+          </button>
+          <button type="button" onClick={clearSelectedSessions} disabled={selectedSessionIds.size === 0 || deleteSessions.isPending}>
+            清空选择
+          </button>
+          <button
+            type="button"
+            className={s.bulkDanger}
+            onClick={() => openDeleteDialog(selectedSessions)}
+            disabled={selectedSessions.length === 0 || deleteSessions.isPending}
+          >
+            <Trash2 size={13} />
+            删除所选
+          </button>
+          <button type="button" onClick={stopBulkDeleteMode} disabled={deleteSessions.isPending}>
+            退出批量删除
+          </button>
+        </div>
+      ) : null}
 
       <div className={s.scroll}>
         {isError ? (
@@ -829,8 +863,8 @@ export function HistoryRoute() {
                 </div>
 
                 {groupIdx === 0 ? (
-                  <div className={s.colHead} aria-hidden="true">
-                    <span />
+                  <div className={s.colHead} data-bulk={bulkDeleteMode ? "true" : undefined} aria-hidden="true">
+                    {bulkDeleteMode ? <span /> : null}
                     <span>ID</span>
                     <span>标题</span>
                     <span>来源</span>
@@ -864,18 +898,21 @@ export function HistoryRoute() {
                       className={s.convRow}
                       data-status={status.kind}
                       data-selected={selected ? "true" : undefined}
+                      data-bulk={bulkDeleteMode ? "true" : undefined}
                       onClick={() => goSession(session)}
                     >
-                      <span className={s.cellSelect}>
-                        <input
-                          type="checkbox"
-                          checked={selected}
-                          disabled={deleteSessions.isPending}
-                          aria-label={`选择会话 ${sessionDisplayTitle(session)}`}
-                          onChange={(event) => toggleSelectedSession(session.id, event.currentTarget.checked)}
-                          onClick={(event) => event.stopPropagation()}
-                        />
-                      </span>
+                      {bulkDeleteMode ? (
+                        <span className={s.cellSelect}>
+                          <input
+                            type="checkbox"
+                            checked={selected}
+                            disabled={deleteSessions.isPending}
+                            aria-label={`选择会话 ${sessionDisplayTitle(session)}`}
+                            onChange={(event) => toggleSelectedSession(session.id, event.currentTarget.checked)}
+                            onClick={(event) => event.stopPropagation()}
+                          />
+                        </span>
+                      ) : null}
                       <span className={s.cellId}>{shortId(session.id)}</span>
                       <span className={s.cellTitle}>
                         {status.kind === "running" ? (

--- a/web/src/routes/projects.module.css
+++ b/web/src/routes/projects.module.css
@@ -157,12 +157,25 @@
   overflow: hidden;
 }
 
+.nameLine {
+  display: flex;
+  align-items: center;
+  gap: 6px;
+  min-width: 0;
+}
+
 .nameCell {
   display: block;
+  min-width: 0;
   font-weight: 600;
   overflow: hidden;
   text-overflow: ellipsis;
   white-space: nowrap;
+}
+
+.titlePin {
+  flex-shrink: 0;
+  color: var(--h-accent);
 }
 
 .pathCell {

--- a/web/src/routes/projects.tsx
+++ b/web/src/routes/projects.tsx
@@ -5,6 +5,8 @@ import {
   ExternalLink,
   FolderPlus,
   MoreHorizontal,
+  Pin,
+  PinOff,
   Plus,
   Search,
   Trash2,
@@ -15,12 +17,13 @@ import { formatTokens, relativeTime } from "@/lib/format";
 import { shortenPath } from "@/lib/paths";
 import {
   normalizeWorkspacePath,
+  readPinnedWorkspaceProjectPaths,
   readSessionWorkspaceMap,
   readWorkspaceProjects,
   rememberWorkspaceProject,
   removeWorkspaceProject,
   subscribeWorkspaceChanges,
-  workspaceNameFromPath,
+  togglePinnedWorkspaceProject,
   type WorkspaceProject,
 } from "@/lib/workspaces";
 import { TopBar, TopBarActionButton } from "@/components/top-bar/top-bar";
@@ -62,12 +65,14 @@ function pickTopModel(sessions: SessionSummary[]): string | null {
 }
 
 interface RowMenuProps {
+  pinned: boolean;
   desktopAvailable: boolean;
+  onTogglePin: () => void;
   onOpenInFinder: () => void;
   onDelete: () => void;
 }
 
-function RowMenu({ desktopAvailable, onOpenInFinder, onDelete }: RowMenuProps) {
+function RowMenu({ pinned, desktopAvailable, onTogglePin, onOpenInFinder, onDelete }: RowMenuProps) {
   return (
     <Popover.Portal>
       <Popover.Content
@@ -78,6 +83,12 @@ function RowMenu({ desktopAvailable, onOpenInFinder, onDelete }: RowMenuProps) {
         role="menu"
         onClick={(event) => event.stopPropagation()}
       >
+        <Popover.Close asChild>
+          <button type="button" onClick={onTogglePin} role="menuitem">
+            {pinned ? <PinOff size={13} /> : <Pin size={13} />}
+            {pinned ? "取消置顶" : "置顶项目"}
+          </button>
+        </Popover.Close>
         {desktopAvailable ? (
           <Popover.Close asChild>
             <button type="button" onClick={onOpenInFinder} role="menuitem">
@@ -100,6 +111,7 @@ export function ProjectsRoute() {
   const { data, isLoading } = useSessions(200, 0);
   const [projects, setProjects] = useState<WorkspaceProject[]>(readWorkspaceProjects);
   const [sessionWorkspaceMap, setSessionWorkspaceMap] = useState(readSessionWorkspaceMap);
+  const [pinnedProjectPaths, setPinnedProjectPaths] = useState(readPinnedWorkspaceProjectPaths);
   const [searchQuery, setSearchQuery] = useState("");
   const [openMenuPath, setOpenMenuPath] = useState<string | null>(null);
 
@@ -107,6 +119,7 @@ export function ProjectsRoute() {
     return subscribeWorkspaceChanges(() => {
       setProjects(readWorkspaceProjects());
       setSessionWorkspaceMap(readSessionWorkspaceMap());
+      setPinnedProjectPaths(readPinnedWorkspaceProjectPaths());
     });
   }, []);
 
@@ -194,6 +207,11 @@ export function ProjectsRoute() {
     }
   }, []);
 
+  const handleTogglePin = useCallback((project: WorkspaceProject) => {
+    setOpenMenuPath(null);
+    setPinnedProjectPaths(togglePinnedWorkspaceProject(project.path));
+  }, []);
+
   const handleDelete = useCallback((project: WorkspaceProject) => {
     setOpenMenuPath(null);
     const confirmed = window.confirm(
@@ -202,6 +220,7 @@ export function ProjectsRoute() {
     if (!confirmed) return;
     removeWorkspaceProject(project.path);
     setProjects(readWorkspaceProjects());
+    setPinnedProjectPaths(readPinnedWorkspaceProjectPaths());
   }, []);
 
   const goProject = useCallback(
@@ -279,6 +298,7 @@ export function ProjectsRoute() {
               <tbody>
                 {filtered.map((item) => {
                   const { project } = item;
+                  const pinned = pinnedProjectPaths.has(project.path);
                   return (
                     <tr
                       key={project.path}
@@ -289,7 +309,10 @@ export function ProjectsRoute() {
                         <span className={s.colorDot} aria-hidden />
                       </td>
                       <td className={s.projectCell} title={`${project.name}\n${project.path}`}>
-                        <span className={s.nameCell}>{project.name}</span>
+                        <span className={s.nameLine}>
+                          <span className={s.nameCell}>{project.name}</span>
+                          {pinned ? <Pin size={12} className={s.titlePin} aria-hidden /> : null}
+                        </span>
                         <span className={s.pathCell}>{shortenPath(project.path)}</span>
                       </td>
                       <td className={s.metricCell}>{item.sessions.length}</td>
@@ -317,7 +340,9 @@ export function ProjectsRoute() {
                             </button>
                           </Popover.Trigger>
                           <RowMenu
+                            pinned={pinned}
                             desktopAvailable={desktopAvailable}
+                            onTogglePin={() => handleTogglePin(project)}
                             onOpenInFinder={() => handleOpenInFinder(project)}
                             onDelete={() => handleDelete(project)}
                           />


### PR DESCRIPTION
## 变更内容

- 新增会话 Pin / Unpin 本地持久化状态，并按当前 profile 隔离。
- 在工作台侧边栏增加「置顶对话」「置顶项目」「最近对话」，最近对话排除已置顶和运行中会话。
- 在工作空间页增加项目置顶 / 取消置顶，删除项目时同步清理置顶状态。
- 在历史页增加单条置顶、批量选择、批量删除确认与部分失败反馈。
- 优化工作台侧边栏入口：移除搜索框和原工作台分组，将「对话历史」「工作空间」改为新建对话下方的普通入口按钮，并显示 `/history`、`/workspace` 指令提示。
- 优化侧边栏会话行：展示关联项目名，右对齐并在空间不足时省略。
- 将版本信息从左下角移到底部状态栏，仅保留内核版本、界面版本和 commit id。

## 验证

- `pnpm typecheck`
- `pnpm test:unit`

Closes #152
