### PR TITLE
fix: inject runtime .env into managed child spawns

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -892,6 +892,12 @@ dependencies = [
 ]
 
 [[package]]
+name = "dotenvy"
+version = "0.15.7"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "1aaf95b3e5c8f23aa320147307562d361db0ae0d51242340f558153b4eb2439b"
+
+[[package]]
 name = "downcast-rs"
 version = "1.2.1"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -1637,6 +1643,7 @@ version = "0.3.2"
 dependencies = [
  "base64 0.22.1",
  "dirs",
+ "dotenvy",
  "ed25519-dalek",
  "env_logger",
  "fs2",

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -43,6 +43,9 @@ portable-pty = "0.9"
 rusqlite = { version = "0.32", features = ["bundled"] }
 libc = "0.2"
 getrandom = "0.3"
+# Parse $HERMES_HOME/.env for per-spawn child env injection (src/env_file.rs).
+# Only from_path_iter is used — the desktop process env is never mutated.
+dotenvy = "0.15"
 
 [target.'cfg(target_os = "windows")'.dependencies]
 windows-sys = { version = "0.61", features = [

--- a/src/commands/im_onboarding.rs
+++ b/src/commands/im_onboarding.rs
@@ -1566,6 +1566,11 @@ fn spawn_managed_gateway_process(hermes_home: &str) -> Result<(u32, PathBuf), St
     let stderr = Stdio::from(log);
 
     let mut cmd = Command::new(&record.executable_path);
+    // User .env first; the explicit desktop wiring below must win. The IM
+    // gateway reads the credentials this onboarding flow just wrote into
+    // $HERMES_HOME/.env, so inject them at spawn instead of relying solely
+    // on the runtime's own dotenv load. See #197.
+    crate::env_file::inject_env_file(&mut cmd, hermes_home, "IM gateway");
     cmd.args(["gateway", "run", "--replace"])
         .current_dir(&record.path)
         .env("HERMES_HOME", hermes_home)

--- a/src/env_file.rs
+++ b/src/env_file.rs
@@ -1,0 +1,207 @@
+// Per-spawn injection of the user's `$HERMES_HOME/.env` into managed child
+// processes (dashboard, IM gateway).
+//
+// The desktop process never loads `.env` into its own environment: mutating
+// process env via `std::env::set_var` is unsound once threads are running
+// (Tauri spawns several before `setup`), and a process-global load would
+// leak one profile's secrets into the next — profile switches respawn the
+// dashboard but the desktop process itself survives. Instead, each spawn
+// site reads the `.env` that belongs to the child's HERMES_HOME and passes
+// the pairs through `Command::envs`, so values are re-read on every respawn
+// (profile switch, YOLO toggle, runtime update) and stay scoped to the
+// right profile. See issue #197.
+//
+// The backend re-loads the same file with override semantics at every
+// entrypoint (`load_hermes_dotenv` in cli.py / run_agent.py /
+// tui_gateway/server.py), so for current runtimes this injection is
+// belt-and-braces; it guarantees user-configured variables reach children
+// even on runtime builds whose entrypoints skip that load.
+
+use std::path::Path;
+use std::process::Command;
+
+/// Keys the desktop wires explicitly on child spawns. `.env` contents must
+/// never rewire them, no matter where the injection call sits relative to
+/// the explicit `.env(...)` calls. `HERMES_YOLO_MODE` in particular is a
+/// security gate driven only by the persisted desktop preference, and
+/// `PATH` decides which executables the child resolves.
+const RESERVED_KEYS: &[&str] = &[
+    "HERMES_HOME",
+    "HERMES_YOLO_MODE",
+    "HERMES_DASHBOARD_SESSION_TOKEN",
+    "HERMES_DASHBOARD_TUI",
+    "HERMES_DASHBOARD_PREWARM_AGENT",
+    "HERMES_DISABLE_LAZY_INSTALLS",
+    "HERMES_WEB_DIST",
+    "HERMES_BUNDLED_SKILLS",
+    "HERMES_BUNDLED_PLUGINS",
+    "HERMES_GATEWAY_LOCK_DIR",
+    "HERMES_GATEWAY_RUNTIME_DIR",
+    "HERMES_GATEWAY_DETACHED",
+    "HERMES_NONINTERACTIVE",
+    "PYTHONUNBUFFERED",
+    "PATH",
+];
+
+/// `HERMES_DESKTOP_*` configures the desktop shell itself (API host/port,
+/// bootstrap mode). Children ignore these, and letting a runtime `.env`
+/// masquerade as desktop configuration would only confuse diagnostics.
+const RESERVED_PREFIX: &str = "HERMES_DESKTOP_";
+
+fn is_reserved(key: &str) -> bool {
+    RESERVED_KEYS.contains(&key) || key.starts_with(RESERVED_PREFIX)
+}
+
+/// Read `$hermes_home/.env` without touching the desktop process
+/// environment. Returns pairs in file order (later duplicates win once
+/// applied to a `Command` env map, matching python-dotenv). Missing file
+/// yields an empty list; a parse error stops reading at the offending line
+/// and everything before it is still returned.
+pub fn read_env_file_vars(hermes_home: &str) -> Vec<(String, String)> {
+    let path = Path::new(hermes_home).join(".env");
+    if !path.is_file() {
+        return Vec::new();
+    }
+    let iter = match dotenvy::from_path_iter(&path) {
+        Ok(iter) => iter,
+        Err(err) => {
+            log::warn!("Failed to read {}: {}", path.display(), err);
+            return Vec::new();
+        }
+    };
+
+    let mut vars: Vec<(String, String)> = Vec::new();
+    for item in iter {
+        match item {
+            Ok((key, value)) => {
+                if is_reserved(&key) {
+                    log::warn!(
+                        "Ignoring desktop-reserved key {} in {}",
+                        key,
+                        path.display()
+                    );
+                    continue;
+                }
+                // Embedded NUL would fail the entire spawn with
+                // InvalidInput; the backend sanitizes these on its own
+                // load, so just skip the broken entry here.
+                if key.contains('\0') || value.contains('\0') {
+                    log::warn!(
+                        "Ignoring key {} in {}: embedded NUL in value",
+                        key,
+                        path.display()
+                    );
+                    continue;
+                }
+                vars.push((key, value));
+            }
+            Err(err) => {
+                log::warn!(
+                    "Stopped reading {} after {} vars: {}",
+                    path.display(),
+                    vars.len(),
+                    err
+                );
+                break;
+            }
+        }
+    }
+    vars
+}
+
+/// Inject the child-HERMES_HOME's `.env` into `cmd`. Call before the
+/// explicit `.env(...)` wiring so desktop-controlled keys win even if a
+/// future key is missing from `RESERVED_KEYS`.
+pub fn inject_env_file(cmd: &mut Command, hermes_home: &str, child: &str) {
+    let vars = read_env_file_vars(hermes_home);
+    if vars.is_empty() {
+        return;
+    }
+    log::info!(
+        "Injecting {} env vars from {} into {} spawn",
+        vars.len(),
+        Path::new(hermes_home).join(".env").display(),
+        child
+    );
+    cmd.envs(vars);
+}
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+    use pretty_assertions::assert_eq;
+    use std::ffi::OsStr;
+    use std::fs;
+    use tempfile::TempDir;
+
+    fn home_with_env(content: &str) -> TempDir {
+        let dir = TempDir::new().unwrap();
+        fs::write(dir.path().join(".env"), content).unwrap();
+        dir
+    }
+
+    fn read(dir: &TempDir) -> Vec<(String, String)> {
+        read_env_file_vars(dir.path().to_str().unwrap())
+    }
+
+    #[test]
+    fn missing_env_file_yields_empty() {
+        let dir = TempDir::new().unwrap();
+        assert_eq!(read(&dir), Vec::new());
+    }
+
+    #[test]
+    fn parses_comments_quotes_and_export_prefix() {
+        let dir = home_with_env(
+            "# providers\nTAVILY_API_KEY=tvly-abc\nOPENAI_API_KEY=\"sk-quoted\"\nexport BRAVE_SEARCH_API_KEY='single'\n",
+        );
+        assert_eq!(
+            read(&dir),
+            vec![
+                ("TAVILY_API_KEY".into(), "tvly-abc".into()),
+                ("OPENAI_API_KEY".into(), "sk-quoted".into()),
+                ("BRAVE_SEARCH_API_KEY".into(), "single".into()),
+            ]
+        );
+    }
+
+    #[test]
+    fn filters_desktop_reserved_keys() {
+        let dir = home_with_env(
+            "HERMES_YOLO_MODE=1\nHERMES_HOME=/elsewhere\nHERMES_DESKTOP_API_PORT=9119\nPATH=/evil\nTAVILY_API_KEY=ok\n",
+        );
+        assert_eq!(read(&dir), vec![("TAVILY_API_KEY".into(), "ok".into())]);
+    }
+
+    #[test]
+    fn parse_error_keeps_earlier_vars() {
+        let dir = home_with_env("TAVILY_API_KEY=ok\n%%% not an env line\nLATER_KEY=lost\n");
+        assert_eq!(read(&dir), vec![("TAVILY_API_KEY".into(), "ok".into())]);
+    }
+
+    #[test]
+    fn skips_values_with_embedded_nul() {
+        let dir = home_with_env("BROKEN_API_KEY=\"a\u{0}b\"\nTAVILY_API_KEY=ok\n");
+        assert_eq!(read(&dir), vec![("TAVILY_API_KEY".into(), "ok".into())]);
+    }
+
+    #[test]
+    fn explicit_desktop_env_wins_over_injection() {
+        let dir = home_with_env("TAVILY_API_KEY=from-file\nFEISHU_APP_ID=cli_x\n");
+        let mut cmd = Command::new("true");
+        inject_env_file(&mut cmd, dir.path().to_str().unwrap(), "test");
+        cmd.env("FEISHU_APP_ID", "cli_explicit");
+
+        let envs: Vec<(&OsStr, Option<&OsStr>)> = cmd.get_envs().collect();
+        assert_eq!(
+            envs,
+            vec![
+                (
+                    OsStr::new("FEISHU_APP_ID"),
+                    Some(OsStr::new("cli_explicit"))
+                ),
+                (OsStr::new("TAVILY_API_KEY"), Some(OsStr::new("from-file"))),
+            ]
+        );
+    }
+}

--- a/src/lib.rs
+++ b/src/lib.rs
@@ -1,5 +1,6 @@
 pub mod commands;
 pub mod cron_runs;
+pub mod env_file;
 pub mod environment;
 pub mod error;
 pub mod prevent_sleep;

--- a/src/process/dashboard.rs
+++ b/src/process/dashboard.rs
@@ -755,6 +755,11 @@ fn spawn_dashboard(options: &EnsureDashboardOptions) -> Result<SpawnedDashboard,
     prefix_args.extend(api_args);
 
     let mut cmd = Command::new(&program);
+    // User-configured $HERMES_HOME/.env goes in first so every explicit
+    // .env(...) below — and the env_remove for HERMES_YOLO_MODE — wins
+    // over file contents. Re-read on every respawn so profile switches and
+    // .env edits take effect without restarting the desktop. See #197.
+    crate::env_file::inject_env_file(&mut cmd, &options.hermes_home, "dashboard");
     let session_token = session_token_for_spawn();
     let gateway_runtime_dir = crate::process::runtime::gateway_runtime_dir();
     let gateway_lock_dir = gateway_runtime_dir.join("token-locks");

--- a/src/process/gateway.rs
+++ b/src/process/gateway.rs
@@ -320,6 +320,8 @@ fn apply_managed_gateway_env(
     gateway_runtime_dir: &Path,
     gateway_lock_dir: &Path,
 ) {
+    // User .env first; the explicit desktop wiring below must win.
+    crate::env_file::inject_env_file(cmd, hermes_home, "gateway helper");
     cmd.env("HERMES_HOME", hermes_home)
         .env("HERMES_GATEWAY_RUNTIME_DIR", gateway_runtime_dir)
         .env("HERMES_GATEWAY_LOCK_DIR", gateway_lock_dir)


### PR DESCRIPTION
## 问题

#197 反馈：桌面端配置了 `TAVILY_API_KEY` 等环境变量后，agent session / MCP / `web_search` 仍然看不到。

桌面端 Rust 层此前从不读取 `$HERMES_HOME/.env`，用户配置的变量能否到达子进程完全依赖后端入口自身的 `load_hermes_dotenv()`。本 PR 在桌面层补上这道保障：**每次 spawn 受管子进程时，按该子进程的 `HERMES_HOME` 读取 `.env` 并经 `Command::envs` 显式注入**。

## 为什么不是进程级加载（对比 #204）

#204 用 `dotenvy::from_path` 在启动时把 `.env` 灌进桌面进程环境，存在三个问题（详见 #204 的审查意见）：

1. **线程安全**：`dotenvy::from_path` 内部走 `std::env::set_var`，插入点在 Tauri `setup` 闭包内，此时多线程已起，glibc 下 `setenv` 与并发 `getenv` 竞争是 UB（Rust 2024 已将 `set_var` 标为 `unsafe`）。
2. **破坏 profile 隔离**：profile 切换只重启 dashboard 子进程、桌面进程不退出（`commands/restart.rs`）。一次性灌入会让 profile A 独有的 secrets 在切到 profile B 后仍被 B 的子进程继承；从 `.env` 删 key 也要整个 app 重启才生效。
3. **行为面扩大**：加载后桌面自身所有 `std::env::var` 读取（`HERMES_DESKTOP_API_HOST/PORT`、`HERMES_DESKTOP_SYNC_BOOTSTRAP` 等）都会被 runtime `.env` 影响，超出"让子进程继承"的意图。

## 本 PR 的做法

- 新增 `src/env_file.rs`：用 `dotenvy::from_path_iter` 解析 `$HERMES_HOME/.env`，**完全不触碰桌面进程环境**（解决 1/3）；按 spawn 对象的 home 每次重读（解决 2，profile 正确、`.env` 删改在下次 respawn 即生效）。
- 过滤桌面保留键：`HERMES_YOLO_MODE`（安全闸门，只能由桌面持久化偏好驱动）、`HERMES_HOME`、`HERMES_DASHBOARD_SESSION_TOKEN`、`PATH`、`HERMES_DESKTOP_*` 及 gateway wiring 键；注入调用一律放在显式 `.env(...)` 之前，双保险确保桌面显式配置优先。
- 注入点：`dashboard.rs::spawn_dashboard`、`im_onboarding.rs` IM gateway（它读的恰是 onboarding 流程刚写入 `.env` 的凭据）、`gateway.rs::apply_managed_gateway_env`。
- 解析失败不撒谎：解析中断时日志报告"读到第 N 个变量后停止"，含 NUL 的条目跳过（避免整个 spawn 失败）。
- 6 个单元测试（`tempfile::TempDir`，覆盖引号/export 前缀/保留键过滤/解析错误/NUL/显式配置优先）。

后端各入口（`cli.py` / `run_agent.py` / `tui_gateway/server.py`）本就会以 override 语义加载同一文件，本 PR 与之不冲突——注入值会被后端的加载确认或覆盖，语义仍以后端为准；收益是覆盖后端入口未执行 dotenv 加载的 runtime 版本/路径，并让 #197 期望的"桌面端启动内置核心时统一传递用户环境变量"在桌面层成立。

## 备注

- 若 #197 复现确认根因是 `.env` 路径错位（用户写在 `~/.hermes/.env` 而桌面用隔离 runtime home）或非 default profile 的 home 错位，则还需要产品侧引导（env 编辑统一落到当前 boot home），本 PR 不覆盖该场景。
- 感谢 @szzhoujiarui-sketch 在 #204 中的定位工作，本 PR 沿用了其 `dotenvy` 依赖选型。
- 本地未跑编译验证（开发机不适合编译），以 CI 为准。

Closes #197
Supersedes #204

🤖 Generated with [Claude Code](https://claude.com/claude-code)