### PR TITLE
feat: add copy button to chat code blocks

### DIFF
--- a/web/src/components/chat/markdown-renderer.module.css
+++ b/web/src/components/chat/markdown-renderer.module.css
@@ -61,3 +61,38 @@
   color: var(--h-accent);
   padding: 0 0.25em;
 }
+
+/* Streamdown 内置代码块控件自带的是 Tailwind 工具类，本项目不引入 Tailwind，
+   需要用 data-streamdown 钩子自行定位：按钮悬浮在代码块头部右侧。 */
+.markdownRoot :global([data-streamdown="code-block"]) {
+  position: relative;
+}
+
+.markdownRoot :global([data-streamdown="code-block-actions"]) {
+  position: absolute;
+  top: 1px;
+  right: 4px;
+  display: flex;
+  align-items: center;
+}
+
+.markdownRoot :global([data-streamdown="code-block-copy-button"]) {
+  display: inline-flex;
+  align-items: center;
+  justify-content: center;
+  border: 0;
+  border-radius: var(--h-r-sm);
+  background: transparent;
+  padding: 5px;
+  color: var(--h-text-3);
+  cursor: pointer;
+}
+
+.markdownRoot :global([data-streamdown="code-block-copy-button"]:hover) {
+  color: var(--h-text);
+}
+
+.markdownRoot :global([data-streamdown="code-block-copy-button"]:disabled) {
+  cursor: default;
+  opacity: 0.5;
+}

--- a/web/src/components/chat/markdown-renderer.tsx
+++ b/web/src/components/chat/markdown-renderer.tsx
@@ -47,6 +47,18 @@ const streamdownLinkSafety: ComponentProps<typeof Streamdown>["linkSafety"] = {
   enabled: false,
 };
 
+// controls 传对象时，省略的键默认为开启，table/mermaid 必须显式关闭
+// 才能保持原 controls={false} 的行为。
+const streamdownControls: ComponentProps<typeof Streamdown>["controls"] = {
+  code: { copy: true, download: false },
+  table: false,
+  mermaid: false,
+};
+
+const streamdownTranslations: ComponentProps<typeof Streamdown>["translations"] = {
+  copyCode: "复制代码",
+};
+
 const markdownSanitizeSchema: SanitizeSchema = {
   ...defaultSchema,
   protocols: {
@@ -555,7 +567,7 @@ export const MarkdownText = memo(function MarkdownText({
     <Streamdown
       className={s.markdownRoot}
       components={streamdownComponents}
-      controls={false}
+      controls={streamdownControls}
       dir="auto"
       isAnimating={streaming}
       lineNumbers={false}
@@ -563,6 +575,7 @@ export const MarkdownText = memo(function MarkdownText({
       mode="streaming"
       plugins={streamdownPlugins}
       rehypePlugins={streamdownRehypePlugins}
+      translations={streamdownTranslations}
     >
       {normalizedText}
     </Streamdown>

--- a/web/src/components/chat/message-timeline.test.tsx
+++ b/web/src/components/chat/message-timeline.test.tsx
@@ -129,6 +129,23 @@ describe("MessageTimeline", () => {
   });
 
 
+  it("renders a copy button on fenced code blocks", () => {
+    const html = ReactDOMServer.renderToStaticMarkup(
+      <MarkdownText text={"```ts\nconst value = 1;\n```"} />,
+    );
+
+    expect(html).toContain('data-streamdown="code-block-copy-button"');
+    expect(html).toContain('title="复制代码"');
+  });
+
+  it("does not render code block controls for inline code", () => {
+    const html = ReactDOMServer.renderToStaticMarkup(
+      <MarkdownText text={"行内 `code` 不需要复制按钮"} />,
+    );
+
+    expect(html).not.toContain('data-streamdown="code-block-copy-button"');
+  });
+
   it("routes Mermaid fences away from the plain code block renderer", () => {
     const html = ReactDOMServer.renderToStaticMarkup(
       <MarkdownText text={"```mermaid\ngraph TD\n  A[开始] --> B{条件判断}\n  B -->|是| C[处理]\n```"} />,


### PR DESCRIPTION
## 背景

对话历史里的围栏代码块此前只能手动选中复制，用户希望一键复制。

## 方案

启用 Streamdown 内置的代码块 controls（仅复制按钮，不开下载），而非手写新组件：

- 内置按钮自带复制成功反馈（图标变对勾约 2s）、流式渲染期间自动禁用（避免复制到半截代码），复制走 `navigator.clipboard.writeText`，与项目现有 `CopyButton` 用法一致，Tauri WebView 下可用
- `controls` 传对象时省略的键默认按开启处理，因此 `table` / `mermaid` 显式传 `false`，保持原 `controls={false}` 行为不变
- 项目未引入 Tailwind，Streamdown 自带定位类不生效：用它输出的 `data-streamdown="code-block-actions"` / `"code-block-copy-button"` 属性钩子把按钮定位到代码块头部右侧，配色沿用消息操作按钮约定（`--h-text-3`，hover 提亮）
- tooltip 通过 `translations` 本地化为「复制代码」

样式挂在渲染器自身的 `.markdownRoot` 作用域下，skills / soul 页复用同一渲染器的代码块同样生效。

## 测试

- 新增 vitest：围栏代码块渲染出复制按钮且 tooltip 为「复制代码」；行内代码不出现复制按钮
- `pnpm typecheck` 通过；`pnpm test:unit` 全量通过（protocol 23 + web 543）

🤖 Generated with [Claude Code](https://claude.com/claude-code)