### PR TITLE
fix: replace cron delivery targets with supported CN channels

### DIFF
--- a/web/src/routes/cron.tsx
+++ b/web/src/routes/cron.tsx
@@ -36,13 +36,20 @@ interface Feedback {
   message: string;
 }
 
+// 仅展示桌面端实际可接入的投递渠道（IM 接入当前支持飞书/微信，见
+// src/commands/im_onboarding.rs）。后端合法平台列表见
+// Hermes-CN-Core cron/scheduler.py 的 _KNOWN_DELIVERY_PLATFORMS。
 const DELIVERY_OPTIONS = [
   { value: "local", label: "本地" },
-  { value: "telegram", label: "Telegram" },
-  { value: "discord", label: "Discord" },
-  { value: "slack", label: "Slack" },
+  { value: "feishu", label: "飞书" },
+  { value: "weixin", label: "微信" },
   { value: "email", label: "Email" },
 ];
+
+function deliveryLabel(value: string): string {
+  if (!value) return "本地";
+  return DELIVERY_OPTIONS.find((item) => item.value === value)?.label ?? value;
+}
 
 const STATUS_FILTERS: Array<{ value: StatusFilter; label: string }> = [
   { value: "all", label: "全部" },
@@ -636,7 +643,7 @@ function JobDetail({ job, busy, onPauseResume, onTrigger, onDelete }: JobDetailP
         </div>
         <div className={s.detailItem}>
           <span>投递目标</span>
-          <strong>{text(job.deliver) || "local"}</strong>
+          <strong>{deliveryLabel(text(job.deliver))}</strong>
         </div>
         <div className={s.detailItem}>
           <span>任务 ID</span>


### PR DESCRIPTION
## 背景

定时任务"投递目标"下拉框此前展示 `本地 / Telegram / Discord / Slack / Email`，桌面端未接入的海外渠道占了大半，而国内用户常用的飞书、微信反而缺失，用户误选后任务无法正常投递。

Closes #198

## 后端能力核实

- `Hermes-CN-Core` 的 `cron/scheduler.py` `_KNOWN_DELIVERY_PLATFORMS` 已包含 `feishu` / `weixin`，且两者均有 home channel 配置项（`FEISHU_HOME_CHANNEL` / `WEIXIN_HOME_CHANNEL`），后端投递能力已就绪
- 桌面端 IM 接入（`src/commands/im_onboarding.rs` 的 `ImPlatform`）当前仅支持飞书和微信，下拉框收敛为这两个 IM 渠道与实际能力一致

## 改动

- 下拉框选项改为 `本地 / 飞书 / 微信 / Email`，移除 Telegram、Discord、Slack（Email 后端支持 `EMAIL_HOME_ADDRESS`，issue 未要求移除，保留）
- 任务详情面板"投递目标"通过 `deliveryLabel()` 映射为中文标签；旧任务的遗留值（如 `telegram`、`feishu:chat_id`）找不到映射时按原样显示
- 表单默认值 `local` 不变，存量任务不受影响

## 验证

- `pnpm typecheck` 全绿
- `pnpm test:unit` 71 个文件 / 533 个测试全部通过
- 未改 Rust 代码（`cargo check` 通过）

🤖 Generated with [Claude Code](https://claude.com/claude-code)