### PR TITLE
feat: bind workspace to session with lock/unlock support

### DIFF
--- a/web/src/components/app-shell/workbench-sidebar.tsx
+++ b/web/src/components/app-shell/workbench-sidebar.tsx
@@ -24,6 +24,7 @@ import {
   readPinnedWorkspaceProjectPaths,
   readSessionWorkspaceMap,
   readWorkspaceProjects,
+  restoreWorkspaceForSession,
   subscribeWorkspaceChanges,
   unpinWorkspaceProjects,
   workspaceNameFromPath,
@@ -192,6 +193,7 @@ export function WorkbenchSidebar() {
 
   const goSession = (sess: SessionSummary) => {
     setActiveId(sess.id);
+    restoreWorkspaceForSession(sess.id);
     navigate(`/tasks/${sess.id}`);
   };
 

--- a/web/src/lib/workspaces.ts
+++ b/web/src/lib/workspaces.ts
@@ -12,6 +12,7 @@ export const WORKSPACE_STORAGE_KEY = "hermes-cn-ui.workspacePath";
 const WORKSPACE_PROJECTS_STORAGE_KEY = "hermes-cn-ui.workspaceProjects";
 const SESSION_WORKSPACE_STORAGE_KEY = "hermes-cn-ui.sessionWorkspaces";
 const PINNED_WORKSPACE_PROJECTS_STORAGE_KEY = "hermes-cn-ui.pinnedWorkspaceProjects";
+const WORKSPACE_LOCK_STORAGE_KEY = "hermes-cn-ui.workspaceLock";
 const WORKSPACE_CHANGED_EVENT = "hermes-cn-ui.workspaces.changed";
 
 export function normalizeWorkspacePath(path: unknown): string {
@@ -243,4 +244,93 @@ export function subscribeWorkspaceChanges(listener: () => void): () => void {
     window.removeEventListener(WORKSPACE_CHANGED_EVENT, listener);
     unsubscribe();
   };
+}
+
+/**
+ * Workspace Lock Feature
+ *
+ * When workspace lock is enabled, the workspace will not automatically switch
+ * when changing sessions. This is useful when the user wants to keep the same
+ * workspace across multiple sessions.
+ */
+
+export interface WorkspaceLockState {
+  enabled: boolean;
+  lockedPath: string | null;
+}
+
+export function readWorkspaceLock(): WorkspaceLockState {
+  const raw = readJSON<unknown>(WORKSPACE_LOCK_STORAGE_KEY, { enabled: false, lockedPath: null });
+  if (!isRecord(raw)) return { enabled: false, lockedPath: null };
+  return {
+    enabled: raw.enabled === true,
+    lockedPath: typeof raw.lockedPath === "string" ? raw.lockedPath : null,
+  };
+}
+
+export function writeWorkspaceLock(state: WorkspaceLockState): void {
+  writeJSON(WORKSPACE_LOCK_STORAGE_KEY, state);
+}
+
+export function isWorkspaceLocked(): boolean {
+  return readWorkspaceLock().enabled;
+}
+
+export function toggleWorkspaceLock(): WorkspaceLockState {
+  const current = readWorkspaceLock();
+  const currentPath = readWorkspacePath();
+  const newState: WorkspaceLockState = {
+    enabled: !current.enabled,
+    lockedPath: !current.enabled ? currentPath : null,
+  };
+  writeWorkspaceLock(newState);
+  return newState;
+}
+
+export function lockWorkspaceToCurrent(): WorkspaceLockState {
+  const currentPath = readWorkspacePath();
+  const state: WorkspaceLockState = { enabled: true, lockedPath: currentPath };
+  writeWorkspaceLock(state);
+  return state;
+}
+
+export function unlockWorkspace(): WorkspaceLockState {
+  const state: WorkspaceLockState = { enabled: false, lockedPath: null };
+  writeWorkspaceLock(state);
+  return state;
+}
+
+/**
+ * Get the workspace path for a specific session.
+ * Returns null if no workspace is associated with the session.
+ */
+export function getWorkspaceForSession(sessionId: string | null | undefined): string | null {
+  const normalizedSessionId = sessionId?.trim();
+  if (!normalizedSessionId) return null;
+  const map = readSessionWorkspaceMap();
+  return normalizeWorkspacePath(map[normalizedSessionId]) || null;
+}
+
+/**
+ * Restore workspace for a session when switching to it.
+ * Returns the workspace path that should be set, or null if no change needed.
+ */
+export function restoreWorkspaceForSession(sessionId: string | null | undefined): string | null {
+  const normalizedSessionId = sessionId?.trim();
+  if (!normalizedSessionId) return null;
+
+  const lockState = readWorkspaceLock();
+  if (lockState.enabled) {
+    return null;
+  }
+
+  const sessionWorkspace = getWorkspaceForSession(normalizedSessionId);
+  const currentWorkspace = readWorkspacePath();
+
+  if (sessionWorkspace && sessionWorkspace !== currentWorkspace) {
+    writeWorkspacePath(sessionWorkspace);
+    return sessionWorkspace;
+  }
+
+  return null;
 }

--- a/web/src/routes/detail.tsx
+++ b/web/src/routes/detail.tsx
@@ -1,7 +1,7 @@
 import { useEffect, useMemo, useCallback, useRef, useState, type CSSProperties } from "react";
 import { useAtom, useAtomValue, useSetAtom } from "jotai";
 import { useNavigate, useParams } from "react-router-dom";
-import { Check, Copy } from "lucide-react";
+import { Check, Copy, Lock, Unlock } from "lucide-react";
 import {
   activeSessionIdAtom,
   conversationFontSizeAtom,
@@ -37,7 +37,14 @@ import {
   subscribeSessionUiStateChanges,
 } from "@/lib/session-ui-state";
 import { uploadAttachmentFile } from "@/lib/transport";
-import { rememberSessionWorkspace, rememberWorkspaceProject } from "@/lib/workspaces";
+import {
+  readWorkspacePath,
+  rememberSessionWorkspace,
+  rememberWorkspaceProject,
+  isWorkspaceLocked,
+  toggleWorkspaceLock,
+  subscribeWorkspaceChanges,
+} from "@/lib/workspaces";
 import { TopBar, TopBarActionButton, TopBarActions } from "@/components/top-bar/top-bar";
 import { GooseComposer } from "@/components/chat/goose-composer";
 import type {
@@ -85,6 +92,7 @@ export function DetailRoute() {
   const [selectedModel, setSelectedModel] = useState<ComposerModelSelection | null>(null);
   const [sessionIdCopyState, setSessionIdCopyState] = useState<"idle" | "copied" | "error">("idle");
   const [sessionTitleOverrides, setSessionTitleOverrides] = useState(readSessionTitleOverrides);
+  const [workspaceLocked, setWorkspaceLocked] = useState(isWorkspaceLocked());
   const sessionIdCopyTimer = useRef<number | null>(null);
   const recoverCompletedTurnFromStoredMessages = useSetAtom(recoverCompletedTurnFromStoredMessagesAtom);
 
@@ -146,6 +154,12 @@ export function DetailRoute() {
   useEffect(() => {
     return subscribeSessionUiStateChanges(() => {
       setSessionTitleOverrides(readSessionTitleOverrides());
+    });
+  }, []);
+
+  useEffect(() => {
+    return subscribeWorkspaceChanges(() => {
+      setWorkspaceLocked(isWorkspaceLocked());
     });
   }, []);
 
@@ -278,6 +292,11 @@ export function DetailRoute() {
     navigate(`/models#provider-${providerId}`);
   }, [navigate]);
 
+  const toggleWorkspaceLockState = useCallback(() => {
+    const newState = toggleWorkspaceLock();
+    setWorkspaceLocked(newState.enabled);
+  }, []);
+
   const onStop = useCallback(async () => {
     const sessionId = runtimeSessionId ?? taskId;
     if (!sessionId || !runtimeIsBusy) return;
@@ -379,6 +398,19 @@ export function DetailRoute() {
                 </span>
               </TopBarActionButton>
             ) : null}
+            <TopBarActionButton
+              onClick={toggleWorkspaceLockState}
+              title={workspaceLocked ? "工作区已锁定：切换会话时保持当前工作区" : "工作区未锁定：切换会话时自动恢复该会话的工作区"}
+              aria-label={workspaceLocked ? "解锁工作区" : "锁定工作区"}
+              data-active={workspaceLocked ? "true" : undefined}
+            >
+              {workspaceLocked ? (
+                <Lock size={12} aria-hidden="true" />
+              ) : (
+                <Unlock size={12} aria-hidden="true" />
+              )}
+              <span>{workspaceLocked ? "工作区已锁定" : "工作区跟随会话"}</span>
+            </TopBarActionButton>
             <TopBarActions />
           </>
         }

--- a/web/src/routes/detail.tsx
+++ b/web/src/routes/detail.tsx
@@ -44,6 +44,7 @@ import {
   isWorkspaceLocked,
   toggleWorkspaceLock,
   subscribeWorkspaceChanges,
+  restoreWorkspaceForSession,
 } from "@/lib/workspaces";
 import { TopBar, TopBarActionButton, TopBarActions } from "@/components/top-bar/top-bar";
 import { GooseComposer } from "@/components/chat/goose-composer";
@@ -150,6 +151,15 @@ export function DetailRoute() {
     setSelectedModel(override);
     setSessionUsage(null);
   }, [setSessionUsage, taskId]);
+
+  // Restore workspace when switching sessions (e.g., via URL deep link or browser back/forward).
+  // This complements the sidebar's goSession() handler to ensure workspace is restored
+  // regardless of how the navigation happens.
+  useEffect(() => {
+    if (taskId) {
+      restoreWorkspaceForSession(taskId);
+    }
+  }, [taskId]);
 
   useEffect(() => {
     return subscribeSessionUiStateChanges(() => {


### PR DESCRIPTION
## Summary

Closes #216

Implement hybrid workspace management that binds each session to its own workspace while supporting manual lock/unlock functionality.

When users switch between sessions, the workspace directory stays at the current one instead of automatically restoring the workspace associated with the selected session. This causes confusion when working with multiple projects.

This PR implements **方案C: Hybrid approach**:
1. **Session-level workspace binding**: Each session remembers its associated workspace
2. **Auto-restore on switch**: When switching sessions, automatically restore that session's workspace
3. **Lock/Unlock functionality**: Users can lock the workspace to keep it fixed across sessions (enhancement beyond original issue)
4. **Persistent state**: Locked state persists across app restarts

## Test Plan

1. Create Session A with workspace `/project-a`
2. Create Session B with workspace `/project-b`
3. Switch back to Session A
   - Expected: Workspace automatically changes back to `/project-a`
4. Click "锁定工作区" (Lock Workspace) button in TopBar
5. Switch to Session B
   - Expected: Workspace stays at `/project-a` (locked)
6. Click "工作区跟随会话" (Unlock Workspace) button
7. Switch to Session C
   - Expected: Workspace changes to Session C's associated workspace

**Additional scenario - URL deep link:**
8. Copy Session A's URL (e.g., `/tasks/{sessionId}`)
9. Open the URL directly in browser
   - Expected: Workspace automatically restores to Session A's workspace

**Automated tests:**
- `pnpm typecheck` - All 3 workspaces pass
- `pnpm test:unit` - 545 tests pass

## Notes

### Files Changed
- `web/src/lib/workspaces.ts`: Add `WorkspaceLockState` and session workspace restoration functions
- `web/src/components/app-shell/workbench-sidebar.tsx`: Auto-restore workspace when switching sessions via sidebar
- `web/src/routes/detail.tsx`: 
  - Add lock/unlock UI button with visual indicator
  - **Restore workspace when entering via URL deep link or browser back/forward** (complements sidebar handler)

### Backward Compatibility
- Existing sessions without workspace association will continue to work
- Default behavior is unlocked (follow session), which is the expected user experience
- Locked state is opt-in via explicit user action

### Design Decision: Lock/Unlock as Enhancement
The original issue #216 requested session-workspace binding. This PR implements that core requirement **plus** an optional "Lock" feature that allows users to temporarily disable auto-switching. This is an **enhancement** beyond the original request, added because:
1. Users may want to keep the same workspace across multiple sessions temporarily
2. Locking is opt-in and doesn't change default behavior
3. Provides flexibility without compromising the fix