### PR TITLE
fix: load .env from boot home on startup

### DIFF
--- a/Cargo.toml
+++ b/Cargo.toml
@@ -40,6 +40,7 @@ portable-pty = "0.9"
 rusqlite = { version = "0.32", features = ["bundled"] }
 libc = "0.2"
 getrandom = "0.3"
+dotenvy = "0.15"
 
 [target.'cfg(target_os = "windows")'.dependencies]
 windows-sys = { version = "0.61", features = [

--- a/src/main.rs
+++ b/src/main.rs
@@ -317,6 +317,13 @@ fn main() {
 
             let boot_home_str = boot_home.to_string_lossy().to_string();
 
+            // 2.5. Load .env from boot home so all child processes inherit it
+            let env_file = boot_home.join(".env");
+            if env_file.is_file() {
+                dotenvy::from_path(&env_file).ok();
+                log::info!("Loaded .env from {}", env_file.display());
+            }
+
             // 3. Resolve host/port
             let host = std::env::var("HERMES_DESKTOP_API_HOST")
                 .unwrap_or_else(|_| "127.0.0.1".to_string());


### PR DESCRIPTION
## Problem

Desktop runtime `.env` file at `$HERMES_HOME/.env` was never loaded into the process environment. Child processes (Dashboard, Gateway) inherit from the desktop process, so they never saw user-configured variables like `TAVILY_API_KEY`. This caused MCP tools and `web_search` to be unavailable despite correct configuration in `.env`.

## Root Cause

The Rust codebase had no `dotenvy` dependency and no code path to load `.env` files. The only existing `.env` handling was `find_env_value()` in `environment.rs` — a hand-rolled single-key parser used only for `AGENT_BROWSER_EXECUTABLE_PATH` diagnostics.

## Fix

1. **`Cargo.toml`**: Added `dotenvy = "0.15"` dependency
2. **`src/main.rs`**: After `boot_home_str` is resolved (line ~318), load `.env` from `$HERMES_HOME/.env`:
   ```rust
   let env_file = boot_home.join(".env");
   if env_file.is_file() {
       dotenvy::from_path(&env_file).ok();
   }
   ```
   Since `Command::new()` inherits the parent's full environment by default, all subsequently spawned child processes (Dashboard, Gateway) automatically inherit `.env` variables.

## Impact

- Zero behavioral change if no `.env` file exists (the `is_file()` check skips gracefully)
- All existing child process spawns benefit automatically — no per-spawn changes needed
- Tested: dashboard subprocess (dashboard.rs:750), gateway subprocess (gateway.rs:338, im_onboarding.rs:1568) all inherit env vars

Closes #197