### PR TITLE
fix: stop turn-rail jump from self-cancelling via bottom-detach

### DIFF
--- a/web/src/components/chat/message-timeline.test.tsx
+++ b/web/src/components/chat/message-timeline.test.tsx
@@ -2,7 +2,7 @@ import ReactDOMServer from "react-dom/server";
 import { describe, expect, it } from "vitest";
 
 import { MarkdownText } from "./markdown-renderer";
-import { MessageTimeline, resolveBottomFollowState } from "./message-timeline";
+import { MessageTimeline, resolveBottomFollowState, shouldDetachOnScroll } from "./message-timeline";
 import type { ChatMessage } from "./chat-types";
 
 describe("MessageTimeline", () => {
@@ -18,6 +18,20 @@ describe("MessageTimeline", () => {
       nearBottom: true,
       userDetachedFromBottom: false,
     });
+  });
+
+  it("treats a genuine user upward scroll as a bottom-detach gesture", () => {
+    expect(shouldDetachOnScroll(800, 1000, false)).toBe(true);
+  });
+
+  it("does not detach while a programmatic turn jump animates upward", () => {
+    // The smooth scrollTo from scrollToTurn drives scrollTop down too; without the
+    // guard handleScroll would cancel its own jump. This locks in the fix.
+    expect(shouldDetachOnScroll(800, 1000, true)).toBe(false);
+  });
+
+  it("does not detach when scrolling downward", () => {
+    expect(shouldDetachOnScroll(1000, 800, false)).toBe(false);
   });
 
   it("uses the optimistic progress model instead of stale session usage", () => {

--- a/web/src/components/chat/message-timeline.tsx
+++ b/web/src/components/chat/message-timeline.tsx
@@ -62,6 +62,17 @@ function distanceFromBottom(element: HTMLElement): number {
   return Math.max(0, element.scrollHeight - element.scrollTop - element.clientHeight);
 }
 
+// 只有"用户主动上滑"才应脱离贴底跟随。程序触发的轮次跳转平滑滚动同样会让 scrollTop
+// 递减，但绝不能被当成用户手势——否则会把自己的跳转动画硬取消掉。
+export function shouldDetachOnScroll(
+  scrollTop: number,
+  lastScrollTop: number,
+  programmaticScroll: boolean,
+): boolean {
+  if (programmaticScroll) return false;
+  return scrollTop < lastScrollTop - 1;
+}
+
 function formatDay(timestamp: number): string {
   const date = new Date(timestamp);
   const now = new Date();
@@ -699,6 +710,11 @@ export function MessageTimeline({
   const autoAnchorRef = useRef(false);
   const autoAnchorTimerRef = useRef<number | null>(null);
   const lastScrollTopRef = useRef(0);
+  // 程序触发的轮次跳转（平滑滚动）守卫：跳转动画期间 onScroll 会被误判为用户上滑而
+  // 触发 detachFromBottomAutoFollow 硬取消滚动，这里用标记把跳转滚动与用户手势区分开。
+  const programmaticScrollRef = useRef(false);
+  const programmaticTargetRef = useRef(0);
+  const programmaticTimerRef = useRef<number | null>(null);
   const messageCountRef = useRef(0);
   const firstMessageIdRef = useRef<string | undefined>(undefined);
   const [activeTurnId, setActiveTurnId] = useState<string | null>(null);
@@ -774,9 +790,22 @@ export function MessageTimeline({
     const containerRect = container.getBoundingClientRect();
     const nodeRect = node.getBoundingClientRect();
     const top = container.scrollTop + nodeRect.top - containerRect.top - 12;
-    nearBottomRef.current = container.scrollHeight - top - container.clientHeight < BOTTOM_FOLLOW_THRESHOLD_PX;
+    const maxTop = Math.max(0, container.scrollHeight - container.clientHeight);
+    const targetTop = Math.min(Math.max(0, top), maxTop);
+    nearBottomRef.current = container.scrollHeight - targetTop - container.clientHeight < BOTTOM_FOLLOW_THRESHOLD_PX;
     userDetachedFromBottomRef.current = !nearBottomRef.current;
-    container.scrollTo({ top, behavior: "smooth" });
+    // 标记这是一次程序跳转：handleScroll 在到达目标前不得把它当成用户上滑。
+    // 兜底定时器防止动画因目标 clamp / 内容重排始终差几像素而无法清除标记。
+    programmaticScrollRef.current = true;
+    programmaticTargetRef.current = targetTop;
+    if (programmaticTimerRef.current !== null) {
+      window.clearTimeout(programmaticTimerRef.current);
+    }
+    programmaticTimerRef.current = window.setTimeout(() => {
+      programmaticScrollRef.current = false;
+      programmaticTimerRef.current = null;
+    }, 700);
+    container.scrollTo({ top: targetTop, behavior: "smooth" });
     lastScrollTopRef.current = container.scrollTop;
     setActiveTurnId(id);
   }, []);
@@ -805,6 +834,12 @@ export function MessageTimeline({
 
   const detachFromBottomAutoFollow = useCallback(() => {
     const container = containerRef.current;
+    // 用户的显式手势（滚轮/拖动）应能中断进行中的轮次跳转并夺回滚动控制。
+    programmaticScrollRef.current = false;
+    if (programmaticTimerRef.current !== null) {
+      window.clearTimeout(programmaticTimerRef.current);
+      programmaticTimerRef.current = null;
+    }
     clearAutoAnchor();
     userDetachedFromBottomRef.current = true;
     nearBottomRef.current = false;
@@ -920,6 +955,9 @@ export function MessageTimeline({
       if (autoAnchorTimerRef.current !== null) {
         window.clearTimeout(autoAnchorTimerRef.current);
       }
+      if (programmaticTimerRef.current !== null) {
+        window.clearTimeout(programmaticTimerRef.current);
+      }
     };
   }, []);
 
@@ -932,8 +970,27 @@ export function MessageTimeline({
   const handleScroll = () => {
     const container = containerRef.current;
     if (!container) return;
+
+    // 轮次跳转动画进行中：不要把它当成用户上滑（否则会自取消）。到达目标后解除守卫。
+    if (programmaticScrollRef.current) {
+      lastScrollTopRef.current = container.scrollTop;
+      if (Math.abs(container.scrollTop - programmaticTargetRef.current) <= 2) {
+        programmaticScrollRef.current = false;
+        if (programmaticTimerRef.current !== null) {
+          window.clearTimeout(programmaticTimerRef.current);
+          programmaticTimerRef.current = null;
+        }
+      }
+      updateActiveTurnFromScroll();
+      return;
+    }
+
     const bottomDistance = distanceFromBottom(container);
-    const scrollingUp = container.scrollTop < lastScrollTopRef.current - 1;
+    const scrollingUp = shouldDetachOnScroll(
+      container.scrollTop,
+      lastScrollTopRef.current,
+      programmaticScrollRef.current,
+    );
 
     if (scrollingUp) {
       detachFromBottomAutoFollow();


### PR DESCRIPTION
## 问题

会话详情页右侧的轮次定位条（turn rail，竖向一排小圆点）点击后无法跳转到对应轮次——尤其是向上跳到较早轮次时，几乎不动。

## 根因

圆点 `onClick` → `scrollToTurn` 执行 `container.scrollTo({ behavior: "smooth" })`。平滑滚动是异步的，向上跳转时动画使 `scrollTop` 递减，被 `handleScroll` 的 `scrollingUp` 判定误认成"用户主动上滑"，进而调用 `detachFromBottomAutoFollow`。该函数（commit `4cd4011`「修复长对话历史上滑回底部」引入）内部 `scrollTo({ top: container.scrollTop, behavior: "auto" })` **把正在进行的跳转动画一帧就硬取消**，跳转因此只动几像素就停下。向下跳转碰巧不受影响，但用户通常在底部往上跳，所以表现为"完全坏掉"。

> 把 `lastScrollTopRef` 预设成目标值的捷径无效——`handleScroll` 每次事件结尾都会把它覆盖为当前 `scrollTop`，下一帧又会判定 `scrollingUp`。必须用显式的"程序滚动中"标记。

## 修复

仅改 `message-timeline.tsx` + 测试，引入"程序滚动中"守卫区分**程序跳转**与**用户手势**：

- `scrollToTurn`：clamp 目标 + 置 `programmaticScrollRef`，加 700ms 兜底定时器。
- `handleScroll`：跳转期间早返回、不触发 detach；到达目标(±2px)或超时后解除守卫。
- `detachFromBottomAutoFollow`：清除守卫——用户滚轮/拖动**仍可中断**跳转、夺回控制。
- 上滑判定抽成导出纯函数 `shouldDetachOnScroll` 并补 3 条回归单测。
- 不改 CSS / `detail.tsx` / store；保留 `4cd4011` 的"用户上滑脱离贴底"行为不回归。

## 验证

- ✅ `pnpm typecheck`（license + version + 3 个 workspace tsc）全过
- ✅ `vitest message-timeline` → 22 passed（含 3 条新测试）
- 手动（建议复核）：多轮长会话停在底部 → 点上方圆点应平滑跳到对应轮次并停住；跳转后发新消息不被拽回底部；贴底手动上滑仍正常脱离跟随。

🤖 Generated with [Claude Code](https://claude.com/claude-code)