### PR TITLE
feat: add reasoning effort selector to composer toolbar

### DIFF
--- a/web/src/components/chat/composer-types.ts
+++ b/web/src/components/chat/composer-types.ts
@@ -1,4 +1,5 @@
 import type { ModelOptionsResult, SkillInfo } from "@hermes/protocol";
+import type { ReasoningEffort } from "@/lib/reasoning-effort";
 
 export type ComposerAttachmentKind = "image" | "file" | "directory";
 export type ComposerAttachmentSource = "browser" | "path" | "uploaded";
@@ -71,6 +72,13 @@ export interface ComposerSkillPickerProps {
   skills: SkillInfo[];
   loading?: boolean;
   error?: string;
+  disabled?: boolean;
+}
+
+export interface ComposerReasoningPickerProps {
+  /** 当前思考强度；null 表示配置里未显式设置（后端回落到默认档）。 */
+  value: ReasoningEffort | null;
+  onSelect: (effort: ReasoningEffort) => void | Promise<void>;
   disabled?: boolean;
 }
 

--- a/web/src/components/chat/goose-composer.tsx
+++ b/web/src/components/chat/goose-composer.tsx
@@ -39,6 +39,7 @@ import {
   type ComposerContextUsage,
   type ComposerModelPickerProps,
   type ComposerModelSelection,
+  type ComposerReasoningPickerProps,
   type ComposerSkillPickerProps,
   type ComposerSubmitControls,
   type ComposerSubmitPayload,
@@ -60,6 +61,7 @@ import {
   modelButtonText,
 } from "./goose-composer-model-picker";
 import { WorkspacePickerModal } from "@/components/composer/workspace-picker";
+import { ReasoningEffortMenu } from "@/components/composer/reasoning-effort-menu";
 import s from "./goose-composer.module.css";
 
 export interface ComposerHint {
@@ -92,6 +94,7 @@ interface GooseComposerProps {
   submitShortcut?: ComposerSubmitShortcut;
   loadingPlaceholder?: string;
   modelPicker?: ComposerModelPickerProps;
+  reasoningPicker?: ComposerReasoningPickerProps;
   skillPicker?: ComposerSkillPickerProps;
   contextUsage?: ComposerContextUsage | null;
   initialWorkspacePath?: string;
@@ -118,6 +121,7 @@ export function GooseComposer({
   hints,
   submitShortcut,
   modelPicker,
+  reasoningPicker,
   skillPicker,
   contextUsage,
   initialWorkspacePath = "",
@@ -849,6 +853,13 @@ export function GooseComposer({
                 <span>模型</span>
                 <small>{modelText}</small>
               </button>
+            ) : null}
+            {reasoningPicker ? (
+              <ReasoningEffortMenu
+                value={reasoningPicker.value}
+                onSelect={reasoningPicker.onSelect}
+                disabled={controlsDisabled || reasoningPicker.disabled}
+              />
             ) : null}
             {showMeta && (
               <>

--- a/web/src/components/composer/reasoning-effort-menu.module.css
+++ b/web/src/components/composer/reasoning-effort-menu.module.css
@@ -1,0 +1,130 @@
+/* Trigger — 与 goose-composer 的 .toolButton 视觉对齐（同高度/圆角/配色），
+   这样它在工具栏里跟「模型」按钮看起来是一套。 */
+.trigger {
+  display: inline-flex;
+  align-items: center;
+  justify-content: center;
+  flex: 0 1 auto;
+  gap: 6px;
+  height: var(--composer-tool-height, 28px);
+  padding: 0 10px;
+  min-width: 0;
+  border: 0;
+  border-radius: var(--h-r-md);
+  background: var(--h-bg-soft);
+  color: var(--h-text-2);
+  font-family: var(--h-font-cn);
+  font-size: 12px;
+  line-height: 1;
+  cursor: pointer;
+}
+
+.trigger:hover:not(:disabled),
+.trigger[data-active="true"] {
+  background: var(--h-bg-chip);
+  color: var(--h-text);
+}
+
+.trigger:disabled {
+  cursor: not-allowed;
+  color: var(--h-text-3);
+  opacity: 0.55;
+}
+
+.triggerIcon {
+  flex: 0 0 auto;
+  width: 14px;
+  height: 14px;
+}
+
+.trigger span {
+  flex: 0 0 auto;
+  overflow: hidden;
+  text-overflow: ellipsis;
+  white-space: nowrap;
+  font-weight: 500;
+  line-height: 1.4;
+}
+
+.trigger small {
+  min-width: 0;
+  overflow: hidden;
+  text-overflow: ellipsis;
+  white-space: nowrap;
+  color: inherit;
+  opacity: 0.76;
+  font-size: 11.5px;
+  line-height: 1.4;
+}
+
+/* Dropdown — 复用应用里 Popover 菜单的统一观感。 */
+.menu {
+  width: 188px;
+  padding: 4px;
+  background: var(--h-bg-pane);
+  border: 1px solid var(--h-line);
+  border-radius: var(--h-r-md);
+  box-shadow: var(--h-shadow-l);
+  font-family: var(--h-font-cn);
+}
+
+.menuTitle {
+  padding: 6px 10px 4px;
+  font-size: 9.5px;
+  text-transform: uppercase;
+  letter-spacing: 0.06em;
+  color: var(--h-text-3);
+  font-weight: 500;
+}
+
+.menuList {
+  display: flex;
+  flex-direction: column;
+}
+
+.menuItem {
+  display: flex;
+  align-items: center;
+  gap: 8px;
+  width: 100%;
+  padding: 7px 10px;
+  border: none;
+  background: transparent;
+  border-radius: var(--h-r-sm);
+  text-align: left;
+  font-family: var(--h-font-cn);
+  font-size: 12px;
+  color: var(--h-text);
+  cursor: pointer;
+}
+
+.menuItem:hover {
+  background: var(--h-line-soft);
+}
+
+.menuItem[data-active="true"] {
+  background: var(--h-bg-chip);
+}
+
+.menuItemLabel {
+  flex: 1;
+  overflow: hidden;
+  text-overflow: ellipsis;
+  white-space: nowrap;
+}
+
+.menuCheck {
+  flex: 0 0 auto;
+  width: 13px;
+  height: 13px;
+  color: var(--h-accent);
+}
+
+.menuFoot {
+  margin-top: 4px;
+  padding: 6px 10px;
+  border-top: 1px solid var(--h-line);
+  font-size: 11px;
+  line-height: 1.45;
+  color: var(--h-text-3);
+}

--- a/web/src/components/composer/reasoning-effort-menu.tsx
+++ b/web/src/components/composer/reasoning-effort-menu.tsx
@@ -1,0 +1,97 @@
+import { useState } from "react";
+import { Brain, Check } from "lucide-react";
+import { Popover } from "@hermes/shared-ui";
+import {
+  DEFAULT_REASONING_EFFORT,
+  REASONING_EFFORTS,
+  REASONING_EFFORT_LABELS,
+  REASONING_EFFORT_SHORT_LABELS,
+  type ReasoningEffort,
+} from "@/lib/reasoning-effort";
+import s from "./reasoning-effort-menu.module.css";
+
+export interface ReasoningEffortMenuProps {
+  /** 当前思考强度；null 表示配置里未显式设置（后端回落到默认档）。 */
+  value: ReasoningEffort | null;
+  onSelect: (effort: ReasoningEffort) => void | Promise<void>;
+  disabled?: boolean;
+}
+
+/**
+ * 工具栏里的「思考强度」入口：紧贴模型选择按钮，展示当前会话的思考强度，
+ * 点开后可在 关闭/最小/低/中/高/极高 之间切换。选择后通过网关
+ * `config.set`（key="reasoning"）落到 config.yaml 并即时作用于当前会话，
+ * 下一轮对话生效。
+ */
+export function ReasoningEffortMenu({ value, onSelect, disabled }: ReasoningEffortMenuProps) {
+  const [open, setOpen] = useState(false);
+
+  const thinkingOn = value !== null && value !== "none";
+  // trigger 副标题：关闭 → "关闭"；已设置 → 档位；未设置 → "默认(中)"。
+  const triggerHint =
+    value === "none"
+      ? REASONING_EFFORT_SHORT_LABELS.none
+      : value
+        ? REASONING_EFFORT_SHORT_LABELS[value]
+        : `默认·${REASONING_EFFORT_SHORT_LABELS[DEFAULT_REASONING_EFFORT]}`;
+  const triggerTitle = value
+    ? `思考强度：${REASONING_EFFORT_LABELS[value]}`
+    : `思考强度未设置，当前按默认「${REASONING_EFFORT_LABELS[DEFAULT_REASONING_EFFORT]}」运行`;
+
+  const handleSelect = (effort: ReasoningEffort) => {
+    setOpen(false);
+    void onSelect(effort);
+  };
+
+  return (
+    <Popover.Root open={open} onOpenChange={setOpen}>
+      <Popover.Trigger asChild>
+        <button
+          type="button"
+          className={s.trigger}
+          disabled={disabled}
+          data-active={thinkingOn || open ? "true" : undefined}
+          data-state={open ? "open" : undefined}
+          title={triggerTitle}
+          aria-haspopup="menu"
+          aria-expanded={open}
+        >
+          <Brain className={s.triggerIcon} aria-hidden="true" />
+          <span>思考</span>
+          <small>{triggerHint}</small>
+        </button>
+      </Popover.Trigger>
+      <Popover.Portal>
+        <Popover.Content className={s.menu} side="top" align="start">
+          <div className={s.menuTitle}>思考强度</div>
+          <div className={s.menuList} role="menu" aria-label="思考强度">
+            {REASONING_EFFORTS.map((effort) => {
+              const isActive = effort === value;
+              return (
+                <button
+                  key={effort}
+                  type="button"
+                  role="menuitemradio"
+                  aria-checked={isActive}
+                  className={s.menuItem}
+                  data-active={isActive ? "true" : undefined}
+                  onClick={() => handleSelect(effort)}
+                >
+                  <span className={s.menuItemLabel}>{REASONING_EFFORT_LABELS[effort]}</span>
+                  {isActive && <Check className={s.menuCheck} aria-hidden="true" />}
+                </button>
+              );
+            })}
+          </div>
+          <div className={s.menuFoot}>
+            {thinkingOn
+              ? "模型会进行推理；强度越高越慢、越耗 Token。"
+              : value === "none"
+                ? "已关闭推理，响应更快、更省 Token。"
+                : `未设置时默认按「${REASONING_EFFORT_LABELS[DEFAULT_REASONING_EFFORT]}」运行。`}
+          </div>
+        </Popover.Content>
+      </Popover.Portal>
+    </Popover.Root>
+  );
+}

--- a/web/src/hooks/use-gateway.ts
+++ b/web/src/hooks/use-gateway.ts
@@ -24,6 +24,7 @@ import {
   invalidateModelOptionsCache,
 } from "@/lib/model-options-cache";
 import { buildGatewayModelConfigValue } from "@/lib/provider-id";
+import type { ReasoningEffort } from "@/lib/reasoning-effort";
 import {
   rememberSessionMapping,
   resolveGatewaySessionId,
@@ -495,6 +496,31 @@ export function useGateway() {
     [ensureSubscribed, queryClient],
   );
 
+  // 思考强度走和模型选择同一条路：网关 config.set（key="reasoning"）。
+  // 后端会把字面档位写进 config.yaml 的 agent.reasoning_effort，并即时更新
+  // 该会话在内存里的 agent.reasoning_config，从而下一轮对话生效。
+  // （PUT /api/config 只落盘、不热更新当前会话，不满足"下一轮生效"。）
+  const setSessionReasoningEffort = useCallback(
+    async (sessionId: string, effort: ReasoningEffort): Promise<ConfigSetResult> => {
+      ensureSubscribed();
+      const result = parseGatewayResult(
+        ConfigSetResult,
+        await getGatewayClient().request("config.set", {
+          session_id: sessionId,
+          key: "reasoning",
+          value: effort,
+        }),
+        "config.set",
+      );
+      await Promise.all([
+        queryClient.invalidateQueries({ queryKey: ["config"] }),
+        queryClient.invalidateQueries({ queryKey: ["model-info"] }),
+      ]);
+      return result;
+    },
+    [ensureSubscribed, queryClient],
+  );
+
   const attachImage = useCallback(
     async (sessionId: string, path: string): Promise<ImageAttachResult> => {
       ensureSubscribed();
@@ -596,6 +622,7 @@ export function useGateway() {
     probeProvider,
     setSessionModel,
     setRuntimeModel,
+    setSessionReasoningEffort,
     attachImage,
     detectDroppedPath,
     interruptSession,

--- a/web/src/lib/reasoning-effort.test.ts
+++ b/web/src/lib/reasoning-effort.test.ts
@@ -1,0 +1,78 @@
+import { describe, expect, it } from "vitest";
+import {
+  DEFAULT_REASONING_EFFORT,
+  REASONING_EFFORTS,
+  REASONING_EFFORT_LABELS,
+  REASONING_EFFORT_SHORT_LABELS,
+  isReasoningEffort,
+  normalizeReasoningEffort,
+  reasoningEffortFromConfig,
+} from "./reasoning-effort";
+
+describe("reasoning-effort", () => {
+  it("exposes the backend's effort set (none + VALID_REASONING_EFFORTS)", () => {
+    expect(REASONING_EFFORTS).toEqual([
+      "none",
+      "minimal",
+      "low",
+      "medium",
+      "high",
+      "xhigh",
+    ]);
+  });
+
+  it("has a label for every effort", () => {
+    for (const effort of REASONING_EFFORTS) {
+      expect(REASONING_EFFORT_LABELS[effort]).toBeTruthy();
+      expect(REASONING_EFFORT_SHORT_LABELS[effort]).toBeTruthy();
+    }
+  });
+
+  it("defaults to the backend fallback effort", () => {
+    expect(DEFAULT_REASONING_EFFORT).toBe("medium");
+    expect(isReasoningEffort(DEFAULT_REASONING_EFFORT)).toBe(true);
+  });
+
+  describe("isReasoningEffort", () => {
+    it("accepts valid values and rejects everything else", () => {
+      expect(isReasoningEffort("high")).toBe(true);
+      expect(isReasoningEffort("none")).toBe(true);
+      expect(isReasoningEffort("HIGH")).toBe(false); // exact match only
+      expect(isReasoningEffort("ultra")).toBe(false);
+      expect(isReasoningEffort(2)).toBe(false);
+      expect(isReasoningEffort(null)).toBe(false);
+    });
+  });
+
+  describe("normalizeReasoningEffort", () => {
+    it("trims and lowercases known values", () => {
+      expect(normalizeReasoningEffort("  High ")).toBe("high");
+      expect(normalizeReasoningEffort("XHIGH")).toBe("xhigh");
+      expect(normalizeReasoningEffort("none")).toBe("none");
+    });
+
+    it("returns null for empty / unknown / non-string", () => {
+      expect(normalizeReasoningEffort("")).toBeNull();
+      expect(normalizeReasoningEffort("   ")).toBeNull();
+      expect(normalizeReasoningEffort("turbo")).toBeNull();
+      expect(normalizeReasoningEffort(undefined)).toBeNull();
+      expect(normalizeReasoningEffort(123)).toBeNull();
+    });
+  });
+
+  describe("reasoningEffortFromConfig", () => {
+    it("reads agent.reasoning_effort from a config object", () => {
+      expect(reasoningEffortFromConfig({ agent: { reasoning_effort: "low" } })).toBe("low");
+      expect(reasoningEffortFromConfig({ agent: { reasoning_effort: "MEDIUM" } })).toBe("medium");
+    });
+
+    it("returns null when the field is missing, empty, or malformed", () => {
+      expect(reasoningEffortFromConfig(undefined)).toBeNull();
+      expect(reasoningEffortFromConfig(null)).toBeNull();
+      expect(reasoningEffortFromConfig({})).toBeNull();
+      expect(reasoningEffortFromConfig({ agent: {} })).toBeNull();
+      expect(reasoningEffortFromConfig({ agent: { reasoning_effort: "" } })).toBeNull();
+      expect(reasoningEffortFromConfig({ agent: "nope" })).toBeNull();
+    });
+  });
+});

--- a/web/src/lib/reasoning-effort.ts
+++ b/web/src/lib/reasoning-effort.ts
@@ -1,0 +1,76 @@
+// 思考强度（Reasoning Effort）——与后端 Hermes-CN-Core 的事实来源对齐。
+//
+// 后端常量 `VALID_REASONING_EFFORTS = ("minimal", "low", "medium", "high",
+// "xhigh")`（hermes_constants.py），外加特殊值 "none" 表示关闭推理
+// （parse_reasoning_effort("none") → {"enabled": False}）。
+// 配置落在 config.yaml 的 `agent.reasoning_effort`；网关 `config.set`
+// （key="reasoning"）会把字面字符串写进该字段，因此这里直接复用同一组取值。
+
+export const REASONING_EFFORTS = [
+  "none",
+  "minimal",
+  "low",
+  "medium",
+  "high",
+  "xhigh",
+] as const;
+
+export type ReasoningEffort = (typeof REASONING_EFFORTS)[number];
+
+// 下拉菜单里的完整中文标签。
+export const REASONING_EFFORT_LABELS: Record<ReasoningEffort, string> = {
+  none: "关闭思考",
+  minimal: "最小",
+  low: "低",
+  medium: "中",
+  high: "高",
+  xhigh: "极高",
+};
+
+// 工具栏 trigger 上的紧凑标签（"关闭思考" 在 trigger 里显得啰嗦）。
+export const REASONING_EFFORT_SHORT_LABELS: Record<ReasoningEffort, string> = {
+  none: "关闭",
+  minimal: "最小",
+  low: "低",
+  medium: "中",
+  high: "高",
+  xhigh: "极高",
+};
+
+// 后端在 `agent.reasoning_effort` 为空时的默认取值（tui_gateway/server.py
+// 的 config.get 对 key="reasoning" 回落到 "medium"）。仅用于向用户说明
+// "未显式设置时实际会用哪一档"，不代表配置里真的写了这个值。
+export const DEFAULT_REASONING_EFFORT: ReasoningEffort = "medium";
+
+/** 是否为合法的思考强度取值。 */
+export function isReasoningEffort(value: unknown): value is ReasoningEffort {
+  return (
+    typeof value === "string" &&
+    (REASONING_EFFORTS as readonly string[]).includes(value)
+  );
+}
+
+/**
+ * 把后端/配置里读到的任意值规整成合法的思考强度。
+ * 大小写不敏感、去空白；无法识别（含空串）返回 null，表示"未显式设置"。
+ */
+export function normalizeReasoningEffort(value: unknown): ReasoningEffort | null {
+  if (typeof value !== "string") return null;
+  const normalized = value.trim().toLowerCase();
+  return isReasoningEffort(normalized) ? normalized : null;
+}
+
+/**
+ * 从 `/api/config` 返回的完整配置里取出 `agent.reasoning_effort`。
+ * 读不到或非法时返回 null（调用方据此回落到后端默认）。
+ */
+export function reasoningEffortFromConfig(
+  config: Record<string, unknown> | undefined | null,
+): ReasoningEffort | null {
+  if (!config || typeof config !== "object") return null;
+  const agent = (config as Record<string, unknown>)["agent"];
+  if (!agent || typeof agent !== "object") return null;
+  return normalizeReasoningEffort(
+    (agent as Record<string, unknown>)["reasoning_effort"],
+  );
+}

--- a/web/src/routes/detail.tsx
+++ b/web/src/routes/detail.tsx
@@ -31,6 +31,7 @@ import {
   estimateRenderedContextTokens,
 } from "@/lib/context-usage";
 import { resolveModelContextWindow } from "@/lib/model-context";
+import { reasoningEffortFromConfig, type ReasoningEffort } from "@/lib/reasoning-effort";
 import { sessionDisplayTitle } from "@/lib/session-title";
 import {
   readSessionTitleOverrides,
@@ -80,6 +81,7 @@ export function DetailRoute() {
     getSessionUsage,
     getModelOptions,
     setSessionModel,
+    setSessionReasoningEffort,
     attachImage,
     detectDroppedPath,
   } = useGateway();
@@ -87,6 +89,10 @@ export function DetailRoute() {
   const { data: modelInfo } = useModelInfo();
   const { data: modelOptionsCache } = useModelOptions();
   const [selectedModel, setSelectedModel] = useState<ComposerModelSelection | null>(null);
+  // 思考强度是全局配置（agent.reasoning_effort），不分会话；本地态仅用于
+  // 选中后即时反馈，等 config 重新拉到后两者一致。null 表示尚未本地改过，
+  // 以配置里的值为准（再读不到则回落到后端默认）。
+  const [reasoningEffortOverride, setReasoningEffortOverride] = useState<ReasoningEffort | null>(null);
   const [sessionIdCopyState, setSessionIdCopyState] = useState<"idle" | "copied" | "error">("idle");
   const [sessionTitleOverrides, setSessionTitleOverrides] = useState(readSessionTitleOverrides);
   const sessionIdCopyTimer = useRef<number | null>(null);
@@ -290,6 +296,21 @@ export function DetailRoute() {
     navigate(`/models#provider-${providerId}`);
   }, [navigate]);
 
+  const configReasoningEffort = useMemo(() => reasoningEffortFromConfig(config), [config]);
+  const reasoningEffort = reasoningEffortOverride ?? configReasoningEffort;
+
+  const onReasoningEffortSelect = useCallback(async (effort: ReasoningEffort) => {
+    setReasoningEffortOverride(effort); // 立即反馈，等 config 重新拉到后一致
+    try {
+      const gatewaySessionId = await ensureGatewaySession();
+      await setSessionReasoningEffort(gatewaySessionId, effort);
+    } catch (error) {
+      // 失败则回退到配置里的实际值（override 置空 → 用 configReasoningEffort）
+      setReasoningEffortOverride(null);
+      console.error("设置思考强度失败：", error);
+    }
+  }, [ensureGatewaySession, setSessionReasoningEffort]);
+
   const onStop = useCallback(async () => {
     const sessionId = runtimeSessionId ?? taskId;
     if (!sessionId || !runtimeIsBusy) return;
@@ -428,6 +449,11 @@ export function DetailRoute() {
             initialOptions: modelOptionsCache ?? null,
             onSelect: onModelSelect,
             onConfigureProvider,
+            disabled: runtimeIsBusy,
+          }}
+          reasoningPicker={{
+            value: reasoningEffort,
+            onSelect: onReasoningEffortSelect,
             disabled: runtimeIsBusy,
           }}
           contextUsage={contextUsage}


### PR DESCRIPTION
## 背景

Closes #218（用户反馈见 #191）。桌面端此前只能**展示**推理过程（`display.show_reasoning`），却没有入口**配置** `agent.reasoning_effort`，用户接入企业 API Key / 支持推理的模型时不知道在哪里调整思考强度。

## 改动

在 composer 工具栏的「模型」按钮旁新增「思考」入口（`ReasoningEffortMenu`）：

- **六档**：关闭思考 / 最小 / 低 / 中 / 高 / 极高 → 后端 `none / minimal / low / medium / high / xhigh`（`none` 即 thinking 关闭）。
- **展示当前档位**：trigger 副标题显示当前强度；配置里未显式设置时回落显示「默认·中」，与后端 `config.get` 对空值回落到 `medium` 一致。
- **持久化 + 即时生效**：选择后通过网关 `config.set`（`key="reasoning"`）写入 `config.yaml` 的 `agent.reasoning_effort`，并热更新当前会话在内存里的 `reasoning_config`，下一轮对话即生效。

对照 issue 期望行为：①✅ 六档选项 ②✅ Thinking 开关（`none`）③✅ 展示当前强度 ④✅ 持久化到 `config.yaml` 且下一轮生效 ⑤ `/reasoning` 斜杠命令（issue 标注为「可选」）本 PR 暂未实现，留作后续。

## 为什么走网关 `config.set` 而不是 `PUT /api/config`

核对了后端 `Hermes-CN-Core`：

| 写入路径 | 落盘 config.yaml | 热更新 live agent | 下一轮生效 |
|---|---|---|---|
| `PUT /api/config` | ✅ | ❌ | ❌（需重启/新会话） |
| `config.set` (key=reasoning) | ✅ | ✅ | ✅ |

`PUT /api/config`（`hermes_cli/web_server.py`）只把配置写盘，不会更新正在跑的会话 agent；而网关 `config.set`（`tui_gateway/server.py`，reasoning 分支）既 `_write_config_key("agent.reasoning_effort", ...)` 又 `session["agent"].reasoning_config = parsed`。新一轮对话读取的是 live agent 的 `reasoning_config`，因此只有 `config.set` 能满足 issue 的「下一轮生效」。这条链路与现有模型选择 `setSessionModel` 完全一致。

## 改动文件

- 新增 `web/src/lib/reasoning-effort.ts`（常量 / 标签 / 规整，含 8 个单测）
- 新增 `web/src/components/composer/reasoning-effort-menu.tsx` + `.module.css`（沿用 shared-ui `Popover` 与设计 token，视觉对齐 `.toolButton`）
- `web/src/hooks/use-gateway.ts`：新增 `setSessionReasoningEffort`
- `web/src/components/chat/{composer-types.ts,goose-composer.tsx}`：新增可选 `reasoningPicker`
- `web/src/routes/detail.tsx`：读取 / 乐观更新 / 接线

## 验证

- `pnpm typecheck`：protocol / shared-ui / web 全部通过
- `pnpm test:unit`：protocol 27/27，web 74 文件 / 601 用例全过（含新增 8 例）
- 未触及 Rust，`cargo` 门槛不适用

🤖 Generated with [Claude Code](https://claude.com/claude-code)
