### PR TITLE
[codex] 更新高级设置路由路径

### DIFF
--- a/web/src/app.tsx
+++ b/web/src/app.tsx
@@ -80,8 +80,15 @@ export function App() {
           <Route path="/logs" element={withBoundary(<LogsRoute />)} />
           <Route path="/debug" element={withBoundary(<DebugRoute />)} />
           <Route path="/theme" element={withBoundary(<ThemeRoute />)} />
+          <Route path="/common" element={withBoundary(<AdvancedRoute />)} />
+          <Route path="/notifications" element={withBoundary(<AdvancedRoute />)} />
+          <Route path="/config" element={withBoundary(<AdvancedRoute />)} />
+          <Route path="/connection" element={withBoundary(<AdvancedRoute />)} />
+          <Route path="/kernel" element={withBoundary(<AdvancedRoute />)} />
+          <Route path="/env" element={withBoundary(<AdvancedRoute />)} />
+          <Route path="/about" element={withBoundary(<AdvancedRoute />)} />
           <Route path="/advanced/*" element={withBoundary(<AdvancedRoute />)} />
-          <Route path="/settings" element={<Navigate to="/advanced" replace />} />
+          <Route path="/settings" element={<Navigate to="/common" replace />} />
           <Route path="*" element={<Navigate to="/" replace />} />
         </Routes>
       </AppShell>

--- a/web/src/components/app-shell/advanced-sidebar.tsx
+++ b/web/src/components/app-shell/advanced-sidebar.tsx
@@ -30,14 +30,14 @@ const OBSERVABILITY_ITEMS: readonly AdvancedItem[] = [
 ];
 
 const ADVANCED_ITEMS: readonly AdvancedItem[] = [
-  { label: "常规", path: "/advanced", icon: SlidersHorizontal },
-  { label: "通知", path: "/advanced/notifications", icon: Bell },
+  { label: "常规", path: "/common", icon: SlidersHorizontal },
+  { label: "通知", path: "/notifications", icon: Bell },
   { label: "主题", path: "/theme", icon: Palette },
-  { label: "配置", path: "/advanced/config", icon: FileCog },
-  { label: "连接", path: "/advanced/connection", icon: Cable },
-  { label: "内核", path: "/advanced/kernel", icon: Cpu },
-  { label: "环境", path: "/advanced/env", icon: MonitorCog },
-  { label: "关于", path: "/advanced/about", icon: Info },
+  { label: "配置", path: "/config", icon: FileCog },
+  { label: "连接", path: "/connection", icon: Cable },
+  { label: "内核", path: "/kernel", icon: Cpu },
+  { label: "环境", path: "/env", icon: MonitorCog },
+  { label: "关于", path: "/about", icon: Info },
 ];
 
 const SECTIONS: readonly {
@@ -53,9 +53,7 @@ export function AdvancedSidebar() {
   const location = useLocation();
 
   const isActive = (path: string) =>
-    path === "/advanced"
-      ? location.pathname === "/advanced" || location.pathname === "/advanced/"
-      : location.pathname === path || location.pathname.startsWith(`${path}/`);
+    location.pathname === path || location.pathname.startsWith(`${path}/`);
 
   return (
     <aside className={s.sidebar} aria-label="高级侧栏">

--- a/web/src/components/app-shell/use-active-top-tab.test.ts
+++ b/web/src/components/app-shell/use-active-top-tab.test.ts
@@ -12,6 +12,16 @@ describe("TOP_TABS", () => {
     expect(tabFor("/config-migration/details")).toBe("skills");
   });
 
+  it("keeps canonical advanced pages under the 03 advanced tab", () => {
+    expect(tabFor("/common")).toBe("advanced");
+    expect(tabFor("/notifications")).toBe("advanced");
+    expect(tabFor("/config")).toBe("advanced");
+    expect(tabFor("/connection")).toBe("advanced");
+    expect(tabFor("/kernel")).toBe("advanced");
+    expect(tabFor("/env")).toBe("advanced");
+    expect(tabFor("/about")).toBe("advanced");
+  });
+
   it("shows config migration in the 021 config sidebar section", () => {
     expect(CONFIG_ITEMS.some((item) => item.label === "配置迁移" && item.path === "/config-migration")).toBe(true);
   });

--- a/web/src/components/app-shell/use-active-top-tab.ts
+++ b/web/src/components/app-shell/use-active-top-tab.ts
@@ -13,6 +13,20 @@ export interface TopTabDef {
   matches: (path: string) => boolean;
 }
 
+const isRoute = (path: string, route: string) => path === route || path.startsWith(`${route}/`);
+
+const ADVANCED_ROUTES = [
+  "/common",
+  "/notifications",
+  "/config",
+  "/connection",
+  "/kernel",
+  "/env",
+  "/about",
+  "/advanced",
+  "/settings",
+] as const;
+
 export const TOP_TABS: readonly TopTabDef[] = [
   {
     id: "workbench",
@@ -55,8 +69,7 @@ export const TOP_TABS: readonly TopTabDef[] = [
       path.startsWith("/logs") ||
       path.startsWith("/debug") ||
       path.startsWith("/theme") ||
-      path.startsWith("/advanced") ||
-      path.startsWith("/settings"),
+      ADVANCED_ROUTES.some((route) => isRoute(path, route)),
   },
 ];
 

--- a/web/src/components/chat/message-timeline.test.tsx
+++ b/web/src/components/chat/message-timeline.test.tsx
@@ -99,10 +99,10 @@ describe("MessageTimeline", () => {
 
   it("keeps safe relative Markdown links renderable", () => {
     const html = ReactDOMServer.renderToStaticMarkup(
-      <MarkdownText text="[内部帮助](/advanced/about)" />,
+      <MarkdownText text="[内部帮助](/about)" />,
     );
 
-    expect(html).toContain("href=\"/advanced/about\"");
+    expect(html).toContain("href=\"/about\"");
     expect(html).toContain("内部帮助");
   });
 

--- a/web/src/lib/config-translations.ts
+++ b/web/src/lib/config-translations.ts
@@ -1,5 +1,5 @@
 /**
- * 配置项（/advanced/config）的中文翻译表。
+ * 配置项（/config）的中文翻译表。
  *
  * 后端 `/api/config/schema` 返回的 `description` 是上游英文：约 20 个字段在内核
  * `_SCHEMA_OVERRIDES` 里有手写英文，其余字段由内核用 key 自动 Title-Case 生成

--- a/web/src/lib/external-links.test.ts
+++ b/web/src/lib/external-links.test.ts
@@ -22,7 +22,7 @@ describe("external-links", () => {
     expect(normalizeExternalUrl("javascript:alert(1)")).toBeNull();
     expect(normalizeExternalUrl("tauri://localhost")).toBeNull();
     expect(normalizeExternalUrl("obsidian:open")).toBeNull();
-    expect(normalizeExternalUrl("/advanced/about")).toBeNull();
+    expect(normalizeExternalUrl("/about")).toBeNull();
   });
 
   it("uses the desktop opener before falling back to window.open", async () => {

--- a/web/src/routes/advanced.tsx
+++ b/web/src/routes/advanced.tsx
@@ -6,6 +6,26 @@ import { EnvironmentSection } from "./environment";
 
 type AdvancedSection = "general" | "notifications" | "config" | "connection" | "kernel" | "env" | "about";
 
+const SECTION_PATHS: Record<AdvancedSection, string> = {
+  general: "/common",
+  notifications: "/notifications",
+  config: "/config",
+  connection: "/connection",
+  kernel: "/kernel",
+  env: "/env",
+  about: "/about",
+};
+
+const LEGACY_SECTION_PATHS: Record<string, AdvancedSection> = {
+  "/advanced": "general",
+  "/advanced/notifications": "notifications",
+  "/advanced/config": "config",
+  "/advanced/connection": "connection",
+  "/advanced/kernel": "kernel",
+  "/advanced/env": "env",
+  "/advanced/about": "about",
+};
+
 const SECTION_META: Record<AdvancedSection, { title: string; sub: string }> = {
   general: { title: "常规", sub: "调整会话显示与输入偏好。" },
   notifications: { title: "通知", sub: "控制任务完成与权限确认的系统通知、提示音。" },
@@ -25,21 +45,20 @@ export function ThemeRoute() {
 }
 
 function sectionFromPath(pathname: string): AdvancedSection | null {
-  if (pathname === "/advanced" || pathname === "/advanced/") return "general";
-  if (pathname === "/advanced/notifications") return "notifications";
-  if (pathname === "/advanced/config") return "config";
-  if (pathname === "/advanced/connection") return "connection";
-  if (pathname === "/advanced/kernel") return "kernel";
-  if (pathname === "/advanced/env") return "env";
-  if (pathname === "/advanced/about") return "about";
-  return null;
+  const normalized = pathname.length > 1 ? pathname.replace(/\/+$/, "") : pathname;
+  const canonicalSection = Object.entries(SECTION_PATHS).find(([, path]) => path === normalized)?.[0];
+  return (canonicalSection as AdvancedSection | undefined) ?? LEGACY_SECTION_PATHS[normalized] ?? null;
 }
 
 export function AdvancedRoute() {
-  const { pathname } = useLocation();
+  const { hash, pathname } = useLocation();
   const section = sectionFromPath(pathname);
 
-  if (!section) return <Navigate to="/advanced" replace />;
+  if (!section) return <Navigate to="/common" replace />;
+
+  const canonicalPath = SECTION_PATHS[section];
+  const normalizedPathname = pathname.length > 1 ? pathname.replace(/\/+$/, "") : pathname;
+  if (normalizedPathname !== canonicalPath) return <Navigate to={`${canonicalPath}${hash}`} replace />;
 
   const meta = SECTION_META[section];
   return (

--- a/web/src/routes/detail.tsx
+++ b/web/src/routes/detail.tsx
@@ -478,7 +478,7 @@ function ApprovalDialog({ approval }: { approval: { requestId: string; sessionId
         <button className={s.approvalDeny} onClick={() => respond("deny")} disabled={responding !== null}>
           {responding === "deny" ? "发送中..." : "拒绝"}
         </button>
-        <button className={s.approvalSettings} onClick={() => navigate("/advanced#approval-mode")} disabled={responding !== null}>
+        <button className={s.approvalSettings} onClick={() => navigate("/common#approval-mode")} disabled={responding !== null}>
           调整审批模式
         </button>
       </div>

--- a/web/src/routes/settings-models-section.tsx
+++ b/web/src/routes/settings-models-section.tsx
@@ -1845,7 +1845,7 @@ export function ModelsSection() {
           onSaveTask={() => void handleSaveAuxiliaryTask()}
           onResetTask={(task) => void handleResetAuxiliaryTask(task)}
           onResetAll={() => void handleResetAllAuxiliary()}
-          onConfigureApprovalMode={() => navigate("/advanced#approval-mode")}
+          onConfigureApprovalMode={() => navigate("/common#approval-mode")}
           imageInputMode={getImageInputMode(config)}
           onImageInputModeChange={(mode) => void handleImageInputModeChange(mode)}
         />


### PR DESCRIPTION
## 变更内容

将高级设置侧栏里的常规页路径改为 `/common`，并把通知、配置、连接、内核、环境、关于等页面从 `/advanced/*` 改为顶层路径。主题页继续保持 `/theme`。

## 影响

用户在高级设置侧栏看到的路径会与新的信息架构一致，相关入口如审批模式设置也会跳转到新的 `/common#approval-mode`。旧的 `/advanced/*` 路径仍会重定向到对应的新路径，避免历史链接直接失效。

## 验证

已本地执行并通过：

- `pnpm typecheck`
- `pnpm test:unit`
- `cargo check`

另外使用当前 worktree 的临时 Vite 服务验证了 `/common` 侧栏显示，以及 `/advanced/config` 自动跳转到 `/config`。