### PR TITLE
[codex] 修复新会话进行中状态显示

### DIFF
--- a/web/src/components/app-shell/app-status-bar.tsx
+++ b/web/src/components/app-shell/app-status-bar.tsx
@@ -10,7 +10,7 @@ import { useRuntimeInfo } from "@/hooks/use-runtime-update";
 import { chatRuntimeBySessionAtom } from "@/stores/chat";
 import { dashboardPortFromUrl, dashboardUrlFromInputs } from "@/lib/dashboard-url";
 import { openExternalUrl } from "@/lib/external-links";
-import { isSessionRunning } from "@/lib/session-activity";
+import { isSessionRunning, mergeLiveRuntimeSessions } from "@/lib/session-activity";
 import { formatTokens } from "@/lib/format";
 import { gatewayRestartButtonLabel, gatewayRestartTitle } from "@/lib/gateway-restart";
 import { buildSidebarVersionRows } from "./sidebar-version-tag";
@@ -52,8 +52,10 @@ export function AppStatusBar() {
   const versionRows = buildSidebarVersionRows({ status, runtimeInfo });
 
   const runningCount = useMemo(() => {
-    if (!sessions?.sessions) return status?.active_sessions ?? 0;
-    return sessions.sessions.filter((sess) => isSessionRunning(sess, runtimeBySession)).length;
+    const merged = mergeLiveRuntimeSessions(sessions?.sessions ?? [], runtimeBySession);
+    const localCount = merged.filter((sess) => isSessionRunning(sess, runtimeBySession)).length;
+    if (sessions?.sessions) return localCount;
+    return Math.max(localCount, status?.active_sessions ?? 0);
   }, [sessions, runtimeBySession, status?.active_sessions]);
 
   const errorsLast24h = useMemo(() => {

--- a/web/src/components/app-shell/workbench-sidebar.tsx
+++ b/web/src/components/app-shell/workbench-sidebar.tsx
@@ -5,7 +5,11 @@ import { Folder, MessageSquare, Plus } from "lucide-react";
 import { chatRuntimeBySessionAtom } from "@/stores/chat";
 import { activeSessionIdAtom } from "@/stores/ui";
 import { useSessions } from "@/hooks/use-sessions";
-import { isSessionRunning } from "@/lib/session-activity";
+import {
+  isSessionRunning,
+  mergeLiveRuntimeSessions,
+  sessionIdMatches,
+} from "@/lib/session-activity";
 import { sessionDisplayTitle } from "@/lib/session-title";
 import {
   readPinnedSessionIds,
@@ -122,11 +126,14 @@ export function WorkbenchSidebar() {
 
   const sessions = useMemo(
     () =>
-      (data?.sessions ?? []).map((sess) => {
-        const override = titleOverrides[sess.id];
-        return override ? { ...sess, title: override } : sess;
-      }),
-    [data?.sessions, titleOverrides],
+      mergeLiveRuntimeSessions(
+        (data?.sessions ?? []).map((sess) => {
+          const override = titleOverrides[sess.id];
+          return override ? { ...sess, title: override } : sess;
+        }),
+        runtimeBySession,
+      ),
+    [data?.sessions, runtimeBySession, titleOverrides],
   );
 
   useEffect(() => {
@@ -245,7 +252,7 @@ export function WorkbenchSidebar() {
                 key={sess.id}
                 session={sess}
                 state="live"
-                active={sess.id === activeSessionId}
+                active={sessionIdMatches(sess.id, activeSessionId)}
                 meta={`${modelShort(sess.model)} · ${elapsed(sess.started_at, now)}`}
                 projectName={projectNameBySessionId.get(sess.id)}
                 onClick={() => goSession(sess)}
@@ -274,7 +281,7 @@ export function WorkbenchSidebar() {
                   key={sess.id}
                   session={sess}
                   state={state}
-                  active={sess.id === activeSessionId}
+                  active={sessionIdMatches(sess.id, activeSessionId)}
                   meta={running ? `${modelShort(sess.model)} · ${elapsed(sess.started_at, now)}` : relTime(ts, now)}
                   projectName={projectNameBySessionId.get(sess.id)}
                   onClick={() => goSession(sess)}
@@ -339,7 +346,7 @@ export function WorkbenchSidebar() {
                   key={sess.id}
                   session={sess}
                   state={state}
-                  active={sess.id === activeSessionId}
+                  active={sessionIdMatches(sess.id, activeSessionId)}
                   meta={meta}
                   projectName={projectNameBySessionId.get(sess.id)}
                   onClick={() => goSession(sess)}

--- a/web/src/lib/session-activity.test.ts
+++ b/web/src/lib/session-activity.test.ts
@@ -1,7 +1,14 @@
-import { describe, expect, it } from "vitest";
+import { beforeEach, describe, expect, it } from "vitest";
 import type { SessionSummary } from "@hermes/protocol";
 import { createEmptyChatRuntime } from "@/stores/chat";
-import { isRuntimeRunning, isSessionRunning } from "./session-activity";
+import { __resetUiStoreForTests } from "@/lib/ui-store";
+import { rememberSessionMapping } from "@/lib/session-map";
+import {
+  isRuntimeRunning,
+  isSessionRunning,
+  mergeLiveRuntimeSessions,
+  sessionIdMatches,
+} from "./session-activity";
 
 function session(overrides: Partial<SessionSummary>): SessionSummary {
   return {
@@ -21,6 +28,10 @@ function session(overrides: Partial<SessionSummary>): SessionSummary {
 }
 
 describe("session activity", () => {
+  beforeEach(() => {
+    __resetUiStoreForTests();
+  });
+
   it("does not treat completed recent sessions as running", () => {
     expect(
       isSessionRunning(
@@ -94,5 +105,65 @@ describe("session activity", () => {
 
     expect(isRuntimeRunning(runtime)).toBe(false);
     expect(isRuntimeRunning({ ...runtime, streamStatus: "error" })).toBe(false);
+  });
+
+  it("adds a running gateway-only session while the REST list has not caught up", () => {
+    const now = 1_700_000_000_000;
+    const sessions = mergeLiveRuntimeSessions([], {
+      "gw-1": {
+        ...createEmptyChatRuntime(now),
+        streamStatus: "streaming",
+        turnStartedAt: now,
+        messages: [
+          {
+            id: "u1",
+            sessionId: "gw-1",
+            role: "user",
+            createdAt: now,
+            status: "complete",
+            parts: [{ type: "text", text: " 分析一下这个项目\n\n的架构 " }],
+          },
+          {
+            id: "a1",
+            sessionId: "gw-1",
+            role: "assistant",
+            createdAt: now,
+            status: "streaming",
+            parts: [{ type: "progress", text: "正在启动Hermes Agent内核..." }],
+          },
+        ],
+      },
+    });
+
+    expect(sessions).toHaveLength(1);
+    expect(sessions[0]?.id).toBe("gw-1");
+    expect(sessions[0]?.preview).toBe("分析一下这个项目 的架构");
+    expect(sessions[0]?.started_at).toBe(1_700_000_000);
+    expect(isSessionRunning(sessions[0]!, {
+      "gw-1": {
+        ...createEmptyChatRuntime(now),
+        streamStatus: "streaming",
+      },
+    })).toBe(true);
+  });
+
+  it("does not duplicate a gateway runtime once it is mapped to a persistent session", () => {
+    rememberSessionMapping("gw-1", "persist-1");
+    const apiSession = session({
+      id: "persist-1",
+      is_active: false,
+      message_count: 2,
+    });
+    const runtime = {
+      ...createEmptyChatRuntime(1_700_000_000_000),
+      streamStatus: "streaming" as const,
+    };
+
+    const sessions = mergeLiveRuntimeSessions([apiSession], { "gw-1": runtime });
+
+    expect(sessions).toHaveLength(1);
+    expect(sessions[0]?.id).toBe("persist-1");
+    expect(isSessionRunning(sessions[0]!, { "gw-1": runtime })).toBe(true);
+    expect(sessionIdMatches("persist-1", "gw-1")).toBe(true);
   });
 });

--- a/web/src/lib/session-activity.ts
+++ b/web/src/lib/session-activity.ts
@@ -1,5 +1,5 @@
-import type { SessionSummary } from "@hermes/protocol";
-import { resolvePersistentSessionId } from "@/lib/session-map";
+import type { HermesMessagePart, HermesUIMessage, SessionSummary } from "@hermes/protocol";
+import { resolvePersistentSessionId, resolveSessionIdAliases } from "@/lib/session-map";
 import type { ChatRuntimeBySession, ChatSessionRuntime } from "@/stores/chat";
 
 export function isRuntimeRunning(runtime: ChatSessionRuntime | undefined): boolean {
@@ -44,4 +44,105 @@ export function isSessionRunning(
   if (runtime) return isRuntimeRunning(runtime);
 
   return session.is_active === true && session.message_count === 0;
+}
+
+function unixSecondsFromRuntimeMs(value: number | undefined): number {
+  if (typeof value !== "number" || !Number.isFinite(value) || value <= 0) {
+    return Math.floor(Date.now() / 1000);
+  }
+  // Runtime timestamps are created from Date.now() in the renderer, while the
+  // REST session API reports Unix seconds. Keep small test fixtures untouched.
+  return value > 100_000_000_000 ? Math.floor(value / 1000) : value;
+}
+
+function textFromPart(part: HermesMessagePart): string {
+  if (part.type === "text" || part.type === "reasoning" || part.type === "progress") {
+    return part.text;
+  }
+  if (part.type === "notice") return part.text;
+  if (part.type === "image") {
+    return part.alt || part.name || part.title || "";
+  }
+  if (part.type === "tool") return part.name;
+  return "";
+}
+
+function compactText(value: string): string {
+  return value.replace(/\s+/g, " ").trim();
+}
+
+function messageText(message: HermesUIMessage): string {
+  return compactText(message.parts.map(textFromPart).filter(Boolean).join(" "));
+}
+
+function firstUserPreview(runtime: ChatSessionRuntime): string | undefined {
+  const user = runtime.messages.find((message) => message.role === "user");
+  const preview = user ? messageText(user) : "";
+  return preview || undefined;
+}
+
+function runtimeStartedAt(runtime: ChatSessionRuntime): number {
+  const firstMessageCreatedAt = runtime.messages[0]?.createdAt;
+  return unixSecondsFromRuntimeMs(runtime.turnStartedAt ?? firstMessageCreatedAt ?? runtime.updatedAt);
+}
+
+function sessionMatchesRuntimeId(session: SessionSummary, runtimeSessionId: string): boolean {
+  const persistentSessionId = resolvePersistentSessionId(runtimeSessionId);
+  return (
+    session.id === runtimeSessionId ||
+    session.id === persistentSessionId ||
+    resolvePersistentSessionId(session.id) === persistentSessionId
+  );
+}
+
+export function sessionIdMatches(a: string | null | undefined, b: string | null | undefined): boolean {
+  if (!a || !b) return false;
+  if (a === b) return true;
+  return resolveSessionIdAliases(a, { includeExpired: true }).includes(b);
+}
+
+function liveRuntimeSessionSummary(
+  sessionId: string,
+  runtime: ChatSessionRuntime,
+): SessionSummary | null {
+  if (!isRuntimeRunning(runtime)) return null;
+  const persistentSessionId = resolvePersistentSessionId(sessionId) ?? sessionId;
+  const preview = firstUserPreview(runtime);
+  const model = runtime.messages.find((message) => message.metadata?.model)?.metadata?.model ?? "";
+
+  return {
+    id: persistentSessionId,
+    source: "gateway",
+    user_id: null,
+    model,
+    title: null,
+    preview,
+    started_at: runtimeStartedAt(runtime),
+    ended_at: null,
+    end_reason: null,
+    message_count: runtime.messages.length,
+    input_tokens: 0,
+    output_tokens: 0,
+    estimated_cost_usd: null,
+    is_active: true,
+  };
+}
+
+export function mergeLiveRuntimeSessions(
+  sessions: readonly SessionSummary[],
+  runtimeBySession: ChatRuntimeBySession = {},
+): SessionSummary[] {
+  const merged = [...sessions];
+  const synthetic: SessionSummary[] = [];
+
+  for (const [runtimeSessionId, runtime] of Object.entries(runtimeBySession)) {
+    if (merged.some((session) => sessionMatchesRuntimeId(session, runtimeSessionId))) {
+      continue;
+    }
+    const summary = liveRuntimeSessionSummary(runtimeSessionId, runtime);
+    if (summary) synthetic.push(summary);
+  }
+
+  synthetic.sort((a, b) => b.started_at - a.started_at);
+  return [...synthetic, ...merged];
 }

--- a/web/src/routes/panel.tsx
+++ b/web/src/routes/panel.tsx
@@ -4,7 +4,7 @@ import { useNavigate } from "react-router-dom";
 import { chatRuntimeBySessionAtom } from "@/stores/chat";
 import { activeSessionIdAtom } from "@/stores/ui";
 import { useSessions } from "@/hooks/use-sessions";
-import { isSessionRunning } from "@/lib/session-activity";
+import { isSessionRunning, mergeLiveRuntimeSessions } from "@/lib/session-activity";
 import {
   readSessionTitleOverrides,
   subscribeSessionUiStateChanges,
@@ -64,11 +64,15 @@ export function PanelRoute() {
   }, []);
 
   const sessions = useMemo(
-    () => (data?.sessions ?? []).flatMap((session) => {
-      const title = sessionTitleOverrides[session.id];
-      return title ? [{ ...session, title }] : [session];
-    }),
-    [data?.sessions, sessionTitleOverrides],
+    () =>
+      mergeLiveRuntimeSessions(
+        (data?.sessions ?? []).flatMap((session) => {
+          const title = sessionTitleOverrides[session.id];
+          return title ? [{ ...session, title }] : [session];
+        }),
+        runtimeBySession,
+      ),
+    [data?.sessions, runtimeBySession, sessionTitleOverrides],
   );
 
   const { active, recent } = useMemo(() => {


### PR DESCRIPTION
## 变更内容

修复新建对话启动后，左侧工作台“进行中”列表和底部状态栏没有立即显示运行中会话的问题。

## 原因

新会话刚通过 Gateway 启动时，前端已经有实时 streaming runtime 状态，但 `/api/sessions` 的 REST 历史列表可能尚未写入或刷新。原来的侧栏、首页任务面板和状态栏只基于 REST 列表筛选运行中会话，因此会出现任务实际在跑但 UI 显示为空的延迟窗口。

## 实现

新增 `mergeLiveRuntimeSessions`，把前端 runtime 中正在 streaming 的 gateway-only 会话合并进会话列表，并通过 session id alias 兼容 gateway session id 与 persistent session id 的映射，避免映射后重复显示或高亮失效。

该逻辑已应用到工作台侧栏、首页任务面板和底部“进行中”计数。

## 验证

- `pnpm typecheck`
- `pnpm test:unit`
- `cargo check`