### PR TITLE
fix: run desktop_notify off the main thread and harden truncation

### DIFF
--- a/src/commands/notify.rs
+++ b/src/commands/notify.rs
@@ -112,8 +112,11 @@ fn system_sound_name() -> &'static str {
     }
 }
 
+// async + spawn_blocking：同步 command 在主线程上执行，而 `builder.show()`
+// 是阻塞的系统调用（Linux 上经 zbus 走同步 D-Bus 往返），通知系统卡顿时会
+// 冻结整个 UI；挪到阻塞线程池后主线程和 async runtime 都不受影响。
 #[tauri::command]
-pub fn desktop_notify(
+pub async fn desktop_notify(
     app: AppHandle,
     input: DesktopNotifyInput,
 ) -> Result<DesktopNotifyResult, AppError> {
@@ -127,6 +130,18 @@ pub fn desktop_notify(
     }
     let body = sanitize_text(&input.body, MAX_BODY_CHARS);
 
+    tauri::async_runtime::spawn_blocking(move || notify_blocking(&app, kind, &title, &body, &input))
+        .await
+        .map_err(|e| AppError::Internal(format!("desktop_notify task failed: {e}")))
+}
+
+fn notify_blocking(
+    app: &AppHandle,
+    kind: NotifyKind,
+    title: &str,
+    body: &str,
+    input: &DesktopNotifyInput,
+) -> DesktopNotifyResult {
     let window = app.get_webview_window(MAIN_WINDOW_LABEL);
     let foreground = window
         .as_ref()
@@ -144,18 +159,18 @@ pub fn desktop_notify(
         .unwrap_or(false);
 
     if should_suppress(input.respect_focus, foreground) {
-        return Ok(DesktopNotifyResult {
+        return DesktopNotifyResult {
             delivered: false,
             focused: foreground,
             attention_requested: false,
             error: None,
-        });
+        };
     }
 
     let mut delivered = false;
     let mut error = None;
     if input.show_system_notification {
-        let mut builder = app.notification().builder().title(&title).body(&body);
+        let mut builder = app.notification().builder().title(title).body(body);
         if input.with_sound {
             builder = builder.sound(system_sound_name());
         }
@@ -178,12 +193,12 @@ pub fn desktop_notify(
         }
     }
 
-    Ok(DesktopNotifyResult {
+    DesktopNotifyResult {
         delivered,
         focused: foreground,
         attention_requested,
         error,
-    })
+    }
 }
 
 #[cfg(test)]

--- a/web/src/lib/notifications.test.ts
+++ b/web/src/lib/notifications.test.ts
@@ -179,6 +179,21 @@ describe("decideNotification — approval.request", () => {
     expect(action?.body.length).toBeLessThanOrEqual(120);
     expect(action?.body.endsWith("…")).toBe(true);
   });
+
+  it("does not split surrogate pairs when truncating", async () => {
+    const { decideNotification } = await loadNotifications();
+    const action = decideNotification({
+      event: approvalEvent({ request_id: "r1", command: "🚀".repeat(200) }),
+      prevRuntime: runtimeWith(),
+      settings: settings(),
+      alreadyNotified: never,
+    });
+    const body = action?.body ?? "";
+    expect(body.endsWith("…")).toBe(true);
+    expect(Array.from(body).length).toBeLessThanOrEqual(120);
+    // 截断点不能落在代理对中间产生孤立代理字符。
+    expect(body).toMatch(/^(?:🚀)+…$/u);
+  });
 });
 
 describe("decideNotification — message.complete", () => {

--- a/web/src/lib/notifications.ts
+++ b/web/src/lib/notifications.ts
@@ -30,7 +30,10 @@ const MAX_DEDUPE_KEYS = 500;
 function truncate(text: string, max: number): string {
   const trimmed = text.replace(/\s+/g, " ").trim();
   if (trimmed.length <= max) return trimmed;
-  return `${trimmed.slice(0, Math.max(0, max - 1))}…`;
+  // 按码点切，`slice` 按 UTF-16 截断会把 emoji 的代理对劈成孤立代理字符。
+  const chars = Array.from(trimmed);
+  if (chars.length <= max) return trimmed;
+  return `${chars.slice(0, Math.max(0, max - 1)).join("")}…`;
 }
 
 function payloadOf(event: GatewayEvent): Record<string, any> {

--- a/web/src/stores/chat.ts
+++ b/web/src/stores/chat.ts
@@ -1113,15 +1113,16 @@ function persistCompletedTurnStats(runtime: ChatSessionRuntime, event: GatewayEv
   });
 }
 
-export const applyGatewayEventAtom = atom(null, (_get, set, event: GatewayEvent) => {
+export const applyGatewayEventAtom = atom(null, (get, set, event: GatewayEvent) => {
   if (!event.session_id) return;
+  // 通知决策需要 reduce 前的快照（pendingApprovals / activeAssistantId 是
+  // 防重放依据），在 set 之外读取——jotai 不承诺 updater 恰好执行一次。
+  // 副作用本身 fire-and-forget，绝不影响 reducer。
+  try {
+    notifyFromGatewayEvent(event, get(chatRuntimeBySessionAtom)[event.session_id]);
+  } catch {}
   set(chatRuntimeBySessionAtom, (state) =>
     updateSessionRuntime(state, event.session_id!, (runtime) => {
-      // 通知决策需要 reduce 前的快照（pendingApprovals / activeAssistantId
-      // 是防重放依据），副作用本身 fire-and-forget，绝不影响 reducer。
-      try {
-        notifyFromGatewayEvent(event, runtime);
-      } catch {}
       const next = reduceGatewayEvent(runtime, event);
       persistCompletedTurnStats(next, event);
       return next;


### PR DESCRIPTION
## 背景

#215 合并后的三处后续修复(代码审查发现)。

## 改动

- **`desktop_notify` 改为 async + `spawn_blocking`**:同步 `#[tauri::command]` 在主线程执行,而 `builder.show()` 是阻塞系统调用(Linux 上经 zbus 走同步 D-Bus 往返),通知系统卡顿时会冻结整个 UI。挪到阻塞线程池后主线程与 async runtime 都不受影响。
- **通知决策移出 jotai updater**:jotai 不承诺 updater 恰好执行一次,改在 `set` 之外读取 reduce 前快照,`updateSessionRuntime` 的 updater 恢复纯函数(去重键此前只是兜底)。
- **前端 `truncate` 按码点截断**:`slice` 按 UTF-16 截断会把 emoji 的代理对劈成孤立代理字符(Rust 侧按 char 截断无此问题),新增回归测试覆盖。

## 测试

- ✅ `cargo fmt` / `clippy -D warnings` / `cargo test`(263 通过)
- ✅ `pnpm typecheck` + vitest 578 通过(含新增代理对截断测试)

🤖 Generated with [Claude Code](https://claude.com/claude-code)