### PR TITLE
[codex] 避免配置页快速切换卡死

### DIFF
--- a/src/commands/memory.rs
+++ b/src/commands/memory.rs
@@ -4,6 +4,7 @@ use std::time::UNIX_EPOCH;
 
 use serde::Serialize;
 use tauri::State;
+use tokio::task;
 
 use crate::error::{AppError, AppResult};
 use crate::state::AppState;
@@ -176,18 +177,28 @@ fn read_memory_from_home(home: &Path) -> MemoryInfo {
     }
 }
 
-#[tauri::command]
-pub fn read_memory(state: State<'_, AppState>) -> AppResult<MemoryInfo> {
-    let home = active_hermes_home(&state)?;
-    Ok(read_memory_from_home(&home))
+async fn run_memory_io<T, F>(work: F) -> AppResult<T>
+where
+    T: Send + 'static,
+    F: FnOnce() -> AppResult<T> + Send + 'static,
+{
+    task::spawn_blocking(work)
+        .await
+        .map_err(|err| AppError::Internal(format!("memory task failed: {}", err)))?
 }
 
 #[tauri::command]
-pub fn add_memory_entry(
+pub async fn read_memory(state: State<'_, AppState>) -> AppResult<MemoryInfo> {
+    let home = active_hermes_home(&state)?;
+    run_memory_io(move || Ok(read_memory_from_home(&home))).await
+}
+
+#[tauri::command]
+pub async fn add_memory_entry(
     content: String,
     state: State<'_, AppState>,
 ) -> AppResult<MemoryMutationResult> {
-    let trimmed = content.trim();
+    let trimmed = content.trim().to_string();
     if trimmed.is_empty() {
         return Ok(MemoryMutationResult {
             success: false,
@@ -196,88 +207,98 @@ pub fn add_memory_entry(
     }
 
     let home = active_hermes_home(&state)?;
-    let path = memory_path(&home);
-    let existing = read_file_safe(&path, MEMORY_CHAR_LIMIT);
-    let mut entries = parse_memory_entries(&existing.content);
-    entries.push(MemoryEntry {
-        index: entries.len(),
-        content: trimmed.to_string(),
-    });
-    let next = serialize_entries(&entries);
-    if char_count(&next) > MEMORY_CHAR_LIMIT {
-        return Ok(MemoryMutationResult {
-            success: false,
-            error: Some(format!(
-                "超过记忆上限（{} / {} 字符）",
-                char_count(&next),
-                MEMORY_CHAR_LIMIT
-            )),
+    run_memory_io(move || {
+        let path = memory_path(&home);
+        let existing = read_file_safe(&path, MEMORY_CHAR_LIMIT);
+        let mut entries = parse_memory_entries(&existing.content);
+        entries.push(MemoryEntry {
+            index: entries.len(),
+            content: trimmed,
         });
-    }
+        let next = serialize_entries(&entries);
+        if char_count(&next) > MEMORY_CHAR_LIMIT {
+            return Ok(MemoryMutationResult {
+                success: false,
+                error: Some(format!(
+                    "超过记忆上限（{} / {} 字符）",
+                    char_count(&next),
+                    MEMORY_CHAR_LIMIT
+                )),
+            });
+        }
 
-    write_file_safe(&path, &next)?;
-    Ok(MemoryMutationResult {
-        success: true,
-        error: None,
+        write_file_safe(&path, &next)?;
+        Ok(MemoryMutationResult {
+            success: true,
+            error: None,
+        })
     })
+    .await
 }
 
 #[tauri::command]
-pub fn update_memory_entry(
+pub async fn update_memory_entry(
     index: usize,
     content: String,
     state: State<'_, AppState>,
 ) -> AppResult<MemoryMutationResult> {
+    let next_content = content.trim().to_string();
     let home = active_hermes_home(&state)?;
-    let path = memory_path(&home);
-    let existing = read_file_safe(&path, MEMORY_CHAR_LIMIT);
-    let mut entries = parse_memory_entries(&existing.content);
+    run_memory_io(move || {
+        let path = memory_path(&home);
+        let existing = read_file_safe(&path, MEMORY_CHAR_LIMIT);
+        let mut entries = parse_memory_entries(&existing.content);
 
-    if index >= entries.len() {
-        return Ok(MemoryMutationResult {
-            success: false,
-            error: Some("没有找到这条记忆".to_string()),
-        });
-    }
+        if index >= entries.len() {
+            return Ok(MemoryMutationResult {
+                success: false,
+                error: Some("没有找到这条记忆".to_string()),
+            });
+        }
 
-    entries[index].content = content.trim().to_string();
-    let next = serialize_entries(&entries);
-    if char_count(&next) > MEMORY_CHAR_LIMIT {
-        return Ok(MemoryMutationResult {
-            success: false,
-            error: Some(format!(
-                "超过记忆上限（{} / {} 字符）",
-                char_count(&next),
-                MEMORY_CHAR_LIMIT
-            )),
-        });
-    }
+        entries[index].content = next_content;
+        let next = serialize_entries(&entries);
+        if char_count(&next) > MEMORY_CHAR_LIMIT {
+            return Ok(MemoryMutationResult {
+                success: false,
+                error: Some(format!(
+                    "超过记忆上限（{} / {} 字符）",
+                    char_count(&next),
+                    MEMORY_CHAR_LIMIT
+                )),
+            });
+        }
 
-    write_file_safe(&path, &next)?;
-    Ok(MemoryMutationResult {
-        success: true,
-        error: None,
+        write_file_safe(&path, &next)?;
+        Ok(MemoryMutationResult {
+            success: true,
+            error: None,
+        })
     })
+    .await
 }
 
 #[tauri::command]
-pub fn remove_memory_entry(index: usize, state: State<'_, AppState>) -> AppResult<bool> {
+pub async fn remove_memory_entry(index: usize, state: State<'_, AppState>) -> AppResult<bool> {
     let home = active_hermes_home(&state)?;
-    let path = memory_path(&home);
-    let existing = read_file_safe(&path, MEMORY_CHAR_LIMIT);
-    let mut entries = parse_memory_entries(&existing.content);
+    run_memory_io(move || {
+        let path = memory_path(&home);
+        let existing = read_file_safe(&path, MEMORY_CHAR_LIMIT);
+        let mut entries = parse_memory_entries(&existing.content);
 
-    if index >= entries.len() {
-        return Ok(false);
-    }
+        if index >= entries.len() {
+            return Ok(false);
+        }
 
-    entries.remove(index);
-    write_file_safe(&path, &serialize_entries(&entries))?;
-    Ok(true)
+        entries.remove(index);
+        write_file_safe(&path, &serialize_entries(&entries))?;
+        Ok(true)
+    })
+    .await
 }
 
 #[tauri::command]
-pub fn write_user_profile(
+pub async fn write_user_profile(
     content: String,
     state: State<'_, AppState>,
 ) -> AppResult<MemoryMutationResult> {
@@ -293,11 +314,14 @@ pub fn write_user_profile(
     }
 
     let home = active_hermes_home(&state)?;
-    write_file_safe(&user_path(&home), &content)?;
-    Ok(MemoryMutationResult {
-        success: true,
-        error: None,
+    run_memory_io(move || {
+        write_file_safe(&user_path(&home), &content)?;
+        Ok(MemoryMutationResult {
+            success: true,
+            error: None,
+        })
     })
+    .await
 }
 
 #[cfg(test)]

--- a/src/commands/runtime_manager.rs
+++ b/src/commands/runtime_manager.rs
@@ -11,9 +11,10 @@ use crate::process::dashboard;
 use crate::process::runtime;
 use crate::state::AppState;
 use std::sync::atomic::Ordering;
+use tokio::task;
 
 #[tauri::command]
-pub fn runtime_info(state: State<'_, AppState>) -> Result<runtime::RuntimeInfo, AppError> {
+pub async fn runtime_info(state: State<'_, AppState>) -> Result<runtime::RuntimeInfo, AppError> {
     let (last_error, process) = {
         let inner = state.inner.lock()?;
         let dashboard = inner.dashboard_handle.as_ref();
@@ -54,7 +55,10 @@ pub fn runtime_info(state: State<'_, AppState>) -> Result<runtime::RuntimeInfo, 
         });
         (inner.last_runtime_error.clone(), process)
     };
-    let mut info = runtime::get_runtime_info(last_error);
+
+    let mut info = task::spawn_blocking(move || runtime::get_runtime_info(last_error))
+        .await
+        .map_err(|err| AppError::Internal(format!("runtime info task failed: {}", err)))?;
     info.process = process;
     Ok(info)
 }

--- a/src/commands/terminal.rs
+++ b/src/commands/terminal.rs
@@ -120,7 +120,7 @@ struct TerminalContext {
 }
 
 #[tauri::command]
-pub fn terminal_start(
+pub async fn terminal_start(
     app: AppHandle,
     state: State<'_, AppState>,
     input: TerminalStartInput,
@@ -135,6 +135,16 @@ pub fn terminal_start(
         }
     };
 
+    tauri::async_runtime::spawn_blocking(move || terminal_start_impl(app, context, input))
+        .await
+        .map_err(|e| format!("终端启动任务失败：{e}"))?
+}
+
+fn terminal_start_impl(
+    app: AppHandle,
+    context: TerminalContext,
+    input: TerminalStartInput,
+) -> Result<TerminalStartResult, String> {
     let cols = normalize_size(input.cols, DEFAULT_COLS, MAX_COLS);
     let rows = normalize_size(input.rows, DEFAULT_ROWS, MAX_ROWS);
     let cwd = resolve_cwd(input.cwd.as_deref(), &context)?;

--- a/web/src/components/app-shell/app-status-bar.tsx
+++ b/web/src/components/app-shell/app-status-bar.tsx
@@ -31,7 +31,7 @@ function formatContext(ctx: number | null | undefined): string {
 export function AppStatusBar() {
   const { data: status, isError: statusError } = useStatus();
   const { data: modelInfo } = useModelInfo();
-  const { data: sessions } = useSessions();
+  const { data: sessions } = useSessions(20);
   const { data: analytics } = useAnalytics(1);
   const { data: runtimeInfo } = useRuntimeInfo();
   const runtimeBySession = useAtomValue(chatRuntimeBySessionAtom);

--- a/web/src/hooks/use-analytics.ts
+++ b/web/src/hooks/use-analytics.ts
@@ -7,7 +7,7 @@ export function useAnalytics(days = 30) {
   const profile = useActiveProfileName();
   return useQuery<AnalyticsResponse>({
     queryKey: ["analytics", profile, days],
-    queryFn: () => fetchJSON(`/api/analytics/usage?days=${days}`, undefined, AnalyticsResponse),
+    queryFn: ({ signal }) => fetchJSON(`/api/analytics/usage?days=${days}`, { signal }, AnalyticsResponse),
     staleTime: 60_000,
   });
 }

--- a/web/src/hooks/use-config.ts
+++ b/web/src/hooks/use-config.ts
@@ -18,7 +18,7 @@ export function useConfig() {
   const profile = useActiveProfileName();
   return useQuery<Record<string, any>>({
     queryKey: ["config", profile],
-    queryFn: () => fetchJSON("/api/config", undefined, ConfigResponse),
+    queryFn: ({ signal }) => fetchJSON("/api/config", { signal }, ConfigResponse),
   });
 }
 
@@ -26,7 +26,7 @@ export function useConfigSchema() {
   // schema 是上游 hermes-agent 代码里的 dataclass，与具体 profile 无关
   return useQuery<ConfigSchemaResponse>({
     queryKey: ["config-schema"],
-    queryFn: () => fetchJSON("/api/config/schema", undefined, ConfigSchemaResponse),
+    queryFn: ({ signal }) => fetchJSON("/api/config/schema", { signal }, ConfigSchemaResponse),
     staleTime: 5 * 60_000,
   });
 }
@@ -35,7 +35,7 @@ export function useModelInfo() {
   const profile = useActiveProfileName();
   return useQuery<ModelInfo>({
     queryKey: ["model-info", profile],
-    queryFn: () => fetchJSON("/api/model/info", undefined, ModelInfo),
+    queryFn: ({ signal }) => fetchJSON("/api/model/info", { signal }, ModelInfo),
   });
 }
 

--- a/web/src/hooks/use-cron.ts
+++ b/web/src/hooks/use-cron.ts
@@ -23,7 +23,7 @@ export function useCronJobs() {
   const profile = useActiveProfileName();
   return useQuery<CronJob[]>({
     queryKey: ["cron-jobs", profile],
-    queryFn: () => fetchJSON("/api/cron/jobs?profile=all", undefined, CronJobsResponse),
+    queryFn: ({ signal }) => fetchJSON("/api/cron/jobs?profile=all", { signal }, CronJobsResponse),
     retry: 1,
     staleTime: 30_000,
   });
@@ -82,10 +82,10 @@ export function useCronRuns(job: CronJob | null | undefined, limit = 30) {
   return useQuery<CronRun[]>({
     queryKey: ["cron-runs", profile, id, limit],
     enabled: Boolean(job?.id),
-    queryFn: async () => {
+    queryFn: async ({ signal }) => {
       const result = await fetchJSON(
         `/__hermes_cron_runs/${encodePart(profile)}/${encodePart(id)}?limit=${limit}`,
-        undefined,
+        { signal },
         CronRunsResponse,
       );
       return result.runs;
@@ -102,9 +102,9 @@ export function useCronRunDetail(run: CronRun | null | undefined) {
   return useQuery({
     queryKey: ["cron-run-detail", profile, jobId, filename],
     enabled: Boolean(run?.job_id && run?.filename),
-    queryFn: () => fetchJSON(
+    queryFn: ({ signal }) => fetchJSON(
       `/__hermes_cron_runs/${encodePart(profile)}/${encodePart(jobId)}/${encodePart(filename)}`,
-      undefined,
+      { signal },
       CronRunDetail,
     ),
     retry: 1,

--- a/web/src/hooks/use-env.ts
+++ b/web/src/hooks/use-env.ts
@@ -12,7 +12,7 @@ export function useEnvVars() {
   const profile = useActiveProfileName();
   return useQuery<Record<string, EnvVarInfo>>({
     queryKey: ["env", profile],
-    queryFn: () => fetchJSON("/api/env", undefined, EnvVarsResponse),
+    queryFn: ({ signal }) => fetchJSON("/api/env", { signal }, EnvVarsResponse),
   });
 }
 

--- a/web/src/hooks/use-environment-check.ts
+++ b/web/src/hooks/use-environment-check.ts
@@ -1,6 +1,7 @@
 import { useQuery } from "@tanstack/react-query";
 import type { EnvironmentCheckResult } from "@hermes/protocol";
 import { runtime } from "@/lib/runtime";
+import { raceAbort } from "@/lib/transport";
 
 const ENVIRONMENT_CHECK_KEY = ["desktop-environment-check"] as const;
 
@@ -13,7 +14,7 @@ function hasEnvironmentBridge(): boolean {
 export function useEnvironmentCheck() {
   return useQuery<EnvironmentCheckResult>({
     queryKey: ENVIRONMENT_CHECK_KEY,
-    queryFn: () => window.hermesDesktop!.environmentCheck!(),
+    queryFn: ({ signal }) => raceAbort(window.hermesDesktop!.environmentCheck!(), signal),
     enabled: hasEnvironmentBridge(),
     staleTime: 10_000,
     refetchInterval: 60_000,

--- a/web/src/hooks/use-fs-list.ts
+++ b/web/src/hooks/use-fs-list.ts
@@ -5,8 +5,8 @@ import { FsListResponse } from "@hermes/protocol";
 export function useFsList(path: string, options?: { enabled?: boolean }) {
   return useQuery({
     queryKey: ["fs-list", path],
-    queryFn: () =>
-      fetchJSON(`/api/fs/list?path=${encodeURIComponent(path)}`, undefined, FsListResponse),
+    queryFn: ({ signal }) =>
+      fetchJSON(`/api/fs/list?path=${encodeURIComponent(path)}`, { signal }, FsListResponse),
     enabled: options?.enabled ?? true,
     staleTime: 0,
     refetchOnWindowFocus: false,

--- a/web/src/hooks/use-im-onboarding.ts
+++ b/web/src/hooks/use-im-onboarding.ts
@@ -1,6 +1,6 @@
 import { useMutation, useQuery, useQueryClient } from "@tanstack/react-query";
 import { useActiveProfileName } from "@/hooks/use-profiles";
-import { fetchJSON, postJSON } from "@/lib/transport";
+import { fetchJSON, postJSON, raceAbort } from "@/lib/transport";
 import type {
   ImOnboardingApplyInput,
   ImOnboardingApplyResult,
@@ -30,7 +30,7 @@ export function useImOnboardingState(platform: ImPlatform) {
   const profile = useActiveProfileName();
   return useQuery<ImOnboardingStateResult>({
     queryKey: ["im-onboarding", platform, profile],
-    queryFn: () => requireDesktop().imOnboardingState!({ platform }),
+    queryFn: ({ signal }) => raceAbort(requireDesktop().imOnboardingState!({ platform }), signal),
     enabled: typeof window !== "undefined" && Boolean(window.hermesDesktop?.imOnboardingState),
     staleTime: 10_000,
   });
@@ -70,9 +70,9 @@ export function useMessagingPlatform(platform: ImPlatform) {
   const profile = useActiveProfileName();
   return useQuery<MessagingPlatformInfo | null>({
     queryKey: ["messaging-platform", platform, profile],
-    queryFn: async () => {
+    queryFn: async ({ signal }) => {
       try {
-        const result = await fetchJSON("/api/messaging/platforms", undefined, MessagingPlatformsResponse);
+        const result = await fetchJSON("/api/messaging/platforms", { signal }, MessagingPlatformsResponse);
         return result.platforms.find((item) => item.id === platform) ?? null;
       } catch {
         // 旧版 runtime 可能还没有官方消息平台接口。接入向导仍然可以用

--- a/web/src/hooks/use-logs.ts
+++ b/web/src/hooks/use-logs.ts
@@ -5,11 +5,11 @@ import { LogsResponse } from "@hermes/protocol";
 export function useLogs(file = "agent", lines = 200, level?: string, component?: string) {
   return useQuery<LogsResponse>({
     queryKey: ["logs", file, lines, level, component],
-    queryFn: () => {
+    queryFn: ({ signal }) => {
       const params = new URLSearchParams({ file, lines: String(lines) });
       if (level && level !== "ALL") params.set("level", level);
       if (component && component !== "all") params.set("component", component);
-      return fetchJSON(`/api/logs?${params}`, undefined, LogsResponse);
+      return fetchJSON(`/api/logs?${params}`, { signal }, LogsResponse);
     },
     staleTime: 5_000,
   });

--- a/web/src/hooks/use-mcp-servers.ts
+++ b/web/src/hooks/use-mcp-servers.ts
@@ -7,7 +7,7 @@ export function useMcpServers() {
   const profile = useActiveProfileName();
   return useQuery<McpServersResponse>({
     queryKey: ["mcp-servers", profile],
-    queryFn: () => fetchJSON("/api/mcp-servers", undefined, McpServersResponse),
+    queryFn: ({ signal }) => fetchJSON("/api/mcp-servers", { signal }, McpServersResponse),
     staleTime: 60_000,
   });
 }

--- a/web/src/hooks/use-memory.ts
+++ b/web/src/hooks/use-memory.ts
@@ -1,5 +1,5 @@
 import { useMutation, useQuery, useQueryClient } from "@tanstack/react-query";
-import { fetchJSON, putJSON } from "@/lib/transport";
+import { fetchJSON, putJSON, raceAbort } from "@/lib/transport";
 import { useActiveProfileName } from "@/hooks/use-profiles";
 import type { MemoryInfo, MemoryMutationResult } from "@/lib/runtime";
 import { MutationOkResponse } from "@hermes/protocol";
@@ -33,7 +33,7 @@ export function useMemory() {
   const profile = useActiveProfileName();
   return useQuery<MemoryInfo>({
     queryKey: ["memory", profile],
-    queryFn: () => ensureMemoryBridge().readMemory!(),
+    queryFn: ({ signal }) => raceAbort(ensureMemoryBridge().readMemory!(), signal),
   });
 }
 
@@ -85,8 +85,8 @@ export function useMemoryProviders(options: { enabled?: boolean } = {}) {
   const profile = useActiveProfileName();
   return useQuery<MemoryProvidersState>({
     queryKey: ["memory-providers", profile],
-    queryFn: async () => {
-      const data = await fetchJSON<DashboardPluginsResponse>("/api/dashboard/plugins");
+    queryFn: async ({ signal }) => {
+      const data = await fetchJSON<DashboardPluginsResponse>("/api/dashboard/plugins", { signal });
       const providers = data.providers ?? {};
       return {
         active: providers.memory_provider ?? "",

--- a/web/src/hooks/use-oauth-providers.ts
+++ b/web/src/hooks/use-oauth-providers.ts
@@ -12,8 +12,8 @@ import {
 export function useOAuthProviders() {
   return useQuery<OAuthProvider[]>({
     queryKey: ["oauth-providers"],
-    queryFn: async () => {
-      const res = await fetchJSON("/api/providers/oauth", undefined, OAuthProvidersResponse);
+    queryFn: async ({ signal }) => {
+      const res = await fetchJSON("/api/providers/oauth", { signal }, OAuthProvidersResponse);
       return res.providers;
     },
   });
@@ -63,10 +63,10 @@ export function usePollOAuthSession(
 ) {
   return useQuery({
     queryKey: ["oauth-poll", providerId, sessionId],
-    queryFn: () =>
+    queryFn: ({ signal }) =>
       fetchJSON(
         `/api/providers/oauth/${encodeURIComponent(providerId!)}/poll/${encodeURIComponent(sessionId!)}`,
-        undefined,
+        { signal },
         OAuthPollResponse,
       ),
     enabled: enabled && !!providerId && !!sessionId,

--- a/web/src/hooks/use-profiles.ts
+++ b/web/src/hooks/use-profiles.ts
@@ -17,8 +17,8 @@ import {
 export function useProfiles() {
   return useQuery<ProfileSummary[]>({
     queryKey: ["profiles"],
-    queryFn: async () => {
-      const r = await fetchJSON("/api/profiles", undefined, ProfilesListResponse);
+    queryFn: async ({ signal }) => {
+      const r = await fetchJSON("/api/profiles", { signal }, ProfilesListResponse);
       return r.profiles;
     },
     // Profile list 不会经常变（用户主动 create/delete 后我们 invalidate），
@@ -30,10 +30,10 @@ export function useProfiles() {
 export function useActiveProfile() {
   return useQuery<string>({
     queryKey: ["profile-active"],
-    queryFn: async () => {
+    queryFn: async ({ signal }) => {
       const r = await fetchJSON(
         "/api/profiles/active",
-        undefined,
+        { signal },
         ActiveProfileResponse,
       );
       return r.name;

--- a/web/src/hooks/use-runtime-update.ts
+++ b/web/src/hooks/use-runtime-update.ts
@@ -6,6 +6,7 @@ import type {
   RuntimeUpdateCheckResult,
 } from "@hermes/protocol";
 import { runtime } from "@/lib/runtime";
+import { raceAbort } from "@/lib/transport";
 import { forceExistingGatewayReconnect } from "@/lib/gateway-client";
 import { runtimeUpdatingAtom } from "@/stores/ui";
 
@@ -27,7 +28,7 @@ async function refreshDesktopGateway(): Promise<void> {
 export function useRuntimeInfo() {
   return useQuery<RuntimeInfo>({
     queryKey: RUNTIME_INFO_KEY,
-    queryFn: () => window.hermesDesktop!.getRuntimeInfo!(),
+    queryFn: ({ signal }) => raceAbort(window.hermesDesktop!.getRuntimeInfo!(), signal),
     enabled: hasRuntimeBridge(),
     refetchInterval: 30_000,
     staleTime: 10_000,

--- a/web/src/hooks/use-sessions.ts
+++ b/web/src/hooks/use-sessions.ts
@@ -30,34 +30,39 @@ function hasAnyMessages(result: MessagesResponse): boolean {
   return result.ui_messages ? result.ui_messages.length > 0 : result.messages.length > 0;
 }
 
-async function fetchSessionLogMessages(id: string): Promise<MessagesResponse | null> {
+function isAbortError(error: unknown): boolean {
+  return error instanceof DOMException && error.name === "AbortError";
+}
+
+async function fetchSessionLogMessages(id: string, signal?: AbortSignal): Promise<MessagesResponse | null> {
   try {
     const result = await fetchJSON(
       `/__hermes_session_log/${encodeURIComponent(id)}`,
-      undefined,
+      { signal },
       MessagesResponse,
     );
     return hasAnyMessages(result) ? result : null;
-  } catch {
+  } catch (error) {
+    if (isAbortError(error)) throw error;
     return null;
   }
 }
 
-async function fetchSessionMessages(id: string): Promise<MessagesResponse> {
+async function fetchSessionMessages(id: string, signal?: AbortSignal): Promise<MessagesResponse> {
   const result = await fetchJSON(
     `/api/sessions/${id}/messages`,
-    undefined,
+    { signal },
     MessagesResponse,
   );
   if (hasAnyMessages(result)) return result;
-  return await fetchSessionLogMessages(id) ?? result;
+  return await fetchSessionLogMessages(id, signal) ?? result;
 }
 
 export function useSessions(limit = 50, offset = 0) {
   const profile = useActiveProfileName();
   return useQuery<SessionsResponse>({
     queryKey: ["sessions", profile, limit, offset],
-    queryFn: () => fetchJSON(`/api/sessions?limit=${limit}&offset=${offset}`, undefined, SessionsResponse),
+    queryFn: ({ signal }) => fetchJSON(`/api/sessions?limit=${limit}&offset=${offset}`, { signal }, SessionsResponse),
   });
 }
 
@@ -65,7 +70,7 @@ export function useSession(id: string | undefined) {
   const profile = useActiveProfileName();
   return useQuery<SessionDetail>({
     queryKey: ["session", profile, id],
-    queryFn: () => fetchJSON(`/api/sessions/${id}`, undefined, SessionDetail),
+    queryFn: ({ signal }) => fetchJSON(`/api/sessions/${id}`, { signal }, SessionDetail),
     enabled: !!id,
   });
 }
@@ -74,7 +79,7 @@ export function useSessionMessages(id: string | undefined) {
   const profile = useActiveProfileName();
   return useQuery<MessagesResponse>({
     queryKey: ["session-messages", profile, id],
-    queryFn: () => fetchSessionMessages(id!),
+    queryFn: ({ signal }) => fetchSessionMessages(id!, signal),
     enabled: !!id,
   });
 }
@@ -83,7 +88,7 @@ export function useSessionSearch(q: string) {
   const profile = useActiveProfileName();
   return useQuery<{ results: SearchResult[] }>({
     queryKey: ["sessions-search", profile, q],
-    queryFn: () => fetchJSON(`/api/sessions/search?q=${encodeURIComponent(q)}&limit=20`, undefined, SearchResponse),
+    queryFn: ({ signal }) => fetchJSON(`/api/sessions/search?q=${encodeURIComponent(q)}&limit=20`, { signal }, SearchResponse),
     enabled: q.length >= 2,
     staleTime: 10_000,
   });

--- a/web/src/hooks/use-skills.ts
+++ b/web/src/hooks/use-skills.ts
@@ -7,7 +7,7 @@ export function useSkills() {
   const profile = useActiveProfileName();
   return useQuery<SkillInfo[]>({
     queryKey: ["skills", profile],
-    queryFn: () => fetchJSON("/api/skills", undefined, SkillsResponse),
+    queryFn: ({ signal }) => fetchJSON("/api/skills", { signal }, SkillsResponse),
     staleTime: 0,
     refetchOnMount: "always",
   });

--- a/web/src/hooks/use-soul.ts
+++ b/web/src/hooks/use-soul.ts
@@ -28,10 +28,10 @@ export function useSoul() {
   const profile = useActiveProfileName();
   return useQuery<ProfileSoulResponse>({
     queryKey: ["soul", profile],
-    queryFn: () =>
+    queryFn: ({ signal }) =>
       fetchJSON(
         `/api/profiles/${encodeURIComponent(profile)}/soul`,
-        undefined,
+        { signal },
         ProfileSoulResponse,
       ),
   });

--- a/web/src/hooks/use-status.ts
+++ b/web/src/hooks/use-status.ts
@@ -7,7 +7,7 @@ export function useStatus() {
   const profile = useActiveProfileName();
   return useQuery<StatusResponse>({
     queryKey: ["status", profile],
-    queryFn: () => fetchJSON("/api/status", undefined, StatusResponse),
+    queryFn: ({ signal }) => fetchJSON("/api/status", { signal }, StatusResponse),
     refetchInterval: 15_000,
     staleTime: 10_000,
   });

--- a/web/src/hooks/use-yolo-mode.ts
+++ b/web/src/hooks/use-yolo-mode.ts
@@ -1,6 +1,7 @@
 import { useMutation, useQuery, useQueryClient } from "@tanstack/react-query";
 import { useSetAtom } from "jotai";
 import { runtime } from "@/lib/runtime";
+import { raceAbort } from "@/lib/transport";
 import { forceExistingGatewayReconnect } from "@/lib/gateway-client";
 import { reloadUiStore } from "@/lib/ui-store";
 import { profileSwitchingAtom } from "@/stores/ui";
@@ -17,10 +18,7 @@ export function useYoloMode() {
   return useQuery<YoloModeStatus>({
     queryKey: ["yolo-mode"],
     enabled: isYoloModeSupported(),
-    queryFn: async () => {
-      const status = await window.hermesDesktop!.getYoloMode!();
-      return status;
-    },
+    queryFn: ({ signal }) => raceAbort(window.hermesDesktop!.getYoloMode!(), signal),
     staleTime: 30_000,
   });
 }

--- a/web/src/lib/transport.ts
+++ b/web/src/lib/transport.ts
@@ -45,6 +45,36 @@ function authOnlyHeaders(extra?: Record<string, string>): Record<string, string>
   return h;
 }
 
+
+function abortError(): DOMException | Error {
+  if (typeof DOMException !== "undefined") {
+    return new DOMException("The operation was aborted.", "AbortError");
+  }
+  const error = new Error("The operation was aborted.");
+  error.name = "AbortError";
+  return error;
+}
+
+function throwIfAborted(signal?: AbortSignal | null): void {
+  if (signal?.aborted) {
+    throw abortError();
+  }
+}
+
+function abortPromise(signal?: AbortSignal | null): Promise<never> | null {
+  if (!signal) return null;
+  if (signal.aborted) return Promise.reject(abortError());
+  return new Promise((_, reject) => {
+    signal.addEventListener("abort", () => reject(abortError()), { once: true });
+  });
+}
+
+export async function raceAbort<T>(work: Promise<T>, signal?: AbortSignal | null): Promise<T> {
+  const aborted = abortPromise(signal);
+  if (!aborted) return work;
+  return Promise.race([work, aborted]);
+}
+
 function shouldUseNativeIpc(path: string): boolean {
   const isLocalDesktopRoute =
     path.startsWith("/__hermes_session_log/") || path.startsWith("/__hermes_cron_runs/");
@@ -75,12 +105,17 @@ async function fetchViaElectron<T>(
   init?: RequestInit,
   parser?: Parser<T>,
 ): Promise<T> {
-  const result = await window.hermesDesktop!.request({
+  const signal = init?.signal ?? null;
+  throwIfAborted(signal);
+
+  const result = await raceAbort(window.hermesDesktop!.request({
     path,
     method: init?.method,
     headers: authHeaders(init?.headers as Record<string, string>),
     body: typeof init?.body === "string" ? init.body : null,
-  });
+  }), signal);
+
+  throwIfAborted(signal);
 
   if (!result.ok) {
     reportRestFailure(init?.method ?? "GET", path, result.status, result.body);

--- a/web/src/routes/config-migration.tsx
+++ b/web/src/routes/config-migration.tsx
@@ -1,4 +1,4 @@
-import { useCallback, useEffect, useMemo, useState } from "react";
+import { useCallback, useEffect, useMemo, useRef, useState } from "react";
 import { useNavigate, useSearchParams } from "react-router-dom";
 import { useQueryClient } from "@tanstack/react-query";
 import { useSetAtom } from "jotai";
@@ -136,6 +136,11 @@ function LegacyConfigMigrationRoute() {
   const [message, setMessage] = useState("");
   const [error, setError] = useState("");
   const [lastImport, setLastImport] = useState<ConfigMigrationImportResult | null>(null);
+  const mountedRef = useRef(true);
+
+  useEffect(() => () => {
+    mountedRef.current = false;
+  }, []);
 
   const candidates = scanResult?.candidates ?? [];
   const selected = useMemo(
@@ -155,20 +160,22 @@ function LegacyConfigMigrationRoute() {
       const api = window.hermesDesktop?.scanConfigMigration;
       if (!api) throw new Error("当前环境不支持桌面端配置迁移。请在 Tauri 桌面端中使用此功能。");
       const result = await api(manualPath ? { manualPath } : undefined);
+      if (!mountedRef.current) return;
       setScanResult(result);
       setSelectedId(result.candidates[0]?.id ?? null);
       if (result.candidates.length === 0) {
         setMessage("没有自动发现可迁移的 Hermes 配置。可以用“手动选择目录”指定已有 .hermes 目录。");
       }
     } catch (err) {
-      setError(err instanceof Error ? err.message : "扫描失败");
+      if (mountedRef.current) setError(err instanceof Error ? err.message : "扫描失败");
     } finally {
-      setLoading(false);
+      if (mountedRef.current) setLoading(false);
     }
   };
 
   useEffect(() => {
-    void scan();
+    const timer = window.setTimeout(() => void scan(), 250);
+    return () => window.clearTimeout(timer);
   }, []);
 
   const chooseManualDirectory = async () => {

--- a/web/src/routes/console.tsx
+++ b/web/src/routes/console.tsx
@@ -61,6 +61,12 @@ export function ConsoleRoute() {
   const [lastCommand, setLastCommand] = useState<string | null>(null);
   const [externalOpening, setExternalOpening] = useState(false);
   const [externalOpened, setExternalOpened] = useState<string | null>(null);
+  const [armed, setArmed] = useState(false);
+
+  useEffect(() => {
+    const timer = window.setTimeout(() => setArmed(true), 250);
+    return () => window.clearTimeout(timer);
+  }, []);
 
   const isDesktopTerminalAvailable = Boolean(window.hermesDesktop?.terminalStart);
   const isExternalTerminalAvailable = Boolean(window.hermesDesktop?.terminalOpenExternal);
@@ -81,7 +87,7 @@ export function ConsoleRoute() {
   }, [status]);
 
   useEffect(() => {
-    if (!containerRef.current) return;
+    if (!armed || !containerRef.current) return;
 
     if (!isDesktopTerminalAvailable) {
       setStatus("unsupported");
@@ -231,7 +237,7 @@ export function ConsoleRoute() {
       terminalRef.current = null;
       fitRef.current = null;
     };
-  }, [autoPurpose, isDesktopTerminalAvailable]);
+  }, [armed, autoPurpose, isDesktopTerminalAvailable]);
 
   const runCommand = (command: string) => {
     const id = terminalIdRef.current;


### PR DESCRIPTION
## 变更

- 将记忆页、runtime 信息和终端启动等容易阻塞的 native IPC 移到异步阻塞线程执行。
- 为 Tauri native REST 代理接入 `AbortSignal`，并让配置区常用查询在路由卸载时取消等待。
- 延迟配置迁移自动扫描和 Console PTY 启动，避免快速扫过侧栏时触发重任务。
- 降低状态栏会话摘要读取量，减少配置页切换时的常驻请求压力。

## 根因

Windows / WebView2 release 下，配置区快速切换会叠加多个首屏请求和同步 IPC。旧页面请求不会取消，配置迁移与终端页还会在短暂停留时启动扫描或 PTY 等重任务，导致 IPC 队列和渲染线程压力被放大，表现为窗口未响应。

## 验证

- `cargo check`
- `cargo test --all-features`
- `pnpm typecheck`
- `pnpm test:unit`
