### PR TITLE
feat(chat): task-level stall watchdog for wedged provider turns

### DIFF
--- a/web/src/components/chat/stall-notice.module.css
+++ b/web/src/components/chat/stall-notice.module.css
@@ -1,0 +1,46 @@
+.notice {
+  display: flex;
+  align-items: center;
+  gap: 8px;
+  width: 100%;
+  max-width: var(--conversation-max-width, 780px);
+  margin: 0 auto 8px;
+  padding: 8px 12px;
+  border-radius: var(--h-r-pill, 10px);
+  border: 1px solid color-mix(in srgb, #c5462b 26%, var(--h-line));
+  background: color-mix(in srgb, #c5462b 6%, var(--h-bg-pane));
+  color: var(--h-text-2);
+  font-family: var(--h-font-cn);
+  font-size: 12.5px;
+  line-height: 1.5;
+}
+
+.icon {
+  flex: 0 0 auto;
+  color: #c5462b;
+}
+
+.text {
+  flex: 1 1 auto;
+}
+
+.action {
+  flex: 0 0 auto;
+  border: 1px solid var(--h-line);
+  border-radius: var(--h-r-pill, 8px);
+  background: var(--h-bg-pane);
+  color: var(--h-text);
+  padding: 3px 12px;
+  font-family: var(--h-font-cn);
+  font-size: 12px;
+  cursor: pointer;
+}
+
+.action:hover:not(:disabled) {
+  border-color: var(--h-accent);
+}
+
+.action:disabled {
+  opacity: 0.6;
+  cursor: default;
+}

--- a/web/src/components/chat/stall-notice.tsx
+++ b/web/src/components/chat/stall-notice.tsx
@@ -1,0 +1,37 @@
+import { AlertTriangle } from "lucide-react";
+import { formatElapsedTimer } from "@/lib/format";
+import s from "./stall-notice.module.css";
+
+interface StallNoticeProps {
+  /** Backend silence so far, in ms. */
+  silenceMs: number;
+  /** Interrupt the wedged turn (reuses the composer Stop → session.interrupt path). */
+  onInterrupt: () => void;
+  interrupting?: boolean;
+}
+
+/**
+ * Shown when a running turn has received nothing from the backend for longer
+ * than the stall threshold — the case the connection heartbeat can't see
+ * (gateway alive, agent turn wedged on a dead provider call). Gives the user a
+ * truthful "no response for Ns" signal and a one-click interrupt instead of a
+ * timer that ticks up forever with no progress.
+ */
+export function StallNotice({ silenceMs, onInterrupt, interrupting = false }: StallNoticeProps) {
+  return (
+    <div className={s.notice} role="alert" aria-live="polite">
+      <AlertTriangle className={s.icon} size={16} aria-hidden />
+      <span className={s.text}>
+        模型服务已 {formatElapsedTimer(silenceMs)} 无响应，可能已卡住。后端会尝试自动重连；如长时间无进展，可手动中断后重试。
+      </span>
+      <button
+        type="button"
+        className={s.action}
+        onClick={onInterrupt}
+        disabled={interrupting}
+      >
+        {interrupting ? "中断中…" : "中断"}
+      </button>
+    </div>
+  );
+}

--- a/web/src/hooks/use-stall-watchdog.ts
+++ b/web/src/hooks/use-stall-watchdog.ts
@@ -1,0 +1,56 @@
+import { useEffect, useState } from "react";
+import type { ChatSessionRuntime } from "@/stores/chat";
+import { STALL_WATCHDOG_THRESHOLD_MS, streamSilenceMs } from "@/lib/session-activity";
+
+/** How often the watchdog re-evaluates silence while a turn is running. */
+const TICK_MS = 2_000;
+
+export interface StallState {
+  /** True once the backend has been silent for >= threshold on a running turn. */
+  isStalled: boolean;
+  /** Current backend-silence in ms (0 when not running). */
+  silenceMs: number;
+}
+
+/**
+ * Task-level stall watchdog, independent of the connection heartbeat.
+ *
+ * The gateway WS heartbeat (`gateway-client.ts`) only proves the
+ * desktop↔gateway socket is alive — it keeps getting pong-equivalent frames
+ * even while the agent turn is wedged on a dead model-provider call, so the
+ * elapsed timer ticks up forever with no progress. This hook watches the time
+ * since the backend last sent *anything* for the running turn and flips
+ * `isStalled` once it crosses the threshold, letting the UI surface a notice
+ * and an interrupt/retry affordance.
+ *
+ * The clock resets automatically the moment any backend event arrives (every
+ * applied gateway event bumps `runtime.lastActivityAt`), so a turn that
+ * recovers clears the stall on its own.
+ */
+export function useStallWatchdog(
+  runtime: ChatSessionRuntime | undefined,
+  thresholdMs: number = STALL_WATCHDOG_THRESHOLD_MS,
+): StallState {
+  const [silenceMs, setSilenceMs] = useState(() => streamSilenceMs(runtime) ?? 0);
+
+  const running = streamSilenceMs(runtime) !== null;
+  // Depend on the stable activity markers (not the runtime object identity,
+  // which changes on every delta) so the interval is only re-armed when the
+  // turn starts/stops or the backend speaks — not on every token.
+  const lastActivityAt = runtime?.lastActivityAt;
+  const turnStartedAt = runtime?.turnStartedAt;
+
+  useEffect(() => {
+    if (!running) {
+      setSilenceMs(0);
+      return;
+    }
+    const update = () => setSilenceMs(streamSilenceMs(runtime) ?? 0);
+    update();
+    const id = window.setInterval(update, TICK_MS);
+    return () => window.clearInterval(id);
+    // eslint-disable-next-line react-hooks/exhaustive-deps
+  }, [running, lastActivityAt, turnStartedAt]);
+
+  return { isStalled: running && silenceMs >= thresholdMs, silenceMs };
+}

--- a/web/src/lib/session-activity.test.ts
+++ b/web/src/lib/session-activity.test.ts
@@ -4,11 +4,14 @@ import { createEmptyChatRuntime } from "@/stores/chat";
 import { __resetUiStoreForTests } from "@/lib/ui-store";
 import { rememberSessionMapping } from "@/lib/session-map";
 import {
+  STALL_WATCHDOG_THRESHOLD_MS,
   isRuntimeRunning,
   isSessionRunning,
   mergeLiveRuntimeSessions,
   sessionIdMatches,
+  streamSilenceMs,
 } from "./session-activity";
+import type { ChatSessionRuntime } from "@/stores/chat";
 
 function session(overrides: Partial<SessionSummary>): SessionSummary {
   return {
@@ -165,5 +168,53 @@ describe("session activity", () => {
     expect(sessions[0]?.id).toBe("persist-1");
     expect(isSessionRunning(sessions[0]!, { "gw-1": runtime })).toBe(true);
     expect(sessionIdMatches("persist-1", "gw-1")).toBe(true);
+  });
+});
+
+describe("streamSilenceMs (stall watchdog input)", () => {
+  function runningRuntime(overrides: Partial<ChatSessionRuntime> = {}): ChatSessionRuntime {
+    return {
+      ...createEmptyChatRuntime(0),
+      streamStatus: "streaming",
+      ...overrides,
+    };
+  }
+
+  it("returns null when the turn is not running", () => {
+    const idle = createEmptyChatRuntime(0); // streamStatus "idle"
+    expect(streamSilenceMs(idle, 10_000)).toBeNull();
+    expect(streamSilenceMs(undefined, 10_000)).toBeNull();
+  });
+
+  it("measures elapsed since the last backend activity while running", () => {
+    const runtime = runningRuntime({ lastActivityAt: 1_000, turnStartedAt: 500 });
+    expect(streamSilenceMs(runtime, 4_000)).toBe(3_000);
+  });
+
+  it("pauses while waiting on a pending approval (not a stall)", () => {
+    const runtime = runningRuntime({
+      lastActivityAt: 1_000,
+      pendingApprovals: [
+        { requestId: "r1", sessionId: "s1", command: "ls" },
+      ],
+    });
+    expect(streamSilenceMs(runtime, 999_000)).toBeNull();
+  });
+
+  it("falls back to turnStartedAt when no activity has been recorded yet", () => {
+    const runtime = runningRuntime({ lastActivityAt: undefined, turnStartedAt: 2_000 });
+    expect(streamSilenceMs(runtime, 5_000)).toBe(3_000);
+  });
+
+  it("never reports negative silence for clock skew", () => {
+    const runtime = runningRuntime({ lastActivityAt: 10_000 });
+    expect(streamSilenceMs(runtime, 1_000)).toBe(0);
+  });
+
+  it("exposes a generous default threshold", () => {
+    // A sanity bound: long enough to outlast normal pre-first-token thinking,
+    // short enough to be useful. Keep it in the tens-of-seconds range.
+    expect(STALL_WATCHDOG_THRESHOLD_MS).toBeGreaterThanOrEqual(30_000);
+    expect(STALL_WATCHDOG_THRESHOLD_MS).toBeLessThanOrEqual(180_000);
   });
 });

--- a/web/src/lib/session-activity.ts
+++ b/web/src/lib/session-activity.ts
@@ -21,6 +21,38 @@ export function isRuntimeRunning(runtime: ChatSessionRuntime | undefined): boole
   );
 }
 
+/**
+ * Default silence window (ms) after which a running turn is considered stalled.
+ *
+ * The connection-level heartbeat in `gateway-client.ts` only proves the
+ * desktop↔gateway socket is alive — it cannot detect a turn wedged on a dead
+ * model-provider call (the gateway keeps answering pings while the agent
+ * thread is blocked). This task-level watchdog covers that gap. The threshold
+ * is deliberately generous: legitimate pre-first-token thinking on large
+ * contexts can be tens of seconds, and the backend itself surfaces a live
+ * `provider_stalled` status around its own stale timeout — so this only fires
+ * when the backend has gone *completely* silent.
+ */
+export const STALL_WATCHDOG_THRESHOLD_MS = 90_000;
+
+/**
+ * Milliseconds since the backend last sent anything for a *running* turn, or
+ * `null` when the turn is not running (so callers can stop their timer).
+ *
+ * Pending approvals pause the clock: the turn is legitimately waiting on the
+ * user, not stalled. Awaiting-approval turns return `null`.
+ */
+export function streamSilenceMs(
+  runtime: ChatSessionRuntime | undefined,
+  now: number = Date.now(),
+): number | null {
+  if (!runtime || !isRuntimeRunning(runtime)) return null;
+  if (runtime.pendingApprovals.length > 0) return null;
+  const last = runtime.lastActivityAt ?? runtime.turnStartedAt ?? runtime.updatedAt;
+  if (typeof last !== "number" || !Number.isFinite(last)) return null;
+  return Math.max(0, now - last);
+}
+
 function findRuntimeForSession(
   sessionId: string,
   runtimeBySession: ChatRuntimeBySession,

--- a/web/src/routes/detail.tsx
+++ b/web/src/routes/detail.tsx
@@ -18,6 +18,7 @@ import { useGateway } from "@/hooks/use-gateway";
 import { useConfig, useModelInfo } from "@/hooks/use-config";
 import { useModelOptions } from "@/hooks/use-model-options";
 import { useComposerTimer } from "@/hooks/use-composer-timer";
+import { useStallWatchdog } from "@/hooks/use-stall-watchdog";
 import { useSessionResolution } from "@/hooks/use-session-resolution";
 import { useSessionUsagePolling } from "@/hooks/use-session-usage-polling";
 import { recordModelUsage } from "@/lib/model-usage-log";
@@ -50,6 +51,7 @@ import type {
   ComposerSubmitPayload,
 } from "@/components/chat/composer-types";
 import { MessageTimeline } from "@/components/chat/message-timeline";
+import { StallNotice } from "@/components/chat/stall-notice";
 import { ConversationWidthControl } from "@/components/chat/conversation-width-control";
 import {
   hermesUIMessagesToChatMessages,
@@ -324,6 +326,9 @@ export function DetailRoute() {
   const pendingApproval = runtime.pendingApprovals[0] ?? null;
 
   const composerTick = useComposerTimer(runtimeIsBusy, runtime.turnStartedAt);
+  // Task-level stall watchdog: detects a turn wedged on a dead provider call
+  // (the connection heartbeat can't — the gateway keeps answering pings).
+  const stall = useStallWatchdog(runtime);
 
   const composerLoadingPlaceholder = runtimeIsBusy && runtime.turnStartedAt
     ? `Hermes 思考中 · ${formatElapsedTimer(composerTick)}`
@@ -413,6 +418,9 @@ export function DetailRoute() {
         progressModel={runtimeIsBusy ? model || undefined : undefined}
       />
       <div className={s.composerArea}>
+        {runtimeIsBusy && stall.isStalled ? (
+          <StallNotice silenceMs={stall.silenceMs} onInterrupt={onStop} />
+        ) : null}
         <GooseComposer
           key={taskId}
           initialWorkspacePath={sessionWorkspace}

--- a/web/src/stores/chat.test.ts
+++ b/web/src/stores/chat.test.ts
@@ -1073,3 +1073,37 @@ describe("manual interrupt (markSessionInterruptedAtom)", () => {
     expect(textFromParts(assistants[assistants.length - 1].parts)).toContain("重试回合");
   });
 });
+
+describe("lastActivityAt (stall watchdog source)", () => {
+  it("stamps lastActivityAt with the event time for applied backend events", () => {
+    const base = createEmptyChatRuntime(0);
+    const started = reduceGatewayEvent(base, { type: "message.start", session_id: "s1" }, 1_000);
+    expect(started.lastActivityAt).toBe(1_000);
+
+    const delta = reduceGatewayEvent(
+      started,
+      { type: "message.delta", session_id: "s1", payload: { text: "hi" } },
+      2_500,
+    );
+    expect(delta.lastActivityAt).toBe(2_500);
+  });
+
+  it("does not advance lastActivityAt for dropped late events on an interrupted turn", () => {
+    const interrupted = {
+      ...createEmptyChatRuntime(0),
+      streamStatus: "streaming" as const,
+      interrupted: true,
+      lastActivityAt: 1_000,
+    };
+    // A late stream delta from the interrupted turn is dropped (no-op) — it must
+    // not count as activity, otherwise an interrupted-but-noisy turn would keep
+    // resetting the watchdog.
+    const next = reduceGatewayEvent(
+      interrupted,
+      { type: "message.delta", session_id: "s1", payload: { text: "late" } },
+      9_000,
+    );
+    expect(next).toBe(interrupted);
+    expect(next.lastActivityAt).toBe(1_000);
+  });
+});

--- a/web/src/stores/chat.ts
+++ b/web/src/stores/chat.ts
@@ -63,6 +63,14 @@ export interface ChatSessionRuntime {
   statusKind?: string;
   statusUpdatedAt?: number;
   updatedAt: number;
+  /**
+   * Wall-clock ms of the last *backend* event reduced for this session. Unlike
+   * {@link updatedAt} (also bumped by local atom mutations like manual
+   * interrupt / reset), this only advances when the gateway actually sends
+   * something, so the stall watchdog can tell a live turn apart from a wedged
+   * one where the backend has gone completely silent. See `session-activity.ts`.
+   */
+  lastActivityAt?: number;
   turnStartedAt?: number;
   turnFirstTokenAt?: number;
   activeAssistantId?: string;
@@ -513,6 +521,20 @@ function finalizeAssistantParts(
 }
 
 export function reduceGatewayEvent(
+  runtime: ChatSessionRuntime,
+  event: GatewayEvent,
+  now = Date.now(),
+): ChatSessionRuntime {
+  const next = reduceGatewayEventInner(runtime, event, now);
+  // Stamp the last time we heard from the backend. `next === runtime` means
+  // the event was a no-op (e.g. a late event from an interrupted turn that was
+  // dropped) — don't count those as activity. Everything the gateway actually
+  // applies resets the stall watchdog's silence timer.
+  if (next === runtime) return next;
+  return { ...next, lastActivityAt: now };
+}
+
+function reduceGatewayEventInner(
   runtime: ChatSessionRuntime,
   event: GatewayEvent,
   now = Date.now(),


### PR DESCRIPTION
## Problem

During long agent sessions the app appears to hang: the elapsed-time counter keeps ticking, but the task is dead. The connection-level heartbeat in `gateway-client.ts` can't catch this — it only proves the **desktop↔gateway** socket is alive. When the *backend agent turn* wedges on a dead model-provider call, the gateway WS loop (on the asyncio event loop, separate from the wedged agent thread) keeps answering our 30s `ping` with an unknown-method error frame, which we count as a pong. So the heartbeat stays "healthy," never reconnects, never emits `gateway.disconnected` — and the UI timer (a pure local `setInterval`) ticks up forever with no progress.

## Fix

A **task-level** stall watchdog, independent of the connection heartbeat:

- Track `lastActivityAt` per session — the last time the **backend** actually sent something. Stamped by a thin wrapper around `reduceGatewayEvent`, so it only advances on applied gateway events (not on local atom mutations like manual interrupt) and not on dropped late events from an interrupted turn.
- `streamSilenceMs()` reports how long a running turn has been silent (paused while awaiting an approval — that's not a stall).
- `useStallWatchdog()` flips `isStalled` once silence crosses a generous threshold (90s, longer than normal pre-first-token thinking). The clock resets the instant any backend event arrives, so a recovered turn clears itself.
- `StallNotice` renders above the composer when tripped — "模型服务已 Ns 无响应，可能已卡住" — with a one-click **中断** that reuses the existing Stop → `session.interrupt` path.

This turns the silent "timer ticking forever" failure into a truthful signal + a way out, while the backend attempts its own reconnect.

## Companion (backend)

The actual reconnect/abort fix lives in `Eynzof/Hermes-CN-Core#34` (P-022): it aborts the live provider transport and bounds stale recovery, and now emits a **live** provider-stall status. This watchdog is the UI safety net for the worst case where the backend is so wedged it can't emit anything at all.

## Tests / checks

- `web/src/lib/session-activity.test.ts` + `web/src/stores/chat.test.ts` — `streamSilenceMs` (idle/running/approval-pause/fallback/clock-skew) and `lastActivityAt` stamping (applied vs dropped events). `pnpm exec vitest run` → 55 passed.
- `pnpm typecheck` (license + version + all workspaces) → clean.

Frontend-only; no Rust changes.

🤖 Generated with [Claude Code](https://claude.com/claude-code)