### PR TITLE
[codex] 修复对话公式渲染错位

### DIFF
--- a/web/src/components/chat/markdown-renderer.module.css
+++ b/web/src/components/chat/markdown-renderer.module.css
@@ -1,3 +1,34 @@
+.markdownRoot {
+  max-width: 100%;
+}
+
+.markdownRoot :global(.katex),
+.markdownRoot :global(.katex *) {
+  overflow-wrap: normal;
+  word-break: normal;
+  line-break: auto;
+  text-autospace: no-autospace;
+  text-spacing-trim: normal;
+  text-wrap: nowrap;
+  hanging-punctuation: none;
+}
+
+.markdownRoot :global(.katex) {
+  white-space: nowrap;
+}
+
+.markdownRoot :global(.katex-display) {
+  max-width: 100%;
+  overflow-x: auto;
+  overflow-y: visible;
+  margin: 12px 0;
+  padding: 4px 0 10px;
+}
+
+.markdownRoot :global(.katex-display > .katex) {
+  padding: 1px 4px 3px;
+}
+
 .richInline {
   color: inherit;
   font-size: inherit;

--- a/web/src/components/chat/markdown-renderer.tsx
+++ b/web/src/components/chat/markdown-renderer.tsx
@@ -1,11 +1,19 @@
 import { cjk } from "@streamdown/cjk";
 import { createMathPlugin } from "@streamdown/math";
 import { mermaid } from "@streamdown/mermaid";
-import type { CSSProperties, ComponentProps, MouseEvent } from "react";
+import {
+  createContext,
+  useContext,
+  useMemo,
+  type CSSProperties,
+  type ComponentProps,
+  type MouseEvent,
+} from "react";
 import rehypeRaw from "rehype-raw";
 import rehypeSanitize, { defaultSchema, type Options as SanitizeSchema } from "rehype-sanitize";
 import { harden } from "rehype-harden";
 import { Streamdown } from "streamdown";
+import "katex/dist/katex.min.css";
 import { MessageImage } from "./message-image";
 import s from "./markdown-renderer.module.css";
 
@@ -26,6 +34,7 @@ type RichInlineProps<T extends "span" | "small" | "time" | "mark"> = Omit<
 const ALLOWED_LINK_PROTOCOLS = ["http", "https", "irc", "ircs", "mailto", "xmpp", "tel", "obsidian"];
 const ALLOWED_EXTERNAL_PROTOCOLS = new Set(["http:", "https:", "mailto:", "tel:", "obsidian:"]);
 const BLOCKED_EXTERNAL_PROTOCOLS = /^(?:javascript|data|file|vbscript|tauri):/i;
+const KatexSpanContext = createContext(false);
 
 const streamdownPlugins = {
   cjk,
@@ -67,6 +76,111 @@ const streamdownRehypePlugins: ComponentProps<typeof Streamdown>["rehypePlugins"
     },
   ],
 ];
+
+function isEscaped(text: string, index: number): boolean {
+  let slashCount = 0;
+  for (let cursor = index - 1; cursor >= 0 && text[cursor] === "\\"; cursor -= 1) {
+    slashCount += 1;
+  }
+  return slashCount % 2 === 1;
+}
+
+function linePrefix(text: string, index: number): string {
+  const lineStart = text.lastIndexOf("\n", index - 1) + 1;
+  return text.slice(lineStart, index);
+}
+
+function fenceAt(text: string, index: number): { marker: "`" | "~"; length: number } | null {
+  const prefix = linePrefix(text, index);
+  if (!/^[ \t]{0,3}$/.test(prefix)) return null;
+  const match = text.slice(index).match(/^(`{3,}|~{3,})/);
+  if (!match) return null;
+  const marker = match[1][0] as "`" | "~";
+  return { marker, length: match[1].length };
+}
+
+function closingFenceAt(text: string, index: number, fence: { marker: "`" | "~"; length: number }): boolean {
+  const found = fenceAt(text, index);
+  return Boolean(found && found.marker === fence.marker && found.length >= fence.length);
+}
+
+function tickRunLength(text: string, index: number): number {
+  let length = 0;
+  while (text[index + length] === "`") length += 1;
+  return length;
+}
+
+function findUnescaped(text: string, needle: string, from: number): number {
+  let index = from;
+  while (index < text.length) {
+    const found = text.indexOf(needle, index);
+    if (found === -1) return -1;
+    if (!isEscaped(text, found)) return found;
+    index = found + needle.length;
+  }
+  return -1;
+}
+
+function normalizeTexMathDelimiters(text: string): string {
+  let result = "";
+  let index = 0;
+  let fence: { marker: "`" | "~"; length: number } | null = null;
+  let inlineTicks = 0;
+
+  while (index < text.length) {
+    if (inlineTicks === 0) {
+      const currentFence = fenceAt(text, index);
+      if (currentFence) {
+        if (fence && closingFenceAt(text, index, fence)) {
+          fence = null;
+        } else if (!fence) {
+          fence = currentFence;
+        }
+        const length = currentFence.length;
+        result += text.slice(index, index + length);
+        index += length;
+        continue;
+      }
+    }
+
+    if (!fence && text[index] === "`") {
+      const length = tickRunLength(text, index);
+      if (inlineTicks === 0) {
+        inlineTicks = length;
+      } else if (length === inlineTicks) {
+        inlineTicks = 0;
+      }
+      result += text.slice(index, index + length);
+      index += length;
+      continue;
+    }
+
+    if (!fence && inlineTicks === 0 && !isEscaped(text, index)) {
+      if (text.startsWith("\\(", index)) {
+        const close = findUnescaped(text, "\\)", index + 2);
+        if (close !== -1) {
+          result += `$${text.slice(index + 2, close)}$`;
+          index = close + 2;
+          continue;
+        }
+      }
+
+      if (text.startsWith("\\[", index)) {
+        const close = findUnescaped(text, "\\]", index + 2);
+        if (close !== -1) {
+          result += `\n\n$$\n${text.slice(index + 2, close).trim()}\n$$\n\n`;
+          index = close + 2;
+          continue;
+        }
+      }
+    }
+
+    result += text[index];
+    index += 1;
+  }
+
+  return result;
+}
 
 function safeHref(value: unknown): string | undefined {
   if (typeof value !== "string") return undefined;
@@ -340,11 +454,42 @@ function richInlineClassName(
   );
 }
 
+function hasRichInlineData(props: Record<string, unknown>): boolean {
+  return Boolean(
+    dataValue(props, "data-tone", "dataTone") ||
+      dataValue(props, "data-size", "dataSize") ||
+      props.style ||
+      props.title,
+  );
+}
+
 function MarkdownSpan({ children, className, node: _node, style, ...props }: RichInlineProps<"span">) {
+  const insideKatex = useContext(KatexSpanContext);
+  const isKatexRoot = typeof className === "string" && /\bkatex\b/.test(className);
+
+  if (insideKatex || isKatexRoot) {
+    const span = (
+      <span {...props} className={className} style={style as CSSProperties | undefined}>
+        {children}
+      </span>
+    );
+
+    return isKatexRoot ? <KatexSpanContext.Provider value>{span}</KatexSpanContext.Provider> : span;
+  }
+
+  const record = props as Record<string, unknown>;
+  if (className && !hasRichInlineData(record)) {
+    return (
+      <span {...props} className={className} style={style as CSSProperties | undefined}>
+        {children}
+      </span>
+    );
+  }
+
   return (
     <span
       {...props}
-      className={richInlineClassName(props as Record<string, unknown>, className)}
+      className={richInlineClassName(record, className)}
       style={sanitizeInlineStyle(style)}
     >
       {children}
@@ -398,8 +543,11 @@ const streamdownComponents = {
 };
 
 export function MarkdownText({ text, streaming = false }: MarkdownTextProps) {
+  const normalizedText = useMemo(() => normalizeTexMathDelimiters(text), [text]);
+
   return (
     <Streamdown
+      className={s.markdownRoot}
       components={streamdownComponents}
       controls={false}
       dir="auto"
@@ -410,7 +558,7 @@ export function MarkdownText({ text, streaming = false }: MarkdownTextProps) {
       plugins={streamdownPlugins}
       rehypePlugins={streamdownRehypePlugins}
     >
-      {text}
+      {normalizedText}
     </Streamdown>
   );
 }

--- a/web/src/components/chat/message-text.tsx
+++ b/web/src/components/chat/message-text.tsx
@@ -1,5 +1,4 @@
 import { lazy, Suspense } from "react";
-import "katex/dist/katex.min.css";
 import s from "./message-timeline.module.css";
 
 interface MessageTextProps {

--- a/web/src/components/chat/message-timeline.module.css
+++ b/web/src/components/chat/message-timeline.module.css
@@ -394,9 +394,9 @@
 .messageText :global(.katex-display) {
   max-width: 100%;
   overflow-x: auto;
-  overflow-y: hidden;
-  margin: 10px 0;
-  padding-bottom: 2px;
+  overflow-y: visible;
+  margin: 12px 0;
+  padding: 4px 0 10px;
 }
 
 .turnText + .turnText,

--- a/web/src/components/chat/message-timeline.test.tsx
+++ b/web/src/components/chat/message-timeline.test.tsx
@@ -139,7 +139,31 @@ describe("MessageTimeline", () => {
     );
 
     expect(html).toContain("katex");
+    expect(html).toContain('class="katex"');
+    expect(html).toContain("style=\"height:");
+    expect(html).not.toContain("_richInline");
     expect(html).not.toContain("$\\boldsymbol");
+  });
+
+  it("renders TeX parenthesis and bracket math delimiters", () => {
+    const html = ReactDOMServer.renderToStaticMarkup(
+      <MarkdownText
+        text={String.raw`两个球体 \(S_1(c_1,r_1)\) 和 \(S_2(c_2,r_2)\) 的条件：\[\|\mathbf{c}_1-\mathbf{c}_2\|\le r_1+r_2\]`}
+      />,
+    );
+
+    expect(html).toContain("katex");
+    expect(html).toContain("katex-display");
+    expect(html).not.toContain("\\(");
+    expect(html).not.toContain("\\[");
+  });
+
+  it("does not normalize TeX delimiters inside code", () => {
+    const html = ReactDOMServer.renderToStaticMarkup(
+      <MarkdownText text={"代码 `\\(x_1\\)` 保持字面量。"} />,
+    );
+
+    expect(html).toContain("\\(x_1\\)");
   });
 
   it("shows a readable fallback for unsupported local image URLs", () => {


### PR DESCRIPTION
## 变更内容

修复对话 Markdown 中公式渲染错位、显示不全，以及 `\(...\)` / `\[...\]` 这类常见 TeX 分隔符无法稳定渲染的问题。

## 原因

KaTeX 会生成大量内部 `span` 并依赖内联定位样式完成上下标、分式、根号等排版。当前 Markdown 富文本 span 组件会接管这些内部节点，清洗掉部分样式并附加 `_richInline` 类，导致公式结构错位，看起来像乱码。同时显示公式容器使用了纵向裁剪，复杂公式下半部分容易被截断。

## 用户影响

对话列表和会话详情中的 LaTeX 公式会按 KaTeX 正常排版；显示公式可横向滚动但不再纵向裁剪；代码块和行内代码中的 TeX 字面量不会被误转换。

## 验证

- `pnpm typecheck`
- `pnpm test:unit`
- `cargo check`
- 临时 Vite 页面浏览器预览，确认球体/AABB 示例公式的上下标、根号和显示公式正常。