### PR TITLE
[codex] style: 调整主题皮肤布局

### DIFF
--- a/web/src/routes/settings.module.css
+++ b/web/src/routes/settings.module.css
@@ -486,20 +486,11 @@
 
 .appearanceHeader {
   display: grid;
-  grid-template-columns: auto minmax(0, 1fr) auto;
+  grid-template-columns: minmax(0, 1fr) auto;
   gap: 18px;
   align-items: start;
   padding: 20px 24px;
   border-bottom: 1px solid var(--h-line-soft);
-}
-
-.appearanceIndex {
-  margin-top: 3px;
-  color: var(--h-accent);
-  font-family: var(--h-font-mono);
-  font-size: 12px;
-  font-weight: 700;
-  letter-spacing: 0.14em;
 }
 
 .appearanceHeaderText {
@@ -579,9 +570,9 @@
 
 .skinPicker {
   display: grid;
-  grid-template-columns: repeat(4, minmax(118px, 1fr));
+  grid-template-columns: repeat(2, minmax(200px, 1fr));
   gap: 8px;
-  width: min(100%, 660px);
+  width: min(100%, 560px);
 }
 
 .skinCard {

--- a/web/src/routes/settings.tsx
+++ b/web/src/routes/settings.tsx
@@ -86,7 +86,6 @@ export function ThemeSection({ showHeading = true }: SettingsSectionProps) {
       {showHeading && <h2 className={s.heading}>主题</h2>}
       <div className={s.appearancePanel}>
         <div className={s.appearanceHeader}>
-          <span className={s.appearanceIndex}>[ 01 ]</span>
           <div className={s.appearanceHeaderText}>
             <h3>外观</h3>
             <p>颜色、密度和对话阅读字号会立即应用到桌面端界面。</p>


### PR DESCRIPTION
## 变更内容

调整主题设置页的外观区域，移除左上角的 `[ 01 ]` 编号，并将四个主题皮肤卡片从单行四列改为两列两行。

## 影响

主题卡片获得更宽的展示空间，皮肤名称和描述文字不再因为 1x4 布局过窄而截断。

## 验证

- `pnpm typecheck`
- `pnpm test:unit`
- `cargo check`
- 本地打开 `http://127.0.0.1:9545/theme` 验证四个皮肤为 2x2 排布，且页面不再显示 `[ 01 ]`。