### PR TITLE
[codex] 添加现代深色皮肤和对话字号设置

### DIFF
--- a/packages/shared-ui/src/hooks/use-theme.ts
+++ b/packages/shared-ui/src/hooks/use-theme.ts
@@ -1,6 +1,6 @@
 import { atom, useAtom } from "jotai";
 
-type ThemeVariant = "light" | "dark" | "dark-modern";
+type ThemeVariant = "light" | "light-modern" | "dark" | "dark-modern";
 type DensityVariant = "comfortable" | "compact";
 
 export interface ThemeConfig {
@@ -14,7 +14,10 @@ const DEFAULT_THEME: ThemeConfig = {
 };
 
 function normalizeTheme(value: Partial<ThemeConfig> | undefined): ThemeConfig {
-  const theme = value?.theme === "light" || value?.theme === "dark-modern" ? value.theme : "dark";
+  const theme =
+    value?.theme === "light" || value?.theme === "light-modern" || value?.theme === "dark-modern"
+      ? value.theme
+      : "dark";
   return {
     theme,
     density: value?.density === "compact" ? "compact" : "comfortable",

--- a/packages/shared-ui/src/hooks/use-theme.ts
+++ b/packages/shared-ui/src/hooks/use-theme.ts
@@ -1,6 +1,6 @@
 import { atom, useAtom } from "jotai";
 
-type ThemeVariant = "light" | "dark";
+type ThemeVariant = "light" | "dark" | "dark-modern";
 type DensityVariant = "comfortable" | "compact";
 
 export interface ThemeConfig {
@@ -14,8 +14,9 @@ const DEFAULT_THEME: ThemeConfig = {
 };
 
 function normalizeTheme(value: Partial<ThemeConfig> | undefined): ThemeConfig {
+  const theme = value?.theme === "light" || value?.theme === "dark-modern" ? value.theme : "dark";
   return {
-    theme: value?.theme === "light" ? "light" : "dark",
+    theme,
     density: value?.density === "compact" ? "compact" : "comfortable",
   };
 }

--- a/packages/shared-ui/src/tokens/colors.css
+++ b/packages/shared-ui/src/tokens/colors.css
@@ -58,6 +58,7 @@
   --h-shadow-l: 0 4px 16px rgba(0, 0, 0, 0.06);
   --h-sidebar-stripe: #fbfaf7;
   --h-accent: #ff7a3d;
+  --h-accent-contrast: #1a0c04;
   --h-accent-soft: #f4dfd0;
   --h-accent-border: #e8b896;
 }
@@ -87,6 +88,7 @@
   --h-shadow-l: 0 12px 40px rgba(0, 0, 0, 0.6);
   --h-sidebar-stripe: var(--ink-100);
   --h-accent: var(--persimmon);
+  --h-accent-contrast: #1a0c04;
   --h-accent-soft: rgba(255, 122, 61, 0.08);
   --h-accent-border: rgba(255, 122, 61, 0.3);
 }
@@ -116,6 +118,7 @@
   --h-shadow-l: 0 18px 48px rgba(0, 0, 0, 0.62);
   --h-sidebar-stripe: #1f1f1f;
   --h-accent: #0078d4;
+  --h-accent-contrast: #ffffff;
   --h-accent-soft: rgba(0, 120, 212, 0.16);
   --h-accent-border: rgba(0, 120, 212, 0.42);
   --sky: #4fc1ff;

--- a/packages/shared-ui/src/tokens/colors.css
+++ b/packages/shared-ui/src/tokens/colors.css
@@ -90,3 +90,37 @@
   --h-accent-soft: rgba(255, 122, 61, 0.08);
   --h-accent-border: rgba(255, 122, 61, 0.3);
 }
+
+[data-theme="dark-modern"] {
+  /* Modern dark: a neutral blue-black desktop palette inspired by current
+     code-editor surfaces, tuned to keep Hermes chrome quiet and readable. */
+  --h-bg-app: #181818;
+  --h-bg-pane: #1f1f1f;
+  --h-bg-soft: #252526;
+  --h-bg-input: #2d2d30;
+  --h-bg-chip: #2a2d2e;
+  --h-bg-code: #1e1e1e;
+  --h-line: #3c3c3c;
+  --h-line-soft: #2b2b2b;
+  --h-text: #d4d4d4;
+  --h-text-2: #c5c5c5;
+  --h-text-3: #9d9d9d;
+  --h-text-4: #6f6f6f;
+  --h-ok: #89d185;
+  --h-ok-soft: rgba(137, 209, 133, 0.1);
+  --h-warn: #cca700;
+  --h-warn-soft: rgba(204, 167, 0, 0.12);
+  --h-err: #f48771;
+  --h-danger: #f48771;
+  --h-shadow: 0 1px 2px rgba(0, 0, 0, 0.5);
+  --h-shadow-l: 0 18px 48px rgba(0, 0, 0, 0.62);
+  --h-sidebar-stripe: #1f1f1f;
+  --h-accent: #0078d4;
+  --h-accent-soft: rgba(0, 120, 212, 0.16);
+  --h-accent-border: rgba(0, 120, 212, 0.42);
+  --sky: #4fc1ff;
+  --plum: #c586c0;
+  --amber: #dcdcaa;
+  --moss: #89d185;
+  --rust: #f48771;
+}

--- a/packages/shared-ui/src/tokens/colors.css
+++ b/packages/shared-ui/src/tokens/colors.css
@@ -63,6 +63,41 @@
   --h-accent-border: #e8b896;
 }
 
+[data-theme="light-modern"] {
+  /* Modern light: a clean editor-style palette with white content surfaces,
+     subtle workbench chrome, quiet separators, and a blue command accent. */
+  --h-bg-app: #f3f3f3;
+  --h-bg-pane: #ffffff;
+  --h-bg-soft: #f8f8f8;
+  --h-bg-input: #ffffff;
+  --h-bg-chip: #f0f0f0;
+  --h-bg-code: #f6f8fa;
+  --h-line: #d7d7d7;
+  --h-line-soft: #e5e5e5;
+  --h-text: #1f1f1f;
+  --h-text-2: #3f3f46;
+  --h-text-3: #6e6e6e;
+  --h-text-4: #a6a6a6;
+  --h-ok: #16825d;
+  --h-ok-soft: rgba(22, 130, 93, 0.1);
+  --h-warn: #9d6b00;
+  --h-warn-soft: rgba(157, 107, 0, 0.1);
+  --h-err: #d13438;
+  --h-danger: #d13438;
+  --h-shadow: 0 1px 2px rgba(0, 0, 0, 0.04);
+  --h-shadow-l: 0 12px 32px rgba(0, 0, 0, 0.08);
+  --h-sidebar-stripe: #f8f8f8;
+  --h-accent: #0078d4;
+  --h-accent-contrast: #ffffff;
+  --h-accent-soft: rgba(0, 120, 212, 0.1);
+  --h-accent-border: rgba(0, 120, 212, 0.36);
+  --sky: #0078d4;
+  --plum: #8e44ad;
+  --amber: #9d6b00;
+  --moss: #16825d;
+  --rust: #d13438;
+}
+
 [data-theme="dark"] {
   /* Dark theme remapped onto the ink/bone palette so existing components
      adopt the prototype's deeper, cooler palette without per-component

--- a/web/src/app.tsx
+++ b/web/src/app.tsx
@@ -27,7 +27,7 @@ import { HealthRoute } from "@/routes/health";
 import { LogsRoute } from "@/routes/logs";
 import { DebugRoute } from "@/routes/debug";
 import { AnalyticsRoute } from "@/routes/analytics";
-import { AdvancedRoute } from "@/routes/advanced";
+import { AdvancedRoute, ThemeRoute } from "@/routes/advanced";
 import { ImOnboardingRoute } from "@/routes/im-onboarding";
 
 function NewTaskRedirect() {
@@ -78,6 +78,7 @@ export function App() {
           <Route path="/analytics" element={withBoundary(<AnalyticsRoute />)} />
           <Route path="/logs" element={withBoundary(<LogsRoute />)} />
           <Route path="/debug" element={withBoundary(<DebugRoute />)} />
+          <Route path="/theme" element={withBoundary(<ThemeRoute />)} />
           <Route path="/advanced/*" element={withBoundary(<AdvancedRoute />)} />
           <Route path="/settings" element={<Navigate to="/advanced" replace />} />
           <Route path="*" element={<Navigate to="/" replace />} />

--- a/web/src/components/app-shell/advanced-sidebar.tsx
+++ b/web/src/components/app-shell/advanced-sidebar.tsx
@@ -8,6 +8,7 @@ import {
   HeartPulse,
   Info,
   MonitorCog,
+  Palette,
   SlidersHorizontal,
   type LucideIcon,
 } from "lucide-react";
@@ -28,6 +29,7 @@ const OBSERVABILITY_ITEMS: readonly AdvancedItem[] = [
 
 const ADVANCED_ITEMS: readonly AdvancedItem[] = [
   { label: "常规", path: "/advanced", icon: SlidersHorizontal },
+  { label: "主题", path: "/theme", icon: Palette },
   { label: "配置", path: "/advanced/config", icon: FileCog },
   { label: "内核", path: "/advanced/kernel", icon: Cpu },
   { label: "环境", path: "/advanced/env", icon: MonitorCog },

--- a/web/src/components/app-shell/app-top-bar.module.css
+++ b/web/src/components/app-shell/app-top-bar.module.css
@@ -255,6 +255,10 @@
   color: var(--amber);
 }
 
+.iconBtn[data-theme-mode="dark-modern"] {
+  color: var(--h-accent);
+}
+
 .iconBtn[data-theme-mode="light"] {
   color: var(--sky);
 }

--- a/web/src/components/app-shell/app-top-bar.module.css
+++ b/web/src/components/app-shell/app-top-bar.module.css
@@ -150,12 +150,14 @@
   background: var(--h-bg-soft);
 }
 
-:global([data-theme="light"]) .navLink:hover {
+:global([data-theme="light"]) .navLink:hover,
+:global([data-theme="light-modern"]) .navLink:hover {
   color: var(--h-text);
   background: color-mix(in srgb, var(--h-accent) 10%, var(--h-bg-chip));
 }
 
-:global([data-theme="light"]) .navLink[data-active="true"] {
+:global([data-theme="light"]) .navLink[data-active="true"],
+:global([data-theme="light-modern"]) .navLink[data-active="true"] {
   color: var(--h-text);
   background: color-mix(in srgb, var(--h-accent) 14%, var(--h-bg-chip));
   box-shadow: inset 0 0 0 1px color-mix(in srgb, var(--h-accent) 28%, transparent);
@@ -174,6 +176,11 @@
 
 :global([data-theme="light"]) .navLink[data-active="true"] .navNum {
   color: var(--persimmon-dim);
+  font-weight: 700;
+}
+
+:global([data-theme="light-modern"]) .navLink[data-active="true"] .navNum {
+  color: var(--h-accent);
   font-weight: 700;
 }
 
@@ -261,4 +268,8 @@
 
 .iconBtn[data-theme-mode="light"] {
   color: var(--sky);
+}
+
+.iconBtn[data-theme-mode="light-modern"] {
+  color: var(--h-accent);
 }

--- a/web/src/components/app-shell/app-top-bar.tsx
+++ b/web/src/components/app-shell/app-top-bar.tsx
@@ -1,7 +1,7 @@
 import type { MouseEvent } from "react";
 import { useNavigate, useLocation } from "react-router-dom";
-import { Moon, Search, Sun } from "lucide-react";
-import { useTheme } from "@hermes/shared-ui";
+import { Moon, Palette, Search, Sun } from "lucide-react";
+import { useTheme, type ThemeConfig } from "@hermes/shared-ui";
 import { HermesLogoMark } from "@/components/brand/hermes-logo-mark";
 import { ProfileSelector } from "@/components/sidebar/profile-selector";
 import { DESKTOP_VERSION, versionLabel } from "@/lib/build-info";
@@ -11,14 +11,21 @@ import s from "./app-top-bar.module.css";
 
 const DESKTOP_VERSION_PARAM = versionLabel(DESKTOP_VERSION);
 const BRAND_URL = `https://hermesagent.org.cn?source=cn_desktop&version=${encodeURIComponent(DESKTOP_VERSION_PARAM)}`;
+const THEME_SEQUENCE: ThemeConfig["theme"][] = ["light", "dark", "dark-modern"];
+const THEME_LABELS: Record<ThemeConfig["theme"], string> = {
+  light: "浅色模式",
+  dark: "经典深色模式",
+  "dark-modern": "现代深色模式",
+};
 
 export function AppTopBar() {
   const navigate = useNavigate();
   const location = useLocation();
   const { config: themeConfig, update: updateTheme } = useTheme();
-  const nextTheme = themeConfig.theme === "dark" ? "light" : "dark";
-  const ThemeIcon = themeConfig.theme === "dark" ? Sun : Moon;
-  const themeToggleLabel = themeConfig.theme === "dark" ? "切换到浅色模式" : "切换到深色模式";
+  const currentThemeIndex = THEME_SEQUENCE.indexOf(themeConfig.theme);
+  const nextTheme = THEME_SEQUENCE[(currentThemeIndex + 1) % THEME_SEQUENCE.length] ?? "dark";
+  const ThemeIcon = themeConfig.theme === "light" ? Moon : themeConfig.theme === "dark-modern" ? Sun : Palette;
+  const themeToggleLabel = `切换到${THEME_LABELS[nextTheme]}`;
   const openBrandSite = (event: MouseEvent<HTMLAnchorElement>) => {
     event.preventDefault();
     void openExternalUrl(BRAND_URL);

--- a/web/src/components/app-shell/app-top-bar.tsx
+++ b/web/src/components/app-shell/app-top-bar.tsx
@@ -11,9 +11,10 @@ import s from "./app-top-bar.module.css";
 
 const DESKTOP_VERSION_PARAM = versionLabel(DESKTOP_VERSION);
 const BRAND_URL = `https://hermesagent.org.cn?source=cn_desktop&version=${encodeURIComponent(DESKTOP_VERSION_PARAM)}`;
-const THEME_SEQUENCE: ThemeConfig["theme"][] = ["light", "dark", "dark-modern"];
+const THEME_SEQUENCE: ThemeConfig["theme"][] = ["light", "light-modern", "dark", "dark-modern"];
 const THEME_LABELS: Record<ThemeConfig["theme"], string> = {
   light: "浅色模式",
+  "light-modern": "现代浅色模式",
   dark: "经典深色模式",
   "dark-modern": "现代深色模式",
 };
@@ -24,7 +25,8 @@ export function AppTopBar() {
   const { config: themeConfig, update: updateTheme } = useTheme();
   const currentThemeIndex = THEME_SEQUENCE.indexOf(themeConfig.theme);
   const nextTheme = THEME_SEQUENCE[(currentThemeIndex + 1) % THEME_SEQUENCE.length] ?? "dark";
-  const ThemeIcon = themeConfig.theme === "light" ? Moon : themeConfig.theme === "dark-modern" ? Sun : Palette;
+  const ThemeIcon =
+    themeConfig.theme === "dark-modern" ? Sun : themeConfig.theme === "dark" || themeConfig.theme === "light" ? Palette : Moon;
   const themeToggleLabel = `切换到${THEME_LABELS[nextTheme]}`;
   const openBrandSite = (event: MouseEvent<HTMLAnchorElement>) => {
     event.preventDefault();
@@ -46,7 +48,7 @@ export function AppTopBar() {
         <HermesLogoMark
           className={s.brandMark}
           size={30}
-          tone={themeConfig.theme === "light" ? "dark" : "light"}
+          tone={themeConfig.theme === "light" || themeConfig.theme === "light-modern" ? "dark" : "light"}
         />
         <span className={s.brandText}>
           <span className={s.wordmark}>

--- a/web/src/components/app-shell/use-active-top-tab.ts
+++ b/web/src/components/app-shell/use-active-top-tab.ts
@@ -54,6 +54,7 @@ export const TOP_TABS: readonly TopTabDef[] = [
       path.startsWith("/analytics") ||
       path.startsWith("/logs") ||
       path.startsWith("/debug") ||
+      path.startsWith("/theme") ||
       path.startsWith("/advanced") ||
       path.startsWith("/settings"),
   },

--- a/web/src/components/app-shell/workbench-sidebar.module.css
+++ b/web/src/components/app-shell/workbench-sidebar.module.css
@@ -20,8 +20,8 @@
   background: linear-gradient(
     180deg,
     transparent,
-    rgba(255, 122, 61, 0.25) 30%,
-    rgba(255, 122, 61, 0.25) 70%,
+    color-mix(in srgb, var(--h-accent) 25%, transparent) 30%,
+    color-mix(in srgb, var(--h-accent) 25%, transparent) 70%,
     transparent
   );
   opacity: 0.4;
@@ -31,8 +31,8 @@
 .newTask {
   margin: 12px 12px 8px;
   height: 36px;
-  background: var(--persimmon);
-  color: #1a0c04;
+  background: var(--h-accent);
+  color: var(--h-accent-contrast, #fff);
   border-radius: 3px;
   display: flex;
   align-items: center;
@@ -48,7 +48,7 @@
 }
 
 .newTask:hover {
-  background: #ff8a52;
+  background: color-mix(in srgb, var(--h-accent) 84%, var(--h-text));
 }
 
 .newTaskLead {

--- a/web/src/components/chat/goose-composer.module.css
+++ b/web/src/components/chat/goose-composer.module.css
@@ -1391,7 +1391,7 @@
 }
 
 .sendButton {
-  --composer-send-accent: var(--persimmon);
+  --composer-send-accent: var(--h-accent);
 
   min-width: 88px;
   height: var(--composer-action-height);
@@ -1399,7 +1399,7 @@
   border: 1px solid var(--composer-send-accent);
   border-radius: var(--h-r-md);
   background: var(--composer-send-accent);
-  color: #fff;
+  color: var(--h-accent-contrast, #fff);
   box-shadow: none;
   font-size: 13px;
   font-weight: 600;
@@ -1429,7 +1429,7 @@
   min-width: 44px;
   border-color: var(--composer-send-accent);
   background: var(--composer-send-accent);
-  color: #fff;
+  color: var(--h-accent-contrast, #fff);
   padding: 0 12px;
 }
 

--- a/web/src/components/chat/message-timeline.module.css
+++ b/web/src/components/chat/message-timeline.module.css
@@ -153,9 +153,9 @@
 }
 
 .systemNoticeText {
-  font-size: 12.5px;
+  font-size: var(--conversation-font-size, 12.5px);
   color: var(--h-text-2);
-  line-height: 1.6;
+  line-height: var(--conversation-line-height, 1.6);
   white-space: pre-wrap;
 }
 
@@ -175,8 +175,8 @@
 .bubble {
   min-width: 0;
   color: var(--h-text);
-  font-size: 14px;
-  line-height: 1.78;
+  font-size: var(--conversation-font-size, 14px);
+  line-height: var(--conversation-line-height, 1.78);
 }
 
 .bubble[data-role="user"] {
@@ -525,7 +525,8 @@
   height: auto;
 }
 
-:global([data-theme="dark"]) .messageText :global([data-streamdown="mermaid"] svg) {
+:global([data-theme="dark"]) .messageText :global([data-streamdown="mermaid"] svg),
+:global([data-theme="dark-modern"]) .messageText :global([data-streamdown="mermaid"] svg) {
   color-scheme: light;
 }
 
@@ -553,8 +554,8 @@
   background: transparent;
   color: var(--h-text-2);
   font-family: var(--h-font-ui);
-  font-size: 13px;
-  line-height: 1.72;
+  font-size: var(--conversation-font-size, 13px);
+  line-height: var(--conversation-line-height, 1.72);
   white-space: pre-wrap;
   overflow-wrap: anywhere;
   font-variant-east-asian: normal;
@@ -576,11 +577,13 @@
   display: block;
 }
 
-:global([data-theme="dark"]) .messageText :global(.shiki) {
+:global([data-theme="dark"]) .messageText :global(.shiki),
+:global([data-theme="dark-modern"]) .messageText :global(.shiki) {
   color: var(--shiki-dark) !important;
 }
 
-:global([data-theme="dark"]) .messageText :global(.shiki span) {
+:global([data-theme="dark"]) .messageText :global(.shiki span),
+:global([data-theme="dark-modern"]) .messageText :global(.shiki span) {
   color: var(--shiki-dark) !important;
 }
 

--- a/web/src/main.tsx
+++ b/web/src/main.tsx
@@ -44,7 +44,7 @@ async function bootstrap() {
 
   const initialTheme = readUiValue<{ theme?: string; density?: string }>("hermes-theme", {});
   const initialThemeMode =
-    initialTheme.theme === "light" || initialTheme.theme === "dark-modern"
+    initialTheme.theme === "light" || initialTheme.theme === "light-modern" || initialTheme.theme === "dark-modern"
       ? initialTheme.theme
       : "dark";
   applyThemeToDOM({

--- a/web/src/main.tsx
+++ b/web/src/main.tsx
@@ -43,8 +43,12 @@ async function bootstrap() {
   await initUiStore();
 
   const initialTheme = readUiValue<{ theme?: string; density?: string }>("hermes-theme", {});
+  const initialThemeMode =
+    initialTheme.theme === "light" || initialTheme.theme === "dark-modern"
+      ? initialTheme.theme
+      : "dark";
   applyThemeToDOM({
-    theme: initialTheme.theme === "light" ? "light" : "dark",
+    theme: initialThemeMode,
     density: initialTheme.density === "compact" ? "compact" : "comfortable",
   });
 

--- a/web/src/routes/advanced.tsx
+++ b/web/src/routes/advanced.tsx
@@ -1,17 +1,25 @@
 import { Navigate, useLocation } from "react-router-dom";
 import { SectionShell } from "./section-shell";
-import { AboutSection, ConfigSection, GeneralSection, KernelSection } from "./settings";
+import { AboutSection, ConfigSection, GeneralSection, KernelSection, ThemeSection } from "./settings";
 import { EnvironmentSection } from "./environment";
 
 type AdvancedSection = "general" | "config" | "kernel" | "env" | "about";
 
 const SECTION_META: Record<AdvancedSection, { title: string; sub: string }> = {
-  general: { title: "常规", sub: "调整主题、密度和对话显示偏好。" },
+  general: { title: "常规", sub: "调整会话显示与输入偏好。" },
   config: { title: "配置", sub: "编辑 Hermes config.yaml 中的高级配置项。" },
   kernel: { title: "内核", sub: "查看运行时、版本和本地路径信息。" },
   env: { title: "环境", sub: "检查 managed runtime 与本机可选工具能力。" },
   about: { title: "关于", sub: "联系方式、社区入口和致谢信息。" },
 };
+
+export function ThemeRoute() {
+  return (
+    <SectionShell title="主题" sub="选择皮肤、信息密度和对话字号。">
+      <ThemeSection showHeading={false} />
+    </SectionShell>
+  );
+}
 
 function sectionFromPath(pathname: string): AdvancedSection | null {
   if (pathname === "/advanced" || pathname === "/advanced/") return "general";

--- a/web/src/routes/detail.tsx
+++ b/web/src/routes/detail.tsx
@@ -1,9 +1,11 @@
 import { useEffect, useMemo, useCallback, useRef, useState, type CSSProperties } from "react";
-import { useAtom, useSetAtom } from "jotai";
+import { useAtom, useAtomValue, useSetAtom } from "jotai";
 import { useNavigate, useParams } from "react-router-dom";
 import { Check, Copy } from "lucide-react";
 import {
   activeSessionIdAtom,
+  conversationFontSizeAtom,
+  conversationFontSizeVars,
   conversationWidthMaxWidth,
   conversationWidthModeAtom,
 } from "@/stores/ui";
@@ -64,6 +66,7 @@ export function DetailRoute() {
   const navigate = useNavigate();
   const [activeSessionId, setActiveId] = useAtom(activeSessionIdAtom);
   const [conversationWidthMode, setConversationWidthMode] = useAtom(conversationWidthModeAtom);
+  const conversationFontSizeMode = useAtomValue(conversationFontSizeAtom);
   const taskId = activeSessionId ?? urlTaskId;
   const [turnStats, setTurnStats] = useState<UiTurnStats[]>([]);
 
@@ -355,10 +358,15 @@ export function DetailRoute() {
     estimatedUsed: estimatedContextUsed,
   });
   const pageStyle = useMemo(
-    () => ({
-      "--conversation-max-width": conversationWidthMaxWidth(conversationWidthMode),
-    }) as CSSProperties,
-    [conversationWidthMode],
+    () => {
+      const font = conversationFontSizeVars(conversationFontSizeMode);
+      return {
+        "--conversation-max-width": conversationWidthMaxWidth(conversationWidthMode),
+        "--conversation-font-size": font.fontSize,
+        "--conversation-line-height": font.lineHeight,
+      } as CSSProperties;
+    },
+    [conversationFontSizeMode, conversationWidthMode],
   );
 
   return (

--- a/web/src/routes/settings.module.css
+++ b/web/src/routes/settings.module.css
@@ -579,9 +579,9 @@
 
 .skinPicker {
   display: grid;
-  grid-template-columns: repeat(3, minmax(116px, 1fr));
+  grid-template-columns: repeat(4, minmax(118px, 1fr));
   gap: 8px;
-  width: min(100%, 520px);
+  width: min(100%, 660px);
 }
 
 .skinCard {

--- a/web/src/routes/settings.module.css
+++ b/web/src/routes/settings.module.css
@@ -472,6 +472,223 @@
   margin-bottom: 0;
 }
 
+/* Appearance */
+.appearancePanel {
+  overflow: hidden;
+  margin: 0 0 18px;
+  border: 1px solid var(--h-line);
+  border-radius: 16px;
+  background:
+    radial-gradient(circle at 16% -12%, color-mix(in srgb, var(--h-accent) 12%, transparent), transparent 34%),
+    linear-gradient(180deg, color-mix(in srgb, var(--h-bg-pane) 96%, var(--h-bg-app)), var(--h-bg-app));
+  box-shadow: var(--h-shadow);
+}
+
+.appearanceHeader {
+  display: grid;
+  grid-template-columns: auto minmax(0, 1fr) auto;
+  gap: 18px;
+  align-items: start;
+  padding: 20px 24px;
+  border-bottom: 1px solid var(--h-line-soft);
+}
+
+.appearanceIndex {
+  margin-top: 3px;
+  color: var(--h-accent);
+  font-family: var(--h-font-mono);
+  font-size: 12px;
+  font-weight: 700;
+  letter-spacing: 0.14em;
+}
+
+.appearanceHeaderText {
+  min-width: 0;
+}
+
+.appearanceHeaderText h3 {
+  margin: 0;
+  color: var(--h-text);
+  font-size: 22px;
+  font-weight: 650;
+  letter-spacing: -0.02em;
+}
+
+.appearanceHeaderText p {
+  margin: 6px 0 0;
+  color: var(--h-text-3);
+  font-size: 12px;
+  line-height: 1.65;
+}
+
+.appearanceMeta {
+  margin-top: 4px;
+  color: var(--h-text-4);
+  font-family: var(--h-font-mono);
+  font-size: 11px;
+  letter-spacing: 0.08em;
+  white-space: nowrap;
+}
+
+.appearanceRow {
+  display: grid;
+  grid-template-columns: minmax(220px, 0.88fr) minmax(260px, 1.18fr) minmax(128px, auto);
+  gap: 22px;
+  align-items: center;
+  padding: 22px 24px;
+  border-bottom: 1px solid var(--h-line-soft);
+}
+
+.appearanceRow:last-child {
+  border-bottom: 0;
+}
+
+.appearanceRowText {
+  min-width: 0;
+}
+
+.appearanceRowLabel {
+  color: var(--h-text);
+  font-size: 18px;
+  font-weight: 620;
+  letter-spacing: -0.01em;
+}
+
+.appearanceRowSub {
+  max-width: 330px;
+  margin-top: 6px;
+  color: var(--h-text-3);
+  font-size: 12.5px;
+  line-height: 1.72;
+}
+
+.appearanceRowControl {
+  min-width: 0;
+  display: flex;
+  justify-content: flex-start;
+}
+
+.appearanceRowMeta {
+  justify-self: end;
+  color: var(--h-text-4);
+  font-family: var(--h-font-mono);
+  font-size: 11px;
+  letter-spacing: 0.05em;
+  white-space: nowrap;
+}
+
+.skinPicker {
+  display: grid;
+  grid-template-columns: repeat(3, minmax(116px, 1fr));
+  gap: 8px;
+  width: min(100%, 520px);
+}
+
+.skinCard {
+  min-width: 0;
+  display: grid;
+  grid-template-columns: 48px minmax(0, 1fr);
+  gap: 10px;
+  align-items: center;
+  padding: 10px;
+  border: 1px solid var(--h-line);
+  border-radius: 12px;
+  background: color-mix(in srgb, var(--h-bg-pane) 78%, transparent);
+  color: var(--h-text-2);
+  cursor: pointer;
+  font-family: var(--h-font-cn);
+  text-align: left;
+  transition: border-color 0.14s ease, background 0.14s ease, transform 0.14s ease, box-shadow 0.14s ease;
+}
+
+.skinCard:hover {
+  border-color: color-mix(in srgb, var(--h-accent) 34%, var(--h-line));
+  background: var(--h-bg-pane);
+  transform: translateY(-1px);
+}
+
+.skinCard[data-active="true"] {
+  border-color: var(--h-accent);
+  background: color-mix(in srgb, var(--h-accent) 10%, var(--h-bg-pane));
+  box-shadow: inset 0 0 0 1px color-mix(in srgb, var(--h-accent) 26%, transparent);
+}
+
+.skinPreview {
+  position: relative;
+  display: block;
+  width: 48px;
+  height: 38px;
+  overflow: hidden;
+  border: 1px solid color-mix(in srgb, var(--skin-text) 18%, transparent);
+  border-radius: 9px;
+  background: var(--skin-bg);
+  box-shadow: 0 8px 18px rgba(0, 0, 0, 0.18);
+}
+
+.skinPreviewTop {
+  display: block;
+  height: 9px;
+  background: var(--skin-pane);
+  border-bottom: 1px solid color-mix(in srgb, var(--skin-text) 14%, transparent);
+}
+
+.skinPreviewBody {
+  display: grid;
+  gap: 4px;
+  padding: 6px 7px 0;
+}
+
+.skinPreviewBody span {
+  display: block;
+  height: 3px;
+  border-radius: var(--h-r-pill);
+  background: color-mix(in srgb, var(--skin-text) 52%, var(--skin-soft));
+}
+
+.skinPreviewBody span:nth-child(2) {
+  width: 72%;
+  opacity: 0.72;
+}
+
+.skinPreviewBody span:nth-child(3) {
+  width: 52%;
+  opacity: 0.56;
+}
+
+.skinPreviewAccent {
+  position: absolute;
+  right: 6px;
+  bottom: 5px;
+  width: 9px;
+  height: 9px;
+  border-radius: 50%;
+  background: var(--skin-accent);
+  box-shadow: 0 0 0 2px color-mix(in srgb, var(--skin-accent) 22%, transparent);
+}
+
+.skinCopy {
+  min-width: 0;
+  display: grid;
+  gap: 2px;
+}
+
+.skinTitle {
+  overflow: hidden;
+  color: var(--h-text);
+  font-size: 12px;
+  font-weight: 650;
+  text-overflow: ellipsis;
+  white-space: nowrap;
+}
+
+.skinSub {
+  overflow: hidden;
+  color: var(--h-text-3);
+  font-size: 10.5px;
+  text-overflow: ellipsis;
+  white-space: nowrap;
+}
+
 /* Toggle */
 .toggle {
   width: 30px;
@@ -2422,6 +2639,35 @@
   }
 
   .providerFormGrid {
+    grid-template-columns: 1fr;
+  }
+
+  .appearanceHeader,
+  .appearanceRow {
+    grid-template-columns: 1fr;
+  }
+
+  .appearanceMeta,
+  .appearanceRowMeta {
+    justify-self: start;
+  }
+
+  .skinPicker {
+    width: 100%;
+  }
+}
+
+@media (max-width: 720px) {
+  .appearancePanel {
+    border-radius: 12px;
+  }
+
+  .appearanceHeader,
+  .appearanceRow {
+    padding: 18px;
+  }
+
+  .skinPicker {
     grid-template-columns: 1fr;
   }
 }

--- a/web/src/routes/settings.tsx
+++ b/web/src/routes/settings.tsx
@@ -1,4 +1,4 @@
-import { useState, useMemo, useEffect, useRef, useCallback } from "react";
+import { useState, useMemo, useEffect, useRef, useCallback, type CSSProperties } from "react";
 import { useAtom, useAtomValue } from "jotai";
 import {
   Activity,
@@ -35,7 +35,14 @@ import {
   useRollbackRuntime,
   useRuntimeInfo,
 } from "@/hooks/use-runtime-update";
-import { composerSubmitShortcutAtom, showReasoningAtom, profileSwitchingAtom } from "@/stores/ui";
+import {
+  CONVERSATION_FONT_SIZE_OPTIONS,
+  composerSubmitShortcutAtom,
+  conversationFontSizeAtom,
+  profileSwitchingAtom,
+  showReasoningAtom,
+  type ConversationFontSizeMode,
+} from "@/stores/ui";
 import { openExternalUrl } from "@/lib/external-links";
 import { buildNestedConfigUpdate, mergeConfigUpdate } from "@/lib/config-update";
 import { translateConfigField, translateConfigOption } from "@/lib/config-translations";
@@ -55,17 +62,54 @@ interface SettingsSectionProps {
 export function GeneralSection({ showHeading = true }: SettingsSectionProps) {
   const { config, update } = useTheme();
   const [showReasoning, setShowReasoning] = useAtom(showReasoningAtom);
+  const [conversationFontSize, setConversationFontSize] = useAtom(conversationFontSizeAtom);
   const [composerSubmitShortcut, setComposerSubmitShortcut] = useAtom(composerSubmitShortcutAtom);
 
   return (
     <div>
       {showHeading && <h2 className={s.heading}>常规</h2>}
-      <Row label="主题" right={
-        <RadioGroup value={config.theme} options={[{ value: "light", label: "浅色" }, { value: "dark", label: "深色" }]} onChange={(v) => update({ theme: v as ThemeConfig["theme"] })} />
-      } />
-      <Row label="信息密度" right={
-        <RadioGroup value={config.density} options={[{ value: "compact", label: "紧凑" }, { value: "comfortable", label: "舒适" }]} onChange={(v) => update({ density: v as ThemeConfig["density"] })} />
-      } />
+      <div className={s.appearancePanel}>
+        <div className={s.appearanceHeader}>
+          <span className={s.appearanceIndex}>[ 01 ]</span>
+          <div className={s.appearanceHeaderText}>
+            <h3>外观</h3>
+            <p>颜色、密度和对话阅读字号会立即应用到桌面端界面。</p>
+          </div>
+          <span className={s.appearanceMeta}>颜色 · 密度 · 字号</span>
+        </div>
+
+        <AppearanceRow
+          label="主题"
+          sub="选择桌面端皮肤。现代深色采用更克制的蓝黑工作台配色。"
+          meta="applied immediately"
+          right={
+            <ThemeSkinPicker
+              value={config.theme}
+              onChange={(theme) => update({ theme })}
+            />
+          }
+        />
+        <AppearanceRow
+          label="密度"
+          sub="调整行与卡片的垂直留白。舒适匹配当前默认布局。"
+          meta="无需重启"
+          right={
+            <RadioGroup value={config.density} options={[{ value: "compact", label: "紧凑" }, { value: "comfortable", label: "舒适" }]} onChange={(v) => update({ density: v as ThemeConfig["density"] })} />
+          }
+        />
+        <AppearanceRow
+          label="对话字号"
+          sub="只影响会话详情里的对话正文；代码块、工具日志和输入框保持原字号。"
+          meta="conversation only"
+          right={
+            <RadioGroup
+              value={conversationFontSize}
+              options={CONVERSATION_FONT_SIZE_OPTIONS.map((option) => ({ value: option.value, label: option.label }))}
+              onChange={(v) => setConversationFontSize(v as ConversationFontSizeMode)}
+            />
+          }
+        />
+      </div>
       <Row label="显示推理过程" sub="在会话中展示模型的思考和推理内容" right={
         <RadioGroup value={showReasoning ? "on" : "off"} options={[{ value: "off", label: "隐藏" }, { value: "on", label: "显示" }]} onChange={(v) => setShowReasoning(v === "on")} />
       } />
@@ -73,6 +117,120 @@ export function GeneralSection({ showHeading = true }: SettingsSectionProps) {
         <RadioGroup value={composerSubmitShortcut} options={[{ value: "enter", label: "Enter 发送" }, { value: "ctrl-enter", label: "Ctrl+Enter 发送" }]} onChange={(v) => setComposerSubmitShortcut(v as ComposerSubmitShortcut)} />
       } />
       {isYoloModeSupported() && <YoloDangerZone />}
+    </div>
+  );
+}
+
+const THEME_SKINS: Array<{
+  value: ThemeConfig["theme"];
+  label: string;
+  sub: string;
+  bg: string;
+  pane: string;
+  soft: string;
+  text: string;
+  accent: string;
+}> = [
+  {
+    value: "light",
+    label: "浅色",
+    sub: "明亮柔和",
+    bg: "#fbfaf7",
+    pane: "#ffffff",
+    soft: "#f5f2ec",
+    text: "#232120",
+    accent: "#ff7a3d",
+  },
+  {
+    value: "dark",
+    label: "经典深色",
+    sub: "暖墨颗粒",
+    bg: "#0a0908",
+    pane: "#11100e",
+    soft: "#232120",
+    text: "#faf7f0",
+    accent: "#ff7a3d",
+  },
+  {
+    value: "dark-modern",
+    label: "现代深色",
+    sub: "蓝黑工作台",
+    bg: "#181818",
+    pane: "#1f1f1f",
+    soft: "#252526",
+    text: "#d4d4d4",
+    accent: "#0078d4",
+  },
+];
+
+function AppearanceRow({
+  label,
+  sub,
+  right,
+  meta,
+}: {
+  label: string;
+  sub: string;
+  right: React.ReactNode;
+  meta?: string;
+}) {
+  return (
+    <div className={s.appearanceRow}>
+      <div className={s.appearanceRowText}>
+        <div className={s.appearanceRowLabel}>{label}</div>
+        <div className={s.appearanceRowSub}>{sub}</div>
+      </div>
+      <div className={s.appearanceRowControl}>{right}</div>
+      {meta ? <div className={s.appearanceRowMeta}>{meta}</div> : null}
+    </div>
+  );
+}
+
+function ThemeSkinPicker({
+  value,
+  onChange,
+}: {
+  value: ThemeConfig["theme"];
+  onChange: (theme: ThemeConfig["theme"]) => void;
+}) {
+  return (
+    <div className={s.skinPicker} role="radiogroup" aria-label="主题皮肤">
+      {THEME_SKINS.map((skin) => {
+        const active = skin.value === value;
+        const style = {
+          "--skin-bg": skin.bg,
+          "--skin-pane": skin.pane,
+          "--skin-soft": skin.soft,
+          "--skin-text": skin.text,
+          "--skin-accent": skin.accent,
+        } as CSSProperties;
+        return (
+          <button
+            key={skin.value}
+            type="button"
+            className={s.skinCard}
+            style={style}
+            role="radio"
+            aria-checked={active}
+            data-active={active ? "true" : undefined}
+            onClick={() => onChange(skin.value)}
+          >
+            <span className={s.skinPreview} aria-hidden="true">
+              <span className={s.skinPreviewTop} />
+              <span className={s.skinPreviewBody}>
+                <span />
+                <span />
+                <span />
+              </span>
+              <span className={s.skinPreviewAccent} />
+            </span>
+            <span className={s.skinCopy}>
+              <span className={s.skinTitle}>{skin.label}</span>
+              <span className={s.skinSub}>{skin.sub}</span>
+            </span>
+          </button>
+        );
+      })}
     </div>
   );
 }

--- a/web/src/routes/settings.tsx
+++ b/web/src/routes/settings.tsx
@@ -97,7 +97,6 @@ export function ThemeSection({ showHeading = true }: SettingsSectionProps) {
         <AppearanceRow
           label="主题"
           sub="选择桌面端皮肤。现代主题采用更克制的工作台配色和蓝色主操作。"
-          meta="applied immediately"
           right={
             <ThemeSkinPicker
               value={config.theme}
@@ -108,7 +107,6 @@ export function ThemeSection({ showHeading = true }: SettingsSectionProps) {
         <AppearanceRow
           label="密度"
           sub="调整行与卡片的垂直留白。舒适匹配当前默认布局。"
-          meta="无需重启"
           right={
             <RadioGroup value={config.density} options={[{ value: "compact", label: "紧凑" }, { value: "comfortable", label: "舒适" }]} onChange={(v) => update({ density: v as ThemeConfig["density"] })} />
           }
@@ -116,7 +114,6 @@ export function ThemeSection({ showHeading = true }: SettingsSectionProps) {
         <AppearanceRow
           label="对话字号"
           sub="只影响会话详情里的对话正文；代码块、工具日志和输入框保持原字号。"
-          meta="conversation only"
           right={
             <RadioGroup
               value={conversationFontSize}

--- a/web/src/routes/settings.tsx
+++ b/web/src/routes/settings.tsx
@@ -80,7 +80,7 @@ export function GeneralSection({ showHeading = true }: SettingsSectionProps) {
 
         <AppearanceRow
           label="主题"
-          sub="选择桌面端皮肤。现代深色采用更克制的蓝黑工作台配色。"
+          sub="选择桌面端皮肤。现代主题采用更克制的工作台配色和蓝色主操作。"
           meta="applied immediately"
           right={
             <ThemeSkinPicker
@@ -140,6 +140,16 @@ const THEME_SKINS: Array<{
     soft: "#f5f2ec",
     text: "#232120",
     accent: "#ff7a3d",
+  },
+  {
+    value: "light-modern",
+    label: "现代浅色",
+    sub: "白色工作台",
+    bg: "#f3f3f3",
+    pane: "#ffffff",
+    soft: "#f0f0f0",
+    text: "#1f1f1f",
+    accent: "#0078d4",
   },
   {
     value: "dark",

--- a/web/src/routes/settings.tsx
+++ b/web/src/routes/settings.tsx
@@ -60,14 +60,30 @@ interface SettingsSectionProps {
 }
 
 export function GeneralSection({ showHeading = true }: SettingsSectionProps) {
-  const { config, update } = useTheme();
   const [showReasoning, setShowReasoning] = useAtom(showReasoningAtom);
-  const [conversationFontSize, setConversationFontSize] = useAtom(conversationFontSizeAtom);
   const [composerSubmitShortcut, setComposerSubmitShortcut] = useAtom(composerSubmitShortcutAtom);
 
   return (
     <div>
       {showHeading && <h2 className={s.heading}>常规</h2>}
+      <Row label="显示推理过程" sub="在会话中展示模型的思考和推理内容" right={
+        <RadioGroup value={showReasoning ? "on" : "off"} options={[{ value: "off", label: "隐藏" }, { value: "on", label: "显示" }]} onChange={(v) => setShowReasoning(v === "on")} />
+      } />
+      <Row label="发送快捷键" sub="控制对话输入框的提交方式；未触发发送的 Enter 会保留为换行。" right={
+        <RadioGroup value={composerSubmitShortcut} options={[{ value: "enter", label: "Enter 发送" }, { value: "ctrl-enter", label: "Ctrl+Enter 发送" }]} onChange={(v) => setComposerSubmitShortcut(v as ComposerSubmitShortcut)} />
+      } />
+      {isYoloModeSupported() && <YoloDangerZone />}
+    </div>
+  );
+}
+
+export function ThemeSection({ showHeading = true }: SettingsSectionProps) {
+  const { config, update } = useTheme();
+  const [conversationFontSize, setConversationFontSize] = useAtom(conversationFontSizeAtom);
+
+  return (
+    <div>
+      {showHeading && <h2 className={s.heading}>主题</h2>}
       <div className={s.appearancePanel}>
         <div className={s.appearanceHeader}>
           <span className={s.appearanceIndex}>[ 01 ]</span>
@@ -110,13 +126,6 @@ export function GeneralSection({ showHeading = true }: SettingsSectionProps) {
           }
         />
       </div>
-      <Row label="显示推理过程" sub="在会话中展示模型的思考和推理内容" right={
-        <RadioGroup value={showReasoning ? "on" : "off"} options={[{ value: "off", label: "隐藏" }, { value: "on", label: "显示" }]} onChange={(v) => setShowReasoning(v === "on")} />
-      } />
-      <Row label="发送快捷键" sub="控制对话输入框的提交方式；未触发发送的 Enter 会保留为换行。" right={
-        <RadioGroup value={composerSubmitShortcut} options={[{ value: "enter", label: "Enter 发送" }, { value: "ctrl-enter", label: "Ctrl+Enter 发送" }]} onChange={(v) => setComposerSubmitShortcut(v as ComposerSubmitShortcut)} />
-      } />
-      {isYoloModeSupported() && <YoloDangerZone />}
     </div>
   );
 }

--- a/web/src/stores/ui.test.ts
+++ b/web/src/stores/ui.test.ts
@@ -137,6 +137,44 @@ describe("conversationWidthModeAtom (persisted)", () => {
   });
 });
 
+describe("conversationFontSizeAtom (persisted)", () => {
+  it("defaults to standard when nothing is stored", async () => {
+    const { conversationFontSizeAtom } = await loadUi();
+    const store = createStore();
+    expect(store.get(conversationFontSizeAtom)).toBe("standard");
+  });
+
+  it("restores a supported font size from the UI store", async () => {
+    const { conversationFontSizeAtom } = await loadUi({
+      "hermes.conversation-font-size": "large",
+    });
+    const store = createStore();
+    expect(store.get(conversationFontSizeAtom)).toBe("large");
+  });
+
+  it("persists font size changes and normalizes unsupported values", async () => {
+    const { conversationFontSizeAtom, uiStore } = await loadUi({
+      "hermes.conversation-font-size": "tiny",
+    });
+    const store = createStore();
+    expect(store.get(conversationFontSizeAtom)).toBe("standard");
+
+    store.set(conversationFontSizeAtom, "small");
+    expect(uiStore.readUiValue("hermes.conversation-font-size", "")).toBe("small");
+
+    store.set(conversationFontSizeAtom, "huge" as never);
+    expect(store.get(conversationFontSizeAtom)).toBe("standard");
+    expect(uiStore.readUiValue("hermes.conversation-font-size", "")).toBe("standard");
+  });
+
+  it("maps the three font size modes to concrete CSS variables", async () => {
+    const { conversationFontSizeVars } = await loadUi();
+    expect(conversationFontSizeVars("small")).toEqual({ fontSize: "13px", lineHeight: "1.72" });
+    expect(conversationFontSizeVars("standard")).toEqual({ fontSize: "14px", lineHeight: "1.78" });
+    expect(conversationFontSizeVars("large")).toEqual({ fontSize: "15.5px", lineHeight: "1.82" });
+  });
+});
+
 describe("profileSwitchingAtom", () => {
   it("defaults to { active: false }", async () => {
     const { profileSwitchingAtom } = await loadUi();

--- a/web/src/stores/ui.ts
+++ b/web/src/stores/ui.ts
@@ -14,9 +14,20 @@ export const CONVERSATION_WIDTH_OPTIONS = [
 
 export type ConversationWidthMode = typeof CONVERSATION_WIDTH_OPTIONS[number]["value"];
 
+export const CONVERSATION_FONT_SIZE_OPTIONS = [
+  { value: "small", label: "小", title: "小字号", fontSize: "13px", lineHeight: "1.72" },
+  { value: "standard", label: "标准", title: "标准字号", fontSize: "14px", lineHeight: "1.78" },
+  { value: "large", label: "大", title: "大字号", fontSize: "15.5px", lineHeight: "1.82" },
+] as const;
+
+export type ConversationFontSizeMode = typeof CONVERSATION_FONT_SIZE_OPTIONS[number]["value"];
+
 const DEFAULT_CONVERSATION_WIDTH_MODE: ConversationWidthMode = "medium";
 const CONVERSATION_WIDTH_KEY = "hermes.conversation-width";
 const CONVERSATION_WIDTH_VALUES = CONVERSATION_WIDTH_OPTIONS.map((option) => option.value);
+const DEFAULT_CONVERSATION_FONT_SIZE_MODE: ConversationFontSizeMode = "standard";
+const CONVERSATION_FONT_SIZE_KEY = "hermes.conversation-font-size";
+const CONVERSATION_FONT_SIZE_VALUES = CONVERSATION_FONT_SIZE_OPTIONS.map((option) => option.value);
 
 export function normalizeConversationWidthMode(value: unknown): ConversationWidthMode {
   return CONVERSATION_WIDTH_VALUES.includes(value as ConversationWidthMode)
@@ -28,6 +39,18 @@ export function conversationWidthMaxWidth(mode: ConversationWidthMode): string {
   return CONVERSATION_WIDTH_OPTIONS.find((option) => option.value === mode)?.maxWidth ?? "780px";
 }
 
+export function normalizeConversationFontSizeMode(value: unknown): ConversationFontSizeMode {
+  return CONVERSATION_FONT_SIZE_VALUES.includes(value as ConversationFontSizeMode)
+    ? (value as ConversationFontSizeMode)
+    : DEFAULT_CONVERSATION_FONT_SIZE_MODE;
+}
+
+export function conversationFontSizeVars(mode: ConversationFontSizeMode): { fontSize: string; lineHeight: string } {
+  const option = CONVERSATION_FONT_SIZE_OPTIONS.find((item) => item.value === mode)
+    ?? CONVERSATION_FONT_SIZE_OPTIONS[1];
+  return { fontSize: option.fontSize, lineHeight: option.lineHeight };
+}
+
 const conversationWidthModeBaseAtom = atom<ConversationWidthMode>(
   normalizeConversationWidthMode(readUiValue(CONVERSATION_WIDTH_KEY, DEFAULT_CONVERSATION_WIDTH_MODE)),
 );
@@ -37,6 +60,18 @@ export const conversationWidthModeAtom = atom(
     const value = normalizeConversationWidthMode(next);
     set(conversationWidthModeBaseAtom, value);
     writeUiValue(CONVERSATION_WIDTH_KEY, value);
+  },
+);
+
+const conversationFontSizeBaseAtom = atom<ConversationFontSizeMode>(
+  normalizeConversationFontSizeMode(readUiValue(CONVERSATION_FONT_SIZE_KEY, DEFAULT_CONVERSATION_FONT_SIZE_MODE)),
+);
+export const conversationFontSizeAtom = atom(
+  (get) => get(conversationFontSizeBaseAtom),
+  (_get, set, next: ConversationFontSizeMode) => {
+    const value = normalizeConversationFontSizeMode(next);
+    set(conversationFontSizeBaseAtom, value);
+    writeUiValue(CONVERSATION_FONT_SIZE_KEY, value);
   },
 );
 


### PR DESCRIPTION
## 变更内容

为桌面端设置页新增外观皮肤选择能力，保留浅色与经典深色，并新增现代深色皮肤。设置页常规区域改为更完整的外观面板，同时加入对话字号三档预设。

## 用户影响

用户可以在设置页即时切换浅色、经典深色和现代深色皮肤，也可以调整会话详情中的对话正文大小。字号设置只影响对话阅读内容，不影响代码块、工具日志、输入框和字体族。

## 验证

- `pnpm --filter @hermes/web exec vitest run src/stores/ui.test.ts`
- `pnpm typecheck`
- `pnpm test:unit`
- `cargo check`
- 浏览器冒烟验证 `/advanced` 外观区域、现代深色切换和字号控件状态。