### PR TITLE
feat: bind workspace to session with lock/unlock support (closes #216)

### DIFF
--- a/web/src/components/app-shell/workbench-sidebar.tsx
+++ b/web/src/components/app-shell/workbench-sidebar.tsx
@@ -38,6 +38,7 @@ import {
   readPinnedWorkspaceProjectPaths,
   readSessionWorkspaceMap,
   readWorkspaceProjects,
+  restoreWorkspaceForSession,
   subscribeWorkspaceChanges,
   unpinWorkspaceProjects,
   workspaceNameFromPath,
@@ -274,6 +275,7 @@ export function WorkbenchSidebar() {
 
   const goSession = (sess: SessionSummary) => {
     setActiveId(sess.id);
+    restoreWorkspaceForSession(sess.id);
     navigate(`/tasks/${sess.id}`);
   };
 

--- a/web/src/lib/workspaces.ts
+++ b/web/src/lib/workspaces.ts
@@ -12,6 +12,7 @@ export const WORKSPACE_STORAGE_KEY = "hermes-cn-ui.workspacePath";
 const WORKSPACE_PROJECTS_STORAGE_KEY = "hermes-cn-ui.workspaceProjects";
 const SESSION_WORKSPACE_STORAGE_KEY = "hermes-cn-ui.sessionWorkspaces";
 const PINNED_WORKSPACE_PROJECTS_STORAGE_KEY = "hermes-cn-ui.pinnedWorkspaceProjects";
+const WORKSPACE_LOCK_STORAGE_KEY = "hermes-cn-ui.workspaceLock";
 const WORKSPACE_CHANGED_EVENT = "hermes-cn-ui.workspaces.changed";
 
 export function normalizeWorkspacePath(path: unknown): string {
@@ -273,4 +274,93 @@ export function subscribeWorkspaceChanges(listener: () => void): () => void {
     window.removeEventListener(WORKSPACE_CHANGED_EVENT, listener);
     unsubscribe();
   };
+}
+
+/**
+ * Workspace Lock Feature
+ *
+ * When workspace lock is enabled, the workspace will not automatically switch
+ * when changing sessions. This is useful when the user wants to keep the same
+ * workspace across multiple sessions.
+ */
+
+export interface WorkspaceLockState {
+  enabled: boolean;
+  lockedPath: string | null;
+}
+
+export function readWorkspaceLock(): WorkspaceLockState {
+  const raw = readJSON<unknown>(WORKSPACE_LOCK_STORAGE_KEY, { enabled: false, lockedPath: null });
+  if (!isRecord(raw)) return { enabled: false, lockedPath: null };
+  return {
+    enabled: raw.enabled === true,
+    lockedPath: typeof raw.lockedPath === "string" ? raw.lockedPath : null,
+  };
+}
+
+export function writeWorkspaceLock(state: WorkspaceLockState): void {
+  writeJSON(WORKSPACE_LOCK_STORAGE_KEY, state);
+}
+
+export function isWorkspaceLocked(): boolean {
+  return readWorkspaceLock().enabled;
+}
+
+export function toggleWorkspaceLock(): WorkspaceLockState {
+  const current = readWorkspaceLock();
+  const currentPath = readWorkspacePath();
+  const newState: WorkspaceLockState = {
+    enabled: !current.enabled,
+    lockedPath: !current.enabled ? currentPath : null,
+  };
+  writeWorkspaceLock(newState);
+  return newState;
+}
+
+export function lockWorkspaceToCurrent(): WorkspaceLockState {
+  const currentPath = readWorkspacePath();
+  const state: WorkspaceLockState = { enabled: true, lockedPath: currentPath };
+  writeWorkspaceLock(state);
+  return state;
+}
+
+export function unlockWorkspace(): WorkspaceLockState {
+  const state: WorkspaceLockState = { enabled: false, lockedPath: null };
+  writeWorkspaceLock(state);
+  return state;
+}
+
+/**
+ * Get the workspace path for a specific session.
+ * Returns null if no workspace is associated with the session.
+ */
+export function getWorkspaceForSession(sessionId: string | null | undefined): string | null {
+  const normalizedSessionId = sessionId?.trim();
+  if (!normalizedSessionId) return null;
+  const map = readSessionWorkspaceMap();
+  return normalizeWorkspacePath(map[normalizedSessionId]) || null;
+}
+
+/**
+ * Restore workspace for a session when switching to it.
+ * Returns the workspace path that should be set, or null if no change needed.
+ */
+export function restoreWorkspaceForSession(sessionId: string | null | undefined): string | null {
+  const normalizedSessionId = sessionId?.trim();
+  if (!normalizedSessionId) return null;
+
+  const lockState = readWorkspaceLock();
+  if (lockState.enabled) {
+    return null;
+  }
+
+  const sessionWorkspace = getWorkspaceForSession(normalizedSessionId);
+  const currentWorkspace = readWorkspacePath();
+
+  if (sessionWorkspace && sessionWorkspace !== currentWorkspace) {
+    writeWorkspacePath(sessionWorkspace);
+    return sessionWorkspace;
+  }
+
+  return null;
 }

--- a/web/src/routes/detail.tsx
+++ b/web/src/routes/detail.tsx
@@ -1,7 +1,7 @@
 import { useEffect, useMemo, useCallback, useRef, useState, type CSSProperties } from "react";
 import { useAtom, useAtomValue, useSetAtom } from "jotai";
 import { useNavigate, useParams, useSearchParams } from "react-router-dom";
-import { Bot, Check, Copy, PanelRight } from "lucide-react";
+import { Bot, Check, Copy, Lock, PanelRight, Unlock } from "lucide-react";
 import {
   activeSessionIdAtom,
   assistantDisplayNameAtom,
@@ -49,9 +49,14 @@ import {
 import { uploadAttachmentFile } from "@/lib/transport";
 import { voiceAutoTtsFromConfig } from "@/lib/voice";
 import {
+  readWorkspacePath,
   rememberSessionWorkspace,
   rememberWorkspaceProject,
   resolveSessionWorkspace,
+  isWorkspaceLocked,
+  toggleWorkspaceLock,
+  subscribeWorkspaceChanges,
+  restoreWorkspaceForSession,
 } from "@/lib/workspaces";
 import { TopBar, TopBarActionButton, TopBarActions } from "@/components/top-bar/top-bar";
 import { GooseComposer } from "@/components/chat/goose-composer";
@@ -130,6 +135,7 @@ export function DetailRoute() {
   const [reasoningEffortOverride, setReasoningEffortOverride] = useState<ReasoningEffort | null>(null);
   const [sessionIdCopyState, setSessionIdCopyState] = useState<"idle" | "copied" | "error">("idle");
   const [sessionTitleOverrides, setSessionTitleOverrides] = useState(readSessionTitleOverrides);
+  const [workspaceLocked, setWorkspaceLocked] = useState(isWorkspaceLocked());
   const sessionIdCopyTimer = useRef<number | null>(null);
   const recoverCompletedTurnFromStoredMessages = useSetAtom(recoverCompletedTurnFromStoredMessagesAtom);
   const appendNotice = useSetAtom(appendNoticeAtom);
@@ -235,9 +241,24 @@ export function DetailRoute() {
     setSessionUsage(null);
   }, [setSessionUsage, taskId]);
 
+  // Restore workspace when switching sessions (e.g., via URL deep link or browser back/forward).
+  // This complements the sidebar's goSession() handler to ensure workspace is restored
+  // regardless of how the navigation happens.
+  useEffect(() => {
+    if (taskId) {
+      restoreWorkspaceForSession(taskId);
+    }
+  }, [taskId]);
+
   useEffect(() => {
     return subscribeSessionUiStateChanges(() => {
       setSessionTitleOverrides(readSessionTitleOverrides());
+    });
+  }, []);
+
+  useEffect(() => {
+    return subscribeWorkspaceChanges(() => {
+      setWorkspaceLocked(isWorkspaceLocked());
     });
   }, []);
 
@@ -513,6 +534,11 @@ export function DetailRoute() {
     }
   }, [ensureGatewaySession, setSessionReasoningEffort]);
 
+  const toggleWorkspaceLockState = useCallback(() => {
+    const newState = toggleWorkspaceLock();
+    setWorkspaceLocked(newState.enabled);
+  }, []);
+
   const onStop = useCallback(async () => {
     const sessionId = runtimeSessionId ?? taskId;
     if (!sessionId || !runtimeIsBusy) return;
@@ -622,6 +648,20 @@ export function DetailRoute() {
               </TopBarActionButton>
             ) : null}
             <TopBarActionButton
+            <TopBarActionButton
+              onClick={toggleWorkspaceLockState}
+              title={workspaceLocked ? "工作区已锁定：切换会话时保持当前工作区" : "工作区未锁定：切换会话时自动恢复该会话的工作区"}
+              aria-label={workspaceLocked ? "解锁工作区" : "锁定工作区"}
+              data-active={workspaceLocked ? "true" : undefined}
+            >
+              {workspaceLocked ? (
+                <Lock size={12} aria-hidden="true" />
+              ) : (
+                <Unlock size={12} aria-hidden="true" />
+              )}
+              <span>{workspaceLocked ? "工作区已锁定" : "工作区跟随会话"}</span>
+            </TopBarActionButton>
+            <TopBarActionButton
               onClick={() => setSubagentPanelOpen((v) => !v)}
               data-active={subagentPanelOpen ? "true" : undefined}
               title="子代理监视"
@@ -645,6 +685,7 @@ export function DetailRoute() {
             >
               <PanelRight size={12} aria-hidden="true" />
               <span>预览</span>
+            </TopBarActionButton>
             </TopBarActionButton>
             <TopBarActions />
           </>


### PR DESCRIPTION
## Summary

Closes #216

Implement hybrid workspace management that binds each session to its own workspace while supporting manual lock/unlock functionality.

## Changes

- Add workspace lock state management (workspaces.ts)
  - isWorkspaceLocked(), toggleWorkspaceLock(), lockWorkspaceToCurrent()
  - WorkspaceLockState interface for persistence
- Add session workspace restoration (workspaces.ts)
  - getWorkspaceForSession(): retrieve workspace for a specific session
  - restoreWorkspaceForSession(): restore workspace when switching sessions
  - Skip restoration when workspace is locked
- Auto-restore workspace on session switch (workbench-sidebar.tsx)
  - Call restoreWorkspaceForSession() in goSession() handler
  - Works for all session types (active, pinned, recent)
- Add workspace lock UI (detail.tsx)
  - Lock/Unlock button in TopBar with visual indicator
  - Shows current state (locked vs following session)
  - Tooltip explains behavior

This implements the '方案 C: Hybrid' approach where:
1. Each session remembers its associated workspace
2. Switching sessions automatically restores that session's workspace
3. Users can lock the workspace to keep it fixed across sessions
4. Locked state persists across app restarts