### PR TITLE
fix: refresh sidebar when switching back to the default profile (#189, #195)

### DIFF
--- a/web/src/hooks/use-profiles.test.ts
+++ b/web/src/hooks/use-profiles.test.ts
@@ -1,0 +1,98 @@
+import { describe, expect, it } from "vitest";
+import { resolveBootstrapProfile } from "./use-profiles";
+
+describe("resolveBootstrapProfile", () => {
+  // 核心回归测试（#189/#195）：首次同步完成后，过期的 /api/profiles/active 值
+  // 不能再把刚切回 default 的 atom 改回旧档案。
+  it("never reverts a deliberate switch once hydrated, even with stale query data", () => {
+    expect(
+      resolveBootstrapProfile({
+        alreadyHydrated: true,
+        current: "default",
+        electronProfile: "default",
+        queryData: "other", // 切换瞬间后端 query 仍是旧值
+      }),
+    ).toEqual({ next: null, hydrated: true });
+  });
+
+  it("stays inert when hydrated regardless of electron profile drift", () => {
+    expect(
+      resolveBootstrapProfile({
+        alreadyHydrated: true,
+        current: "work",
+        electronProfile: "default",
+        queryData: "default",
+      }),
+    ).toEqual({ next: null, hydrated: true });
+  });
+
+  describe("electron mode (first run)", () => {
+    it("hydrates the atom to the runtime profile when atom is still default", () => {
+      expect(
+        resolveBootstrapProfile({
+          alreadyHydrated: false,
+          current: "default",
+          electronProfile: "other",
+          queryData: undefined,
+        }),
+      ).toEqual({ next: "other", hydrated: true });
+    });
+
+    it("no-ops but marks hydrated when runtime is already default", () => {
+      expect(
+        resolveBootstrapProfile({
+          alreadyHydrated: false,
+          current: "default",
+          electronProfile: "default",
+          queryData: undefined,
+        }),
+      ).toEqual({ next: null, hydrated: true });
+    });
+
+    it("does not overwrite a non-default atom from the runtime value", () => {
+      expect(
+        resolveBootstrapProfile({
+          alreadyHydrated: false,
+          current: "other",
+          electronProfile: "default",
+          queryData: undefined,
+        }),
+      ).toEqual({ next: null, hydrated: true });
+    });
+  });
+
+  describe("web mode (first run)", () => {
+    it("waits (not hydrated) until the backend sticky arrives", () => {
+      expect(
+        resolveBootstrapProfile({
+          alreadyHydrated: false,
+          current: "default",
+          electronProfile: undefined,
+          queryData: undefined,
+        }),
+      ).toEqual({ next: null, hydrated: false });
+    });
+
+    it("hydrates the atom from the backend sticky once it loads", () => {
+      expect(
+        resolveBootstrapProfile({
+          alreadyHydrated: false,
+          current: "default",
+          electronProfile: undefined,
+          queryData: "other",
+        }),
+      ).toEqual({ next: "other", hydrated: true });
+    });
+
+    it("no-ops but marks hydrated when the backend sticky is also default", () => {
+      expect(
+        resolveBootstrapProfile({
+          alreadyHydrated: false,
+          current: "default",
+          electronProfile: undefined,
+          queryData: "default",
+        }),
+      ).toEqual({ next: null, hydrated: true });
+    });
+  });
+});

--- a/web/src/hooks/use-profiles.ts
+++ b/web/src/hooks/use-profiles.ts
@@ -1,4 +1,4 @@
-import { useEffect } from "react";
+import { useEffect, useRef } from "react";
 import { useAtomValue, useSetAtom } from "jotai";
 import { useMutation, useQuery, useQueryClient } from "@tanstack/react-query";
 import { deleteJSON, fetchJSON, postJSON, putJSON } from "@/lib/transport";
@@ -54,20 +54,56 @@ export function useActiveProfileName(): string {
 // arg 推到 __HERMES_RUNTIME__ 里——直接读它就够了，不需要走后端 query
 // （而且桌面端的 dashboard 进程绑定的就是这个 profile，绕开 query 减少
 // 一次启动 RTT）。Web 模式下走 query 路径。
+
+export interface BootstrapDecision {
+  /** 要把 atom 设成的 profile 名；null 表示保持不变。 */
+  next: string | null;
+  /** 本次是否已完成首次同步——调用方据此置 ref，之后不再覆盖。 */
+  hydrated: boolean;
+}
+
+// 纯函数（导出供测试）：决定引导期「一次性 hydration」的目标。
+//
+// 关键点：这是 *一次性* 引导。`useActiveProfile`（/api/profiles/active，staleTime 30s）
+// 在切换瞬间会短暂返回旧 profile；老逻辑每次 atom 变化都重跑，于是用户从其他档案切回
+// default 时，刚 setActive("default") 又被过期的 query 值改回旧档案（#189/#195 根因）。
+// 一旦 alreadyHydrated 为 true，这里一律返回 next=null——绝不回退用户的主动切换。
+export function resolveBootstrapProfile(input: {
+  alreadyHydrated: boolean;
+  current: string;
+  electronProfile: string | undefined;
+  queryData: string | undefined;
+}): BootstrapDecision {
+  const { alreadyHydrated, current, electronProfile, queryData } = input;
+  // 首次同步完成后，运行期的 profile 切换由 useSetActiveProfile 全权负责。
+  if (alreadyHydrated) return { next: null, hydrated: true };
+  // 桌面端：主进程已同步把权威 profile 推进 __HERMES_RUNTIME__，启动即可得。
+  if (electronProfile) {
+    const next =
+      current === "default" && electronProfile !== "default" ? electronProfile : null;
+    return { next, hydrated: true };
+  }
+  // Web：等后端 sticky 到达再决定；未到达则先不标记 hydrated，待下次重试。
+  if (queryData === undefined) return { next: null, hydrated: false };
+  const next = current === "default" && queryData !== "default" ? queryData : null;
+  return { next, hydrated: true };
+}
+
 export function useBootstrapActiveProfile() {
   const setActive = useSetAtom(activeProfileAtom);
   const current = useAtomValue(activeProfileAtom);
   const electronProfile = runtime.getCurrentProfile();
   const query = useActiveProfile();
+  const hydratedRef = useRef(false);
   useEffect(() => {
-    if (electronProfile && current === "default" && electronProfile !== "default") {
-      setActive(electronProfile);
-      return;
-    }
-    if (!query.data) return;
-    if (current === "default" && query.data !== "default") {
-      setActive(query.data);
-    }
+    const decision = resolveBootstrapProfile({
+      alreadyHydrated: hydratedRef.current,
+      current,
+      electronProfile,
+      queryData: query.data,
+    });
+    if (decision.hydrated) hydratedRef.current = true;
+    if (decision.next !== null) setActive(decision.next);
   }, [electronProfile, query.data, current, setActive]);
 }
 


### PR DESCRIPTION
## Problem

Switching from a non-default profile **back to `default`** leaves the sidebar (session + task lists) stuck on the old profile, while the chat area and the profile selector look correct. Users often have to restart the app. The first click frequently appears to do nothing, and it only happens when returning to `default`. Closes #189. Closes #195.

## Root cause (not a readiness race)

`useBootstrapActiveProfile` (`web/src/hooks/use-profiles.ts`) is mounted in the long-lived app root (`app.tsx`) and its effect re-runs on every atom change. `useActiveProfile` (`GET /api/profiles/active`) is cached with `staleTime: 30s`.

So right after `useSetActiveProfile.onSuccess` sets the atom to `"default"`, the bootstrap effect re-fires while the query **still returns the stale previous profile**, and this branch reverts the atom:

```ts
if (current === "default" && query.data !== "default") {
  setActive(query.data); // ← sets it back to the OLD profile
}
```

Because the whole block is gated on `current === "default"`, only switches **back to default** get sabotaged — exactly matching the reported asymmetry and "first click does nothing". The sidebar (`useSessions`) and the selector both key off this reverted atom, so they show the old profile.

## Fix (root cause, minimal)

Make bootstrap a true **one-shot hydration**:

- Extract the decision into a pure, exported `resolveBootstrapProfile()` (testable like the repo's other hook helpers).
- Guard the effect with a `useRef` so that after the initial sync it **never overrides a deliberate switch**. Runtime profile switching stays fully owned by `useSetActiveProfile`.

This deliberately avoids the timing band-aid (500ms delay + `retry` + `keepPreviousData`): it doesn't address this root cause, and `keepPreviousData` would actually entrench the stale list.

## Scope note

This PR does **only** the profile-switch fix. The `.env` loading (#197) and the "stop stream on terminate" (#185) changes that were bundled into the earlier attempt (PR #206) are already on `main` via #213/#211 and #209 respectively, so they are intentionally not re-done here.

## Tests / verification

- New `web/src/hooks/use-profiles.test.ts` — 8 cases, core one being "a stale `/api/profiles/active` value cannot revert the atom once hydrated".
- `pnpm typecheck` ✅
- `pnpm test:unit` ✅ (web 610 / protocol 27, all green)

🤖 Generated with [Claude Code](https://claude.com/claude-code)