### PR TITLE
fix(desktop): 修复 #165 遗留的配置迁移页 StrictMode 卡死与 raceAbort 漏处理

### DIFF
--- a/web/src/lib/transport.ts
+++ b/web/src/lib/transport.ts
@@ -72,6 +72,9 @@ function abortPromise(signal?: AbortSignal | null): Promise<never> | null {
 export async function raceAbort<T>(work: Promise<T>, signal?: AbortSignal | null): Promise<T> {
   const aborted = abortPromise(signal);
   if (!aborted) return work;
+  // abort 胜出后底层（原生 IPC）的 work 仍在后台跑，若它随后 reject 会变成
+  // unhandled rejection——在“快速切换”这一高频场景里尤其刷屏。兜底吞掉它。
+  work.catch(() => {});
   return Promise.race([work, aborted]);
 }
 

--- a/web/src/routes/config-migration.tsx
+++ b/web/src/routes/config-migration.tsx
@@ -138,8 +138,14 @@ function LegacyConfigMigrationRoute() {
   const [lastImport, setLastImport] = useState<ConfigMigrationImportResult | null>(null);
   const mountedRef = useRef(true);
 
-  useEffect(() => () => {
-    mountedRef.current = false;
+  useEffect(() => {
+    // StrictMode（dev）会模拟 mount→unmount→remount，卸载时已把 mountedRef 置 false，
+    // 必须在重新挂载时复位为 true，否则后续 scan 完成时会被 `!mountedRef.current` 拦掉，
+    // 页面永远停在“扫描中”。
+    mountedRef.current = true;
+    return () => {
+      mountedRef.current = false;
+    };
   }, []);
 
   const candidates = scanResult?.candidates ?? [];


### PR DESCRIPTION
## 背景

跟进 #165（《避免配置页快速切换卡死》，已合并）的 review,修两个该 PR 引入/遗留的问题。

## 变更

### 1. 配置迁移页在 StrictMode（dev）下卡死 🟠

`web/src/routes/config-migration.tsx` 用 `mountedRef` 防止卸载后写 state,但只在卸载时置 `false`,**重新挂载时没复位为 `true`**。本仓库 `web/src/main.tsx` 启用了 `<StrictMode>`,dev 下会模拟 mount→unmount→remount:第一次模拟卸载把 `mountedRef.current` 置成 `false`,remount 后它再也不会变回 `true`。于是 250ms 后 `scan()` 跑完时命中 `if (!mountedRef.current) return;`,`setScanResult` / `setLoading(false)` 全被跳过,而 `setLoading(true)` 已在开头执行——**dev 下配置迁移页永远停在“扫描中”,不显示任何候选**。生产构建因不双调用 effect 不受影响,但本地调试很迷惑。

修法:在 effect body 里复位 `mountedRef.current = true`。

### 2. `raceAbort` 在 abort 后可能产生 unhandled rejection 🟡

`web/src/lib/transport.ts` 的 `raceAbort` 用 `Promise.race` 让 abort 提前 reject,但底层 `work`(走原生 IPC 的 Tauri 命令)**仍在后台继续跑**。若它随后 reject(后端返回 Err),没人 catch 就会变成 unhandled rejection——恰好在“快速切换侧栏”这一高频场景里刷屏。给被丢弃的 `work` 挂 `.catch(() => {})` 兜底。

> 注:这也再次说明 `raceAbort` 对原生 IPC 路径只改善前端“不再傻等”的观感,**并不会取消后端工作**;真正给主线程减压的是 #165 里 Rust 命令改 `async` + `spawn_blocking` 那部分。

## 验证

- `pnpm typecheck` ✅
- `pnpm test:unit` ✅(66 文件 / 511 用例全绿)

## review 里其余几点（本 PR 未动,留作参考）

- `useSessions(20)` 把 status bar 的 query key 从共享的 `[...,50,0]` 叉开,与 workbench-sidebar/panel 不再共享缓存——两者同时挂载时会多一条 session 列表请求。属取舍,需产品意图确认,故未改。
- `spawn_blocking` 来源不统一(`terminal.rs` 用 `tauri::async_runtime`,其余用 `tokio::task`),纯一致性 nit。
- 250ms 防抖是魔法数字且在两处各写一遍,可抽常量。

🤖 Generated with [Claude Code](https://claude.com/claude-code)