### PR TITLE
feat: 会话切换时详情区显示对话骨架屏

### DIFF
--- a/web/src/components/chat/message-skeleton.module.css
+++ b/web/src/components/chat/message-skeleton.module.css
@@ -1,0 +1,60 @@
+/* 会话切换加载骨架。容器延迟 ~120ms 淡入：hover 预取命中时数据通常更早
+   返回（骨架还没出现就被卸载），只有真正的慢加载才会看到它。 */
+.skeleton {
+  display: flex;
+  flex-direction: column;
+  gap: 18px;
+  padding: 24px 4px;
+  opacity: 0;
+  animation: skeleton-appear 0.18s ease-out 0.12s forwards;
+}
+
+.user {
+  align-self: flex-end;
+  height: 34px;
+  border-radius: var(--h-r-md);
+  background: var(--h-bg-chip);
+  animation: skeleton-pulse 1.4s ease-in-out infinite;
+}
+
+.assistant {
+  display: flex;
+  flex-direction: column;
+  gap: 10px;
+  align-self: stretch;
+}
+
+.line {
+  height: 14px;
+  border-radius: var(--h-r-sm);
+  background: var(--h-bg-chip);
+  animation: skeleton-pulse 1.4s ease-in-out infinite;
+}
+
+@keyframes skeleton-appear {
+  to {
+    opacity: 1;
+  }
+}
+
+@keyframes skeleton-pulse {
+  0%,
+  100% {
+    opacity: 1;
+  }
+  50% {
+    opacity: 0.45;
+  }
+}
+
+@media (prefers-reduced-motion: reduce) {
+  .skeleton {
+    animation-delay: 0s;
+    animation-duration: 0.01s;
+  }
+
+  .user,
+  .line {
+    animation: none;
+  }
+}

--- a/web/src/components/chat/message-skeleton.test.tsx
+++ b/web/src/components/chat/message-skeleton.test.tsx
@@ -1,0 +1,22 @@
+// 与 pill.test.tsx 同款：ReactDOMServer.renderToStaticMarkup，不引 jsdom /
+// @testing-library，只锁渲染契约（无障碍语义 + 对话骨架结构）。
+import ReactDOMServer from "react-dom/server";
+import { describe, expect, it } from "vitest";
+
+import { MessageSkeleton } from "./message-skeleton";
+
+describe("MessageSkeleton", () => {
+  it("renders an accessible loading status container", () => {
+    const html = ReactDOMServer.renderToStaticMarkup(<MessageSkeleton />);
+    expect(html).toContain('role="status"');
+    expect(html).toContain('aria-label="加载对话中"');
+  });
+
+  it("mimics the conversation layout with user bubbles and assistant lines", () => {
+    const html = ReactDOMServer.renderToStaticMarkup(<MessageSkeleton />);
+    // 2 组用户气泡 + 2 组助手段落（共 5 行）——结构变了说明骨架被改动，
+    // 需要同步确认视觉效果仍接近真实对话布局。
+    expect(html.match(/user/g)?.length).toBe(2);
+    expect(html.match(/line/g)?.length).toBe(5);
+  });
+});

--- a/web/src/components/chat/message-skeleton.tsx
+++ b/web/src/components/chat/message-skeleton.tsx
@@ -1,0 +1,26 @@
+import s from "./message-skeleton.module.css";
+
+// 会话切换时右侧详情区的加载骨架：模拟「用户气泡（右）→ 助手段落（左）」的
+// 对话布局，替代纯文本占位，切换瞬间版面不塌缩。只在目标会话既无缓存也无
+// 实时消息时由 MessageTimeline 的 loading 分支渲染；hover 预取命中时请求
+// 通常百毫秒内返回，容器延迟 ~120ms 才淡入（见 CSS），数据先到则骨架根本
+// 不会被看到，避免骨架自己成为新的闪烁源。
+//
+// 宽度是刻意错落的静态值（不随机化）：SSR/重渲染稳定，视觉上足够像对话。
+export function MessageSkeleton() {
+  return (
+    <div className={s.skeleton} role="status" aria-label="加载对话中">
+      <div className={s.user} style={{ width: "38%" }} />
+      <div className={s.assistant}>
+        <div className={s.line} style={{ width: "92%" }} />
+        <div className={s.line} style={{ width: "78%" }} />
+        <div className={s.line} style={{ width: "55%" }} />
+      </div>
+      <div className={s.user} style={{ width: "26%" }} />
+      <div className={s.assistant}>
+        <div className={s.line} style={{ width: "85%" }} />
+        <div className={s.line} style={{ width: "64%" }} />
+      </div>
+    </div>
+  );
+}

--- a/web/src/components/chat/message-timeline.tsx
+++ b/web/src/components/chat/message-timeline.tsx
@@ -5,6 +5,7 @@ import { AlertTriangle, ChevronRight, Info } from "lucide-react";
 import { showReasoningAtom } from "@/stores/ui";
 import type { AssistantMessageStats, ChatMessage, ChatToolItem } from "./chat-types";
 import { MessageImage } from "./message-image";
+import { MessageSkeleton } from "./message-skeleton";
 import { MessageText } from "./message-text";
 import { CopyButton } from "@/components/ui/copy-button";
 import s from "./message-timeline.module.css";
@@ -981,7 +982,7 @@ export function MessageTimeline({
         </div>
       ) : null}
       <div ref={messagesRef} className={s.messages}>
-        {loading ? <div className={s.empty}>加载对话中...</div> : null}
+        {loading ? <MessageSkeleton /> : null}
         {!loading && visibleMessages.length === 0 && !statusMessage && !pendingApproval ? (
           <div className={s.empty}>
             <div className={s.emptyTitle}>暂无对话记录</div>


### PR DESCRIPTION
## 需求

切换会话时右侧详情区添加 loading 状态与 Skeleton（beta.2 验收后的增量需求）。

## 设计取舍

- **显示条件**：沿用 `MessageTimeline` 既有 `loading` prop（detail.tsx：`isLoading && runtime.messages.length === 0`）——只有目标会话**既无缓存也无实时消息**时才显示骨架；#208 的 30s 消息缓存命中时是瞬时渲染，骨架完全不出现。
- **防骨架闪烁**：容器延迟 ~120ms 淡入（纯 CSS `animation-delay`）。hover 预取（#208）命中时请求通常百毫秒内返回，数据先到则骨架在可见之前就被卸载——慢加载才看得到它。
- **形态**：模拟「用户气泡（右对齐）→ 助手段落（左侧多行）」交替两组的对话布局，宽度错落的静态值（不随机化，渲染稳定）；替代原纯文本「加载对话中...」占位，消除切换瞬间的版面塌缩。
- **规范**：CSS Modules + 设计 token（`--h-bg-chip`/`--h-r-md`/`--h-r-sm`），无硬编码颜色；`role="status"` + `aria-label`；`prefers-reduced-motion` 下关闭脉冲与延迟动画。

## 变更

- 新增 `web/src/components/chat/message-skeleton.tsx` + `.module.css`
- `message-timeline.tsx` loading 分支：纯文本占位 → `<MessageSkeleton />`
- 新增渲染契约测试（renderToStaticMarkup 风格，同 pill.test.tsx）

## 验证

- typecheck 全绿；vitest web 545 全绿（新增 2 例）
- 纯 web/ 改动，无 Rust 变更

🤖 Generated with [Claude Code](https://claude.com/claude-code)