### PR TITLE
[codex] 优化健康检查页面

### DIFF
--- a/web/src/components/panel/health-grid.module.css
+++ b/web/src/components/panel/health-grid.module.css
@@ -1,173 +1,686 @@
-.bar {
+.root {
+  min-width: 0;
+}
+
+.root[data-variant="page"] {
   display: flex;
+  flex-direction: column;
+  gap: 16px;
+}
+
+.hero {
+  display: grid;
+  grid-template-columns: auto minmax(0, 1fr) auto;
+  gap: 16px;
+  align-items: start;
+  padding: 22px;
+  border: 1px solid var(--h-line);
+  border-radius: var(--h-r-lg, 14px);
+  background:
+    radial-gradient(circle at 0% 0%, color-mix(in srgb, var(--h-accent) 10%, transparent), transparent 42%),
+    linear-gradient(135deg, color-mix(in srgb, var(--h-bg-pane) 96%, transparent), var(--h-bg-soft));
+  box-shadow: var(--h-shadow-l);
+}
+
+.hero[data-tone="ok"] {
+  border-color: color-mix(in srgb, var(--h-ok) 24%, var(--h-line));
+}
+
+.hero[data-tone="warn"] {
+  background:
+    radial-gradient(circle at 0% 0%, color-mix(in srgb, var(--h-warn) 14%, transparent), transparent 42%),
+    linear-gradient(135deg, color-mix(in srgb, var(--h-warn-soft) 40%, var(--h-bg-pane)), var(--h-bg-soft));
+  border-color: color-mix(in srgb, var(--h-warn) 32%, var(--h-line));
+}
+
+.hero[data-tone="err"] {
+  background:
+    radial-gradient(circle at 0% 0%, color-mix(in srgb, var(--h-err) 14%, transparent), transparent 42%),
+    linear-gradient(135deg, color-mix(in srgb, var(--h-err) 8%, var(--h-bg-pane)), var(--h-bg-soft));
+  border-color: color-mix(in srgb, var(--h-err) 36%, var(--h-line));
+}
+
+.heroMark {
+  width: 46px;
+  height: 46px;
+  display: inline-flex;
   align-items: center;
-  gap: 12px;
-  width: 100%;
-  padding: 11px 16px;
+  justify-content: center;
+  border-radius: var(--h-r-lg, 14px);
+  border: 1px solid var(--h-line);
   background: var(--h-bg-pane);
+  color: var(--h-text-2);
+}
+
+.heroMark[data-tone="ok"] {
+  color: var(--h-ok);
+  background: var(--h-ok-soft);
+  border-color: color-mix(in srgb, var(--h-ok) 28%, var(--h-line));
+}
+
+.heroMark[data-tone="warn"] {
+  color: var(--h-warn);
+  background: var(--h-warn-soft);
+  border-color: color-mix(in srgb, var(--h-warn) 28%, var(--h-line));
+}
+
+.heroMark[data-tone="err"] {
+  color: var(--h-err);
+  background: color-mix(in srgb, var(--h-err) 12%, var(--h-bg-pane));
+  border-color: color-mix(in srgb, var(--h-err) 32%, var(--h-line));
+}
+
+.heroBody {
+  min-width: 0;
+}
+
+.eyebrow {
+  margin-bottom: 6px;
+  font-family: var(--h-font-mono);
+  font-size: 10px;
+  letter-spacing: 0.14em;
+  text-transform: uppercase;
+  color: var(--h-text-3);
+}
+
+.heroBody h2 {
+  margin: 0;
+  color: var(--h-text);
+  font-size: 24px;
+  line-height: 1.2;
+  font-weight: 720;
+  letter-spacing: -0.02em;
+}
+
+.heroBody p {
+  max-width: 760px;
+  margin: 8px 0 0;
+  color: var(--h-text-2);
+  font-size: 13px;
+  line-height: 1.7;
+}
+
+.heroActions {
+  display: flex;
+  flex-wrap: wrap;
+  justify-content: flex-end;
+  gap: 8px;
+  min-width: 220px;
+}
+
+.actionButton {
+  display: inline-flex;
+  align-items: center;
+  justify-content: center;
+  gap: 6px;
+  min-height: 32px;
+  padding: 7px 11px;
   border: 1px solid var(--h-line);
   border-radius: var(--h-r-md, 8px);
+  background: color-mix(in srgb, var(--h-bg-pane) 92%, transparent);
+  color: var(--h-text-2);
   font: inherit;
-  font-size: 12.5px;
-  color: var(--h-text);
-  text-align: left;
+  font-size: 12px;
+  white-space: nowrap;
   cursor: pointer;
-  transition: background 0.12s, border-color 0.12s;
+  transition: background 0.12s, border-color 0.12s, color 0.12s, transform 0.12s;
 }
 
-.bar:hover {
+.actionButton:hover:not(:disabled) {
   background: var(--h-bg-soft);
+  border-color: color-mix(in srgb, var(--h-accent) 34%, var(--h-line));
+  color: var(--h-text);
+  transform: translateY(-1px);
 }
 
-.bar[data-tone="warn"] {
-  background: color-mix(in srgb, var(--h-warn-soft) 35%, var(--h-bg-pane));
+.actionButton:disabled {
+  cursor: not-allowed;
+  opacity: 0.55;
+}
+
+.metrics {
+  display: grid;
+  grid-template-columns: repeat(4, minmax(0, 1fr));
+  gap: 10px;
+}
+
+.metric {
+  min-width: 0;
+  padding: 14px 15px;
+  border: 1px solid var(--h-line);
+  border-radius: var(--h-r-md, 10px);
+  background: var(--h-bg-pane);
+}
+
+.metric[data-tone="ok"] {
+  border-color: color-mix(in srgb, var(--h-ok) 18%, var(--h-line));
+}
+
+.metric[data-tone="warn"] {
+  background: color-mix(in srgb, var(--h-warn-soft) 30%, var(--h-bg-pane));
   border-color: color-mix(in srgb, var(--h-warn) 25%, var(--h-line));
 }
 
-.bar[data-tone="err"] {
+.metric[data-tone="err"] {
   background: color-mix(in srgb, var(--h-err) 8%, var(--h-bg-pane));
   border-color: color-mix(in srgb, var(--h-err) 30%, var(--h-line));
 }
 
-.barLabel {
-  font-weight: 500;
-  color: var(--h-text);
-}
-
-.barSummary {
-  color: var(--h-text-3);
-  font-size: 11.5px;
-}
-
-.barChev {
-  margin-left: auto;
+.metricLabel {
   color: var(--h-text-3);
   font-size: 11px;
 }
 
-.grid {
-  display: grid;
-  grid-template-columns: repeat(12, minmax(0, 1fr));
-  gap: 8px;
-  margin-top: 10px;
+.metricValue {
+  margin-top: 5px;
+  color: var(--h-text);
+  font-size: 24px;
+  line-height: 1.1;
+  font-weight: 720;
 }
 
-.cell {
-  grid-column: span 2;
-  background: var(--h-bg-pane);
-  border: 1px solid var(--h-line);
-  border-radius: var(--h-r-md, 8px);
-  padding: 12px 14px;
+.metricSub {
+  margin-top: 5px;
+  color: var(--h-text-3);
+  font-size: 11.5px;
+  white-space: nowrap;
+  overflow: hidden;
+  text-overflow: ellipsis;
+}
+
+.pageGrid {
+  display: grid;
+  grid-template-columns: minmax(0, 1fr) 310px;
+  gap: 14px;
+  align-items: start;
+}
+
+.groups {
   display: flex;
   flex-direction: column;
-  gap: 6px;
+  gap: 14px;
   min-width: 0;
-  appearance: none;
+}
+
+.group {
+  min-width: 0;
+  padding: 16px;
+  border: 1px solid var(--h-line);
+  border-radius: var(--h-r-lg, 14px);
+  background: var(--h-bg-pane);
+}
+
+.group[data-tone="warn"] {
+  border-color: color-mix(in srgb, var(--h-warn) 22%, var(--h-line));
+}
+
+.group[data-tone="err"] {
+  border-color: color-mix(in srgb, var(--h-err) 28%, var(--h-line));
+}
+
+.groupHead {
+  display: grid;
+  grid-template-columns: auto minmax(0, 1fr) auto;
+  gap: 10px;
+  align-items: start;
+  margin-bottom: 14px;
+}
+
+.groupIcon {
+  width: 28px;
+  height: 28px;
+  display: inline-flex;
+  align-items: center;
+  justify-content: center;
+  border-radius: var(--h-r-md, 8px);
+  border: 1px solid var(--h-line);
+  background: var(--h-bg-soft);
+  color: var(--h-text-2);
+}
+
+.groupIcon[data-tone="ok"] {
+  color: var(--h-ok);
+  background: var(--h-ok-soft);
+  border-color: color-mix(in srgb, var(--h-ok) 22%, var(--h-line));
+}
+
+.groupIcon[data-tone="warn"] {
+  color: var(--h-warn);
+  background: var(--h-warn-soft);
+  border-color: color-mix(in srgb, var(--h-warn) 24%, var(--h-line));
+}
+
+.groupIcon[data-tone="err"] {
+  color: var(--h-err);
+  background: color-mix(in srgb, var(--h-err) 12%, var(--h-bg-pane));
+  border-color: color-mix(in srgb, var(--h-err) 30%, var(--h-line));
+}
+
+.groupHead h3 {
+  margin: 0;
+  color: var(--h-text);
+  font-size: 15px;
+  line-height: 1.25;
+  font-weight: 680;
+}
+
+.groupHead p {
+  margin: 4px 0 0;
+  color: var(--h-text-3);
+  font-size: 12px;
+  line-height: 1.5;
+}
+
+.groupStatus,
+.itemTone {
+  display: inline-flex;
+  align-items: center;
+  justify-content: center;
+  padding: 2px 7px;
+  border: 1px solid var(--h-line);
+  border-radius: 999px;
+  background: var(--h-bg-soft);
+  color: var(--h-text-3);
+  font-size: 10.5px;
+  line-height: 1.45;
+  white-space: nowrap;
+}
+
+.groupStatus[data-tone="ok"],
+.itemTone[data-tone="ok"] {
+  color: var(--h-ok);
+  background: var(--h-ok-soft);
+  border-color: color-mix(in srgb, var(--h-ok) 24%, var(--h-line));
+}
+
+.groupStatus[data-tone="warn"],
+.itemTone[data-tone="warn"] {
+  color: var(--h-warn);
+  background: var(--h-warn-soft);
+  border-color: color-mix(in srgb, var(--h-warn) 24%, var(--h-line));
+}
+
+.groupStatus[data-tone="err"],
+.itemTone[data-tone="err"] {
+  color: var(--h-err);
+  background: color-mix(in srgb, var(--h-err) 12%, var(--h-bg-pane));
+  border-color: color-mix(in srgb, var(--h-err) 30%, var(--h-line));
+}
+
+.itemGrid {
+  display: grid;
+  grid-template-columns: repeat(auto-fit, minmax(210px, 1fr));
+  gap: 10px;
+}
+
+.item {
+  min-width: 0;
+  min-height: 126px;
+  display: flex;
+  flex-direction: column;
+  gap: 7px;
+  padding: 13px 14px;
+  border: 1px solid var(--h-line);
+  border-radius: var(--h-r-md, 10px);
+  background: color-mix(in srgb, var(--h-bg-pane) 96%, transparent);
   color: inherit;
   font: inherit;
   text-align: left;
+  appearance: none;
 }
 
-.cell[data-size="wide"] {
-  grid-column: span 4;
+.item[data-tone="warn"] {
+  background: color-mix(in srgb, var(--h-warn-soft) 32%, var(--h-bg-pane));
+  border-color: color-mix(in srgb, var(--h-warn) 24%, var(--h-line));
 }
 
-.cell[data-warn="true"] {
-  background: color-mix(in srgb, var(--h-warn-soft) 35%, var(--h-bg-pane));
-  border-color: color-mix(in srgb, var(--h-warn) 25%, var(--h-line));
-}
-
-.cell[data-err="true"] {
+.item[data-tone="err"] {
   background: color-mix(in srgb, var(--h-err) 8%, var(--h-bg-pane));
   border-color: color-mix(in srgb, var(--h-err) 30%, var(--h-line));
 }
 
-.cell[data-action="true"] {
+.item[data-action="true"] {
   cursor: pointer;
   transition: background 0.12s, border-color 0.12s, transform 0.12s;
 }
 
-.cell[data-action="true"]:hover {
+.item[data-action="true"]:hover {
   background: var(--h-bg-soft);
   border-color: color-mix(in srgb, var(--h-accent) 35%, var(--h-line));
   transform: translateY(-1px);
 }
 
-.cell[data-action="true"]:focus-visible {
+.item[data-action="true"]:focus-visible {
   outline: 2px solid color-mix(in srgb, var(--h-accent) 70%, transparent);
   outline-offset: 2px;
 }
 
-.cell[data-action="true"][data-warn="true"]:hover {
-  background: color-mix(in srgb, var(--h-warn-soft) 55%, var(--h-bg-pane));
-  border-color: color-mix(in srgb, var(--h-warn) 45%, var(--h-line));
-}
-
-.cell[data-action="true"][data-err="true"]:hover {
-  background: color-mix(in srgb, var(--h-err) 12%, var(--h-bg-pane));
-  border-color: color-mix(in srgb, var(--h-err) 45%, var(--h-line));
-}
-
-.label {
+.itemTop {
   display: flex;
   align-items: center;
-  gap: 6px;
-  font-size: 11px;
+  justify-content: space-between;
+  gap: 8px;
+}
+
+.itemLabel {
+  min-width: 0;
   color: var(--h-text-3);
+  font-size: 11.5px;
   white-space: nowrap;
   overflow: hidden;
   text-overflow: ellipsis;
 }
 
-.value {
-  font-size: 14px;
-  font-weight: 600;
+.itemValue {
   color: var(--h-text);
+  font-size: 15px;
+  font-weight: 680;
+  line-height: 1.28;
+  white-space: nowrap;
   overflow: hidden;
   text-overflow: ellipsis;
-  white-space: nowrap;
 }
 
-.value[data-mono="true"] {
+.itemValue[data-mono="true"] {
   font-family: var(--h-font-mono, ui-monospace, "SF Mono", monospace);
-  font-size: 12px;
-  font-weight: 500;
+  font-size: 12.5px;
+  font-weight: 560;
 }
 
-.sub {
-  font-size: 10.5px;
+.itemSub {
   color: var(--h-text-3);
   font-family: var(--h-font-mono, ui-monospace, "SF Mono", monospace);
+  font-size: 11px;
+  line-height: 1.45;
+  white-space: nowrap;
   overflow: hidden;
   text-overflow: ellipsis;
-  white-space: nowrap;
 }
 
-.cell[data-warn="true"] .sub {
+.item[data-tone="warn"] .itemSub {
   color: color-mix(in srgb, var(--h-warn) 80%, var(--h-text-3));
 }
 
-@media (max-width: 1100px) {
-  .grid {
-    grid-template-columns: repeat(6, minmax(0, 1fr));
+.item[data-tone="err"] .itemSub {
+  color: color-mix(in srgb, var(--h-err) 82%, var(--h-text-3));
+}
+
+.itemDetail {
+  margin: 0;
+  color: var(--h-text-2);
+  font-size: 12px;
+  line-height: 1.55;
+  display: -webkit-box;
+  -webkit-line-clamp: 3;
+  -webkit-box-orient: vertical;
+  overflow: hidden;
+}
+
+.itemAction {
+  margin-top: auto;
+  display: inline-flex;
+  align-items: center;
+  gap: 5px;
+  color: var(--h-accent);
+  font-size: 12px;
+  font-weight: 560;
+}
+
+.aside {
+  position: sticky;
+  top: 0;
+  display: flex;
+  flex-direction: column;
+  gap: 12px;
+  min-width: 0;
+}
+
+.asideCard {
+  padding: 14px;
+  border: 1px solid var(--h-line);
+  border-radius: var(--h-r-lg, 14px);
+  background: var(--h-bg-pane);
+}
+
+.asideHead {
+  display: flex;
+  align-items: center;
+  gap: 7px;
+  color: var(--h-text);
+  font-size: 13px;
+  font-weight: 650;
+}
+
+.fixList {
+  display: flex;
+  flex-direction: column;
+  gap: 8px;
+  margin-top: 12px;
+}
+
+.fixItem {
+  display: grid;
+  grid-template-columns: auto minmax(0, 1fr) auto;
+  align-items: center;
+  gap: 9px;
+  width: 100%;
+  padding: 10px;
+  border: 1px solid var(--h-line);
+  border-radius: var(--h-r-md, 10px);
+  background: var(--h-bg-soft);
+  color: inherit;
+  font: inherit;
+  text-align: left;
+  cursor: pointer;
+}
+
+.fixItem:disabled {
+  cursor: default;
+}
+
+.fixItem[data-tone="warn"] {
+  border-color: color-mix(in srgb, var(--h-warn) 22%, var(--h-line));
+}
+
+.fixItem[data-tone="err"] {
+  border-color: color-mix(in srgb, var(--h-err) 28%, var(--h-line));
+}
+
+.fixItem:not(:disabled):hover {
+  border-color: color-mix(in srgb, var(--h-accent) 35%, var(--h-line));
+  background: var(--h-bg-pane);
+}
+
+.fixIcon {
+  display: inline-flex;
+  color: var(--h-text-3);
+}
+
+.fixItem[data-tone="warn"] .fixIcon {
+  color: var(--h-warn);
+}
+
+.fixItem[data-tone="err"] .fixIcon {
+  color: var(--h-err);
+}
+
+.fixText {
+  min-width: 0;
+  display: flex;
+  flex-direction: column;
+  gap: 2px;
+}
+
+.fixText strong {
+  color: var(--h-text);
+  font-size: 12px;
+  font-weight: 620;
+}
+
+.fixText span {
+  color: var(--h-text-3);
+  font-size: 11px;
+  white-space: nowrap;
+  overflow: hidden;
+  text-overflow: ellipsis;
+}
+
+.emptyState {
+  display: flex;
+  align-items: flex-start;
+  gap: 8px;
+  margin-top: 12px;
+  padding: 12px;
+  border: 1px solid color-mix(in srgb, var(--h-ok) 22%, var(--h-line));
+  border-radius: var(--h-r-md, 10px);
+  background: var(--h-ok-soft);
+  color: var(--h-text-2);
+  font-size: 12px;
+  line-height: 1.55;
+}
+
+.emptyState svg {
+  flex: 0 0 auto;
+  color: var(--h-ok);
+}
+
+.asideText {
+  margin: 10px 0 0;
+  color: var(--h-text-2);
+  font-size: 12px;
+  line-height: 1.65;
+}
+
+.compactHead {
+  display: flex;
+  align-items: center;
+  justify-content: space-between;
+  gap: 12px;
+  width: 100%;
+  padding: 11px 14px;
+  margin-bottom: 10px;
+  background: var(--h-bg-pane);
+  border: 1px solid var(--h-line);
+  border-radius: var(--h-r-md, 8px);
+}
+
+.compactHead[data-tone="warn"] {
+  background: color-mix(in srgb, var(--h-warn-soft) 35%, var(--h-bg-pane));
+  border-color: color-mix(in srgb, var(--h-warn) 25%, var(--h-line));
+}
+
+.compactHead[data-tone="err"] {
+  background: color-mix(in srgb, var(--h-err) 8%, var(--h-bg-pane));
+  border-color: color-mix(in srgb, var(--h-err) 30%, var(--h-line));
+}
+
+.compactMain {
+  display: flex;
+  align-items: center;
+  gap: 9px;
+  min-width: 0;
+}
+
+.compactTitle {
+  color: var(--h-text);
+  font-size: 12.5px;
+  font-weight: 600;
+  white-space: nowrap;
+}
+
+.compactSub,
+.compactMeta {
+  color: var(--h-text-3);
+  font-size: 11.5px;
+  white-space: nowrap;
+  overflow: hidden;
+  text-overflow: ellipsis;
+}
+
+.compactMeta {
+  flex: 0 0 auto;
+  font-family: var(--h-font-mono);
+}
+
+.root[data-variant="compact"] .item {
+  min-height: 104px;
+  padding: 12px 13px;
+}
+
+.root[data-variant="compact"] .itemDetail {
+  display: none;
+}
+
+.root[data-variant="compact"] .itemGrid {
+  grid-template-columns: repeat(auto-fit, minmax(170px, 1fr));
+  gap: 8px;
+}
+
+.root[data-variant="compact"] .itemValue {
+  font-size: 14px;
+}
+
+.root[data-variant="compact"] .itemValue[data-mono="true"] {
+  font-size: 12px;
+}
+
+@media (max-width: 1180px) {
+  .hero {
+    grid-template-columns: auto minmax(0, 1fr);
   }
 
-  .cell {
-    grid-column: span 1;
+  .heroActions {
+    grid-column: 1 / -1;
+    justify-content: flex-start;
+    min-width: 0;
   }
 
-  .cell[data-size="wide"] {
-    grid-column: span 2;
+  .pageGrid {
+    grid-template-columns: minmax(0, 1fr);
+  }
+
+  .aside {
+    position: static;
+    display: grid;
+    grid-template-columns: repeat(2, minmax(0, 1fr));
   }
 }
 
-@media (max-width: 640px) {
-  .grid {
-    grid-template-columns: repeat(2, minmax(0, 1fr));
+@media (max-width: 760px) {
+  .hero {
+    grid-template-columns: minmax(0, 1fr);
+    padding: 18px;
   }
 
-  .cell,
-  .cell[data-size="wide"] {
-    grid-column: span 2;
+  .heroMark {
+    width: 40px;
+    height: 40px;
+  }
+
+  .heroBody h2 {
+    font-size: 21px;
+  }
+
+  .metrics,
+  .aside {
+    grid-template-columns: 1fr;
+  }
+
+  .groupHead {
+    grid-template-columns: auto minmax(0, 1fr);
+  }
+
+  .groupStatus {
+    grid-column: 2;
+    justify-self: start;
+  }
+
+  .compactHead {
+    align-items: flex-start;
+    flex-direction: column;
+  }
+
+  .compactMain {
+    width: 100%;
   }
 }

--- a/web/src/components/panel/health-grid.tsx
+++ b/web/src/components/panel/health-grid.tsx
@@ -1,4 +1,19 @@
-import { useEffect, useMemo, useState } from "react";
+import { useMemo, type ReactNode } from "react";
+import {
+  Activity,
+  AlertTriangle,
+  ArrowRight,
+  CheckCircle2,
+  Copy,
+  FolderOpen,
+  RefreshCw,
+  ServerCog,
+  ShieldCheck,
+  SlidersHorizontal,
+  Sparkles,
+  Wrench,
+  XCircle,
+} from "lucide-react";
 import { useNavigate } from "react-router-dom";
 import { useStatus } from "@/hooks/use-status";
 import { useConfig, useModelInfo } from "@/hooks/use-config";
@@ -6,24 +21,40 @@ import { useEnvVars } from "@/hooks/use-env";
 import { useSkills } from "@/hooks/use-skills";
 import { useMcpServers } from "@/hooks/use-mcp-servers";
 import { useLastUsedModel } from "@/lib/last-used-model";
-import { readUiValue, writeUiValue } from "@/lib/ui-store";
+import { CopyButton } from "@/components/ui/copy-button";
 import { Dot } from "@/components/ui/pill";
 import s from "./health-grid.module.css";
 
-const STORAGE_KEY = "hermes:panel:health-open";
 const DEFAULT_DESKTOP_DASHBOARD_ORIGIN = "127.0.0.1:9120";
+const TOKEN_KEYS = ["ANTHROPIC_API_KEY", "OPENAI_API_KEY", "GLM_API_KEY", "DEEPSEEK_API_KEY"];
 
 type Tone = "ok" | "warn" | "err";
+type HealthVariant = "compact" | "page";
+type HealthGroup = "runtime" | "model" | "extensions";
 
-interface CellData {
+interface HealthGridProps {
+  variant?: HealthVariant;
+}
+
+interface HealthItem {
+  id: string;
+  group: HealthGroup;
   label: string;
   tone: Tone;
   value: string;
   sub?: string;
+  detail?: string;
   mono?: boolean;
   title?: string;
-  wide?: boolean;
   actionTo?: string;
+  actionLabel?: string;
+}
+
+interface HealthMetric {
+  label: string;
+  value: string;
+  sub: string;
+  tone: Tone;
 }
 
 function formatContextLength(n: number | undefined | null): string {
@@ -31,14 +62,6 @@ function formatContextLength(n: number | undefined | null): string {
   if (n >= 1_000_000) return `${(n / 1_000_000).toFixed(0)}M ctx`;
   if (n >= 1_000) return `${(n / 1_000).toFixed(0)}k ctx`;
   return `${n} ctx`;
-}
-
-function readOpen(): boolean {
-  return readUiValue(STORAGE_KEY, false);
-}
-
-function writeOpen(open: boolean) {
-  writeUiValue(STORAGE_KEY, open);
 }
 
 function originFromHealthUrl(url: string | null | undefined): string {
@@ -50,31 +73,160 @@ function originFromHealthUrl(url: string | null | undefined): string {
   }
 }
 
-function Cell({ cell, onNavigate }: { cell: CellData; onNavigate: (to: string) => void }) {
-  const title = cell.title ?? [cell.value, cell.sub].filter(Boolean).join(" · ");
+function isRecord(value: unknown): value is Record<string, unknown> {
+  return typeof value === "object" && value !== null && !Array.isArray(value);
+}
+
+function toneLabel(tone: Tone): string {
+  if (tone === "ok") return "正常";
+  if (tone === "warn") return "注意";
+  return "异常";
+}
+
+function toneIcon(tone: Tone, size = 16): ReactNode {
+  if (tone === "ok") return <CheckCircle2 size={size} />;
+  if (tone === "warn") return <AlertTriangle size={size} />;
+  return <XCircle size={size} />;
+}
+
+function groupTitle(group: HealthGroup): string {
+  if (group === "runtime") return "运行时与路径";
+  if (group === "model") return "模型与凭证";
+  return "扩展能力";
+}
+
+function groupSub(group: HealthGroup): string {
+  if (group === "runtime") return "Dashboard、Gateway 与本地 Hermes 数据目录。";
+  if (group === "model") return "默认模型、API Token 与 provider 字段校验。";
+  return "Skills、MCP 以及会话扩展能力。";
+}
+
+function groupIcon(group: HealthGroup): ReactNode {
+  if (group === "runtime") return <ServerCog size={15} />;
+  if (group === "model") return <SlidersHorizontal size={15} />;
+  return <Sparkles size={15} />;
+}
+
+function groupTone(items: HealthItem[]): Tone {
+  if (items.some((item) => item.tone === "err")) return "err";
+  if (items.some((item) => item.tone === "warn")) return "warn";
+  return "ok";
+}
+
+function providerMap(config: Record<string, unknown> | undefined): Record<string, unknown> {
+  const providers = config?.providers;
+  return isRecord(providers) ? providers : {};
+}
+
+function findInvalidProviderApiKeys(providers: Record<string, unknown>): string[] {
+  const invalid: string[] = [];
+  for (const [name, cfg] of Object.entries(providers)) {
+    if (!isRecord(cfg)) continue;
+    const key = typeof cfg.api_key === "string" ? cfg.api_key.trim() : "";
+    if (key && /^https?:\/\//i.test(key)) invalid.push(name);
+  }
+  return invalid;
+}
+
+function formatTokenNames(keys: string[]): string {
+  return keys.map((key) => key.toLowerCase().replace(/_api_key/g, "")).join(" · ");
+}
+
+function healthDigestText(counts: { ok: number; warn: number; err: number }, total: number): string {
+  const parts = [`${counts.ok}/${total} 项正常`];
+  if (counts.warn > 0) parts.push(`${counts.warn} 项注意`);
+  if (counts.err > 0) parts.push(`${counts.err} 项异常`);
+  return parts.join(" · ");
+}
+
+function buildDiagnosticsPayload(input: {
+  status: ReturnType<typeof useStatus>["data"];
+  modelInfo: ReturnType<typeof useModelInfo>["data"];
+  env: ReturnType<typeof useEnvVars>["data"];
+  skills: ReturnType<typeof useSkills>["data"];
+  mcp: ReturnType<typeof useMcpServers>["data"];
+  providerTotal: number;
+  invalidProviders: string[];
+  counts: { ok: number; warn: number; err: number };
+}) {
+  const envSummary = input.env
+    ? Object.fromEntries(
+        Object.entries(input.env).map(([key, info]) => [
+          key,
+          {
+            is_set: info.is_set,
+            category: info.category,
+            tools: info.tools,
+          },
+        ]),
+      )
+    : null;
+
+  return JSON.stringify(
+    {
+      generatedAt: new Date().toISOString(),
+      summary: input.counts,
+      dashboard: input.status
+        ? {
+            version: input.status.version,
+            hermes_home: input.status.hermes_home ?? null,
+            config_path: input.status.config_path ?? null,
+            env_path: input.status.env_path ?? null,
+            gateway_running: input.status.gateway_running,
+            gateway_state: input.status.gateway_state,
+            gateway_health_url: input.status.gateway_health_url,
+            active_sessions: input.status.active_sessions,
+          }
+        : null,
+      model: input.modelInfo ?? null,
+      env: envSummary,
+      skills: input.skills
+        ? {
+            total: input.skills.length,
+            enabled: input.skills.filter((skill) => skill.enabled).length,
+          }
+        : null,
+      mcp: input.mcp?.summary ?? null,
+      providers: {
+        total: input.providerTotal,
+        invalidApiKeyLooksLikeUrl: input.invalidProviders,
+      },
+    },
+    null,
+    2,
+  );
+}
+
+function HealthItemCard({ item, onNavigate }: { item: HealthItem; onNavigate: (to: string) => void }) {
+  const title = item.title ?? [item.value, item.sub, item.detail].filter(Boolean).join(" · ");
   const content = (
     <>
-      <div className={s.label}>
-        <Dot tone={cell.tone} />
-        <span>{cell.label}</span>
+      <div className={s.itemTop}>
+        <span className={s.itemLabel}>{item.label}</span>
+        <span className={s.itemTone} data-tone={item.tone}>{toneLabel(item.tone)}</span>
       </div>
-      <div className={s.value} data-mono={cell.mono ? "true" : undefined}>{cell.value}</div>
-      {cell.sub && <div className={s.sub}>{cell.sub}</div>}
+      <div className={s.itemValue} data-mono={item.mono ? "true" : undefined}>{item.value}</div>
+      {item.sub && <div className={s.itemSub}>{item.sub}</div>}
+      {item.detail && <p className={s.itemDetail}>{item.detail}</p>}
+      {item.actionTo && (
+        <span className={s.itemAction}>
+          {item.actionLabel ?? "去处理"}
+          <ArrowRight size={13} aria-hidden="true" />
+        </span>
+      )}
     </>
   );
 
-  if (cell.actionTo) {
-    const actionTo = cell.actionTo;
+  if (item.actionTo) {
+    const actionTo = item.actionTo;
     return (
       <button
         type="button"
-        className={s.cell}
-        data-size={cell.wide ? "wide" : undefined}
-        data-warn={cell.tone === "warn" ? "true" : undefined}
-        data-err={cell.tone === "err" ? "true" : undefined}
+        className={s.item}
+        data-tone={item.tone}
         data-action="true"
         title={title}
-        aria-label={`${cell.label}: ${cell.value}${cell.sub ? `，${cell.sub}` : ""}`}
+        aria-label={`${item.label}: ${item.value}${item.sub ? `，${item.sub}` : ""}`}
         onClick={() => onNavigate(actionTo)}
       >
         {content}
@@ -83,52 +235,51 @@ function Cell({ cell, onNavigate }: { cell: CellData; onNavigate: (to: string) =
   }
 
   return (
-    <div
-      className={s.cell}
-      data-size={cell.wide ? "wide" : undefined}
-      data-warn={cell.tone === "warn" ? "true" : undefined}
-      data-err={cell.tone === "err" ? "true" : undefined}
-      title={title}
-    >
+    <div className={s.item} data-tone={item.tone} title={title}>
       {content}
     </div>
   );
 }
 
-export function HealthGrid() {
+function MetricCard({ metric }: { metric: HealthMetric }) {
+  return (
+    <div className={s.metric} data-tone={metric.tone}>
+      <div className={s.metricLabel}>{metric.label}</div>
+      <div className={s.metricValue}>{metric.value}</div>
+      <div className={s.metricSub}>{metric.sub}</div>
+    </div>
+  );
+}
+
+export function HealthGrid({ variant = "compact" }: HealthGridProps) {
   const navigate = useNavigate();
-  const { data: status } = useStatus();
-  const { data: modelInfo } = useModelInfo();
-  const { data: config } = useConfig();
-  const { data: env } = useEnvVars();
-  const { data: skills } = useSkills();
-  const { data: mcp, isError: mcpError } = useMcpServers();
+  const statusQuery = useStatus();
+  const modelInfoQuery = useModelInfo();
+  const configQuery = useConfig();
+  const envQuery = useEnvVars();
+  const skillsQuery = useSkills();
+  const mcpQuery = useMcpServers();
+  const status = statusQuery.data;
+  const modelInfo = modelInfoQuery.data;
+  const config = configQuery.data;
+  const env = envQuery.data;
+  const skills = skillsQuery.data;
+  const mcp = mcpQuery.data;
   const lastUsedModel = useLastUsedModel();
-  const [open, setOpen] = useState(readOpen);
 
-  useEffect(() => {
-    writeOpen(open);
-  }, [open]);
-
-  const cells = useMemo<CellData[]>(() => {
+  const health = useMemo(() => {
     // `gateway_running` is the *PTY daemon* status — a Python subprocess
     // the dashboard *can* spawn for the embedded chat tab. With P-009
     // the SSE+POST transport calls tui_gateway.dispatch() in-process,
     // so the daemon stays "stopped" by design and that's fine. The real
-    // health signal is whether the dashboard responded to /api/status
-    // at all — that's `!!status` (React Query keeps `data` undefined
-    // on transport / 5xx errors).
+    // health signal is whether the dashboard responded to /api/status.
     const dashboardReachable = !!status;
     const daemonRunning = status?.gateway_running === true;
-    const gatewayState =
-      status?.gateway_state || (daemonRunning ? "running" : "stopped");
-
-    const tokenKeys = ["ANTHROPIC_API_KEY", "OPENAI_API_KEY", "GLM_API_KEY", "DEEPSEEK_API_KEY"];
-    const setTokens = env ? tokenKeys.filter((k) => env[k]?.is_set) : [];
-    const anyTokenSet = setTokens.length > 0;
-
-    const hermesHome = status?.hermes_home;
+    const gatewayState = status?.gateway_state || (daemonRunning ? "running" : "stopped");
     const dashboardOrigin = originFromHealthUrl(status?.gateway_health_url);
+
+    const setTokens = env ? TOKEN_KEYS.filter((key) => env[key]?.is_set) : [];
+    const anyTokenSet = setTokens.length > 0;
 
     const modelName = lastUsedModel?.model || modelInfo?.model || "—";
     const ctxLabel = formatContextLength(
@@ -138,150 +289,319 @@ export function HealthGrid() {
     );
 
     const skillsTotal = skills?.length ?? 0;
-    const skillsEnabled = skills?.filter((sk) => sk.enabled).length ?? 0;
-
+    const skillsEnabled = skills?.filter((skill) => skill.enabled).length ?? 0;
     const mcpTotal = mcp?.summary.total ?? 0;
     const mcpEnabled = mcp?.summary.enabled ?? 0;
 
-    // Provider api_key sanity check.
-    // Catches a common foot-gun in `~/.hermes/config.yaml` where the user pastes
-    // base_url into the api_key field by mistake (or vice-versa). Dashboard's
-    // `list_authenticated_providers` doesn't validate the key shape — the broken
-    // provider stays in the model picker, then any session that lands on it
-    // sends `Authorization: Bearer https://...` to the upstream API and 401s
-    // (sometimes manifesting as obscure credential-pool warnings).
-    const providers = (config?.providers as Record<string, { api_key?: unknown }> | undefined) || {};
-    const invalidProviders: string[] = [];
-    for (const [name, cfg] of Object.entries(providers)) {
-      const key = typeof cfg?.api_key === "string" ? cfg.api_key.trim() : "";
-      if (key && /^https?:\/\//i.test(key)) invalidProviders.push(name);
-    }
+    const providers = providerMap(config);
+    const invalidProviders = findInvalidProviderApiKeys(providers);
     const providerTotal = Object.keys(providers).length;
     const providersOk = providerTotal > 0 && invalidProviders.length === 0;
 
-    return [
+    const items: HealthItem[] = [
       {
-        label: "Gateway",
-        tone: dashboardReachable ? "ok" : "err",
+        id: "gateway",
+        group: "runtime",
+        label: "Dashboard / Gateway",
+        tone: statusQuery.isError ? "err" : dashboardReachable ? "ok" : "warn",
         value: dashboardOrigin,
-        sub: dashboardReachable
-          ? daemonRunning
-            ? "运行中"
-            : "就绪 · in-process"
-          : "未响应",
+        sub: statusQuery.isError
+          ? "状态接口未响应"
+          : dashboardReachable
+            ? daemonRunning
+              ? "Gateway daemon 运行中"
+              : "Dashboard 就绪 · in-process dispatch"
+            : "正在连接",
+        detail: dashboardReachable
+          ? "聊天传输在桌面端优先走 SSE+POST 的进程内 dispatch；gateway_state=stopped 不再等同于不可用。"
+          : "如果长时间停留在连接中，请确认 managed runtime 已启动，或在状态栏执行 Gateway 重启。",
         mono: true,
-        wide: true,
         title: `dashboardReachable=${dashboardReachable}; gateway_state=${gatewayState}. P-009 后 SSE+POST 走进程内 dispatch，gateway_state=stopped 是预期值。`,
       },
       {
+        id: "home",
+        group: "runtime",
         label: "Hermes Home",
-        tone: "ok",
-        value: hermesHome || "—",
-        sub: hermesHome ? "可读" : undefined,
+        tone: status?.hermes_home ? "ok" : "warn",
+        value: status?.hermes_home || "—",
+        sub: status?.hermes_home ? "数据目录已识别" : "等待 /api/status 返回路径",
+        detail: status?.config_path || status?.env_path
+          ? `配置：${status?.config_path ?? "—"}；环境变量：${status?.env_path ?? "—"}`
+          : "这是桌面端当前 profile 的配置、会话和环境变量根目录。",
         mono: true,
-        wide: true,
       },
       {
-        label: "模型",
+        id: "model",
+        group: "model",
+        label: "默认模型",
         tone: modelName !== "—" ? "ok" : "warn",
         value: modelName,
-        sub: modelName !== "—" ? ctxLabel : "前往模型设置",
+        sub: modelName !== "—" ? ctxLabel : "尚未选择可用模型",
+        detail: modelName !== "—"
+          ? `Provider：${lastUsedModel?.providerName ?? lastUsedModel?.provider ?? modelInfo?.provider ?? "—"}`
+          : "没有默认模型时，新任务可能无法直接发送。",
         mono: true,
-        wide: true,
         actionTo: modelName === "—" ? "/models" : undefined,
+        actionLabel: "配置模型",
       },
       {
-        label: "Token",
-        tone: anyTokenSet ? "ok" : "warn",
-        value: anyTokenSet ? "已配置" : "未配置",
-        sub: anyTokenSet
-          ? setTokens.join(" · ").toLowerCase().replace(/_api_key/g, "")
-          : "前往模型设置",
+        id: "token",
+        group: "model",
+        label: "API Token",
+        tone: envQuery.isError ? "err" : env ? (anyTokenSet ? "ok" : "warn") : "warn",
+        value: envQuery.isError ? "读取失败" : env ? (anyTokenSet ? "已配置" : "未配置") : "检测中",
+        sub: anyTokenSet ? formatTokenNames(setTokens) : "模型调用需要至少一个可用 Token",
+        detail: anyTokenSet
+          ? "仅展示已设置的变量名称，不会暴露密钥内容。"
+          : "可在模型设置里补齐 Anthropic、OpenAI、GLM 或 DeepSeek 等服务商密钥。",
         actionTo: anyTokenSet ? undefined : "/models",
+        actionLabel: "填写 Token",
       },
       {
-        label: "Skills",
-        tone: skillsEnabled > 0 ? "ok" : "warn",
-        value: `${skillsEnabled} 启用`,
-        sub: `共 ${skillsTotal}`,
-      },
-      {
-        label: "MCP",
-        tone: mcpError ? "err" : mcpTotal === 0 ? "warn" : "ok",
-        value: mcpError ? "未接入" : `${mcpEnabled} / ${mcpTotal}`,
-        sub: mcpError ? "需重启 dashboard" : mcpTotal === 0 ? "未配置" : `共 ${mcpTotal}`,
-        mono: !mcpError,
-      },
-      {
+        id: "provider",
+        group: "model",
         label: "Provider 配置",
-        tone: providersOk ? "ok" : invalidProviders.length > 0 ? "warn" : "warn",
+        tone: providersOk ? "ok" : "warn",
         value: providerTotal === 0
           ? "未配置"
           : invalidProviders.length > 0
             ? `${invalidProviders.length} / ${providerTotal} 异常`
             : `${providerTotal} 个有效`,
         sub: invalidProviders.length > 0
-          ? `api_key 是 URL: ${invalidProviders.join(", ")}`
+          ? `api_key 是 URL：${invalidProviders.join(", ")}`
           : providerTotal === 0
-            ? "前往模型设置"
-            : "api_key 字段健康",
-        title: invalidProviders.length > 0
-          ? `这些 provider 的 api_key 字段填的是 URL 不是真 key，会让 dashboard 发请求时把 URL 当 Bearer token，必定 401。请到 ~/.hermes/config.yaml 修正。`
+            ? "缺少 providers 配置"
+            : "api_key 字段形态正常",
+        detail: invalidProviders.length > 0
+          ? "这些 provider 会把 URL 当作 Bearer token 发送，上游通常会返回 401。"
           : providerTotal === 0
-            ? "config.yaml 缺 providers。点击进入模型页选择服务商，填写 API Key，并设为当前模型。"
-            : undefined,
+            ? "选择服务商并保存模型后会自动写入 provider 配置。"
+            : "已完成基础形态检查；真实额度与连通性仍以模型页探测结果为准。",
         actionTo: providerTotal === 0 || invalidProviders.length > 0 ? "/models" : undefined,
+        actionLabel: "修正配置",
+      },
+      {
+        id: "skills",
+        group: "extensions",
+        label: "Skills",
+        tone: skillsQuery.isError ? "err" : skills ? (skillsEnabled > 0 ? "ok" : "warn") : "warn",
+        value: skillsQuery.isError ? "读取失败" : skills ? `${skillsEnabled} 启用` : "检测中",
+        sub: skills ? `共 ${skillsTotal} 个` : "正在读取 Skill 列表",
+        detail: skillsEnabled > 0
+          ? "新任务可通过 / 选择已启用 Skill。"
+          : "未启用 Skill 不影响基础对话，但会降低任务模板和专长能力。",
+      },
+      {
+        id: "mcp",
+        group: "extensions",
+        label: "MCP 服务",
+        tone: mcpQuery.isError ? "err" : mcp ? (mcpTotal === 0 ? "warn" : "ok") : "warn",
+        value: mcpQuery.isError ? "未接入" : mcp ? `${mcpEnabled} / ${mcpTotal}` : "检测中",
+        sub: mcpQuery.isError ? "需重启 dashboard" : mcp ? (mcpTotal === 0 ? "未配置" : `共 ${mcpTotal} 个`) : "正在读取 MCP 列表",
+        detail: mcpQuery.isError
+          ? "Dashboard 没有返回 MCP 列表，通常由后端尚未加载或运行时状态过期导致。"
+          : mcpTotal === 0
+            ? "没有 MCP 不影响基础聊天；需要外部工具时再接入。"
+            : "启用的 MCP 会作为外部工具能力参与任务执行。",
+        mono: Boolean(mcp),
       },
     ];
-  }, [config, env, lastUsedModel, mcp, mcpError, modelInfo, skills, status]);
 
-  const counts = useMemo(() => {
-    let ok = 0;
-    let warn = 0;
-    let err = 0;
-    for (const c of cells) {
-      if (c.tone === "ok") ok += 1;
-      else if (c.tone === "warn") warn += 1;
-      else err += 1;
+    const counts = { ok: 0, warn: 0, err: 0 };
+    for (const item of items) {
+      counts[item.tone] += 1;
     }
-    return { ok, warn, err };
-  }, [cells]);
-
-  const overallTone: Tone =
-    counts.err > 0 ? "err" : counts.warn > 0 ? "warn" : "ok";
-
-  const summaryLabel =
-    overallTone === "err"
+    const overallTone: Tone = counts.err > 0 ? "err" : counts.warn > 0 ? "warn" : "ok";
+    const summaryLabel = overallTone === "err"
       ? `${counts.err} 项异常`
       : overallTone === "warn"
         ? `${counts.warn} 项需要关注`
         : "系统正常";
+    const summarySub = healthDigestText(counts, items.length);
 
-  const summarySub = `${counts.ok}/${cells.length} 项 OK${counts.warn > 0 ? ` · ${counts.warn} warn` : ""}${counts.err > 0 ? ` · ${counts.err} err` : ""}`;
+    return {
+      items,
+      counts,
+      overallTone,
+      summaryLabel,
+      summarySub,
+      providerTotal,
+      invalidProviders,
+      metrics: [
+        { label: "正常项", value: String(counts.ok), sub: `共 ${items.length} 项`, tone: "ok" as Tone },
+        { label: "注意项", value: String(counts.warn), sub: counts.warn ? "建议尽快处理" : "无需处理", tone: counts.warn ? "warn" as Tone : "ok" as Tone },
+        { label: "异常项", value: String(counts.err), sub: counts.err ? "影响功能可用性" : "未发现异常", tone: counts.err ? "err" as Tone : "ok" as Tone },
+        { label: "活跃会话", value: String(status?.active_sessions ?? 0), sub: status ? `Dashboard v${status.version}` : "等待状态接口", tone: status ? "ok" as Tone : "warn" as Tone },
+      ] satisfies HealthMetric[],
+    };
+  }, [config, env, envQuery.isError, lastUsedModel, mcp, mcpQuery.isError, modelInfo, skills, skillsQuery.isError, status, statusQuery.isError]);
+
+  const isRefreshing = statusQuery.isFetching
+    || modelInfoQuery.isFetching
+    || configQuery.isFetching
+    || envQuery.isFetching
+    || skillsQuery.isFetching
+    || mcpQuery.isFetching;
+
+  const refreshAll = () => {
+    void Promise.all([
+      statusQuery.refetch(),
+      modelInfoQuery.refetch(),
+      configQuery.refetch(),
+      envQuery.refetch(),
+      skillsQuery.refetch(),
+      mcpQuery.refetch(),
+    ]);
+  };
+
+  const openHermesHome = () => {
+    if (!status?.hermes_home || !window.hermesDesktop?.openWorkspacePath) return;
+    void window.hermesDesktop.openWorkspacePath({ path: status.hermes_home }).catch(() => undefined);
+  };
+
+  const attentionItems = health.items.filter((item) => item.tone !== "ok");
+  const groups: HealthGroup[] = ["runtime", "model", "extensions"];
+
+  if (variant === "page") {
+    return (
+      <section className={s.root} data-variant="page">
+        <div className={s.hero} data-tone={health.overallTone}>
+          <div className={s.heroMark} data-tone={health.overallTone} aria-hidden="true">
+            {toneIcon(health.overallTone, 24)}
+          </div>
+          <div className={s.heroBody}>
+            <div className={s.eyebrow}>桌面端健康检查</div>
+            <h2>{health.summaryLabel}</h2>
+            <p>
+              {status
+                ? `Dashboard 已响应，当前版本 ${status.version}，活跃会话 ${status.active_sessions} 个。这里展示启动链路、模型凭证和扩展能力的实时诊断结果。`
+                : statusQuery.isError
+                  ? "无法读取 Dashboard 状态接口，优先检查 managed runtime 是否启动，以及本机端口是否被占用。"
+                  : "正在读取 Dashboard 状态、模型配置、环境变量、Skills 与 MCP 服务。"}
+            </p>
+          </div>
+          <div className={s.heroActions}>
+            <button className={s.actionButton} type="button" onClick={refreshAll} disabled={isRefreshing}>
+              <RefreshCw size={13} aria-hidden="true" />
+              {isRefreshing ? "刷新中" : "刷新检查"}
+            </button>
+            <CopyButton
+              className={s.actionButton}
+              text={() => buildDiagnosticsPayload({
+                status,
+                modelInfo,
+                env,
+                skills,
+                mcp,
+                providerTotal: health.providerTotal,
+                invalidProviders: health.invalidProviders,
+                counts: health.counts,
+              })}
+            >
+              <Copy size={13} aria-hidden="true" />
+              复制诊断 JSON
+            </CopyButton>
+            <button
+              className={s.actionButton}
+              type="button"
+              onClick={openHermesHome}
+              disabled={!status?.hermes_home || !window.hermesDesktop?.openWorkspacePath}
+            >
+              <FolderOpen size={13} aria-hidden="true" />
+              打开 HERMES_HOME
+            </button>
+          </div>
+        </div>
+
+        <div className={s.metrics}>
+          {health.metrics.map((metric) => <MetricCard key={metric.label} metric={metric} />)}
+        </div>
+
+        <div className={s.pageGrid}>
+          <div className={s.groups}>
+            {groups.map((group) => {
+              const groupItems = health.items.filter((item) => item.group === group);
+              const tone = groupTone(groupItems);
+              return (
+                <section className={s.group} key={group} data-tone={tone}>
+                  <div className={s.groupHead}>
+                    <div className={s.groupIcon} data-tone={tone} aria-hidden="true">{groupIcon(group)}</div>
+                    <div>
+                      <h3>{groupTitle(group)}</h3>
+                      <p>{groupSub(group)}</p>
+                    </div>
+                    <span className={s.groupStatus} data-tone={tone}>{toneLabel(tone)}</span>
+                  </div>
+                  <div className={s.itemGrid}>
+                    {groupItems.map((item) => <HealthItemCard key={item.id} item={item} onNavigate={navigate} />)}
+                  </div>
+                </section>
+              );
+            })}
+          </div>
+
+          <aside className={s.aside} aria-label="健康检查建议">
+            <div className={s.asideCard}>
+              <div className={s.asideHead}>
+                <Wrench size={15} aria-hidden="true" />
+                <span>建议处理顺序</span>
+              </div>
+              {attentionItems.length > 0 ? (
+                <div className={s.fixList}>
+                  {attentionItems.map((item) => (
+                    <button
+                      key={item.id}
+                      className={s.fixItem}
+                      type="button"
+                      data-tone={item.tone}
+                      onClick={() => item.actionTo ? navigate(item.actionTo) : undefined}
+                      disabled={!item.actionTo}
+                    >
+                      <span className={s.fixIcon} aria-hidden="true">{toneIcon(item.tone, 14)}</span>
+                      <span className={s.fixText}>
+                        <strong>{item.label}</strong>
+                        <span>{item.sub ?? item.value}</span>
+                      </span>
+                      {item.actionTo && <ArrowRight size={13} aria-hidden="true" />}
+                    </button>
+                  ))}
+                </div>
+              ) : (
+                <div className={s.emptyState}>
+                  <ShieldCheck size={18} aria-hidden="true" />
+                  <span>当前没有需要处理的健康项，可以直接新建任务。</span>
+                </div>
+              )}
+            </div>
+
+            <div className={s.asideCard}>
+              <div className={s.asideHead}>
+                <Activity size={15} aria-hidden="true" />
+                <span>刷新节奏</span>
+              </div>
+              <p className={s.asideText}>
+                `/api/status` 会自动轮询，其它配置项在进入页面和手动刷新时读取。这里不会再折叠隐藏详情，避免排查问题时漏看异常项。
+              </p>
+            </div>
+          </aside>
+        </div>
+      </section>
+    );
+  }
 
   return (
-    <div>
-      <button
-        type="button"
-        className={s.bar}
-        data-tone={overallTone}
-        data-open={open}
-        onClick={() => setOpen((v) => !v)}
-        aria-expanded={open}
-      >
-        <Dot tone={overallTone} />
-        <span className={s.barLabel}>{summaryLabel}</span>
-        <span className={s.barSummary}>{summarySub}</span>
-        <span className={s.barChev} aria-hidden="true">{open ? "▴" : "▾"}</span>
-      </button>
-
-      {open && (
-        <div className={s.grid}>
-          {cells.map((cell) => (
-            <Cell key={cell.label} cell={cell} onNavigate={navigate} />
-          ))}
+    <section className={s.root} data-variant="compact">
+      <div className={s.compactHead} data-tone={health.overallTone}>
+        <div className={s.compactMain}>
+          <Dot tone={health.overallTone} />
+          <span className={s.compactTitle}>{health.summaryLabel}</span>
+          <span className={s.compactSub}>{health.summarySub}</span>
         </div>
-      )}
-    </div>
+        <span className={s.compactMeta}>实时状态</span>
+      </div>
+      <div className={s.itemGrid}>
+        {health.items.map((item) => <HealthItemCard key={item.id} item={item} onNavigate={navigate} />)}
+      </div>
+    </section>
   );
 }

--- a/web/src/routes/health.tsx
+++ b/web/src/routes/health.tsx
@@ -8,7 +8,7 @@ export function HealthRoute() {
   const sub = formatHealthSubtitle(status, isError);
   return (
     <SectionShell title="健康检查" sub={sub}>
-      <HealthGrid />
+      <HealthGrid variant="page" />
     </SectionShell>
   );
 }


### PR DESCRIPTION
## 变更内容

优化桌面端 `/health` 健康检查页，将原本简陋且可折叠的状态块改为完整诊断页面。

## 为什么

健康检查页用于排查桌面端运行状态，不应该继承工作台区域的折叠交互；同时现有信息层级过于简单，无法快速定位 Dashboard、模型凭证、Skills 和 MCP 等关键状态。

## 用户影响

- `/health` 页面始终展开，不再出现折叠按钮。
- 页面增加总体健康状态、指标卡、分组诊断项和建议处理顺序。
- 支持手动刷新、复制诊断 JSON、打开 HERMES_HOME。
- 工作台健康区保留紧凑展示，但不再隐藏详情。

## 验证

- `pnpm typecheck`
- `pnpm test:unit`
- `cargo check`
- 本地浏览器打开 `/health` 进行视觉检查，并确认健康检查内容没有折叠控件残留。