### PR TITLE
[codex] 修复中断后重复显示 Hermes 消息

### DIFF
--- a/web/src/components/chat/message-adapter.test.ts
+++ b/web/src/components/chat/message-adapter.test.ts
@@ -537,6 +537,57 @@ describe("message adapter", () => {
     expect(merged[0]?.id).toBe("live-assistant-10");
   });
 
+  it("dedups an interrupted live assistant against the stored tool transcript", () => {
+    const stored = [
+      uiMessage({
+        id: "stored-interrupted-turn",
+        parts: [
+          { type: "text", text: "好，先装 MCP SDK，然后写一个 context7 工具集。" },
+          {
+            type: "tool",
+            toolCallId: "call-install",
+            name: "terminal",
+            state: "done",
+            output: "ERROR: No matching distribution found for mcp",
+            startedAt: 1_000,
+            completedAt: 2_000,
+          },
+        ],
+        metadata: { persistedId: 417 },
+      }),
+    ];
+    const live = [
+      uiMessage({
+        id: "live-interrupted-turn",
+        parts: [
+          { type: "text", text: "好，先装 MCP SDK，然后写一个 context7 工具集。" },
+          {
+            type: "tool",
+            toolCallId: "call-install",
+            name: "terminal",
+            state: "done",
+            startedAt: 1_000,
+            completedAt: 2_000,
+          },
+          { type: "text", text: "Operation interrupted: waiting for model response (1.7s elapsed)." },
+        ],
+        metadata: {
+          finishReason: "interrupted",
+          timing: { startedAt: 100, firstTokenAt: 200, completedAt: 1_700 },
+        },
+      }),
+    ];
+
+    const merged = mergeHermesUIMessages(stored, live);
+    const chat = hermesUIMessagesToChatMessages(merged);
+
+    expect(merged).toHaveLength(1);
+    expect(merged[0]?.id).toBe("live-interrupted-turn");
+    expect(chat).toHaveLength(1);
+    expect(chat[0]?.text).toContain("Operation interrupted");
+    expect(chat[0]?.stats?.finishReason).toBe("interrupted");
+  });
+
   it("keeps persisted stats when a matching live message has no metadata", () => {
     const stored = [
       uiMessage({

--- a/web/src/components/chat/message-adapter.ts
+++ b/web/src/components/chat/message-adapter.ts
@@ -816,6 +816,37 @@ function canonicalToolComparable(message: HermesUIMessage): string {
     .join("|");
 }
 
+function canonicalToolIdentityComparable(message: HermesUIMessage): string {
+  return message.parts
+    .filter((part): part is HermesToolPart => part.type === "tool")
+    .map((tool) => [tool.toolCallId, tool.name].join(":"))
+    .join("|");
+}
+
+function hasInterruptedCompletion(message: HermesUIMessage, canonicalMessageText: string): boolean {
+  if (message.metadata?.finishReason === "interrupted") return true;
+  return canonicalMessageText.toLowerCase().includes("operationinterrupted:");
+}
+
+function isInterruptedLiveSuperset(
+  stored: HermesUIMessage,
+  live: HermesUIMessage,
+  storedText: string,
+  liveText: string,
+  storedImages: string,
+  liveImages: string,
+): boolean {
+  if (!hasInterruptedCompletion(live, liveText)) return false;
+  if ((storedImages || liveImages) && storedImages !== liveImages) return false;
+
+  const storedTools = canonicalToolIdentityComparable(stored);
+  const liveTools = canonicalToolIdentityComparable(live);
+  if (!storedTools || storedTools !== liveTools) return false;
+
+  if (!storedText) return true;
+  return liveText.startsWith(storedText) && liveText.length > storedText.length;
+}
+
 function hasSamePersistedId(stored: HermesUIMessage, live: HermesUIMessage): boolean {
   const storedPersisted = stored.metadata?.persistedId;
   const livePersisted = live.metadata?.persistedId;
@@ -840,6 +871,10 @@ function isSameCanonicalMessage(stored: HermesUIMessage, live: HermesUIMessage):
       const storedLooseText = looseComparableText(storedText);
       const liveLooseText = looseComparableText(liveText);
       if (storedLooseText && liveLooseText && storedLooseText === liveLooseText) {
+        return true;
+      }
+
+      if (isInterruptedLiveSuperset(stored, live, storedText, liveText, storedImages, liveImages)) {
         return true;
       }
 

--- a/web/src/components/chat/message-timeline.tsx
+++ b/web/src/components/chat/message-timeline.tsx
@@ -478,6 +478,7 @@ const FINISH_REASON_LABEL: Record<string, string> = {
   tool_use: "调用工具",
   tool_calls: "调用工具",
   error: "错误",
+  interrupted: "中断",
   content_filter: "内容过滤",
 };
 

--- a/web/src/stores/chat.test.ts
+++ b/web/src/stores/chat.test.ts
@@ -400,6 +400,26 @@ describe("chat runtime reducer", () => {
     });
   });
 
+  it("records interrupted completions as finishReason metadata", () => {
+    let rt = reduceGatewayEvent(
+      createEmptyChatRuntime(1),
+      { type: "message.delta", session_id: "s1", payload: { text: "处理中" } },
+      100,
+    );
+    rt = reduceGatewayEvent(rt, {
+      type: "message.complete",
+      session_id: "s1",
+      payload: {
+        status: "interrupted",
+        text: "Operation interrupted: waiting for model response (1.7s elapsed).",
+      },
+    }, 1_100);
+
+    expect(assistantMessage(rt).status).toBe("complete");
+    expect(assistantMessage(rt).metadata?.finishReason).toBe("interrupted");
+    expect(rt.streamStatus).toBe("complete");
+  });
+
   it("warning and error completion generate notice messages without replacing assistant content", () => {
     let rt = reduceGatewayEvent(
       createEmptyChatRuntime(1),

--- a/web/src/stores/chat.ts
+++ b/web/src/stores/chat.ts
@@ -479,7 +479,9 @@ function completionMetadata(
       ? usage.finish_reason
       : typeof payload.finish_reason === "string"
         ? payload.finish_reason
-        : undefined;
+        : typeof payload.status === "string" && payload.status !== "complete"
+          ? payload.status
+          : undefined;
   if (finishReason) metadata.finishReason = finishReason;
   if (typeof usage?.cost_usd === "number" || usage?.cost_usd === null) {
     metadata.costUsd = usage.cost_usd;


### PR DESCRIPTION
## 摘要

修复桌面端会话被打断后，同一轮 Hermes 回复同时从 live Gateway runtime 与 REST/SQLite 持久化消息渲染，导致页面出现两条近似重复 Hermes 消息的问题。

## 根因

中断发生在模型 API 调用期间时，live 消息会带上 `Operation interrupted...` 的补尾，而 stored 消息只保存了已有文本和工具转录。原来的 `mergeHermesUIMessages` 主要按完整文本和工具内容去重，无法识别这两者属于同一轮回复。

## 改动

- 为 interrupted completion 记录 `finishReason: "interrupted"`。
- 在消息合并逻辑中识别“stored 工具转录 + live 中断补尾”的同一轮消息，并优先保留带中断提示和实时统计的 live 消息。
- 统计详情中将 `interrupted` 显示为“中断”。
- 增加回归测试覆盖中断后 live/stored 合并场景。

## 验证

- `pnpm --filter @hermes/web exec vitest run src/components/chat/message-adapter.test.ts src/stores/chat.test.ts`
- `pnpm typecheck`
- `pnpm test:unit`
- `cargo check`
