### PR TITLE
fix: restore per-session workspace when switching sessions (#216)

### DIFF
--- a/packages/protocol/src/hermes-api.test.ts
+++ b/packages/protocol/src/hermes-api.test.ts
@@ -1,5 +1,13 @@
 import { describe, expect, it } from "vitest";
-import { AnalyticsResponse, CronJob, CronJobsResponse, CronRunDetail, CronRunsResponse } from "./hermes-api";
+import {
+  AnalyticsResponse,
+  CronJob,
+  CronJobsResponse,
+  CronRunDetail,
+  CronRunsResponse,
+  SessionsResponse,
+  SessionSummary,
+} from "./hermes-api";
 
 describe("CronJobsResponse", () => {
   it("parses current dashboard cron jobs with structured schedules", () => {
@@ -207,5 +215,44 @@ describe("AnalyticsResponse", () => {
         },
       }),
     ).toThrow();
+  });
+});
+
+describe("SessionSummary cwd (#216)", () => {
+  const baseSession = {
+    id: "20260613_000000_abcd",
+    model: "claude-opus-4-8",
+    title: "Demo",
+    started_at: 1,
+    ended_at: null,
+    message_count: 2,
+    input_tokens: 10,
+    output_tokens: 20,
+    estimated_cost_usd: null,
+  };
+
+  it("carries the backend per-session cwd", () => {
+    const parsed = SessionSummary.parse({ ...baseSession, cwd: "/Users/claw/project-a" });
+    expect(parsed.cwd).toBe("/Users/claw/project-a");
+  });
+
+  it("accepts a null cwd for sessions with no explicit workspace", () => {
+    const parsed = SessionSummary.parse({ ...baseSession, cwd: null });
+    expect(parsed.cwd).toBeNull();
+  });
+
+  it("treats cwd as optional for older payloads", () => {
+    const parsed = SessionSummary.parse(baseSession);
+    expect(parsed.cwd).toBeUndefined();
+  });
+
+  it("preserves cwd through the /api/sessions list response", () => {
+    const parsed = SessionsResponse.parse({
+      sessions: [{ ...baseSession, cwd: "/Users/claw/project-b" }],
+      total: 1,
+      limit: 50,
+      offset: 0,
+    });
+    expect(parsed.sessions[0]?.cwd).toBe("/Users/claw/project-b");
   });
 });

--- a/packages/protocol/src/hermes-api.ts
+++ b/packages/protocol/src/hermes-api.ts
@@ -112,6 +112,10 @@ export const SessionSummary = z.object({
   model: NullableStringAsEmpty,
   title: z.string().nullable(),
   preview: z.string().optional(),
+  // Backend-stored working directory for the session (sessions.cwd). Null when
+  // the user never explicitly picked a workspace ("No workspace"). Used to
+  // restore the per-session workspace when switching sessions (see #216).
+  cwd: z.string().nullable().optional(),
   started_at: z.number(),
   ended_at: z.number().nullable(),
   end_reason: z.string().nullable().optional(),

--- a/web/src/lib/workspaces.test.ts
+++ b/web/src/lib/workspaces.test.ts
@@ -8,6 +8,7 @@ import {
   rememberSessionWorkspace,
   rememberWorkspaceProject,
   removeWorkspaceProject,
+  resolveSessionWorkspace,
   togglePinnedWorkspaceProject,
   unpinWorkspaceProjects,
   writePinnedWorkspaceProjectPaths,
@@ -54,6 +55,44 @@ describe("workspace persistence helpers", () => {
     expect(readSessionWorkspaceMap()).toEqual({
       "session-2": "/Users/claw/Project",
     });
+  });
+
+  it("resolveSessionWorkspace prefers the backend cwd over the client map", () => {
+    __resetUiStoreForTests({
+      "hermes-cn-ui.sessionWorkspaces": { "sess-1": "/Users/claw/from-map" },
+    });
+
+    // Backend cwd wins, and is normalized (trailing slash stripped).
+    expect(resolveSessionWorkspace("/Users/claw/from-backend/", ["sess-1"])).toBe(
+      "/Users/claw/from-backend",
+    );
+  });
+
+  it("resolveSessionWorkspace falls back to the client map when backend cwd is blank", () => {
+    __resetUiStoreForTests({
+      "hermes-cn-ui.sessionWorkspaces": { "sess-1": "/Users/claw/from-map" },
+    });
+
+    expect(resolveSessionWorkspace(null, ["sess-1"])).toBe("/Users/claw/from-map");
+    expect(resolveSessionWorkspace(undefined, ["sess-1"])).toBe("/Users/claw/from-map");
+    expect(resolveSessionWorkspace("   ", ["sess-1"])).toBe("/Users/claw/from-map");
+  });
+
+  it("resolveSessionWorkspace checks each provided id in order and skips blanks", () => {
+    __resetUiStoreForTests({
+      "hermes-cn-ui.sessionWorkspaces": { "persistent-id": "/Users/claw/proj" },
+    });
+
+    expect(
+      resolveSessionWorkspace(null, [null, "  ", "gateway-id", "persistent-id"]),
+    ).toBe("/Users/claw/proj");
+  });
+
+  it("resolveSessionWorkspace returns empty string when no workspace is known", () => {
+    __resetUiStoreForTests();
+
+    expect(resolveSessionWorkspace(null, ["unknown", null])).toBe("");
+    expect(resolveSessionWorkspace("", [])).toBe("");
   });
 
   it("stores workspace projects without duplicating equivalent paths", () => {

--- a/web/src/lib/workspaces.ts
+++ b/web/src/lib/workspaces.ts
@@ -215,6 +215,36 @@ export function rememberSessionWorkspace(sessionId: string | null | undefined, p
   rememberWorkspaceProject(normalizedPath);
 }
 
+/**
+ * Resolve the workspace that should be shown for a session.
+ *
+ * Precedence:
+ *   1. The backend's stored `cwd` for the session (source of truth — survives
+ *      across devices, storage clears, and sessions created before this build).
+ *   2. The client-side session→workspace map, keyed by any of the session's ids
+ *      (gateway / persistent), for sessions the backend has no explicit cwd for
+ *      (legacy sessions, or ones where the user never picked a folder).
+ *
+ * Returns "" when no workspace is known for the session, so the caller can fall
+ * back to its own default (e.g. the last-used global workspace).
+ */
+export function resolveSessionWorkspace(
+  backendCwd: string | null | undefined,
+  sessionIds: Array<string | null | undefined>,
+): string {
+  const fromBackend = normalizeWorkspacePath(backendCwd);
+  if (fromBackend) return fromBackend;
+
+  const map = readSessionWorkspaceMap();
+  for (const sessionId of sessionIds) {
+    const key = sessionId?.trim();
+    if (!key) continue;
+    const fromMap = normalizeWorkspacePath(map[key]);
+    if (fromMap) return fromMap;
+  }
+  return "";
+}
+
 export function mirrorSessionWorkspaceMapping(
   gatewaySessionId: string | null | undefined,
   persistentSessionId: string | null | undefined,

--- a/web/src/routes/detail.tsx
+++ b/web/src/routes/detail.tsx
@@ -37,7 +37,11 @@ import {
   subscribeSessionUiStateChanges,
 } from "@/lib/session-ui-state";
 import { uploadAttachmentFile } from "@/lib/transport";
-import { rememberSessionWorkspace, rememberWorkspaceProject } from "@/lib/workspaces";
+import {
+  rememberSessionWorkspace,
+  rememberWorkspaceProject,
+  resolveSessionWorkspace,
+} from "@/lib/workspaces";
 import { TopBar, TopBarActionButton, TopBarActions } from "@/components/top-bar/top-bar";
 import { GooseComposer } from "@/components/chat/goose-composer";
 import type {
@@ -112,6 +116,14 @@ export function DetailRoute() {
     (item) => item.id === restSessionId || item.id === taskId,
   );
   const copyableSessionId = sessionData?.id ?? sessionSummary?.id ?? restSessionId ?? taskId ?? "";
+
+  // Workspace bound to *this* session (#216): prefer the backend's stored cwd
+  // (source of truth), then the client-side session→workspace map. Empty string
+  // lets the composer fall back to its own default (last-used global workspace).
+  const sessionWorkspace = useMemo(
+    () => resolveSessionWorkspace(sessionData?.cwd ?? sessionSummary?.cwd, [restSessionId, taskId]),
+    [sessionData?.cwd, sessionSummary?.cwd, restSessionId, taskId],
+  );
 
   // Sync URL → atom on mount and whenever URL changes (browser back/forward
   // or a deep-link entry). Sidebar / history clicks already update the atom
@@ -402,6 +414,8 @@ export function DetailRoute() {
       />
       <div className={s.composerArea}>
         <GooseComposer
+          key={taskId}
+          initialWorkspacePath={sessionWorkspace}
           onSend={onSend}
           loadingPlaceholder={composerLoadingPlaceholder}
           showMeta={false}


### PR DESCRIPTION
## 背景 · Closes #216

切换到历史会话时，工作区显示的是「上次新建对话所选的目录」，而不是该会话自己的目录。用户预期工作区应与每个会话绑定。

## 根因

- `detail.tsx` 渲染 `GooseComposer` 时**未传 `initialWorkspacePath`**，组件只能回退到全局「上次选择的工作区」这一个值（`goose-composer.tsx` 的 `readWorkspacePath()`）。
- 仓库里已有的 `session→workspace` 客户端映射只被用于侧栏/项目分组的**显示标签**，从未用于切会话时回填工作区。
- 注：这是**显示层** bug —— `prompt.submit` 不携带 cwd，后端始终在会话存储的目录里执行；界面显示错，但命令实际跑的目录是对的。

## 关键发现：后端早已支持，无需改动

Hermes-CN-Core 把工作区作为每会话的持久属性 `sessions.cwd`：创建时绑定、`session.resume` 时从 SQLite 还原、并通过 REST `GET /api/sessions` 与 `/api/sessions/{id}` 返回。前端却因 `SessionSummary` 是严格 schema（无 `cwd`、无 `.passthrough()`）把它丢弃了。因此本 PR 以**后端 cwd 为唯一可信源**，纯前端改动即可修复。

## 改动

- **protocol**：`SessionSummary` 增加 `cwd`，让后端早已下发的 per-session cwd 带类型地流通到列表与详情。
- **workspaces**：新增纯函数 `resolveSessionWorkspace(backendCwd, sessionIds)` —— 优先后端 cwd，其次客户端映射（alias-aware，兼容 gateway/persistent 双 id），再无则空串。
- **detail**：解析出本会话工作区并传 `initialWorkspacePath` + `key={taskId}` 给 composer。

> composer 不订阅全局工作区变化、也不在 key 之外重挂；只写全局值无法刷新 chip —— 这正是为何「仅写全局值」的改法在应用内切会话时会失效。`key={taskId}` 与上方 `MessageTimeline` 同构，并顺带修掉切会话时草稿串台的旧问题。

## 行为 & 边界

- 显式选过工作区的会话：从后端精确恢复（跨设备 / 清缓存 / 历史老会话均可）。
- 从未显式选工作区的会话（后端 `cwd=NULL`）：回退客户端映射，再无则沿用全局默认，不劣于现状。
- **未在本 PR 处理**（建议另开 issue）：桌面端给「已有会话」改工作区不会落库到后端（未接 `session.cwd.set`）。本 PR 只修显示，未触碰该路径。

## 与 #217 的关系

#217 同样关闭本 issue，采用纯客户端映射 + Lock/Unlock 增强。本 PR 改以**后端 cwd 为可信源**（覆盖跨设备/清缓存/老会话），并修正了 composer 不随全局值刷新这一点。二选一即可。

## 测试

- 新增单测：`resolveSessionWorkspace` 优先级 / 回退 / 多 id / 空值（`workspaces.test.ts`）；`SessionSummary.cwd` 解析与列表透传（`hermes-api.test.ts`）。
- `pnpm test:unit` → protocol 27 + web 593 = **620 全绿**
- `pnpm typecheck` → license / version / 三个 workspace 全过

🤖 Generated with [Claude Code](https://claude.com/claude-code)
