### PR TITLE
feat: dynamic bootstrap subtitle + multi-step onboarding wizard

### DIFF
--- a/web/src/components/app-shell/model-onboarding-guard.tsx
+++ b/web/src/components/app-shell/model-onboarding-guard.tsx
@@ -1,27 +1,26 @@
 import { useEffect, useState } from "react";
-import { useLocation, useNavigate } from "react-router-dom";
-import { KeyRound, Settings2, Sparkles } from "lucide-react";
+import { useLocation } from "react-router-dom";
 import { useModelInfo } from "@/hooks/use-config";
-import s from "./model-onboarding-guard.module.css";
+import { OnboardingWizard } from "@/components/onboarding/onboarding-wizard";
 
-const DEFAULT_PROVIDER_HASH = "#provider-deepseek";
-let dismissedForWindow = false;
+const SKIP_KEY = "hermes-onboarding-skipped";
 
 function hasConfiguredModel(modelInfo: { model?: string; provider?: string } | undefined): boolean {
   return Boolean(modelInfo?.model?.trim() && modelInfo?.provider?.trim());
 }
 
 export function ModelOnboardingGuard() {
-  const navigate = useNavigate();
   const location = useLocation();
   const { data: modelInfo, isLoading, isError } = useModelInfo();
-  const [dismissed, setDismissed] = useState(() => dismissedForWindow);
+  const [dismissed, setDismissed] = useState(() => {
+    try { return localStorage.getItem(SKIP_KEY) === "true"; } catch { return false; }
+  });
 
   const configured = hasConfiguredModel(modelInfo);
 
   useEffect(() => {
     if (!configured || typeof window === "undefined") return;
-    dismissedForWindow = false;
+    try { localStorage.removeItem(SKIP_KEY); } catch { /* ignore */ }
     setDismissed(false);
   }, [configured]);
 
@@ -36,39 +35,5 @@ export function ModelOnboardingGuard() {
     return null;
   }
 
-  const goModels = () => {
-    navigate(`/models${DEFAULT_PROVIDER_HASH}`);
-  };
-
-  const dismiss = () => {
-    dismissedForWindow = true;
-    setDismissed(true);
-  };
-
-  return (
-    <div className={s.backdrop} role="presentation">
-      <section className={s.card} role="dialog" aria-modal="true" aria-labelledby="model-onboarding-title">
-        <div className={s.iconWrap} aria-hidden="true">
-          <Sparkles size={22} />
-        </div>
-        <div className={s.copy}>
-          <p className={s.kicker}>首次初始化</p>
-          <h2 id="model-onboarding-title">先配置模型 API Key</h2>
-          <p>
-            当前桌面端正在使用独立的 Hermes Agent runtime，新的 <code>hermes-home</code> 里还没有模型服务商和默认模型。
-            请进入模型页选择服务商，粘贴 API Key，保存后设为当前模型。
-          </p>
-          <div className={s.steps}>
-            <span><KeyRound size={13} /> 填写 API Key</span>
-            <span><Settings2 size={13} /> 保存配置</span>
-            <span><Sparkles size={13} /> 设为当前模型</span>
-          </div>
-        </div>
-        <div className={s.actions}>
-          <button type="button" className={s.secondary} onClick={dismiss}>先看看界面</button>
-          <button type="button" className={s.primary} onClick={goModels} autoFocus>进入模型页</button>
-        </div>
-      </section>
-    </div>
-  );
+  return <OnboardingWizard />;
 }

--- a/web/src/components/onboarding/onboarding-wizard.module.css
+++ b/web/src/components/onboarding/onboarding-wizard.module.css
@@ -1,0 +1,318 @@
+.backdrop {
+  position: absolute;
+  inset: 0;
+  z-index: 20;
+  display: flex;
+  align-items: center;
+  justify-content: center;
+  padding: 28px;
+  background:
+    radial-gradient(circle at 50% 32%, color-mix(in srgb, var(--h-accent) 16%, transparent), transparent 42%),
+    color-mix(in srgb, var(--h-bg-app) 78%, transparent);
+  backdrop-filter: blur(10px);
+}
+
+.card {
+  width: min(600px, 100%);
+  max-height: calc(100vh - 56px);
+  overflow-y: auto;
+  border: 1px solid color-mix(in srgb, var(--h-accent) 34%, var(--h-line));
+  border-radius: 20px;
+  background: color-mix(in srgb, var(--h-bg-pane) 94%, var(--h-accent) 6%);
+  box-shadow: 0 24px 70px color-mix(in srgb, #000 28%, transparent);
+  padding: 24px;
+}
+
+/* Step indicators */
+.steps {
+  display: flex;
+  justify-content: center;
+  gap: 6px;
+  margin-bottom: 20px;
+}
+
+.stepActive,
+.stepDone,
+.stepPending {
+  display: flex;
+  align-items: center;
+  gap: 6px;
+  font-size: 12px;
+  font-weight: 600;
+}
+
+.stepActive { color: var(--h-accent); }
+.stepDone   { color: color-mix(in srgb, var(--h-accent) 60%, var(--h-text-2)); }
+.stepPending { color: var(--h-text-2); }
+
+.stepDot {
+  display: grid;
+  place-items: center;
+  width: 22px;
+  height: 22px;
+  border-radius: 50%;
+  font-size: 11px;
+  font-weight: 700;
+}
+
+.stepActive .stepDot {
+  background: var(--h-accent);
+  color: #1a0c04;
+}
+.stepDone .stepDot {
+  background: color-mix(in srgb, var(--h-accent) 28%, transparent);
+  color: var(--h-accent);
+}
+.stepPending .stepDot {
+  background: var(--h-bg-soft);
+  border: 1px solid var(--h-line-soft);
+}
+
+.stepLabel { white-space: nowrap; }
+
+/* Heading */
+.card h2 {
+  margin: 0;
+  color: var(--h-text);
+  font-size: 20px;
+}
+
+.desc {
+  margin: 6px 0 0;
+  color: var(--h-text-2);
+  font-size: 13px;
+  line-height: 1.6;
+}
+
+/* Content area */
+.content {
+  margin-top: 14px;
+  min-height: 80px;
+  max-height: 300px;
+  overflow-y: auto;
+}
+
+.loading {
+  color: var(--h-text-2);
+  font-size: 13px;
+  text-align: center;
+  padding: 24px 0;
+}
+
+.error {
+  display: flex;
+  align-items: center;
+  gap: 6px;
+  color: var(--h-danger, #c44);
+  font-size: 13px;
+  padding: 8px 12px;
+  background: color-mix(in srgb, var(--h-danger, #c44) 8%, transparent);
+  border-radius: 8px;
+}
+
+.empty {
+  display: flex;
+  align-items: center;
+  gap: 8px;
+  padding: 16px 0;
+  color: var(--h-text-2);
+  font-size: 13px;
+}
+
+.iconOk { color: color-mix(in srgb, #22c55e 80%, var(--h-text)); flex-shrink: 0; }
+.iconErr { color: var(--h-danger, #c44); flex-shrink: 0; }
+.iconWarn { color: var(--h-warning, #f59e0b); flex-shrink: 0; }
+
+/* Results list */
+.results { display: flex; flex-direction: column; gap: 8px; }
+
+.group {
+  border: 1px solid var(--h-line-soft);
+  border-radius: 10px;
+  padding: 10px 12px;
+}
+
+.groupTitle {
+  display: flex;
+  align-items: center;
+  gap: 6px;
+  font-size: 12px;
+  font-weight: 700;
+  margin-bottom: 6px;
+  color: var(--h-text);
+}
+
+.item {
+  display: flex;
+  flex-direction: column;
+  gap: 2px;
+  padding: 4px 0;
+  font-size: 12px;
+  color: var(--h-text-2);
+}
+
+.hint {
+  font-size: 11px;
+  color: var(--h-text-2);
+  opacity: 0.7;
+}
+
+.info {
+  font-size: 13px;
+  color: var(--h-text-2);
+  margin: 0 0 8px;
+  line-height: 1.55;
+}
+
+.info strong {
+  color: var(--h-accent);
+}
+
+.warn {
+  display: flex;
+  align-items: center;
+  gap: 4px;
+  font-size: 11px;
+  color: var(--h-warning, #f59e0b);
+  margin: 4px 0 0;
+}
+
+/* Candidate card */
+.candidate {
+  border: 1px solid var(--h-line-soft);
+  border-radius: 8px;
+  padding: 8px 10px;
+  margin-bottom: 6px;
+}
+
+.candidatePath {
+  font-size: 11px;
+  font-family: var(--h-font-mono);
+  color: var(--h-text);
+  word-break: break-all;
+  margin-bottom: 6px;
+}
+
+.tags { display: flex; flex-wrap: wrap; gap: 4px; }
+
+.tag {
+  font-size: 10px;
+  padding: 2px 6px;
+  border-radius: 999px;
+  background: var(--h-bg-soft);
+  border: 1px solid var(--h-line-soft);
+  color: var(--h-text-2);
+}
+
+/* Steps list (Step 3) */
+.stepsList {
+  margin-top: 16px;
+  display: flex;
+  flex-wrap: wrap;
+  gap: 8px;
+}
+
+.stepsList span {
+  height: 28px;
+  padding: 0 10px;
+  border-radius: 999px;
+  display: inline-flex;
+  align-items: center;
+  gap: 6px;
+  color: var(--h-text-2);
+  background: var(--h-bg-soft);
+  border: 1px solid var(--h-line-soft);
+  font-size: 12px;
+}
+
+/* Summary */
+.summary {
+  margin-top: 14px;
+  border: 1px solid var(--h-line-soft);
+  border-radius: 10px;
+  padding: 10px 12px;
+}
+
+.summaryRow {
+  display: flex;
+  justify-content: space-between;
+  align-items: center;
+  padding: 4px 0;
+  font-size: 12px;
+  color: var(--h-text-2);
+}
+
+.badgeOk {
+  font-size: 11px;
+  padding: 2px 8px;
+  border-radius: 999px;
+  background: color-mix(in srgb, #22c55e 16%, transparent);
+  color: color-mix(in srgb, #22c55e 82%, var(--h-text));
+  font-weight: 600;
+}
+
+.badgeWarn {
+  font-size: 11px;
+  padding: 2px 8px;
+  border-radius: 999px;
+  background: color-mix(in srgb, var(--h-warning, #f59e0b) 16%, transparent);
+  color: var(--h-warning, #f59e0b);
+  font-weight: 600;
+}
+
+/* Icon wrap */
+.iconWrap {
+  width: 46px;
+  height: 46px;
+  border-radius: 16px;
+  display: grid;
+  place-items: center;
+  color: #1a0c04;
+  background: var(--h-accent);
+  box-shadow: 0 10px 28px color-mix(in srgb, var(--h-accent) 24%, transparent);
+  margin-bottom: 8px;
+}
+
+/* Actions */
+.actions {
+  display: flex;
+  justify-content: flex-end;
+  gap: 8px;
+  margin-top: 16px;
+  flex-wrap: wrap;
+}
+
+.primary,
+.secondary {
+  height: 34px;
+  border-radius: 9px;
+  padding: 0 14px;
+  font-size: 12.5px;
+  font-weight: 700;
+  cursor: pointer;
+  display: inline-flex;
+  align-items: center;
+  gap: 4px;
+}
+
+.primary {
+  border: 1px solid color-mix(in srgb, var(--h-accent) 75%, var(--h-line));
+  color: #ffffff;
+  background: var(--h-accent);
+}
+
+.primary:disabled {
+  opacity: 0.5;
+  cursor: not-allowed;
+}
+
+.secondary {
+  border: 1px solid var(--h-line);
+  color: var(--h-text-2);
+  background: var(--h-bg-soft);
+}
+
+.primary:hover,
+.secondary:hover {
+  filter: brightness(1.04);
+}

--- a/web/src/components/onboarding/onboarding-wizard.tsx
+++ b/web/src/components/onboarding/onboarding-wizard.tsx
@@ -1,0 +1,276 @@
+import { useEffect, useState, useCallback } from "react";
+import { useNavigate } from "react-router-dom";
+import { KeyRound, Settings2, Sparkles, CheckCircle2, AlertTriangle, XCircle, ArrowRight, ArrowLeft, ExternalLink } from "lucide-react";
+import { useModelInfo } from "@/hooks/use-config";
+import type { EnvironmentCheckResult, ConfigMigrationScanResult } from "@hermes/protocol";
+import s from "./onboarding-wizard.module.css";
+
+const SKIP_KEY = "hermes-onboarding-skipped";
+
+function getSkipState(): boolean {
+  try {
+    return localStorage.getItem(SKIP_KEY) === "true";
+  } catch {
+    return false;
+  }
+}
+
+function setSkipState() {
+  try {
+    localStorage.setItem(SKIP_KEY, "true");
+  } catch { /* ignore */ }
+}
+
+export function OnboardingWizard() {
+  const navigate = useNavigate();
+  const { data: modelInfo, isLoading: modelLoading } = useModelInfo();
+  const configured = Boolean(modelInfo?.model?.trim() && modelInfo?.provider?.trim());
+
+  const [step, setStep] = useState(0);
+  const [dismissed, setDismissed] = useState(() => getSkipState());
+
+  // Step 1 state
+  const [envCheck, setEnvCheck] = useState<EnvironmentCheckResult | null>(null);
+  const [envLoading, setEnvLoading] = useState(false);
+  const [envError, setEnvError] = useState<string | null>(null);
+
+  // Step 2 state
+  const [migrationScan, setMigrationScan] = useState<ConfigMigrationScanResult | null>(null);
+  const [migrationLoading, setMigrationLoading] = useState(false);
+  const [migrationError, setMigrationError] = useState<string | null>(null);
+
+  const hasEnvAPI = typeof window !== "undefined" && window.hermesDesktop?.environmentCheck;
+  const hasMigrationAPI = typeof window !== "undefined" && window.hermesDesktop?.scanConfigMigration;
+
+  const hasCandidates = migrationScan && migrationScan.candidates && migrationScan.candidates.length > 0;
+
+  const runEnvCheck = useCallback(async () => {
+    if (envCheck || !hasEnvAPI) return;
+    setEnvLoading(true);
+    setEnvError(null);
+    try {
+      const result = await window.hermesDesktop!.environmentCheck();
+      setEnvCheck(result);
+    } catch (e) {
+      setEnvError(e instanceof Error ? e.message : "环境检测失败");
+    } finally {
+      setEnvLoading(false);
+    }
+  }, [envCheck, hasEnvAPI]);
+
+  const runMigrationScan = useCallback(async () => {
+    if (migrationScan || !hasMigrationAPI) return;
+    setMigrationLoading(true);
+    setMigrationError(null);
+    try {
+      const result = await window.hermesDesktop!.scanConfigMigration();
+      setMigrationScan(result);
+    } catch (e) {
+      setMigrationError(e instanceof Error ? e.message : "配置扫描失败");
+    } finally {
+      setMigrationLoading(false);
+    }
+  }, [migrationScan, hasMigrationAPI]);
+
+  // Auto-run environment check on step 1
+  useEffect(() => {
+    if (step === 0) runEnvCheck();
+  }, [step, runEnvCheck]);
+
+  // Auto-run migration scan on step 2
+  useEffect(() => {
+    if (step === 1) runMigrationScan();
+  }, [step, runMigrationScan]);
+
+  // Re-check dismissed state when model becomes configured
+  useEffect(() => {
+    if (!configured) return;
+    try { localStorage.removeItem(SKIP_KEY); } catch { /* ignore */ }
+    setDismissed(false);
+  }, [configured]);
+
+  const skip = () => {
+    setSkipState();
+    setDismissed(true);
+  };
+
+  const next = () => setStep((s) => Math.min(s + 1, 3));
+  const prev = () => setStep((s) => Math.max(s - 1, 0));
+
+  const goModels = () => navigate("/models#provider-deepseek");
+  const goMigration = () => navigate("/config-migration");
+
+  const envErrors = envCheck?.items?.filter((i) => i.status === "Error" || i.status === "error") ?? [];
+  const envWarnings = envCheck?.items?.filter((i) => i.status === "Warning" || i.status === "warning") ?? [];
+  const envOk = envCheck?.items?.filter((i) => i.status === "Ok" || i.status === "ok") ?? [];
+
+  // Don't show if model is loading, already configured, or dismissed
+  if (modelLoading || configured || dismissed) return null;
+
+  return (
+    <div className={s.backdrop} role="presentation">
+      <div className={s.card} role="dialog" aria-modal="true" aria-labelledby="onboarding-title">
+        {/* Step indicators */}
+        <div className={s.steps}>
+          {["环境检测", "配置发现", "模型配置", "完成"].map((label, i) => (
+            <div key={label} className={i === step ? s.stepActive : i < step ? s.stepDone : s.stepPending}>
+              <span className={s.stepDot}>{i < step ? <CheckCircle2 size={14} /> : i + 1}</span>
+              <span className={s.stepLabel}>{label}</span>
+            </div>
+          ))}
+        </div>
+
+        {/* Step 1: Environment check */}
+        {step === 0 && (
+          <>
+            <h2 id="onboarding-title">检测本机环境</h2>
+            <p className={s.desc}>检查桌面端运行环境是否满足 Hermes Agent 的要求。</p>
+            <div className={s.content}>
+              {envLoading && <p className={s.loading}>正在检测…</p>}
+              {envError && <p className={s.error}><XCircle size={14} /> {envError}</p>}
+              {envCheck && (
+                <div className={s.results}>
+                  {envErrors.length > 0 && (
+                    <div className={s.group}>
+                      <div className={s.groupTitle}><XCircle size={14} className={s.iconErr} /> 需要修复 ({envErrors.length})</div>
+                      {envErrors.map((item) => (
+                        <div key={item.id} className={s.item}>
+                          <span>{item.label}</span>
+                          {item.recommendation && <span className={s.hint}>{item.recommendation}</span>}
+                        </div>
+                      ))}
+                    </div>
+                  )}
+                  {envWarnings.length > 0 && (
+                    <div className={s.group}>
+                      <div className={s.groupTitle}><AlertTriangle size={14} className={s.iconWarn} /> 建议检查 ({envWarnings.length})</div>
+                      {envWarnings.map((item) => (
+                        <div key={item.id} className={s.item}>
+                          <span>{item.label}</span>
+                          {item.summary && <span className={s.hint}>{item.summary}</span>}
+                        </div>
+                      ))}
+                    </div>
+                  )}
+                  {envOk.length > 0 && (
+                    <div className={s.group}>
+                      <div className={s.groupTitle}><CheckCircle2 size={14} className={s.iconOk} /> 正常 ({envOk.length})</div>
+                    </div>
+                  )}
+                </div>
+              )}
+            </div>
+            <div className={s.actions}>
+              <button type="button" className={s.secondary} onClick={skip}>跳过设置</button>
+              <button type="button" className={s.primary} onClick={next} disabled={envLoading}>
+                下一步 <ArrowRight size={14} />
+              </button>
+            </div>
+          </>
+        )}
+
+        {/* Step 2: Config discovery */}
+        {step === 1 && (
+          <>
+            <h2>发现已有配置</h2>
+            <p className={s.desc}>检测到本机已安装 Hermes，可一键迁移配置到桌面端。</p>
+            <div className={s.content}>
+              {migrationLoading && <p className={s.loading}>正在扫描…</p>}
+              {migrationError && <p className={s.error}><XCircle size={14} /> {migrationError}</p>}
+              {migrationScan && !hasCandidates && (
+                <div className={s.empty}>
+                  <CheckCircle2 size={20} className={s.iconOk} />
+                  <p>未发现已有 Hermes 配置，可以全新开始。</p>
+                </div>
+              )}
+              {hasCandidates && (
+                <div className={s.results}>
+                  <p className={s.info}>桌面端使用<strong>独立的 hermes-home</strong>，与现有 CLI / 终端版并存、不冲突。</p>
+                  {migrationScan.candidates.map((c, i) => (
+                    <div key={c.id || i} className={s.candidate}>
+                      <div className={s.candidatePath}>{c.path}</div>
+                      <div className={s.tags}>
+                        {c.hasConfig && <span className={s.tag}>config.yaml</span>}
+                        {c.hasEnv && <span className={s.tag}>.env</span>}
+                        {c.hasAuth && <span className={s.tag}>auth</span>}
+                        {c.hasSkills && <span className={s.tag}>skills</span>}
+                        {c.hasMemories && <span className={s.tag}>memories</span>}
+                      </div>
+                    </div>
+                  ))}
+                  {migrationScan.warnings?.map((w, i) => (
+                    <p key={i} className={s.warn}><AlertTriangle size={12} /> {w}</p>
+                  ))}
+                </div>
+              )}
+            </div>
+            <div className={s.actions}>
+              <button type="button" className={s.secondary} onClick={prev}><ArrowLeft size={14} /> 上一步</button>
+              <button type="button" className={s.secondary} onClick={skip}>跳过设置</button>
+              {hasCandidates ? (
+                <button type="button" className={s.primary} onClick={goMigration}>
+                  迁移已有配置 <ExternalLink size={13} />
+                </button>
+              ) : (
+                <button type="button" className={s.primary} onClick={next}>
+                  全新开始 <ArrowRight size={14} />
+                </button>
+              )}
+            </div>
+          </>
+        )}
+
+        {/* Step 3: Model config */}
+        {step === 2 && (
+          <>
+            <div className={s.iconWrap} aria-hidden="true"><Sparkles size={22} /></div>
+            <h2>配置模型 API Key</h2>
+            <p className={s.desc}>
+              请进入模型页选择服务商，粘贴 API Key，保存后设为当前模型。
+            </p>
+            <div className={s.stepsList}>
+              <span><KeyRound size={13} /> 填写 API Key</span>
+              <span><Settings2 size={13} /> 保存配置</span>
+              <span><Sparkles size={13} /> 设为当前模型</span>
+            </div>
+            <div className={s.actions}>
+              <button type="button" className={s.secondary} onClick={prev}><ArrowLeft size={14} /> 上一步</button>
+              <button type="button" className={s.secondary} onClick={skip}>稍后再说</button>
+              <button type="button" className={s.primary} onClick={goModels} autoFocus>进入模型页</button>
+            </div>
+          </>
+        )}
+
+        {/* Step 4: Summary */}
+        {step === 3 && (
+          <>
+            <div className={s.iconWrap} aria-hidden="true"><CheckCircle2 size={22} /></div>
+            <h2>设置完成</h2>
+            <p className={s.desc}>
+              环境检测通过，模型已就绪。可以开始使用 Hermes Agent 了。
+            </p>
+            {envCheck && (
+              <div className={s.summary}>
+                <div className={s.summaryRow}>
+                  <span>环境检测</span>
+                  <span className={envErrors.length > 0 ? s.badgeWarn : s.badgeOk}>
+                    {envErrors.length > 0 ? `${envErrors.length} 项需修复` : "通过"}
+                  </span>
+                </div>
+                {modelInfo?.model && (
+                  <div className={s.summaryRow}>
+                    <span>当前模型</span>
+                    <span className={s.badgeOk}>{modelInfo.model}</span>
+                  </div>
+                )}
+              </div>
+            )}
+            <div className={s.actions}>
+              <button type="button" className={s.primary} onClick={skip} autoFocus>开始使用</button>
+            </div>
+          </>
+        )}
+      </div>
+    </div>
+  );
+}

--- a/web/src/lib/tauri-bridge.ts
+++ b/web/src/lib/tauri-bridge.ts
@@ -377,6 +377,14 @@ const tauriBridge = {
 // because the bridge isn't ready (no apiBaseUrl => API calls would
 // throw). Phase strings match the `runtime-status` event emitted by
 // src/main.rs::emit_runtime_status.
+
+/** Map bootstrap phase to a user-facing subtitle (replaces hardcoded "首次启动"). */
+const BOOTSTRAP_PHASE_SUBTITLE: Record<string, string> = {
+  installing: "正在完成首次环境准备…",
+  "checking-env": "正在检查本机环境…",
+  "starting-dashboard": "正在启动 Agent 内核…",
+  error: "启动失败",
+};
 function showBootstrapOverlay(initialMessage: string): {
   update(phase: string, message: string): void;
   dismiss(): void;
@@ -516,7 +524,7 @@ function showBootstrapOverlay(initialMessage: string): {
     "font-family:'JetBrains Mono',ui-monospace,monospace;font-size:11px;" +
       "color:rgba(255,255,255,0.45);letter-spacing:0.06em;text-transform:uppercase;",
   );
-  sub.textContent = "Hermes Agent 中文社区桌面版 · 首次启动";
+  sub.textContent = "正在启动…";
   panel.appendChild(sub);
 
   root.appendChild(panel);
@@ -550,6 +558,14 @@ function showBootstrapOverlay(initialMessage: string): {
 
   return {
     update(phase, msg) {
+      // Update subtitle based on phase
+      if (phase && phase in BOOTSTRAP_PHASE_SUBTITLE) {
+        sub.textContent = BOOTSTRAP_PHASE_SUBTITLE[phase];
+      } else if (msg && msg.includes("更新")) {
+        sub.textContent = "正在更新 Agent 内核…";
+      } else if (msg && msg.includes("安装")) {
+        sub.textContent = "正在完成首次环境准备…";
+      }
       if (phase === "error") {
         lastErrorMessage = msg || "未知启动错误";
         root.setAttribute("role", "alert");
@@ -558,7 +574,7 @@ function showBootstrapOverlay(initialMessage: string): {
         errorText.textContent = lastErrorMessage;
         detail.style.display = "block";
         copyButton.disabled = false;
-        sub.textContent = "首次启动失败";
+        sub.textContent = "启动失败";
       } else if (msg) {
         message.textContent = msg;
       }


### PR DESCRIPTION
## Summary

Closes #220

## Problem

启动屏文案始终显示"首次启动"，无论首启还是日常重启都相同（`web/src/lib/tauri-bridge.ts`）。新手引导只有单步 API Key 配置，缺少环境检测、已有 Hermes 配置发现、配置迁移入口。skip 状态仅内存级，重启后失效。

## Solution

**1. Bootstrap overlay — dynamic subtitle**

- 移除硬编码的 "首次启动"，改为根据 `runtime-status` event phase 动态展示
- `installing` → "正在完成首次环境准备…"
- `checking-env` → "正在检查本机环境…"
- `starting-dashboard` → "正在启动 Agent 内核…"
- `error` → "启动失败"（原为"首次启动失败"）

**2. Multi-step onboarding wizard**

新增 `OnboardingWizard` 组件，替换原有单步 `ModelOnboardingGuard`：

| 步骤 | 内容 | 技术 |
|------|------|------|
| Step 1 | 环境检测 | 调用已有 `environmentCheck()`，展示 Error/Warning/Ok |
| Step 2 | 配置发现 | 调用已有 `scanConfigMigration()`，展示候选配置 + 独立 hermes-home 说明 |
| Step 3 | 模型配置 | 保留现有 API Key 流程 + 本地 provider 入口 |
| Step 4 | 完成摘要 | 展示环境状态和当前模型 |

**3. Skip persistence**

skip 状态从 `dismissedForWindow`（内存级）改为 `localStorage` 持久化，重启后不再重复弹窗。

## Test Plan

- [ ] Fresh install: bootstrap overlay shows "正在完成首次环境准备…"
- [ ] Normal restart: bootstrap overlay shows "正在启动…"
- [ ] Runtime update: subtitle shows appropriate message
- [ ] No model configured: 4-step wizard appears
- [ ] Click "跳过设置": wizard dismissed, persists across restart
- [ ] Step 2 shows candidates if ~/.hermes exists
- [ ] "迁移已有配置" button navigates to /config-migration

## Notes

### Files Changed

- `web/src/lib/tauri-bridge.ts` — phase-based subtitle + error "启动失败"
- `web/src/components/onboarding/onboarding-wizard.tsx` — new: 4-step wizard
- `web/src/components/onboarding/onboarding-wizard.module.css` — new: wizard styles
- `web/src/components/app-shell/model-onboarding-guard.tsx` — thin shell wrapping wizard

### Backward Compatibility

- Existing bootstrap overlay behavior unchanged — only the subtitle text is dynamic
- Existing model-onboarding-guard still renders, now delegates to OnboardingWizard
- No model configured check unchanged — guard still skips when model is ready