### PR TITLE
feat(desktop): manual /compress context compaction + slash-palette entry

### DIFF
--- a/packages/protocol/src/hermes-api.ts
+++ b/packages/protocol/src/hermes-api.ts
@@ -830,6 +830,27 @@ export const SessionUsageResult = z.object({
 }).passthrough();
 export type SessionUsageResult = z.infer<typeof SessionUsageResult>;
 
+// Manual context compaction — mirrors the backend `session.compress` RPC
+// (tui_gateway/server.py). `focus_topic` lets the user steer which thread to
+// keep; the backend refuses (error 4009) while a turn is running.
+export const SessionCompressParams = z.object({
+  session_id: z.string(),
+  focus_topic: z.string().optional(),
+});
+export type SessionCompressParams = z.infer<typeof SessionCompressParams>;
+
+export const SessionCompressResult = z.object({
+  status: z.string().optional(),
+  removed: z.number().optional(),
+  before_messages: z.number().optional(),
+  after_messages: z.number().optional(),
+  before_tokens: z.number().optional(),
+  after_tokens: z.number().optional(),
+  summary: z.string().optional(),
+  usage: SessionUsageResult.optional(),
+}).passthrough();
+export type SessionCompressResult = z.infer<typeof SessionCompressResult>;
+
 export const GatewayModelProvider = z.object({
   slug: z.string(),
   name: z.string().optional(),
@@ -932,6 +953,9 @@ export const GatewayMessageUsage = z
     context_used: z.number().optional(),
     context_max: z.number().optional(),
     context_percent: z.number().optional(),
+    // Backend `_get_usage` reports this on every usage payload; declaring it
+    // lets the live message-stream count match the polled session.usage one.
+    compressions: z.number().optional(),
     cost_usd: z.number().nullable().optional(),
     cost_status: z.string().optional(),
     finish_reason: z.string().optional(),

--- a/web/src/components/chat/goose-composer-context.tsx
+++ b/web/src/components/chat/goose-composer-context.tsx
@@ -142,6 +142,7 @@ export function ContextIndicator({
               {riskText}
             </span>
           ) : null}
+          <span className={s.contextPopoverMeta}>输入 /compress 手动压缩上下文</span>
         </span>
       ) : null}
     </span>

--- a/web/src/components/chat/goose-composer.tsx
+++ b/web/src/components/chat/goose-composer.tsx
@@ -18,8 +18,14 @@ import {
   extractBodyAfterLeadingSlashToken,
   filterComposerSkills,
   getLeadingSlashToken,
+  replaceLeadingSlashToken,
   type ComposerSkillCandidate,
 } from "@/lib/composer-skills";
+import {
+  filterBuiltinCommands,
+  isBuiltinComposerCommandToken,
+  type ComposerCommandCandidate,
+} from "@/lib/builtin-commands";
 import { contextUsageRisk } from "@/lib/context-usage";
 import {
   composerSubmitShortcutHint,
@@ -174,18 +180,33 @@ export function GooseComposer({
     () => selectedSkill ? null : getLeadingSlashToken(value, selectionStart, selectionEnd),
     [selectionEnd, selectionStart, selectedSkill, value],
   );
+  // A built-in slash command (e.g. /compress) is handled client-side on submit,
+  // so keep the skill picker out of its way — otherwise Enter could select a
+  // fuzzy skill match instead of running the command.
+  const builtinSlash = useMemo(
+    () => Boolean(slashToken && isBuiltinComposerCommandToken(slashToken.token)),
+    [slashToken],
+  );
   const skillCandidates = useMemo(
-    () => slashToken && skillPicker
+    () => slashToken && skillPicker && !builtinSlash
       ? filterComposerSkills(skillPicker.skills, slashToken.query)
       : [],
-    [skillPicker, slashToken],
+    [builtinSlash, skillPicker, slashToken],
   );
+  // Built-in commands (e.g. /compress) share the suggestion panel with skills.
+  // They surface for partial input ("/comp"); a fully-typed "/compress" sets
+  // builtinSlash, the panel closes, and Enter runs the command immediately.
+  const commandCandidates = useMemo(
+    () => slashToken && !builtinSlash ? filterBuiltinCommands(slashToken.query) : [],
+    [builtinSlash, slashToken],
+  );
+  const totalCandidates = commandCandidates.length + skillCandidates.length;
   const skillPanelOpen = Boolean(
     slashToken &&
-    skillPicker &&
+    !builtinSlash &&
     !controlsDisabled &&
-    !skillPicker.disabled &&
-    dismissedSlashToken !== slashToken.token,
+    dismissedSlashToken !== slashToken.token &&
+    (commandCandidates.length > 0 || (skillPicker && !skillPicker.disabled)),
   );
   const resolvedPlaceholder = selectedSkill
     ? `继续描述给 ${selectedSkill.displayName} 的任务…`
@@ -256,7 +277,7 @@ export function GooseComposer({
 
   useEffect(() => {
     setSkillActiveIndex(0);
-  }, [slashToken?.token, skillCandidates.length]);
+  }, [slashToken?.token, commandCandidates.length, skillCandidates.length]);
 
   // Picker now groups candidates internally (recent / configured /
   // recommended / more) from the catalog + usage log. Composer just hands it
@@ -425,6 +446,25 @@ export function GooseComposer({
     });
   };
 
+  const commitCommandSelection = (candidate: ComposerCommandCandidate) => {
+    if (!slashToken) return;
+    // Fill "/compress " so the user can optionally append a focus topic; a
+    // following Enter runs it via the detail-route built-in interception.
+    const next = replaceLeadingSlashToken(value, slashToken, candidate.name);
+    setValue(next.text);
+    setSelectionStart(next.cursor);
+    setSelectionEnd(next.cursor);
+    setDismissedSlashToken("");
+    window.requestAnimationFrame(() => {
+      const textarea = textareaRef.current;
+      if (!textarea) return;
+      textarea.focus();
+      textarea.setSelectionRange(next.cursor, next.cursor);
+      setSelectionStart(next.cursor);
+      setSelectionEnd(next.cursor);
+    });
+  };
+
   const clearSelectedSkill = () => {
     setSelectedSkill(null);
     window.requestAnimationFrame(() => {
@@ -486,20 +526,25 @@ export function GooseComposer({
       if (event.key === "ArrowDown") {
         event.preventDefault();
         setSkillActiveIndex((current) =>
-          skillCandidates.length ? (current + 1) % skillCandidates.length : 0);
+          totalCandidates ? (current + 1) % totalCandidates : 0);
         return;
       }
       if (event.key === "ArrowUp") {
         event.preventDefault();
         setSkillActiveIndex((current) =>
-          skillCandidates.length
-            ? (current - 1 + skillCandidates.length) % skillCandidates.length
+          totalCandidates
+            ? (current - 1 + totalCandidates) % totalCandidates
             : 0);
         return;
       }
-      if ((event.key === "Enter" || event.key === "Tab") && skillCandidates.length > 0) {
+      if ((event.key === "Enter" || event.key === "Tab") && totalCandidates > 0) {
         event.preventDefault();
-        commitSkillSelection(skillCandidates[Math.min(skillActiveIndex, skillCandidates.length - 1)]!);
+        const index = Math.min(skillActiveIndex, totalCandidates - 1);
+        if (index < commandCandidates.length) {
+          commitCommandSelection(commandCandidates[index]!);
+        } else {
+          commitSkillSelection(skillCandidates[index - commandCandidates.length]!);
+        }
         return;
       }
     }
@@ -750,48 +795,76 @@ export function GooseComposer({
         />
 
         {skillPanelOpen ? (
-          <div className={s.skillPanel} role="listbox" aria-label="选择 Skill">
+          <div className={s.skillPanel} role="listbox" aria-label="命令与 Skill">
             <div className={s.skillPanelHead}>
               <span>
                 <Sparkles aria-hidden="true" />
-                选择 Skill
+                命令与 Skill
               </span>
               <small>Enter / Tab 选择，Esc 关闭</small>
             </div>
-            {skillPicker?.loading && skillCandidates.length === 0 ? (
-              <div className={s.skillPanelState}>正在读取已启用 Skill…</div>
-            ) : skillPicker?.error && skillCandidates.length === 0 ? (
-              <div className={s.skillPanelState} data-tone="error">
-                {skillPicker.error}
-              </div>
-            ) : skillCandidates.length === 0 ? (
-              <div className={s.skillPanelState}>没有匹配的 Skill</div>
-            ) : (
+            {commandCandidates.length > 0 ? (
               <div className={s.skillList}>
-                {skillCandidates.map((candidate, index) => (
+                {commandCandidates.map((candidate, index) => (
                   <button
-                    key={candidate.skill.name}
+                    key={`cmd-${candidate.name}`}
                     type="button"
                     className={s.skillOption}
                     data-active={index === skillActiveIndex}
+                    data-kind="command"
                     role="option"
                     aria-selected={index === skillActiveIndex}
                     onMouseEnter={() => setSkillActiveIndex(index)}
                     onMouseDown={(event) => event.preventDefault()}
-                    onClick={() => commitSkillSelection(candidate)}
+                    onClick={() => commitCommandSelection(candidate)}
                   >
                     <span className={s.skillCommand}>{candidate.command}</span>
                     <span className={s.skillMain}>
                       <span className={s.skillName}>{candidate.displayName}</span>
                       <span className={s.skillDesc}>{candidate.description}</span>
                     </span>
-                    <span className={s.skillMeta}>
-                      {candidate.originLabel} · {candidate.categoryLabel}
-                    </span>
+                    <span className={s.skillMeta}>内置命令</span>
                   </button>
                 ))}
               </div>
-            )}
+            ) : null}
+            {skillPicker?.loading && totalCandidates === 0 ? (
+              <div className={s.skillPanelState}>正在读取已启用 Skill…</div>
+            ) : skillPicker?.error && totalCandidates === 0 ? (
+              <div className={s.skillPanelState} data-tone="error">
+                {skillPicker.error}
+              </div>
+            ) : totalCandidates === 0 ? (
+              <div className={s.skillPanelState}>没有匹配的 Skill</div>
+            ) : skillCandidates.length > 0 ? (
+              <div className={s.skillList}>
+                {skillCandidates.map((candidate, index) => {
+                  const combinedIndex = commandCandidates.length + index;
+                  return (
+                    <button
+                      key={candidate.skill.name}
+                      type="button"
+                      className={s.skillOption}
+                      data-active={combinedIndex === skillActiveIndex}
+                      role="option"
+                      aria-selected={combinedIndex === skillActiveIndex}
+                      onMouseEnter={() => setSkillActiveIndex(combinedIndex)}
+                      onMouseDown={(event) => event.preventDefault()}
+                      onClick={() => commitSkillSelection(candidate)}
+                    >
+                      <span className={s.skillCommand}>{candidate.command}</span>
+                      <span className={s.skillMain}>
+                        <span className={s.skillName}>{candidate.displayName}</span>
+                        <span className={s.skillDesc}>{candidate.description}</span>
+                      </span>
+                      <span className={s.skillMeta}>
+                        {candidate.originLabel} · {candidate.categoryLabel}
+                      </span>
+                    </button>
+                  );
+                })}
+              </div>
+            ) : null}
           </div>
         ) : null}
 

--- a/web/src/hooks/use-gateway.ts
+++ b/web/src/hooks/use-gateway.ts
@@ -14,6 +14,7 @@ import {
   SessionTitleResult,
   SlashCompletionResult,
   SessionUsageResult,
+  SessionCompressResult,
   type GatewayEvent,
 } from "@hermes/protocol";
 import { CN_BACKEND_PROVIDER_SLUGS } from "@/lib/cn-provider-slugs";
@@ -373,6 +374,31 @@ export function useGateway() {
     [ensureSubscribed],
   );
 
+  const compressSession = useCallback(
+    async (
+      sessionId: string,
+      focusTopic?: string,
+    ): Promise<SessionCompressResult> => {
+      ensureSubscribed();
+      const focus = focusTopic?.trim();
+      return parseGatewayResult(
+        SessionCompressResult,
+        await getGatewayClient().request(
+          "session.compress",
+          {
+            session_id: sessionId,
+            ...(focus ? { focus_topic: focus } : {}),
+          },
+          // Compaction summarises the whole history through the model; the
+          // backend classifies it as a slow handler, so give it room.
+          { timeoutMs: 180_000 },
+        ),
+        "session.compress",
+      );
+    },
+    [ensureSubscribed],
+  );
+
   const getModelOptions = useCallback(
     async (sessionId?: string): Promise<ModelOptionsResult> => {
       ensureSubscribed();
@@ -616,6 +642,7 @@ export function useGateway() {
     resumeSession,
     sendPrompt,
     getSessionUsage,
+    compressSession,
     getModelOptions,
     completeSlash,
     dispatchCommand,

--- a/web/src/lib/builtin-commands.test.ts
+++ b/web/src/lib/builtin-commands.test.ts
@@ -1,0 +1,74 @@
+import { describe, expect, it } from "vitest";
+import {
+  filterBuiltinCommands,
+  isBuiltinComposerCommandToken,
+  parseBuiltinComposerCommand,
+} from "./builtin-commands";
+
+describe("parseBuiltinComposerCommand", () => {
+  it("matches /compress with no argument", () => {
+    expect(parseBuiltinComposerCommand("/compress")).toEqual({ name: "compress", arg: "" });
+  });
+
+  it("captures a focus topic argument", () => {
+    expect(parseBuiltinComposerCommand("/compress keep the auth thread")).toEqual({
+      name: "compress",
+      arg: "keep the auth thread",
+    });
+  });
+
+  it("treats /compact as an alias for compress", () => {
+    expect(parseBuiltinComposerCommand("/compact")).toEqual({ name: "compress", arg: "" });
+  });
+
+  it("is case-insensitive and tolerates leading whitespace", () => {
+    expect(parseBuiltinComposerCommand("  /COMPRESS  ")).toEqual({ name: "compress", arg: "" });
+  });
+
+  it("ignores commands that only share a prefix", () => {
+    expect(parseBuiltinComposerCommand("/compressed now")).toBeNull();
+  });
+
+  it("ignores slashes that are not at the start", () => {
+    expect(parseBuiltinComposerCommand("please run /compress")).toBeNull();
+  });
+
+  it("ignores unknown commands and plain text", () => {
+    expect(parseBuiltinComposerCommand("/status")).toBeNull();
+    expect(parseBuiltinComposerCommand("hello world")).toBeNull();
+  });
+});
+
+describe("isBuiltinComposerCommandToken", () => {
+  it("recognises exact built-in tokens with or without the slash", () => {
+    expect(isBuiltinComposerCommandToken("/compress")).toBe(true);
+    expect(isBuiltinComposerCommandToken("compress")).toBe(true);
+    expect(isBuiltinComposerCommandToken("/compact")).toBe(true);
+  });
+
+  it("does not recognise partial input or other commands", () => {
+    expect(isBuiltinComposerCommandToken("/comp")).toBe(false);
+    expect(isBuiltinComposerCommandToken("/status")).toBe(false);
+  });
+});
+
+describe("filterBuiltinCommands", () => {
+  it("lists every built-in command for an empty query", () => {
+    const all = filterBuiltinCommands("");
+    expect(all.map((c) => c.command)).toEqual(["/compress"]);
+  });
+
+  it("matches a partial prefix of the command name", () => {
+    expect(filterBuiltinCommands("comp").map((c) => c.name)).toEqual(["compress"]);
+    expect(filterBuiltinCommands("compa").map((c) => c.name)).toEqual(["compress"]);
+  });
+
+  it("matches via an alias prefix", () => {
+    // "compact" is an alias of compress
+    expect(filterBuiltinCommands("compact").map((c) => c.name)).toEqual(["compress"]);
+  });
+
+  it("returns nothing for an unrelated query", () => {
+    expect(filterBuiltinCommands("deploy")).toEqual([]);
+  });
+});

--- a/web/src/lib/builtin-commands.ts
+++ b/web/src/lib/builtin-commands.ts
@@ -1,0 +1,96 @@
+import { parseLeadingSlashCommand } from "./composer-skills";
+
+// Desktop-native slash commands handled by the client itself — distinct from
+// skill commands (which dispatch to the backend skill registry via
+// `command.dispatch`). Today this is just manual context compaction; the list
+// is intentionally tiny and explicit so a typo never silently becomes a prompt
+// sent to the model.
+
+export type BuiltinCommandName = "compress";
+
+export interface BuiltinCommandMatch {
+  name: BuiltinCommandName;
+  /** Free-form argument after the command — for /compress this is the focus topic. */
+  arg: string;
+}
+
+const BUILTIN_ALIASES: Readonly<Record<string, BuiltinCommandName>> = {
+  compress: "compress",
+  compact: "compress",
+};
+
+function canonicalName(raw: string): BuiltinCommandName | null {
+  return BUILTIN_ALIASES[raw.replace(/^\/+/, "").trim().toLowerCase()] ?? null;
+}
+
+/**
+ * True when a leading slash token (e.g. "/compress") is exactly a built-in
+ * command. Used by the composer to suppress the skill picker so Enter submits
+ * the command instead of selecting a fuzzy skill match. Partial input like
+ * "/comp" returns false so skill suggestions still surface while typing.
+ */
+export function isBuiltinComposerCommandToken(token: string): boolean {
+  return canonicalName(token) !== null;
+}
+
+/**
+ * Parse composer input as a built-in command. Returns null unless the text
+ * starts with a recognised command (optionally followed by an argument).
+ */
+export function parseBuiltinComposerCommand(text: string): BuiltinCommandMatch | null {
+  const parsed = parseLeadingSlashCommand(text);
+  if (!parsed) return null;
+  const name = canonicalName(parsed.name);
+  if (!name) return null;
+  return { name, arg: parsed.arg };
+}
+
+// Suggestion-panel metadata for the built-in commands, mirroring the shape the
+// skill picker uses (`ComposerSkillCandidate`) so the panel can render both in
+// one list.
+export interface ComposerCommandCandidate {
+  name: BuiltinCommandName;
+  command: string;
+  displayName: string;
+  description: string;
+}
+
+const BUILTIN_COMMANDS: readonly ComposerCommandCandidate[] = [
+  {
+    name: "compress",
+    command: "/compress",
+    displayName: "压缩上下文",
+    description: "压缩当前会话上下文，可追加聚焦主题（如 /compress 保留鉴权讨论）",
+  },
+];
+
+// Every alias that should match a built-in command in the palette, grouped by
+// canonical name (so "/compact" surfaces the compress row too).
+const ALIASES_BY_NAME: Readonly<Record<BuiltinCommandName, readonly string[]>> = {
+  compress: Object.entries(BUILTIN_ALIASES)
+    .filter(([, name]) => name === "compress")
+    .map(([alias]) => alias),
+};
+
+/**
+ * Rank built-in commands for the slash palette against the typed query (the
+ * text after "/"). Empty query lists all; otherwise an alias prefix match wins
+ * over a substring match in the display name / description.
+ */
+export function filterBuiltinCommands(query: string): ComposerCommandCandidate[] {
+  const q = query.trim().toLowerCase();
+  if (!q) return [...BUILTIN_COMMANDS];
+
+  const ranked: { candidate: ComposerCommandCandidate; rank: number }[] = [];
+  for (const candidate of BUILTIN_COMMANDS) {
+    const aliases = ALIASES_BY_NAME[candidate.name];
+    let rank: number | null = null;
+    if (aliases.some((alias) => alias === q)) rank = 0;
+    else if (aliases.some((alias) => alias.startsWith(q))) rank = 10;
+    else if (candidate.displayName.toLowerCase().includes(q)) rank = 30;
+    else if (candidate.description.toLowerCase().includes(q)) rank = 50;
+    if (rank !== null) ranked.push({ candidate, rank });
+  }
+
+  return ranked.sort((a, b) => a.rank - b.rank).map((item) => item.candidate);
+}

--- a/web/src/lib/compress-feedback.test.ts
+++ b/web/src/lib/compress-feedback.test.ts
@@ -1,0 +1,42 @@
+import { describe, expect, it } from "vitest";
+import { formatCompressNotice } from "./compress-feedback";
+
+describe("formatCompressNotice", () => {
+  it("summarises a real compaction with message and token deltas", () => {
+    const text = formatCompressNotice({
+      status: "compressed",
+      removed: 12,
+      before_messages: 40,
+      after_messages: 8,
+      before_tokens: 85_000,
+      after_tokens: 12_000,
+    });
+    expect(text).toBe("已压缩上下文：40 → 8 条消息，约 85.0k → 12.0k tokens。");
+  });
+
+  it("reports a no-op when nothing was removed", () => {
+    const text = formatCompressNotice({
+      status: "compressed",
+      removed: 0,
+      before_messages: 6,
+      after_messages: 6,
+      before_tokens: 9_000,
+      after_tokens: 9_000,
+    });
+    expect(text).toBe("上下文无需压缩：当前6 条消息、约 9.0k tokens。");
+  });
+
+  it("includes the focus topic when provided", () => {
+    const text = formatCompressNotice(
+      { removed: 3, before_messages: 20, after_messages: 10, before_tokens: 50_000, after_tokens: 30_000 },
+      "保留鉴权相关讨论",
+    );
+    expect(text).toBe(
+      "已压缩上下文（聚焦：保留鉴权相关讨论）：20 → 10 条消息，约 50.0k → 30.0k tokens。",
+    );
+  });
+
+  it("degrades gracefully when the backend omits counts", () => {
+    expect(formatCompressNotice({ status: "compressed", removed: 5 })).toBe("已压缩上下文。");
+  });
+});

--- a/web/src/lib/compress-feedback.ts
+++ b/web/src/lib/compress-feedback.ts
@@ -1,0 +1,42 @@
+import type { SessionCompressResult } from "@hermes/protocol";
+
+function formatTokens(value: number | undefined): string {
+  if (typeof value !== "number" || !Number.isFinite(value) || value <= 0) return "0";
+  if (value >= 1_000_000) return `${(value / 1_000_000).toFixed(1)}M`;
+  if (value >= 1_000) return `${(value / 1_000).toFixed(1)}k`;
+  return String(Math.round(value));
+}
+
+/**
+ * Build the localized system-notice text shown after a manual /compress.
+ * Derives wording from the backend's structured before/after counts rather than
+ * its English `summary`, so the Chinese UI stays consistent.
+ */
+export function formatCompressNotice(result: SessionCompressResult, focus = ""): string {
+  const before = result.before_messages;
+  const after = result.after_messages;
+  const beforeTok = result.before_tokens;
+  const afterTok = result.after_tokens;
+  const focusText = focus.trim();
+  const focusSuffix = focusText ? `（聚焦：${focusText}）` : "";
+
+  const noChange =
+    result.removed === 0 ||
+    (typeof before === "number" && typeof after === "number" && before === after);
+
+  if (noChange) {
+    const size = typeof beforeTok === "number" ? `约 ${formatTokens(beforeTok)} tokens` : "";
+    const count = typeof before === "number" ? `${before} 条消息` : "";
+    const detail = [count, size].filter(Boolean).join("、");
+    return `上下文无需压缩${focusSuffix}${detail ? `：当前${detail}` : ""}。`;
+  }
+
+  const msgPart =
+    typeof before === "number" && typeof after === "number" ? `${before} → ${after} 条消息` : "";
+  const tokPart =
+    typeof beforeTok === "number" && typeof afterTok === "number"
+      ? `约 ${formatTokens(beforeTok)} → ${formatTokens(afterTok)} tokens`
+      : "";
+  const detail = [msgPart, tokPart].filter(Boolean).join("，");
+  return `已压缩上下文${focusSuffix}${detail ? `：${detail}` : ""}。`;
+}

--- a/web/src/lib/context-usage.test.ts
+++ b/web/src/lib/context-usage.test.ts
@@ -12,7 +12,14 @@ describe("context usage helpers", () => {
   });
 
   it("computes percentage from used and max", () => {
-    expect(contextUsagePercent({ used: 1_600_000, max: 1_000_000 })).toBe(160);
+    expect(contextUsagePercent({ used: 500_000, max: 1_000_000 })).toBe(50);
+  });
+
+  it("caps the percentage at 100 even when the window is exceeded", () => {
+    expect(contextUsagePercent({ used: 1_600_000, max: 1_000_000 })).toBe(100);
+    expect(contextUsagePercent({ percent: 160 })).toBe(100);
+    // ...but it still reads as danger.
+    expect(contextUsageRisk({ used: 1_600_000, max: 1_000_000 })).toBe("danger");
   });
 
   it("classifies warning and danger levels", () => {

--- a/web/src/lib/context-usage.ts
+++ b/web/src/lib/context-usage.ts
@@ -141,18 +141,22 @@ export function buildComposerContextUsage({
   };
 }
 
+// Percentage is capped at 100: a session can exceed its window (used > max),
+// but the ring fills at 100% and a ">100%" label reads as a rendering bug. The
+// token label (used / max) still conveys the overflow numerically, and the
+// danger risk still fires since the cap lands exactly on CONTEXT_DANGER_PERCENT.
 export function contextUsagePercent(usage: ContextUsageLike | null | undefined): number | undefined {
   if (!usage) return undefined;
 
   const explicit = finiteNumber(usage.percent);
   if (explicit !== undefined) {
-    return Math.max(0, explicit);
+    return Math.min(100, Math.max(0, explicit));
   }
 
   const used = finiteNumber(usage.used);
   const max = finiteNumber(usage.max);
   if (used === undefined || max === undefined || max <= 0) return undefined;
-  return Math.max(0, (used / max) * 100);
+  return Math.min(100, Math.max(0, (used / max) * 100));
 }
 
 export function contextUsageRisk(usage: ContextUsageLike | null | undefined): ContextRisk {

--- a/web/src/routes/detail.tsx
+++ b/web/src/routes/detail.tsx
@@ -10,6 +10,7 @@ import {
   conversationWidthModeAtom,
 } from "@/stores/ui";
 import {
+  appendNoticeAtom,
   recoverCompletedTurnFromStoredMessagesAtom,
   removeApprovalAtom,
 } from "@/stores/chat";
@@ -23,6 +24,8 @@ import { useSessionUsagePolling } from "@/hooks/use-session-usage-polling";
 import { recordModelUsage } from "@/lib/model-usage-log";
 import { readSessionModelOverride } from "@/lib/session-model-override";
 import { prepareComposerPrompt } from "@/lib/composer-prompt";
+import { parseBuiltinComposerCommand } from "@/lib/builtin-commands";
+import { formatCompressNotice } from "@/lib/compress-feedback";
 import { formatElapsedTimer } from "@/lib/format";
 import { getGatewayClient } from "@/lib/gateway-client";
 import { useSessionTurnStats } from "@/hooks/use-session-turn-stats";
@@ -79,6 +82,7 @@ export function DetailRoute() {
     sendPrompt,
     interruptSession,
     getSessionUsage,
+    compressSession,
     getModelOptions,
     setSessionModel,
     setSessionReasoningEffort,
@@ -97,6 +101,7 @@ export function DetailRoute() {
   const [sessionTitleOverrides, setSessionTitleOverrides] = useState(readSessionTitleOverrides);
   const sessionIdCopyTimer = useRef<number | null>(null);
   const recoverCompletedTurnFromStoredMessages = useSetAtom(recoverCompletedTurnFromStoredMessagesAtom);
+  const appendNotice = useSetAtom(appendNoticeAtom);
 
   const {
     restSessionId,
@@ -243,11 +248,40 @@ export function DetailRoute() {
     storedMessages,
   ]);
 
+  // Manual context compaction (/compress). Fire-and-forget so the composer
+  // clears immediately; the backend pins a "正在压缩上下文…" status while it
+  // works and we surface the before/after result as a system notice.
+  const runManualCompress = useCallback(async (sessionId: string, focus: string) => {
+    try {
+      const result = await compressSession(sessionId, focus);
+      appendNotice({ sessionId, text: formatCompressNotice(result, focus), level: "system" });
+      // session.compress also emits session.info, but the composer indicator
+      // reads polled session.usage — refresh it so the bar/count update now.
+      await getSessionUsage(sessionId).then(setSessionUsage).catch(() => {});
+    } catch (error) {
+      const message = error instanceof Error ? error.message : String(error);
+      const busy = message.toLowerCase().includes("session busy");
+      appendNotice({
+        sessionId,
+        text: busy
+          ? "当前回合正在进行，请先停止后再压缩上下文。"
+          : `压缩上下文失败：${message}`,
+        level: busy ? "info" : "error",
+      });
+    }
+  }, [appendNotice, compressSession, getSessionUsage, setSessionUsage]);
+
   const onSend = useCallback(async (
     payload: ComposerSubmitPayload,
     controls: ComposerSubmitControls,
   ) => {
     if (!taskId) return;
+    const builtin = parseBuiltinComposerCommand(payload.text);
+    if (builtin?.name === "compress") {
+      const sessionId = await ensureGatewaySession();
+      void runManualCompress(sessionId, builtin.arg);
+      return;
+    }
     const gatewaySessionId = await ensureGatewaySession();
     if (payload.workspacePath) {
       rememberWorkspaceProject(payload.workspacePath);
@@ -265,7 +299,7 @@ export function DetailRoute() {
       displayText: prepared.displayText,
       displayImages: prepared.displayImages,
     });
-  }, [attachImage, detectDroppedPath, ensureGatewaySession, restSessionId, sendPrompt, taskId]);
+  }, [attachImage, detectDroppedPath, ensureGatewaySession, restSessionId, runManualCompress, sendPrompt, taskId]);
 
   // Capability discovery is server-global — don't piggy-back on
   // ensureGatewaySession here. That helper can trigger session.resume, which

--- a/web/src/stores/chat.ts
+++ b/web/src/stores/chat.ts
@@ -432,6 +432,16 @@ function appendNoticeMessage(
   };
 }
 
+// Map backend status.update lifecycle signals to localized, user-facing text.
+// Returns "" to clear the status line, undefined to leave it unchanged.
+function localizeStatusUpdate(kind: string, text: string): string | undefined {
+  if (kind === "compressing") return "正在压缩上下文…";
+  // session.compress pins a neutral "ready" status when compaction settles —
+  // surface nothing rather than a raw English "ready" string in the timeline.
+  if (kind === "ready" || text === "ready") return "";
+  return text || undefined;
+}
+
 function gatewayUsageMetadata(usage: GatewayMessageUsageT | undefined): HermesMessageMetadata["usage"] | undefined {
   if (!usage) return undefined;
   const next: NonNullable<HermesMessageMetadata["usage"]> = {};
@@ -800,9 +810,11 @@ export function reduceGatewayEvent(
 
     case "status.update": {
       const kind = typeof payload.kind === "string" ? payload.kind : "status";
+      const text = typeof payload.text === "string" ? payload.text : "";
+      const localized = localizeStatusUpdate(kind, text);
       return {
         ...runtime,
-        statusMessage: typeof payload.text === "string" ? payload.text : runtime.statusMessage,
+        statusMessage: localized !== undefined ? localized : runtime.statusMessage,
         statusKind: kind,
         statusUpdatedAt: now,
         updatedAt: now,
@@ -1032,6 +1044,29 @@ export const startPromptAtom = atom(
         turnFirstTokenAt: undefined,
         activeAssistantId: assistantId,
       })),
+    );
+  },
+);
+
+/** Append a standalone system/notice message to a session — used for client-side
+ *  command results (e.g. manual /compress) that aren't part of a model turn. */
+export const appendNoticeAtom = atom(
+  null,
+  (
+    _get,
+    set,
+    params: {
+      sessionId: string;
+      text: string;
+      level?: "info" | "warning" | "error" | "system";
+      now?: number;
+    },
+  ) => {
+    const now = params.now ?? Date.now();
+    set(chatRuntimeBySessionAtom, (state) =>
+      updateSessionRuntime(state, params.sessionId, (runtime) =>
+        appendNoticeMessage(runtime, params.sessionId, now, params.text, params.level ?? "system"),
+      ),
     );
   },
 );


### PR DESCRIPTION
## 背景

中文社区桌面版此前**没有手动上下文压缩**：输入 `/compress` 会被当成普通消息发给模型；上下文用量显示也有几处问题（百分比可超 100%、`compressions` 计数滞后）。后端 `tui_gateway` 早已暴露专用的 `session.compress` RPC，但桌面端一直没接上。本 PR 对齐官方桌面端，补齐手动压缩，并修复显示问题。

## 改动

**功能 — 手动 `/compress`**
- 协议层新增 `SessionCompressParams/Result` schema，`use-gateway` 新增 `compressSession` 方法（调后端 `session.compress`，支持 `focus_topic`，180s 超时）。
- composer 提交时拦截 `/compress`（含 `/compact` 别名）：fire-and-forget，输入框立即清空；忙时给出友好提示；压缩完成后以系统消息回显前后对比（消息数 / token），并即时刷新用量。
- 压缩中状态文案本地化为「正在压缩上下文…」，结束清掉后端遗留的英文 `ready`。

**功能 — 斜杠命令面板**
- `/compress` 进入斜杠命令建议面板（与 Skill 同列）：输入 `/` 或 `/comp` 即可发现；选中后填入 `/compress `，可继续追加聚焦主题，回车执行。完整输入 `/compress` 直接回车仍即时运行（不回退一键路径）。

**显示修复**
- `contextUsagePercent` clamp 到 ≤100（环形与百分比标签不再割裂；token 标签仍显示真实溢出，danger 风险仍触发）。
- `GatewayMessageUsage` 补 `compressions` 字段，手动压缩后即时刷新计数。

## 测试

- `pnpm typecheck` ✅；`pnpm test:unit` ✅（protocol 27 / web 620，含新增 `filterBuiltinCommands` / `parseBuiltinComposerCommand` / `formatCompressNotice` / 百分比 clamp 用例）。
- 未触及 Rust，跳过 `cargo check`。
- **功能 / 手动 QA 由作者负责**：建议验证 `/`、`/comp` 列出 `/compress`；选中填入 `/compress `；完整 `/compress` + 回车即时运行并回显前后对比；超限会话不再显示 >100%。

> 注：基于 `origin/main` 最新（含 #248 reasoning-effort、#249 设置路由），三处重叠文件已 3-way 合并，无冲突。

🤖 Generated with [Claude Code](https://claude.com/claude-code)
