### PR TITLE
fix: stop rendering stream output after manual interrupt

### DIFF
--- a/web/src/hooks/use-gateway.ts
+++ b/web/src/hooks/use-gateway.ts
@@ -37,6 +37,7 @@ import {
   ensureChatSessionAtom,
   gwConnectionAtom,
   gwSessionIdAtom,
+  markSessionInterruptedAtom,
   markStreamsReconnectingAtom,
   resetChatSessionAtom,
   resetStreamStateAtom,
@@ -229,6 +230,7 @@ export function useGateway() {
   const ensureChatSession = useSetAtom(ensureChatSessionAtom);
   const resetChatSession = useSetAtom(resetChatSessionAtom);
   const resetStreamState = useSetAtom(resetStreamStateAtom);
+  const markSessionInterrupted = useSetAtom(markSessionInterruptedAtom);
   const startPrompt = useSetAtom(startPromptAtom);
   const setSessionError = useSetAtom(setSessionErrorAtom);
   const terminateAllStreams = useSetAtom(terminateAllStreamsAtom);
@@ -539,8 +541,10 @@ export function useGateway() {
         setSessionError({ sessionId: gatewaySessionId, message: errorMessage(error) });
         throw error;
       }
+
+      markSessionInterrupted(gatewaySessionId);
     },
-    [ensureSubscribed, setSessionError],
+    [ensureSubscribed, markSessionInterrupted, setSessionError],
   );
 
   const setSessionTitle = useCallback(

--- a/web/src/stores/chat.test.ts
+++ b/web/src/stores/chat.test.ts
@@ -2,12 +2,15 @@ import { createStore } from "jotai/vanilla";
 import { describe, expect, it } from "vitest";
 import type { HermesMessagePart, HermesUIMessage } from "@hermes/protocol";
 import {
+  applyGatewayEventAtom,
   chatRuntimeBySessionAtom,
   createEmptyChatRuntime,
   drainLiveMessagesAtom,
+  markSessionInterruptedAtom,
   markStreamsReconnectingAtom,
   recoverCompletedTurnFromStoredMessagesAtom,
   reduceGatewayEvent,
+  resetStreamStateAtom,
   startPromptAtom,
   terminateAllStreamsAtom,
 } from "./chat";
@@ -953,5 +956,120 @@ describe("drainLiveMessagesAtom", () => {
     const remaining = store.get(chatRuntimeBySessionAtom).s1.messages;
     expect(remaining).toHaveLength(1);
     expect(remaining[0]).toMatchObject({ role: "system", status: "error" });
+  });
+});
+
+describe("manual interrupt (markSessionInterruptedAtom)", () => {
+  function storeWithStreamingTurn() {
+    const store = createStore();
+    store.set(startPromptAtom, { sessionId: "s1", text: "你好", now: 1_000 });
+    store.set(applyGatewayEventAtom, { type: "message.start", session_id: "s1", payload: {} });
+    store.set(applyGatewayEventAtom, {
+      type: "message.delta",
+      session_id: "s1",
+      payload: { text: "部分回复" },
+    });
+    return store;
+  }
+
+  function runtimeOf(store: ReturnType<typeof createStore>) {
+    return store.get(chatRuntimeBySessionAtom).s1;
+  }
+
+  it("marks the session idle so the composer can send again", () => {
+    const store = storeWithStreamingTurn();
+
+    store.set(markSessionInterruptedAtom, "s1");
+
+    const runtime = runtimeOf(store);
+    expect(runtime.streamStatus).toBe("idle");
+    expect(runtime.interrupted).toBe(true);
+    expect(runtime.activeAssistantId).toBeDefined();
+  });
+
+  it("drops late stream events from the interrupted turn", () => {
+    const store = storeWithStreamingTurn();
+    store.set(markSessionInterruptedAtom, "s1");
+
+    store.set(applyGatewayEventAtom, {
+      type: "message.delta",
+      session_id: "s1",
+      payload: { text: "迟到的输出" },
+    });
+    store.set(applyGatewayEventAtom, {
+      type: "tool.start",
+      session_id: "s1",
+      payload: { id: "t1", name: "shell" },
+    });
+    store.set(applyGatewayEventAtom, {
+      type: "status.update",
+      session_id: "s1",
+      payload: { text: "处理中" },
+    });
+
+    const runtime = runtimeOf(store);
+    expect(runtime.streamStatus).toBe("idle");
+    expect(runtime.statusMessage).toBe("");
+    expect(textFromParts(assistantMessage(runtime).parts)).not.toContain("迟到的输出");
+    expect(assistantMessage(runtime).parts.some((part) => part.type === "tool")).toBe(false);
+  });
+
+  it("still finalizes the interrupted turn on message.complete", () => {
+    const store = storeWithStreamingTurn();
+    store.set(markSessionInterruptedAtom, "s1");
+
+    store.set(applyGatewayEventAtom, {
+      type: "message.complete",
+      session_id: "s1",
+      payload: { status: "interrupted", text: "部分回复" },
+    });
+
+    const runtime = runtimeOf(store);
+    expect(assistantMessage(runtime).status).toBe("complete");
+    expect(assistantMessage(runtime).metadata?.finishReason).toBe("interrupted");
+    expect(runtime.interrupted).toBeUndefined();
+  });
+
+  it("resumes rendering when the next turn starts without a local prompt", () => {
+    const store = storeWithStreamingTurn();
+    store.set(markSessionInterruptedAtom, "s1");
+
+    store.set(applyGatewayEventAtom, { type: "message.start", session_id: "s1", payload: {} });
+    store.set(applyGatewayEventAtom, {
+      type: "message.delta",
+      session_id: "s1",
+      payload: { text: "新回合" },
+    });
+
+    const runtime = runtimeOf(store);
+    expect(runtime.interrupted).toBeUndefined();
+    expect(runtime.streamStatus).toBe("streaming");
+  });
+
+  it("clears the interrupt gate when the user sends the next prompt", () => {
+    const store = storeWithStreamingTurn();
+    store.set(markSessionInterruptedAtom, "s1");
+
+    store.set(startPromptAtom, { sessionId: "s1", text: "再来", now: 2_000 });
+
+    expect(runtimeOf(store).interrupted).toBeUndefined();
+  });
+
+  it("keeps resetStreamStateAtom free of interrupt semantics (sendPrompt busy-retry path)", () => {
+    const store = createStore();
+    store.set(startPromptAtom, { sessionId: "s1", text: "你好", now: 1_000 });
+
+    store.set(resetStreamStateAtom, "s1");
+    store.set(applyGatewayEventAtom, { type: "message.start", session_id: "s1", payload: {} });
+    store.set(applyGatewayEventAtom, {
+      type: "message.delta",
+      session_id: "s1",
+      payload: { text: "重试回合" },
+    });
+
+    const runtime = runtimeOf(store);
+    expect(runtime.streamStatus).toBe("streaming");
+    const assistants = runtime.messages.filter((message) => message.role === "assistant");
+    expect(textFromParts(assistants[assistants.length - 1].parts)).toContain("重试回合");
   });
 });

--- a/web/src/stores/chat.ts
+++ b/web/src/stores/chat.ts
@@ -65,6 +65,7 @@ export interface ChatSessionRuntime {
   turnStartedAt?: number;
   turnFirstTokenAt?: number;
   activeAssistantId?: string;
+  interrupted?: boolean;
 }
 
 export type ChatRuntimeBySession = Record<string, ChatSessionRuntime>;
@@ -518,6 +519,17 @@ export function reduceGatewayEvent(
   const payload = payloadOf(event);
   const sessionId = sessionIdFor(runtime, event);
 
+  if (runtime.interrupted) {
+    if (event.type === "message.start") {
+      // 新回合开始即解除屏蔽，远程发起的回合和 busy 重试都依赖这里恢复渲染
+      return reduceGatewayEvent({ ...runtime, interrupted: undefined }, event, now);
+    }
+    if (event.type !== "message.complete" && event.type !== "error") {
+      // 丢弃被中断回合迟到的流式事件；终态事件放行，让半截消息正常收尾
+      return runtime;
+    }
+  }
+
   switch (event.type) {
     case "message.start": {
       const id =
@@ -689,6 +701,7 @@ export function reduceGatewayEvent(
         turnStartedAt: undefined,
         turnFirstTokenAt: undefined,
         activeAssistantId: undefined,
+        interrupted: undefined,
         updatedAt: now,
       };
     }
@@ -812,6 +825,7 @@ export function reduceGatewayEvent(
         statusKind: "error",
         statusUpdatedAt: now,
         activeAssistantId: undefined,
+        interrupted: undefined,
         updatedAt: now,
       };
     }
@@ -873,6 +887,23 @@ export const resetStreamStateAtom = atom(null, (_get, set, sessionId: string) =>
     updateSessionRuntime(state, sessionId, (runtime) => ({
       ...resetStream(runtime, now),
       streamStatus: "idle",
+    })),
+  );
+});
+
+// 手动终止：立即把会话标记为非运行态，并屏蔽旧回合迟到的流式事件。
+// 故意保留 activeAssistantId / turnStartedAt，迟到的 message.complete 才能收尾正确的消息。
+export const markSessionInterruptedAtom = atom(null, (_get, set, sessionId: string) => {
+  const now = Date.now();
+  set(chatRuntimeBySessionAtom, (state) =>
+    updateSessionRuntime(state, sessionId, (runtime) => ({
+      ...runtime,
+      interrupted: true,
+      streamStatus: "idle",
+      statusMessage: "",
+      statusKind: undefined,
+      statusUpdatedAt: undefined,
+      updatedAt: now,
     })),
   );
 });
@@ -974,6 +1005,7 @@ export const startPromptAtom = atom(
     set(chatRuntimeBySessionAtom, (state) =>
       updateSessionRuntime(state, params.sessionId, (runtime) => ({
         ...resetStream(runtime, now),
+        interrupted: undefined,
         messages: [
           ...runtime.messages,
           {


### PR DESCRIPTION
## 问题

点击「终止」按钮只发送 `session.interrupt` RPC，前端流状态完全不动。后端收尾期间持续到达的 `message.delta` / `thinking.delta` / `tool.*` 等 SSE 事件仍会被 `reduceGatewayEvent` 追加到界面上，用户看到"点了终止还在输出"。客户端唯一的流清理机制 `terminateAllStreamsAtom` 只在 gateway 断连时触发，手动终止路径从未调用过任何清理。

Closes #185

## 修复

**`web/src/stores/chat.ts`**
- `ChatSessionRuntime` 新增 `interrupted?: boolean`
- 新增独立的 `markSessionInterruptedAtom`：置 `streamStatus: "idle"`（终止按钮立即恢复为发送态）、清空状态栏、标记 `interrupted: true`。刻意保留 `activeAssistantId` / `turnStartedAt`，迟到的 `message.complete` 才能收尾正确的消息
- `reduceGatewayEvent` 顶部按事件类型分层拦截：
  - `message.start`（新回合，含 busy 重试与远程发起的回合）→ 解除屏蔽并正常渲染
  - `message.complete` / `error` → 放行，半截消息正常收尾，保留 `finishReason: "interrupted"` 元数据
  - 其余迟到的 delta / tool / status 事件 → 丢弃
- `startPromptAtom` 发送新 prompt 时清除标志

**`web/src/hooks/use-gateway.ts`**
- `interruptSession` 在 RPC 成功后调用 `markSessionInterrupted(gatewaySessionId)`

## 设计要点

- **不复用 `resetStreamStateAtom`**：它同时服务于 `sendPrompt` 的 session-busy 恢复路径（interrupt → reset → 重新提交，且重试不会再次走 `startPromptAtom`）。如果在它上面挂中断语义，重试回合的所有事件会被永久丢弃。该 atom 一行未动
- **拦截只针对被中断的旧回合**：新回合以 `message.start` 开始即自动解锁，cron / IM 通道 / 其他客户端发起的回合不受影响
- **终态事件放行**：被中断的半截消息能正常标记完成、关闭进度指示，不会永远卡在"生成中"

## 测试

新增 6 个单元测试（`web/src/stores/chat.test.ts`）：

1. 终止后 `streamStatus` 立即变 `idle`，composer 可再次发送
2. 旧回合迟到的 `message.delta` / `tool.start` / `status.update` 被丢弃
3. `message.complete(status: "interrupted")` 仍能收尾消息并记录 `finishReason` 元数据
4. 无本地 prompt 的新回合（`message.start`）自动恢复渲染
5. 用户发送下一条 prompt 清除中断标志
6. `sendPrompt` busy 重试路径行为不变（回归守护）

`pnpm typecheck` 通过，`pnpm test:unit` 545 个测试全部通过。Rust 侧无改动。

🤖 Generated with [Claude Code](https://claude.com/claude-code)