### PR TITLE
[codex] 新增语音输入和配置向导

### DIFF
--- a/Info.plist
+++ b/Info.plist
@@ -1,0 +1,8 @@
+<?xml version="1.0" encoding="UTF-8"?>
+<!DOCTYPE plist PUBLIC "-//Apple//DTD PLIST 1.0//EN" "http://www.apple.com/DTDs/PropertyList-1.0.dtd">
+<plist version="1.0">
+<dict>
+  <key>NSMicrophoneUsageDescription</key>
+  <string>Hermes 需要访问麦克风，用于在 Composer 中录音并转写为文本。</string>
+</dict>
+</plist>

--- a/docs/desktop-prd/05-feature-parity-gap.md
+++ b/docs/desktop-prd/05-feature-parity-gap.md
@@ -60,7 +60,7 @@
 |---|---|---|---|---|
 | **右栏富预览（三栏）** | `app/chat/right-rail/{preview,preview-pane,preview-file,preview-console}.tsx`：网页沙箱 iframe 预览、文件/代码/JSON 预览、工具输出 console、**磁盘文件实时 watch** | `web/src/routes/detail.tsx` + `components/chat/message-timeline.tsx` 为**单栏时间线**，无集成预览（仅有独立 `console.tsx` 终端页、`logs.tsx` 日志页） | 🔴 高 | **已计划**（proto 03–06，PRD §5.1 三栏，未实现） |
 | **富 Composer** | `app/chat/composer/`：斜杠 `/skill` 弹层（`skin-slash-popover.tsx`、`trigger-popover.tsx`）、`@`-mention 内联引用文件/URL/历史会话（`inline-refs.ts`）、URL 元数据弹窗（`url-dialog.tsx`）、**队列/批量发送**（`queue-panel.tsx`）、补全抽屉（`completion-drawer.tsx`） | `components/chat/goose-composer*.tsx` 有附件 + 模型选择（`lib/composer-skills.ts` 部分能力），**缺队列 / URL 弹窗 / `@`-mention / 斜杠弹层** | 🟡 中 | 部分计划（proto 02） |
-| **Composer 语音 I/O** | 麦克风录音 + 静音检测（`composer/voice-activity.tsx`）+ Whisper 转写 + TTS 朗读 | **仅在设置暴露 `voice.*`/`tts.*` 配置项**（`lib/config-translations.ts`、`lib/env-translations.ts`），无录音 / 朗读 UI（后端已支持，缺前端） | 🟢 低 | 未提及 |
+| **Composer 语音 I/O** | 麦克风录音 + 静音检测（`composer/voice-activity.tsx`）+ Whisper 转写 + TTS 朗读 | 已补 Composer 录音转写入口、助手回复朗读/停止入口和 `/voice` 语音模型配置向导，复用 `/api/audio/transcribe`、`/api/audio/speak` 与 `voice.*`/`stt.*`/`tts.*` 配置；暂未实现官方连续语音对话模式 | 🟢 低 | 未提及 |
 
 ### 3.2 我们缺的独立页面
 

--- a/packages/protocol/src/hermes-api.test.ts
+++ b/packages/protocol/src/hermes-api.test.ts
@@ -1,13 +1,58 @@
 import { describe, expect, it } from "vitest";
 import {
   AnalyticsResponse,
+  AudioSpeakResponse,
+  AudioTranscriptionResponse,
   CronJob,
   CronJobsResponse,
   CronRunDetail,
   CronRunsResponse,
+  ElevenLabsVoicesResponse,
   SessionsResponse,
   SessionSummary,
 } from "./hermes-api";
+
+
+describe("Audio API schemas", () => {
+  it("parses desktop transcription responses", () => {
+    const parsed = AudioTranscriptionResponse.parse({
+      ok: true,
+      transcript: "你好 Hermes",
+      provider: "openai",
+    });
+
+    expect(parsed.transcript).toBe("你好 Hermes");
+    expect(parsed.provider).toBe("openai");
+  });
+
+  it("parses desktop speech responses with nullable provider", () => {
+    const parsed = AudioSpeakResponse.parse({
+      ok: true,
+      data_url: "data:audio/mpeg;base64,AAAA",
+      mime_type: "audio/mpeg",
+      provider: null,
+    });
+
+    expect(parsed.data_url).toContain("data:audio/mpeg");
+    expect(parsed.provider).toBeNull();
+  });
+
+  it("parses ElevenLabs voice list responses", () => {
+    const parsed = ElevenLabsVoicesResponse.parse({
+      available: true,
+      voices: [
+        {
+          voice_id: "voice-1",
+          name: "Rachel",
+          label: "Rachel (premade)",
+        },
+      ],
+    });
+
+    expect(parsed.available).toBe(true);
+    expect(parsed.voices[0]?.voice_id).toBe("voice-1");
+  });
+});
 
 describe("CronJobsResponse", () => {
   it("parses current dashboard cron jobs with structured schedules", () => {

--- a/packages/protocol/src/hermes-api.ts
+++ b/packages/protocol/src/hermes-api.ts
@@ -41,6 +41,44 @@ export const StatusResponse = z.object({
 });
 export type StatusResponse = z.infer<typeof StatusResponse>;
 
+// ── Audio (/api/audio/*) ──────────────────────────────────────────────
+
+export const AudioTranscriptionResponse = z
+  .object({
+    ok: z.boolean(),
+    transcript: z.string(),
+    provider: z.string().nullable().optional(),
+  })
+  .passthrough();
+export type AudioTranscriptionResponse = z.infer<typeof AudioTranscriptionResponse>;
+
+export const AudioSpeakResponse = z
+  .object({
+    ok: z.boolean(),
+    data_url: z.string(),
+    mime_type: z.string(),
+    provider: z.string().nullable().optional(),
+  })
+  .passthrough();
+export type AudioSpeakResponse = z.infer<typeof AudioSpeakResponse>;
+
+export const ElevenLabsVoice = z
+  .object({
+    voice_id: z.string(),
+    name: z.string(),
+    label: z.string(),
+  })
+  .passthrough();
+export type ElevenLabsVoice = z.infer<typeof ElevenLabsVoice>;
+
+export const ElevenLabsVoicesResponse = z
+  .object({
+    available: z.boolean(),
+    voices: z.array(ElevenLabsVoice),
+  })
+  .passthrough();
+export type ElevenLabsVoicesResponse = z.infer<typeof ElevenLabsVoicesResponse>;
+
 // ── Messaging platforms (/api/messaging/platforms) ────────────────────
 
 export const MessagingEnvVarInfo = z

--- a/src/commands/api_proxy.rs
+++ b/src/commands/api_proxy.rs
@@ -25,6 +25,7 @@ use crate::state::AppState;
 const SESSION_LOG_ROUTE_PREFIX: &str = "/__hermes_session_log/";
 const EXTERNAL_TIMEOUT: Duration = Duration::from_secs(15);
 const DASHBOARD_PROXY_TIMEOUT: Duration = Duration::from_secs(30);
+const DASHBOARD_AUDIO_PROXY_TIMEOUT: Duration = Duration::from_secs(180);
 const UPLOAD_TIMEOUT: Duration = Duration::from_secs(60);
 const MAX_UPLOAD_BYTES: usize = 100 * 1024 * 1024;
 const MAX_UPLOAD_BASE64_LEN: usize = MAX_UPLOAD_BYTES.div_ceil(3) * 4;
@@ -33,6 +34,12 @@ static DASHBOARD_PROXY_HTTP_CLIENT: LazyLock<reqwest::Client> = LazyLock::new(||
         .timeout(DASHBOARD_PROXY_TIMEOUT)
         .build()
         .expect("valid dashboard proxy HTTP client")
+});
+static DASHBOARD_AUDIO_PROXY_HTTP_CLIENT: LazyLock<reqwest::Client> = LazyLock::new(|| {
+    reqwest::Client::builder()
+        .timeout(DASHBOARD_AUDIO_PROXY_TIMEOUT)
+        .build()
+        .expect("valid dashboard audio proxy HTTP client")
 });
 static UPLOAD_HTTP_CLIENT: LazyLock<reqwest::Client> = LazyLock::new(|| {
     reqwest::Client::builder()
@@ -89,6 +96,10 @@ fn url_path(path: &str) -> String {
     } else {
         path.split('?').next().unwrap_or(path).to_string()
     }
+}
+
+fn is_audio_api_path(path: &str) -> bool {
+    url_path(path).starts_with("/api/audio/")
 }
 
 fn upload_limit_error() -> AppError {
@@ -247,6 +258,13 @@ mod tests {
     #[test]
     fn url_path_handles_root() {
         assert_eq!(url_path("/"), "/");
+    }
+
+    #[test]
+    fn audio_api_path_matches_audio_routes_with_queries() {
+        assert!(is_audio_api_path("/api/audio/transcribe"));
+        assert!(is_audio_api_path("/api/audio/speak?debug=1"));
+        assert!(!is_audio_api_path("/api/model/info"));
     }
 
     #[test]
@@ -435,8 +453,12 @@ pub async fn api_request_impl_with_home_base(
         format!("{}{}", base, p)
     };
 
-    let mut req = DASHBOARD_PROXY_HTTP_CLIENT
-        .request(method.parse().unwrap_or(reqwest::Method::GET), &full_url);
+    let dashboard_client = if is_audio_api_path(path) {
+        &*DASHBOARD_AUDIO_PROXY_HTTP_CLIENT
+    } else {
+        &*DASHBOARD_PROXY_HTTP_CLIENT
+    };
+    let mut req = dashboard_client.request(method.parse().unwrap_or(reqwest::Method::GET), &full_url);
 
     // Inject auth headers
     if let Some(token) = session_token {

--- a/src/commands/api_proxy.rs
+++ b/src/commands/api_proxy.rs
@@ -458,7 +458,8 @@ pub async fn api_request_impl_with_home_base(
     } else {
         &*DASHBOARD_PROXY_HTTP_CLIENT
     };
-    let mut req = dashboard_client.request(method.parse().unwrap_or(reqwest::Method::GET), &full_url);
+    let mut req =
+        dashboard_client.request(method.parse().unwrap_or(reqwest::Method::GET), &full_url);
 
     // Inject auth headers
     if let Some(token) = session_token {

--- a/tauri.conf.json
+++ b/tauri.conf.json
@@ -21,7 +21,7 @@
       }
     ],
     "security": {
-      "csp": "default-src 'self'; script-src 'self' 'unsafe-inline'; style-src 'self' 'unsafe-inline'; connect-src 'self' http://127.0.0.1:* ws://127.0.0.1:* wss://127.0.0.1:*; img-src 'self' data: blob:"
+      "csp": "default-src 'self'; script-src 'self' 'unsafe-inline'; style-src 'self' 'unsafe-inline'; connect-src 'self' http://127.0.0.1:* ws://127.0.0.1:* wss://127.0.0.1:*; img-src 'self' data: blob:; media-src 'self' data: blob:"
     }
   },
   "bundle": {

--- a/web/src/app.tsx
+++ b/web/src/app.tsx
@@ -16,6 +16,7 @@ import { ProjectsRoute } from "@/routes/projects";
 import { ProjectDetailRoute } from "@/routes/project-detail";
 import { SkillsRoute } from "@/routes/skills";
 import { ModelsRoute } from "@/routes/models";
+import { VoiceRoute } from "@/routes/voice";
 import { BackupRoute } from "@/routes/backup";
 import { ConfigMigrationRoute } from "@/routes/config-migration";
 import { McpRoute } from "@/routes/mcp";
@@ -66,6 +67,7 @@ export function App() {
           <Route path="/projects/:workspacePath" element={withBoundary(<ProjectDetailRoute />)} />
           <Route path="/skills" element={withBoundary(<SkillsRoute />)} />
           <Route path="/models" element={withBoundary(<ModelsRoute />)} />
+          <Route path="/voice" element={withBoundary(<VoiceRoute />)} />
           <Route path="/backup" element={withBoundary(<BackupRoute />)} />
           <Route path="/config-migration" element={withBoundary(<ConfigMigrationRoute />)} />
           <Route path="/mcp" element={withBoundary(<McpRoute />)} />

--- a/web/src/components/app-shell/app-top-bar.module.css
+++ b/web/src/components/app-shell/app-top-bar.module.css
@@ -22,6 +22,7 @@
   position: relative;
   z-index: 10;
   -webkit-app-region: drag;
+  min-width: 0;
 }
 
 .topbar > *:not([data-no-drag]) {
@@ -118,12 +119,16 @@
 .nav {
   display: flex;
   align-items: center;
+  flex: 0 0 auto;
+  flex-wrap: nowrap;
   gap: 2px;
   margin-left: 0;
   -webkit-app-region: no-drag;
+  white-space: nowrap;
 }
 
 .navLink {
+  flex: 0 0 auto;
   padding: 6px 10px;
   font-size: 12px;
   color: var(--h-text-2);
@@ -138,6 +143,7 @@
   background: transparent;
   border: none;
   transition: color 0.12s, background 0.12s;
+  white-space: nowrap;
 }
 
 .navLink:hover {
@@ -185,8 +191,9 @@
 }
 
 .search {
-  flex: 0 1 clamp(220px, 28vw, 360px);
-  width: clamp(220px, 28vw, 360px);
+  flex: 1 1 clamp(96px, 28vw, 360px);
+  width: auto;
+  min-width: 96px;
   max-width: 360px;
   margin-left: auto;
   height: var(--h-topbar-control-h);
@@ -204,6 +211,14 @@
   -webkit-app-region: no-drag;
   user-select: none;
   transition: var(--h-topbar-control-transition);
+  overflow: hidden;
+}
+
+.search > span:not(.searchKbd) {
+  min-width: 0;
+  overflow: hidden;
+  text-overflow: ellipsis;
+  white-space: nowrap;
 }
 
 .search:hover {
@@ -213,6 +228,7 @@
 }
 
 .searchKbd {
+  flex: 0 0 auto;
   margin-left: auto;
   font-family: var(--h-font-mono);
   font-size: 9.5px;
@@ -227,6 +243,7 @@
 .actions {
   display: flex;
   align-items: center;
+  flex: 0 0 auto;
   gap: 6px;
   margin-left: 0;
   -webkit-app-region: no-drag;

--- a/web/src/components/app-shell/capability-sidebar.tsx
+++ b/web/src/components/app-shell/capability-sidebar.tsx
@@ -7,6 +7,7 @@ import {
   Clock,
   Ghost,
   Cpu,
+  Mic,
   Puzzle,
   Sparkles,
   TerminalSquare,
@@ -28,6 +29,7 @@ interface CapabilityItem {
 
 export const CONFIG_ITEMS: readonly CapabilityItem[] = [
   { label: "模型", path: "/models", icon: Cpu },
+  { label: "语音", path: "/voice", icon: Mic },
   {
     label: "档案",
     path: "/profiles",

--- a/web/src/components/app-shell/use-active-top-tab.test.ts
+++ b/web/src/components/app-shell/use-active-top-tab.test.ts
@@ -36,6 +36,11 @@ describe("TOP_TABS", () => {
     expect(BACKUP_ITEMS.some((item) => item.label === "备份恢复" && item.path === "/backup")).toBe(true);
   });
 
+  it("keeps voice setup under the 02 config tab and sidebar section", () => {
+    expect(tabFor("/voice")).toBe("skills");
+    expect(CONFIG_ITEMS.some((item) => item.label === "语音" && item.path === "/voice")).toBe(true);
+  });
+
   it("keeps soul under the 02 config tab and sidebar section", () => {
     expect(tabFor("/soul")).toBe("skills");
     expect(tabFor("/soul/edit")).toBe("skills");

--- a/web/src/components/app-shell/use-active-top-tab.ts
+++ b/web/src/components/app-shell/use-active-top-tab.ts
@@ -52,6 +52,7 @@ export const TOP_TABS: readonly TopTabDef[] = [
       path.startsWith("/mcp") ||
       path.startsWith("/profiles") ||
       path.startsWith("/models") ||
+      path.startsWith("/voice") ||
       path.startsWith("/config-migration") ||
       path.startsWith("/soul") ||
       path.startsWith("/memory") ||

--- a/web/src/components/chat/goose-composer.module.css
+++ b/web/src/components/chat/goose-composer.module.css
@@ -4,6 +4,7 @@
 
 .box {
   position: relative;
+  container: hermes-composer / inline-size;
   width: 100%;
   border: 1px solid var(--h-line);
   border-radius: 18px;
@@ -413,6 +414,78 @@
   white-space: nowrap;
 }
 
+
+.voiceActivity {
+  display: inline-flex;
+  align-items: center;
+  gap: 8px;
+  max-width: 100%;
+  margin: 0 2px 10px;
+  border: 1px solid color-mix(in srgb, var(--h-accent) 24%, var(--h-line));
+  border-radius: 999px;
+  background: color-mix(in srgb, var(--h-accent-soft) 54%, var(--h-bg-soft));
+  color: var(--h-text-2);
+  font-size: 12px;
+  line-height: 1;
+  padding: 6px 9px;
+}
+
+.box[data-variant="big"] .voiceActivity {
+  margin: 14px 18px 0;
+}
+
+.voiceActivityIcon {
+  display: inline-flex;
+  align-items: center;
+  justify-content: center;
+  width: 18px;
+  height: 18px;
+  border-radius: 999px;
+  background: color-mix(in srgb, var(--h-accent) 13%, transparent);
+  color: var(--h-accent);
+}
+
+.voiceActivityIcon svg {
+  width: 12px;
+  height: 12px;
+  stroke-width: 2.2;
+}
+
+.voiceActivityIcon[data-status="transcribing"] svg,
+.iconButton[data-status="transcribing"] svg {
+  animation: spin 0.85s linear infinite;
+}
+
+.voiceActivityText {
+  color: var(--h-text);
+  font-weight: 600;
+}
+
+.voiceActivityTime {
+  color: var(--h-text-3);
+  font-family: var(--h-font-mono);
+  font-size: 11px;
+  font-variant-numeric: tabular-nums;
+}
+
+.voiceBars {
+  display: inline-flex;
+  align-items: center;
+  gap: 2px;
+  width: 28px;
+  height: 14px;
+  color: var(--h-accent);
+}
+
+.voiceBars span {
+  width: 2px;
+  min-height: 3px;
+  border-radius: 999px;
+  background: currentColor;
+  opacity: 0.72;
+  transition: height 0.1s ease-out;
+}
+
 .skillPanel {
   margin: 8px 2px 0;
   border: 1px solid var(--h-line);
@@ -572,6 +645,26 @@
 
 .errorText {
   margin-top: 8px;
+  display: flex;
+  align-items: center;
+  flex-wrap: wrap;
+  gap: 8px;
+}
+
+.errorAction {
+  border: 1px solid color-mix(in srgb, var(--h-err) 34%, var(--h-line));
+  border-radius: 999px;
+  background: color-mix(in srgb, var(--h-err) 8%, transparent);
+  color: var(--h-err);
+  cursor: pointer;
+  font-family: var(--h-font-cn);
+  font-size: 11px;
+  line-height: 1;
+  padding: 4px 9px;
+}
+
+.errorAction:hover {
+  background: color-mix(in srgb, var(--h-err) 12%, transparent);
 }
 
 .contextWarning {
@@ -1141,6 +1234,7 @@
   align-items: center;
   justify-content: space-between;
   gap: 12px;
+  min-width: 0;
   min-height: var(--composer-action-height);
   margin-top: 8px;
 }
@@ -1154,7 +1248,13 @@
   min-height: var(--composer-action-height);
 }
 
+.leftTools {
+  flex: 1 1 auto;
+  overflow: hidden;
+}
+
 .rightTools {
+  flex: 0 0 auto;
   margin-left: auto;
 }
 
@@ -1180,6 +1280,16 @@
   padding: 0;
 }
 
+.iconButton:hover:not(:disabled),
+.iconButton[data-active="true"] {
+  background: var(--h-bg-chip);
+  color: var(--h-text);
+}
+
+.iconButton[data-active="true"] {
+  color: var(--h-accent);
+}
+
 .iconButton:disabled {
   cursor: not-allowed;
   opacity: 0.55;
@@ -1187,6 +1297,7 @@
 
 .toolButton {
   flex: 0 1 auto;
+  max-width: min(232px, 34%);
   height: var(--composer-tool-height);
   gap: 6px;
   border-radius: var(--h-r-md);
@@ -1393,6 +1504,7 @@
 .sendButton {
   --composer-send-accent: var(--h-accent);
 
+  flex: 0 0 auto;
   min-width: 88px;
   height: var(--composer-action-height);
   gap: 7px;
@@ -1444,11 +1556,68 @@
   flex: 0 0 auto;
 }
 
+@container hermes-composer (max-width: 760px) {
+  .toolbar {
+    gap: 8px;
+  }
+
+  .leftTools,
+  .rightTools {
+    gap: 5px;
+  }
+
+  .toolButton {
+    max-width: none;
+    padding: 0 9px;
+  }
+
+  .toolButton small,
+  .leftTools > button small {
+    display: none;
+  }
+
+  .sendButton {
+    min-width: 76px;
+    padding: 0 12px;
+  }
+}
+
+@container hermes-composer (max-width: 620px) {
+  .toolButton,
+  .leftTools > button[aria-haspopup="menu"] {
+    width: var(--composer-tool-height);
+    padding: 0;
+  }
+
+  .toolButton span,
+  .leftTools > button[aria-haspopup="menu"] span {
+    display: none;
+  }
+}
+
+@container hermes-composer (max-width: 520px) {
+  .sendButton {
+    min-width: var(--composer-action-height);
+    width: var(--composer-action-height);
+    padding: 0;
+  }
+
+  .sendButton span {
+    display: none;
+  }
+}
+
 .liveDot {
   width: 8px;
   height: 8px;
   border-radius: 999px;
   background: var(--h-ok);
+}
+
+@keyframes spin {
+  to {
+    transform: rotate(360deg);
+  }
 }
 
 @keyframes pulse {

--- a/web/src/components/chat/goose-composer.test.tsx
+++ b/web/src/components/chat/goose-composer.test.tsx
@@ -1,0 +1,28 @@
+import ReactDOMServer from "react-dom/server";
+import { describe, expect, it } from "vitest";
+
+import { ComposerErrorMessage } from "./goose-composer";
+
+describe("ComposerErrorMessage", () => {
+  it("shows a voice setup action for missing STT provider errors", () => {
+    const html = ReactDOMServer.renderToStaticMarkup(
+      <ComposerErrorMessage
+        message="语音识别尚未配置可用提供方。请到“语音”设置选择本地识别。"
+        onConfigureVoice={() => {}}
+      />,
+    );
+
+    expect(html).toContain("语音识别尚未配置可用提供方");
+    expect(html).toContain("去配置语音");
+  });
+
+  it("does not show a voice setup action for generic composer errors", () => {
+    const html = ReactDOMServer.renderToStaticMarkup(
+      <ComposerErrorMessage message="发送失败" onConfigureVoice={() => {}} />,
+    );
+
+    expect(html).toContain("发送失败");
+    expect(html).not.toContain("去配置语音");
+  });
+});
+

--- a/web/src/components/chat/goose-composer.tsx
+++ b/web/src/components/chat/goose-composer.tsx
@@ -10,7 +10,8 @@ import {
   type KeyboardEvent,
 } from "react";
 import { useAtomValue } from "jotai";
-import { Cpu, Folder, Plus, Sparkles, X } from "lucide-react";
+import { useNavigate } from "react-router-dom";
+import { Cpu, Folder, Loader2, Mic, Plus, Sparkles, Square, X } from "lucide-react";
 import type { ModelOptionsResult } from "@hermes/protocol";
 import { fileNameFromPath } from "@/lib/composer-prompt";
 import {
@@ -33,6 +34,14 @@ import {
   type ComposerSubmitShortcut,
 } from "@/lib/composer-submit-shortcut";
 import { composerSubmitShortcutAtom } from "@/stores/ui";
+import { useMicRecorder } from "@/hooks/use-mic-recorder";
+import {
+  isVoiceSetupErrorMessage,
+  sttEnabledFromConfig,
+  transcribeAudioBlob,
+  voiceErrorMessage,
+  voiceMaxRecordingSecondsFromConfig,
+} from "@/lib/voice";
 import {
   normalizeWorkspacePath,
   readWorkspacePath,
@@ -104,10 +113,38 @@ interface GooseComposerProps {
   skillPicker?: ComposerSkillPickerProps;
   contextUsage?: ComposerContextUsage | null;
   initialWorkspacePath?: string;
+  voiceConfig?: Record<string, unknown> | null;
 }
 
 function messageFromError(error: unknown): string {
   return error instanceof Error ? error.message : String(error || "发送失败");
+}
+
+function formatVoiceElapsed(seconds: number): string {
+  const safeSeconds = Math.max(0, Math.floor(seconds));
+  const minutes = Math.floor(safeSeconds / 60);
+  const remainingSeconds = safeSeconds % 60;
+  return `${minutes}:${remainingSeconds.toString().padStart(2, "0")}`;
+}
+
+export function ComposerErrorMessage({
+  message,
+  onConfigureVoice,
+}: {
+  message: string;
+  onConfigureVoice?: () => void;
+}) {
+  const showVoiceSetup = isVoiceSetupErrorMessage(message);
+  return (
+    <div className={s.errorText}>
+      <span>{message}</span>
+      {showVoiceSetup && onConfigureVoice ? (
+        <button type="button" className={s.errorAction} onClick={onConfigureVoice}>
+          去配置语音
+        </button>
+      ) : null}
+    </div>
+  );
 }
 
 export function GooseComposer({
@@ -131,7 +168,9 @@ export function GooseComposer({
   skillPicker,
   contextUsage,
   initialWorkspacePath = "",
+  voiceConfig = null,
 }: GooseComposerProps) {
+  const navigate = useNavigate();
   const configuredSubmitShortcut = useAtomValue(composerSubmitShortcutAtom);
   const effectiveSubmitShortcut = submitShortcut ?? configuredSubmitShortcut;
   const submitHint = composerSubmitShortcutHint(effectiveSubmitShortcut);
@@ -157,13 +196,23 @@ export function GooseComposer({
   const [skillActiveIndex, setSkillActiveIndex] = useState(0);
   const [dismissedSlashToken, setDismissedSlashToken] = useState("");
   const [dragActive, setDragActive] = useState(false);
+  const [voiceStatus, setVoiceStatus] = useState<"idle" | "recording" | "transcribing">("idle");
+  const [voiceElapsedSeconds, setVoiceElapsedSeconds] = useState(0);
+  const { handle: micRecorder, level: voiceLevel } = useMicRecorder();
   const textareaRef = useRef<HTMLTextAreaElement>(null);
+  const valueRef = useRef(initial);
+  const voiceStatusRef = useRef(voiceStatus);
   const fileInputRef = useRef<HTMLInputElement>(null);
   const attachmentsRef = useRef<ComposerAttachment[]>([]);
   const modelLoadPromiseRef = useRef<Promise<ModelOptionsResult> | null>(null);
   const selectedModelRef = useRef<ComposerModelSelection | null>(modelPicker?.selected ?? null);
   const dragDepthRef = useRef(0);
+  const voiceStartedAtRef = useRef(0);
+  const voiceIntervalRef = useRef<number | null>(null);
+  const voiceTimeoutRef = useRef<number | null>(null);
   const hasProcessingAttachment = attachments.some(isAttachmentBusy);
+  const sttEnabled = sttEnabledFromConfig(voiceConfig);
+  const maxRecordingSeconds = voiceMaxRecordingSecondsFromConfig(voiceConfig);
   const contextRisk = contextUsageRisk(contextUsage);
   const contextWarning = contextRiskText(contextRisk, loading);
   const controlsDisabled = disabled || loading;
@@ -212,6 +261,120 @@ export function GooseComposer({
     ? `继续描述给 ${selectedSkill.displayName} 的任务…`
     : placeholder ?? `发送消息，${submitHint}…`;
 
+  const clearVoiceTimers = useCallback(() => {
+    if (voiceIntervalRef.current !== null) {
+      window.clearInterval(voiceIntervalRef.current);
+      voiceIntervalRef.current = null;
+    }
+    if (voiceTimeoutRef.current !== null) {
+      window.clearTimeout(voiceTimeoutRef.current);
+      voiceTimeoutRef.current = null;
+    }
+  }, []);
+
+  const focusTextareaAt = useCallback((cursor: number) => {
+    window.requestAnimationFrame(() => {
+      const textarea = textareaRef.current;
+      if (!textarea) return;
+      textarea.focus();
+      textarea.setSelectionRange(cursor, cursor);
+      setSelectionStart(cursor);
+      setSelectionEnd(cursor);
+    });
+  }, []);
+
+  const insertTranscript = useCallback((transcript: string) => {
+    const text = transcript.trim();
+    if (!text) return;
+
+    const current = valueRef.current;
+    const textarea = textareaRef.current;
+    const rawStart = textarea?.selectionStart ?? selectionStart;
+    const rawEnd = textarea?.selectionEnd ?? selectionEnd;
+    const start = Math.max(0, Math.min(rawStart, current.length));
+    const end = Math.max(start, Math.min(rawEnd, current.length));
+    const before = current.slice(0, start);
+    const after = current.slice(end);
+    const prefix = before && !/\s$/.test(before) ? " " : "";
+    const suffix = after && !/^\s/.test(after) ? " " : "";
+    const next = `${before}${prefix}${text}${suffix}${after}`;
+    const cursor = before.length + prefix.length + text.length;
+
+    valueRef.current = next;
+    setValue(next);
+    setDismissedSlashToken("");
+    focusTextareaAt(cursor);
+  }, [focusTextareaAt, selectionEnd, selectionStart]);
+
+  const stopVoiceRecording = useCallback(async () => {
+    if (voiceStatusRef.current !== "recording") return;
+    clearVoiceTimers();
+    voiceStatusRef.current = "transcribing";
+    setVoiceStatus("transcribing");
+    try {
+      const result = await micRecorder.stop();
+      if (!result) {
+        voiceStatusRef.current = "idle";
+        setVoiceStatus("idle");
+        return;
+      }
+      const response = await transcribeAudioBlob(result.audio);
+      const transcript = response.transcript.trim();
+      if (!transcript) {
+        setSubmitError("未识别到语音，请再试一次。");
+      } else {
+        setSubmitError("");
+        insertTranscript(transcript);
+      }
+    } catch (error) {
+      setSubmitError(voiceErrorMessage(error, "语音转写失败"));
+    } finally {
+      voiceStatusRef.current = "idle";
+      setVoiceStatus("idle");
+      setVoiceElapsedSeconds(0);
+    }
+  }, [clearVoiceTimers, insertTranscript, micRecorder]);
+
+  const startVoiceRecording = useCallback(async () => {
+    if (controlsDisabled || voiceStatus !== "idle") return;
+    if (!sttEnabled) {
+      setSubmitError("语音识别（STT）已在设置中关闭，请先启用 stt.enabled。");
+      return;
+    }
+
+    setSubmitError("");
+    try {
+      await micRecorder.start({
+        onError: (error) => setSubmitError(voiceErrorMessage(error, "录音失败")),
+      });
+      voiceStartedAtRef.current = Date.now();
+      setVoiceElapsedSeconds(0);
+      voiceStatusRef.current = "recording";
+      setVoiceStatus("recording");
+      voiceIntervalRef.current = window.setInterval(() => {
+        setVoiceElapsedSeconds((Date.now() - voiceStartedAtRef.current) / 1000);
+      }, 250);
+      voiceTimeoutRef.current = window.setTimeout(() => {
+        void stopVoiceRecording();
+      }, maxRecordingSeconds * 1000);
+    } catch (error) {
+      clearVoiceTimers();
+      voiceStatusRef.current = "idle";
+      setVoiceStatus("idle");
+      setSubmitError(voiceErrorMessage(error, "录音失败"));
+    }
+  }, [clearVoiceTimers, controlsDisabled, maxRecordingSeconds, micRecorder, stopVoiceRecording, sttEnabled, voiceStatus]);
+
+  const toggleVoiceRecording = useCallback(() => {
+    if (voiceStatus === "recording") {
+      void stopVoiceRecording();
+      return;
+    }
+    if (voiceStatus === "idle") {
+      void startVoiceRecording();
+    }
+  }, [startVoiceRecording, stopVoiceRecording, voiceStatus]);
+
   // Make `initial` reactive so external prefill (e.g. quick-start recipes) takes
   // effect after mount. We focus the textarea on non-empty external pushes so
   // the user can keep typing without an extra click.
@@ -246,11 +409,18 @@ export function GooseComposer({
   }, [initialWorkspacePath]);
 
   useEffect(() => {
+    valueRef.current = value;
     const textarea = textareaRef.current;
     if (!textarea) return;
     textarea.style.height = "auto";
     textarea.style.height = `${Math.min(textarea.scrollHeight, 196)}px`;
   }, [value]);
+
+  useEffect(() => {
+    voiceStatusRef.current = voiceStatus;
+  }, [voiceStatus]);
+
+  useEffect(() => () => clearVoiceTimers(), [clearVoiceTimers]);
 
   useEffect(() => {
     attachmentsRef.current = attachments;
@@ -704,6 +874,14 @@ export function GooseComposer({
   }, [modelPicker?.initialOptions, modelOptions]);
 
   const modelText = modelButtonText(modelPicker, modelOptions);
+  const voiceButtonTitle = !sttEnabled
+    ? "语音识别（STT）已关闭"
+    : voiceStatus === "recording"
+      ? "停止录音并转写"
+      : voiceStatus === "transcribing"
+        ? "正在转写语音"
+        : `语音输入（最多 ${maxRecordingSeconds} 秒）`;
+  const voiceButtonDisabled = controlsDisabled || voiceStatus === "transcribing" || !sttEnabled;
 
   return (
     <div className={s.wrapper} data-compact={compact} data-variant={variant}>
@@ -770,6 +948,34 @@ export function GooseComposer({
               </button>
             </div>
             <span className={s.selectedSkillHint}>继续输入任务描述，Backspace 可移除</span>
+          </div>
+        ) : null}
+
+        {voiceStatus !== "idle" ? (
+          <div className={s.voiceActivity} role="status" aria-live="polite">
+            <span className={s.voiceActivityIcon} data-status={voiceStatus}>
+              {voiceStatus === "recording" ? (
+                <Mic aria-hidden="true" />
+              ) : (
+                <Loader2 aria-hidden="true" />
+              )}
+            </span>
+            <span className={s.voiceActivityText}>
+              {voiceStatus === "recording" ? "正在录音" : "正在转写"}
+            </span>
+            <span className={s.voiceActivityTime}>
+              {formatVoiceElapsed(voiceElapsedSeconds)}
+            </span>
+            <span className={s.voiceBars} aria-hidden="true">
+              {[0.5, 0.78, 1, 0.78, 0.5].map((weight, index) => (
+                <span
+                  key={index}
+                  style={{
+                    height: `${Math.round((0.24 + Math.min(0.7, voiceLevel * weight)) * 100)}%`,
+                  }}
+                />
+              ))}
+            </span>
           </div>
         ) : null}
 
@@ -879,7 +1085,12 @@ export function GooseComposer({
           </div>
         ) : null}
 
-        {submitError ? <div className={s.errorText}>{submitError}</div> : null}
+        {submitError ? (
+          <ComposerErrorMessage
+            message={submitError}
+            onConfigureVoice={() => navigate("/voice")}
+          />
+        ) : null}
 
         {contextWarning ? (
           <div className={s.contextWarning} data-risk={contextRisk}>
@@ -898,6 +1109,25 @@ export function GooseComposer({
               aria-label="添加附件"
             >
               <Plus className={s.toolIcon} aria-hidden="true" />
+            </button>
+            <button
+              className={s.iconButton}
+              type="button"
+              onClick={toggleVoiceRecording}
+              disabled={voiceButtonDisabled}
+              data-active={voiceStatus !== "idle"}
+              data-status={voiceStatus}
+              title={voiceButtonTitle}
+              aria-label={voiceButtonTitle}
+              aria-pressed={voiceStatus === "recording"}
+            >
+              {voiceStatus === "recording" ? (
+                <Square className={s.toolIcon} aria-hidden="true" />
+              ) : voiceStatus === "transcribing" ? (
+                <Loader2 className={s.toolIcon} aria-hidden="true" />
+              ) : (
+                <Mic className={s.toolIcon} aria-hidden="true" />
+              )}
             </button>
             <button
               className={s.toolButton}

--- a/web/src/components/chat/message-timeline.module.css
+++ b/web/src/components/chat/message-timeline.module.css
@@ -639,6 +639,35 @@
   color: var(--h-err);
 }
 
+.messageActions button[data-speech-state] {
+  display: inline-flex;
+  align-items: center;
+  gap: 3px;
+}
+
+.messageActions button[data-speech-state] svg {
+  width: 11px;
+  height: 11px;
+  stroke-width: 2;
+}
+
+.messageActions button[data-speech-state="preparing"] svg {
+  animation: spin 0.85s linear infinite;
+}
+
+.messageActions button[data-speech-state="preparing"],
+.messageActions button[data-speech-state="speaking"] {
+  color: var(--h-accent);
+}
+
+.messageSpeechError {
+  max-width: min(360px, 52vw);
+  overflow: hidden;
+  color: var(--h-err);
+  text-overflow: ellipsis;
+  white-space: nowrap;
+}
+
 .messageStats {
   position: relative;
   display: inline-flex;
@@ -1132,5 +1161,11 @@
 
   .toolActivityMeta {
     max-width: 180px;
+  }
+}
+
+@keyframes spin {
+  to {
+    transform: rotate(360deg);
   }
 }

--- a/web/src/components/chat/message-timeline.test.tsx
+++ b/web/src/components/chat/message-timeline.test.tsx
@@ -259,4 +259,31 @@ describe("MessageTimeline", () => {
 
     expect(html).not.toContain("对话轮次定位");
   });
+  it("renders read-aloud controls only for completed assistant messages", () => {
+    const messages: ChatMessage[] = [
+      { id: "user-1", role: "user", createdAt: 1, text: "问题" },
+      { id: "assistant-1", role: "assistant", createdAt: 2, status: "complete", text: "回答" },
+    ];
+
+    const html = ReactDOMServer.renderToStaticMarkup(
+      <MessageTimeline messages={messages} />,
+    );
+
+    expect(html).toContain('title="朗读回复"');
+    expect(html).toContain("朗读");
+  });
+
+  it("does not render read-aloud controls for user or streaming assistant messages", () => {
+    const messages: ChatMessage[] = [
+      { id: "user-1", role: "user", createdAt: 1, text: "问题" },
+      { id: "assistant-1", role: "assistant", createdAt: 2, status: "streaming", text: "回答中" },
+    ];
+
+    const html = ReactDOMServer.renderToStaticMarkup(
+      <MessageTimeline messages={messages} />,
+    );
+
+    expect(html).not.toContain('title="朗读回复"');
+  });
+
 });

--- a/web/src/components/chat/message-timeline.tsx
+++ b/web/src/components/chat/message-timeline.tsx
@@ -1,7 +1,7 @@
 import { useCallback, useEffect, useLayoutEffect, useMemo, useRef, useState } from "react";
 import type { ReactNode, WheelEvent } from "react";
 import { useAtomValue } from "jotai";
-import { AlertTriangle, ChevronRight, Info } from "lucide-react";
+import { AlertTriangle, ChevronRight, Info, Loader2, Volume2, VolumeX } from "lucide-react";
 import { showReasoningAtom } from "@/stores/ui";
 import type { AssistantMessageStats, ChatMessage, ChatToolItem } from "./chat-types";
 import { MessageImage } from "./message-image";
@@ -12,6 +12,7 @@ import s from "./message-timeline.module.css";
 import { summarizeToolActivity } from "./tool-activity";
 import { groupConsecutiveTools, groupElapsedMs } from "./group-tools";
 import { truncateMiddle } from "@/lib/truncate-middle";
+import { sanitizeTextForSpeech, speakText, voiceErrorMessage } from "@/lib/voice";
 import {
   formatDurationMs,
   formatElapsedTimer,
@@ -32,12 +33,32 @@ interface MessageTimelineProps {
   turnStartedAt?: number;
   sessionUsage?: SessionUsageResult | null;
   progressModel?: string;
+  autoTts?: boolean;
 }
 
 interface TurnAnchor {
   id: string;
   index: number;
   title: string;
+}
+
+type SpeechPlaybackStatus = "idle" | "preparing" | "speaking";
+
+interface SpeechPlaybackState {
+  messageId: string | null;
+  status: SpeechPlaybackStatus;
+}
+
+interface SpeechPlaybackError {
+  message: string;
+  messageId: string;
+}
+
+interface SpeechPlaybackControls {
+  error: SpeechPlaybackError | null;
+  onSpeak: (messageId: string, text: string) => void;
+  onStop: () => void;
+  state: SpeechPlaybackState;
 }
 
 export function resolveBottomFollowState(
@@ -483,6 +504,18 @@ function getCopyableText(message: ChatMessage): string | undefined {
   return message.text || message.reasoning;
 }
 
+function getReadableText(message: ChatMessage): string | undefined {
+  if (message.blocks?.length) {
+    const text = message.blocks
+      .filter((block) => block.type === "text")
+      .map((block) => block.text)
+      .join("\n\n")
+      .trim();
+    return text || undefined;
+  }
+  return message.text?.trim() || undefined;
+}
+
 const FINISH_REASON_LABEL: Record<string, string> = {
   stop: "正常",
   end_turn: "正常",
@@ -598,15 +631,21 @@ interface MessageBubbleProps {
   turnStartedAt?: number;
   sessionUsage?: SessionUsageResult | null;
   progressModel?: string;
+  speech?: SpeechPlaybackControls;
 }
 
-function MessageBubble({ message, turnStartedAt, sessionUsage, progressModel }: MessageBubbleProps) {
+function MessageBubble({ message, turnStartedAt, sessionUsage, progressModel, speech }: MessageBubbleProps) {
   const showReasoning = useAtomValue(showReasoningAtom);
   const isUser = message.role === "user";
   const isToolOnly = message.role === "tool";
   const isSystem = message.role === "system";
   const streaming = message.status === "streaming";
   const copyable = getCopyableText(message);
+  const readable = !isUser && !isSystem && !isToolOnly && !streaming && message.status !== "error"
+    ? getReadableText(message)
+    : undefined;
+  const speechStatus = speech?.state.messageId === message.id ? speech.state.status : "idle";
+  const speechBusy = speechStatus === "preparing" || speechStatus === "speaking";
   const hasBlocks = !isUser && Boolean(message.blocks?.length);
 
   if (isToolOnly) {
@@ -685,6 +724,33 @@ function MessageBubble({ message, turnStartedAt, sessionUsage, progressModel }: 
                 复制
               </CopyButton>
             ) : null}
+            {readable && speech ? (
+              <button
+                type="button"
+                onClick={() => {
+                  if (speechBusy) {
+                    speech.onStop();
+                  } else {
+                    speech.onSpeak(message.id, readable);
+                  }
+                }}
+                data-speech-state={speechStatus}
+                aria-pressed={speechBusy}
+                title={speechBusy ? "停止朗读" : "朗读回复"}
+              >
+                {speechStatus === "preparing" ? (
+                  <Loader2 aria-hidden="true" />
+                ) : speechStatus === "speaking" ? (
+                  <VolumeX aria-hidden="true" />
+                ) : (
+                  <Volume2 aria-hidden="true" />
+                )}
+                <span>{speechBusy ? "停止" : "朗读"}</span>
+              </button>
+            ) : null}
+            {speech?.error?.messageId === message.id ? (
+              <span className={s.messageSpeechError}>{speech.error.message}</span>
+            ) : null}
           </span>
           {message.stats ? <MessageStatsFooter stats={message.stats} /> : null}
         </div>
@@ -701,6 +767,7 @@ export function MessageTimeline({
   turnStartedAt,
   sessionUsage,
   progressModel,
+  autoTts = false,
 }: MessageTimelineProps) {
   const containerRef = useRef<HTMLDivElement>(null);
   const messagesRef = useRef<HTMLDivElement>(null);
@@ -717,7 +784,17 @@ export function MessageTimeline({
   const programmaticTimerRef = useRef<number | null>(null);
   const messageCountRef = useRef(0);
   const firstMessageIdRef = useRef<string | undefined>(undefined);
+  const speechAudioRef = useRef<HTMLAudioElement | null>(null);
+  const speechStopRef = useRef<(() => void) | null>(null);
+  const speechSequenceRef = useRef(0);
+  const autoTtsSeenRef = useRef<Set<string>>(new Set());
+  const autoTtsSessionKeyRef = useRef<string | undefined>(undefined);
   const [activeTurnId, setActiveTurnId] = useState<string | null>(null);
+  const [speechState, setSpeechState] = useState<SpeechPlaybackState>({
+    messageId: null,
+    status: "idle",
+  });
+  const [speechError, setSpeechError] = useState<SpeechPlaybackError | null>(null);
   const visibleMessages = useMemo(
     () =>
       messages.filter(
@@ -744,6 +821,116 @@ export function MessageTimeline({
     return anchors;
   }, [visibleMessages]);
   const showTurnRail = turnAnchors.length > 1;
+
+  const stopSpeech = useCallback(() => {
+    speechSequenceRef.current += 1;
+    speechStopRef.current?.();
+    speechStopRef.current = null;
+    if (speechAudioRef.current) {
+      speechAudioRef.current.pause();
+      speechAudioRef.current.src = "";
+      speechAudioRef.current.load();
+      speechAudioRef.current = null;
+    }
+    setSpeechState({ messageId: null, status: "idle" });
+  }, []);
+
+  const playSpeech = useCallback(async (messageId: string, text: string) => {
+    const speakableText = sanitizeTextForSpeech(text);
+    if (!speakableText) {
+      setSpeechError({ messageId, message: "没有可朗读的文本。" });
+      return;
+    }
+
+    stopSpeech();
+    const ownSequence = speechSequenceRef.current;
+    setSpeechError(null);
+    setSpeechState({ messageId, status: "preparing" });
+
+    try {
+      const response = await speakText(speakableText);
+      if (speechSequenceRef.current !== ownSequence) return;
+
+      const audio = new Audio(response.data_url);
+      speechAudioRef.current = audio;
+      setSpeechState({ messageId, status: "speaking" });
+
+      await new Promise<void>((resolve, reject) => {
+        const cleanup = () => {
+          audio.removeEventListener("ended", onEnded);
+          audio.removeEventListener("error", onError);
+          if (speechStopRef.current === onStop) speechStopRef.current = null;
+        };
+        const onEnded = () => {
+          cleanup();
+          resolve();
+        };
+        const onError = () => {
+          cleanup();
+          reject(new Error("音频播放失败"));
+        };
+        const onStop = () => {
+          cleanup();
+          resolve();
+        };
+        speechStopRef.current = onStop;
+        audio.addEventListener("ended", onEnded, { once: true });
+        audio.addEventListener("error", onError, { once: true });
+        void audio.play().catch(reject);
+      });
+
+      if (speechSequenceRef.current !== ownSequence) return;
+      speechAudioRef.current = null;
+      setSpeechState({ messageId: null, status: "idle" });
+    } catch (error) {
+      if (speechSequenceRef.current !== ownSequence) return;
+      speechAudioRef.current = null;
+      speechStopRef.current = null;
+      setSpeechState({ messageId: null, status: "idle" });
+      setSpeechError({ messageId, message: voiceErrorMessage(error, "朗读失败") });
+    }
+  }, [stopSpeech]);
+
+  useEffect(() => () => {
+    speechSequenceRef.current += 1;
+    speechStopRef.current?.();
+    speechStopRef.current = null;
+    if (speechAudioRef.current) {
+      speechAudioRef.current.pause();
+      speechAudioRef.current.src = "";
+      speechAudioRef.current.load();
+      speechAudioRef.current = null;
+    }
+  }, []);
+
+  useEffect(() => {
+    const completed = messages.filter((message) =>
+      message.role === "assistant" &&
+      message.status === "complete" &&
+      Boolean(getReadableText(message)),
+    );
+    const sessionKey = messages[0]?.id;
+    if (autoTtsSessionKeyRef.current !== sessionKey) {
+      autoTtsSessionKeyRef.current = sessionKey;
+      autoTtsSeenRef.current = new Set(completed.map((message) => message.id));
+      return;
+    }
+
+    const fresh = completed.filter((message) => !autoTtsSeenRef.current.has(message.id));
+    for (const message of completed) autoTtsSeenRef.current.add(message.id);
+    if (!autoTts || fresh.length === 0) return;
+
+    const target = fresh[fresh.length - 1];
+    const text = target ? getReadableText(target) : undefined;
+    if (target && text) void playSpeech(target.id, text);
+  }, [autoTts, messages, playSpeech]);
+
+  const speechControls = useMemo<SpeechPlaybackControls>(() => ({
+    error: speechError,
+    onSpeak: (messageId, text) => void playSpeech(messageId, text),
+    onStop: stopSpeech,
+    state: speechState,
+  }), [playSpeech, speechError, speechState, stopSpeech]);
 
   const setTurnAnchorNode = useCallback((id: string, node: HTMLDivElement | null) => {
     if (node) {
@@ -1063,6 +1250,7 @@ export function MessageTimeline({
                 turnStartedAt={isLast ? turnStartedAt : undefined}
                 sessionUsage={isLast ? sessionUsage : undefined}
                 progressModel={isLast ? progressModel : undefined}
+                speech={speechControls}
               />
             </div>
           );

--- a/web/src/components/panel/panel-composer.tsx
+++ b/web/src/components/panel/panel-composer.tsx
@@ -154,6 +154,7 @@ export function PanelComposer() {
         ]}
         showMeta={false}
         loading={sending}
+        voiceConfig={config ?? null}
         modelPicker={{
           selected: selectedModel,
           label: modelInfo?.model,

--- a/web/src/hooks/use-mic-recorder.ts
+++ b/web/src/hooks/use-mic-recorder.ts
@@ -1,0 +1,257 @@
+import { useEffect, useRef, useState } from "react";
+
+type BrowserAudioContext = typeof AudioContext;
+
+export interface MicRecorderOptions {
+  onError?: (error: Error) => void;
+  onLevel?: (level: number) => void;
+  onSilence?: () => void;
+  silenceLevel?: number;
+  silenceMs?: number;
+  idleSilenceMs?: number;
+}
+
+export interface MicRecording {
+  audio: Blob;
+  durationMs: number;
+  heardSpeech: boolean;
+}
+
+interface MicRecorderHandle {
+  start: (options?: MicRecorderOptions) => Promise<void>;
+  stop: () => Promise<MicRecording | null>;
+  cancel: () => void;
+}
+
+function micError(error: unknown): Error {
+  const name = error instanceof DOMException ? error.name : "";
+
+  if (name === "NotAllowedError" || name === "SecurityError") {
+    return new Error("麦克风权限已被拒绝，请在系统设置中允许 Hermes 访问麦克风。");
+  }
+  if (name === "NotFoundError" || name === "DevicesNotFoundError") {
+    return new Error("没有找到可用麦克风。");
+  }
+  if (name === "NotReadableError" || name === "TrackStartError") {
+    return new Error("麦克风正被其它应用占用，请关闭占用麦克风的应用后重试。");
+  }
+  if (name === "OverconstrainedError") {
+    return new Error("当前麦克风不支持所需录音参数。");
+  }
+  if (error instanceof Error) return error;
+  return new Error("无法启动麦克风录音。");
+}
+
+function supportedMimeType(): string {
+  if (typeof MediaRecorder === "undefined") return "";
+  return [
+    "audio/webm;codecs=opus",
+    "audio/webm",
+    "audio/mp4",
+    "audio/ogg;codecs=opus",
+    "audio/ogg",
+    "audio/wav",
+  ].find((type) => MediaRecorder.isTypeSupported(type)) ?? "";
+}
+
+export function useMicRecorder(): {
+  handle: MicRecorderHandle;
+  level: number;
+  recording: boolean;
+} {
+  const [level, setLevel] = useState(0);
+  const [recording, setRecording] = useState(false);
+
+  const recorderRef = useRef<MediaRecorder | null>(null);
+  const streamRef = useRef<MediaStream | null>(null);
+  const chunksRef = useRef<Blob[]>([]);
+  const audioContextRef = useRef<AudioContext | null>(null);
+  const animationRef = useRef<number | null>(null);
+  const startedAtRef = useRef(0);
+  const heardSpeechRef = useRef(false);
+  const silenceTriggeredRef = useRef(false);
+  const silenceStartedAtRef = useRef<number | null>(null);
+  const stopResolverRef = useRef<((recording: MicRecording | null) => void) | null>(null);
+
+  const cleanup = () => {
+    if (animationRef.current) {
+      window.cancelAnimationFrame(animationRef.current);
+      animationRef.current = null;
+    }
+    void audioContextRef.current?.close();
+    audioContextRef.current = null;
+    streamRef.current?.getTracks().forEach((track) => track.stop());
+    streamRef.current = null;
+    recorderRef.current = null;
+    setLevel(0);
+    setRecording(false);
+    silenceTriggeredRef.current = false;
+    silenceStartedAtRef.current = null;
+  };
+
+  useEffect(() => () => cleanup(), []);
+
+  const startMeter = (stream: MediaStream, options: MicRecorderOptions) => {
+    const audioWindow = window as Window & { webkitAudioContext?: BrowserAudioContext };
+    const AudioContextCtor = window.AudioContext || audioWindow.webkitAudioContext;
+    if (!AudioContextCtor) return;
+
+    try {
+      const audioContext = new AudioContextCtor();
+      const analyser = audioContext.createAnalyser();
+      const source = audioContext.createMediaStreamSource(stream);
+      analyser.fftSize = 256;
+      const data = new Uint8Array(analyser.fftSize);
+      source.connect(analyser);
+      audioContextRef.current = audioContext;
+
+      const tick = () => {
+        analyser.getByteTimeDomainData(data);
+        let sum = 0;
+        for (const value of data) {
+          const centered = value - 128;
+          sum += centered * centered;
+        }
+        const rms = Math.sqrt(sum / data.length);
+        const normalized = Math.min(1, rms / 42);
+        const now = Date.now();
+        setLevel(normalized);
+        options.onLevel?.(normalized);
+
+        const speechThreshold = options.silenceLevel ?? 0.02;
+        if (normalized >= speechThreshold) {
+          heardSpeechRef.current = true;
+          silenceStartedAtRef.current = null;
+        }
+
+        const silenceMs = options.silenceMs ?? 0;
+        const idleSilenceMs = options.idleSilenceMs ?? 0;
+        if (options.onSilence && !silenceTriggeredRef.current) {
+          if (heardSpeechRef.current && normalized < speechThreshold && silenceMs > 0) {
+            silenceStartedAtRef.current ??= now;
+            if (now - silenceStartedAtRef.current >= silenceMs) {
+              silenceTriggeredRef.current = true;
+              options.onSilence();
+              return;
+            }
+          } else if (!heardSpeechRef.current && idleSilenceMs > 0 && now - startedAtRef.current >= idleSilenceMs) {
+            silenceTriggeredRef.current = true;
+            options.onSilence();
+            return;
+          }
+        }
+
+        animationRef.current = window.requestAnimationFrame(tick);
+      };
+
+      tick();
+    } catch {
+      setLevel(0);
+    }
+  };
+
+  const start: MicRecorderHandle["start"] = async (options = {}) => {
+    if (recorderRef.current) return;
+    if (!navigator.mediaDevices?.getUserMedia || typeof MediaRecorder === "undefined") {
+      throw new Error("当前运行环境不支持麦克风录音。");
+    }
+
+    const permitted = await window.hermesDesktop?.requestMicrophoneAccess?.();
+    if (permitted === false) {
+      throw new Error("麦克风权限已被拒绝，请在系统设置中允许 Hermes 访问麦克风。");
+    }
+
+    let stream: MediaStream;
+    try {
+      stream = await navigator.mediaDevices.getUserMedia({
+        audio: { echoCancellation: true, noiseSuppression: true },
+      });
+    } catch (error) {
+      throw micError(error);
+    }
+
+    const mimeType = supportedMimeType();
+    let recorder: MediaRecorder;
+    try {
+      recorder = new MediaRecorder(stream, mimeType ? { mimeType } : undefined);
+    } catch (error) {
+      stream.getTracks().forEach((track) => track.stop());
+      throw micError(error);
+    }
+
+    chunksRef.current = [];
+    streamRef.current = stream;
+    recorderRef.current = recorder;
+    heardSpeechRef.current = false;
+    silenceTriggeredRef.current = false;
+    silenceStartedAtRef.current = null;
+    startedAtRef.current = Date.now();
+
+    recorder.ondataavailable = (event) => {
+      if (event.data.size > 0) chunksRef.current.push(event.data);
+    };
+
+    recorder.onstop = () => {
+      const chunks = chunksRef.current;
+      const recordingType = recorder.mimeType || mimeType || "audio/webm";
+      const durationMs = Date.now() - startedAtRef.current;
+      const heardSpeech = heardSpeechRef.current;
+      chunksRef.current = [];
+      cleanup();
+
+      const resolver = stopResolverRef.current;
+      stopResolverRef.current = null;
+      if (!chunks.length) {
+        resolver?.(null);
+        return;
+      }
+      resolver?.({
+        audio: new Blob(chunks, { type: recordingType }),
+        durationMs,
+        heardSpeech,
+      });
+    };
+
+    recorder.onerror = (event) => {
+      const error = micError((event as Event & { error?: unknown }).error);
+      const resolver = stopResolverRef.current;
+      stopResolverRef.current = null;
+      cleanup();
+      options.onError?.(error);
+      resolver?.(null);
+    };
+
+    recorder.start();
+    setRecording(true);
+    startMeter(stream, options);
+  };
+
+  const stop: MicRecorderHandle["stop"] = () =>
+    new Promise<MicRecording | null>((resolve) => {
+      const recorder = recorderRef.current;
+      if (!recorder || recorder.state === "inactive") {
+        cleanup();
+        resolve(null);
+        return;
+      }
+      stopResolverRef.current = resolve;
+      recorder.stop();
+    });
+
+  const cancel: MicRecorderHandle["cancel"] = () => {
+    const recorder = recorderRef.current;
+    const resolver = stopResolverRef.current;
+    stopResolverRef.current = null;
+
+    if (recorder && recorder.state !== "inactive") {
+      recorder.ondataavailable = null;
+      recorder.onerror = null;
+      recorder.onstop = null;
+      recorder.stop();
+    }
+    cleanup();
+    resolver?.(null);
+  };
+
+  return { handle: { start, stop, cancel }, level, recording };
+}

--- a/web/src/lib/runtime.ts
+++ b/web/src/lib/runtime.ts
@@ -245,6 +245,7 @@ declare global {
       uploadFile?(input: FileUploadInput): Promise<ElectronApiRequestResult>;
       pickFiles?(): Promise<ElectronFilePickerResult>;
       pickDirectory?(): Promise<ElectronFilePickerResult>;
+      requestMicrophoneAccess?(): Promise<boolean>;
       createWorkspaceProject?(): Promise<ElectronFilePickerResult>;
       openWorkspacePath?(input: { path: string }): Promise<ElectronApiRequestResult>;
       openExternalUrl?(input: { url: string }): Promise<ElectronSimpleResult>;

--- a/web/src/lib/voice-config.test.ts
+++ b/web/src/lib/voice-config.test.ts
@@ -1,0 +1,148 @@
+import { describe, expect, it } from "vitest";
+import type { ConfigSchemaResponse, EnvVarInfo } from "@hermes/protocol";
+
+import {
+  buildVoiceEnvUpdates,
+  buildVoiceSaveConfig,
+  envConfigured,
+  voiceProviderEnvKey,
+  voiceProviderOptions,
+  voiceSettingsDraftFromConfig,
+  type VoiceSettingsDraft,
+} from "./voice-config";
+
+const schema: ConfigSchemaResponse = {
+  category_order: ["stt", "tts", "voice"],
+  fields: {
+    "stt.provider": {
+      type: "select",
+      description: "Speech-to-text provider",
+      category: "stt",
+      options: ["local", "groq", "openai", "mistral", "xai", "elevenlabs"],
+    },
+    "tts.provider": {
+      type: "select",
+      description: "Text-to-speech provider",
+      category: "tts",
+      options: ["edge", "openai", "elevenlabs", "neutts"],
+    },
+  },
+};
+
+function draft(overrides: Partial<VoiceSettingsDraft> = {}): VoiceSettingsDraft {
+  return {
+    sttEnabled: true,
+    sttProvider: "openai",
+    ttsProvider: "elevenlabs",
+    autoTts: false,
+    maxRecordingSeconds: 120,
+    values: {
+      "stt.openai.model": "gpt-4o-mini-transcribe",
+      "tts.elevenlabs.model_id": "eleven_multilingual_v2",
+      "tts.elevenlabs.voice_id": "voice-1",
+    },
+    sttApiKey: "",
+    ttsApiKey: "",
+    ...overrides,
+  };
+}
+
+describe("voice provider helpers", () => {
+  it("maps provider API keys", () => {
+    expect(voiceProviderEnvKey("stt", "groq")).toBe("GROQ_API_KEY");
+    expect(voiceProviderEnvKey("stt", "openai")).toBe("VOICE_TOOLS_OPENAI_KEY");
+    expect(voiceProviderEnvKey("tts", "elevenlabs")).toBe("ELEVENLABS_API_KEY");
+    expect(voiceProviderEnvKey("tts", "edge")).toBeUndefined();
+  });
+
+  it("filters STT providers through the desktop-supported allowlist", () => {
+    const providers = voiceProviderOptions("stt", schema, "local").map((item) => item.id);
+
+    expect(providers).toEqual(["local", "groq", "openai", "xai", "elevenlabs"]);
+    expect(providers).not.toContain("mistral");
+  });
+
+  it("keeps unsupported current providers visible as compatibility entries", () => {
+    const providers = voiceProviderOptions("stt", schema, "mistral");
+    const current = providers.find((item) => item.id === "mistral");
+
+    expect(current?.unsupported).toBe(true);
+    expect(current?.label).toContain("当前配置");
+  });
+});
+
+describe("voice save helpers", () => {
+  it("builds nested config updates for selected STT and TTS providers", () => {
+    const next = buildVoiceSaveConfig(
+      { stt: { provider: "local" }, tts: { provider: "edge" }, voice: {} },
+      draft({ autoTts: true, maxRecordingSeconds: 42 }),
+    );
+
+    expect(next).toMatchObject({
+      stt: {
+        enabled: true,
+        provider: "openai",
+        openai: { model: "gpt-4o-mini-transcribe" },
+      },
+      tts: {
+        provider: "elevenlabs",
+        elevenlabs: {
+          model_id: "eleven_multilingual_v2",
+          voice_id: "voice-1",
+        },
+      },
+      voice: { auto_tts: true, max_recording_seconds: 42 },
+    });
+  });
+
+  it("does not write empty API key inputs", () => {
+    expect(buildVoiceEnvUpdates(draft())).toEqual([]);
+  });
+
+  it("deduplicates shared OpenAI voice API key updates", () => {
+    const updates = buildVoiceEnvUpdates(draft({
+      ttsProvider: "openai",
+      sttApiKey: "sk-stt",
+      ttsApiKey: "sk-tts",
+    }));
+
+    expect(updates).toEqual([{ key: "VOICE_TOOLS_OPENAI_KEY", value: "sk-tts" }]);
+  });
+
+  it("reads draft state from nested config", () => {
+    const value = voiceSettingsDraftFromConfig({
+      stt: { enabled: false, provider: "groq" },
+      tts: { provider: "edge", edge: { voice: "zh-CN-XiaoxiaoNeural" } },
+      voice: { auto_tts: true, max_recording_seconds: "30" },
+    });
+
+    expect(value).toMatchObject({
+      sttEnabled: false,
+      sttProvider: "groq",
+      ttsProvider: "edge",
+      autoTts: true,
+      maxRecordingSeconds: 30,
+    });
+    expect(value.values["tts.edge.voice"]).toBe("zh-CN-XiaoxiaoNeural");
+  });
+
+  it("reports existing env keys as configured", () => {
+    const envVars: Record<string, EnvVarInfo> = {
+      ELEVENLABS_API_KEY: {
+        is_set: true,
+        redacted_value: "••••",
+        description: "",
+        url: null,
+        category: "provider",
+        is_password: true,
+        tools: [],
+        advanced: false,
+      },
+    };
+
+    expect(envConfigured(envVars, "ELEVENLABS_API_KEY")).toBe(true);
+    expect(envConfigured(envVars, "GROQ_API_KEY")).toBe(false);
+    expect(envConfigured(envVars, undefined)).toBe(true);
+  });
+});
+

--- a/web/src/lib/voice-config.ts
+++ b/web/src/lib/voice-config.ts
@@ -1,0 +1,287 @@
+import type { ConfigSchemaResponse, EnvVarInfo } from "@hermes/protocol";
+import { buildNestedConfigUpdate, mergeConfigUpdate } from "@/lib/config-update";
+
+export type VoiceConfigKind = "stt" | "tts";
+
+export interface VoiceProviderMeta {
+  id: string;
+  label: string;
+  description: string;
+  envKey?: string;
+  configKeys: readonly string[];
+  local?: boolean;
+  unsupported?: boolean;
+}
+
+export interface VoiceSettingsDraft {
+  sttEnabled: boolean;
+  sttProvider: string;
+  ttsProvider: string;
+  autoTts: boolean;
+  maxRecordingSeconds: number;
+  values: Record<string, string | boolean | number>;
+  sttApiKey: string;
+  ttsApiKey: string;
+}
+
+export interface VoiceEnvUpdate {
+  key: string;
+  value: string;
+}
+
+const STT_PROVIDER_ALLOWLIST = new Set(["local", "groq", "openai", "xai", "elevenlabs"]);
+
+const STT_PROVIDER_META: Record<string, VoiceProviderMeta> = {
+  local: {
+    id: "local",
+    label: "本地识别",
+    description: "优先使用 faster-whisper 或本地 whisper CLI，不需要云端 API Key。",
+    local: true,
+    configKeys: ["stt.local.model", "stt.local.language"],
+  },
+  groq: {
+    id: "groq",
+    label: "Groq Whisper",
+    description: "云端 Whisper，速度快，有免费额度，需要 GROQ_API_KEY。",
+    envKey: "GROQ_API_KEY",
+    configKeys: [],
+  },
+  openai: {
+    id: "openai",
+    label: "OpenAI Whisper",
+    description: "OpenAI 语音转文字，优先读取 VOICE_TOOLS_OPENAI_KEY。",
+    envKey: "VOICE_TOOLS_OPENAI_KEY",
+    configKeys: ["stt.openai.model"],
+  },
+  xai: {
+    id: "xai",
+    label: "xAI Grok STT",
+    description: "xAI Grok 语音识别，需要 XAI_API_KEY 或已配置 xAI OAuth。",
+    envKey: "XAI_API_KEY",
+    configKeys: [],
+  },
+  elevenlabs: {
+    id: "elevenlabs",
+    label: "ElevenLabs Scribe",
+    description: "ElevenLabs Scribe 语音识别，需要 ELEVENLABS_API_KEY。",
+    envKey: "ELEVENLABS_API_KEY",
+    configKeys: [
+      "stt.elevenlabs.model_id",
+      "stt.elevenlabs.language_code",
+      "stt.elevenlabs.tag_audio_events",
+      "stt.elevenlabs.diarize",
+    ],
+  },
+};
+
+const TTS_PROVIDER_META: Record<string, VoiceProviderMeta> = {
+  edge: {
+    id: "edge",
+    label: "Edge TTS",
+    description: "Microsoft Edge 神经网络语音，免费，不需要 API Key。",
+    local: true,
+    configKeys: ["tts.edge.voice"],
+  },
+  openai: {
+    id: "openai",
+    label: "OpenAI TTS",
+    description: "OpenAI 语音合成，优先读取 VOICE_TOOLS_OPENAI_KEY。",
+    envKey: "VOICE_TOOLS_OPENAI_KEY",
+    configKeys: ["tts.openai.model", "tts.openai.voice"],
+  },
+  elevenlabs: {
+    id: "elevenlabs",
+    label: "ElevenLabs TTS",
+    description: "ElevenLabs 高质量语音合成，需要 ELEVENLABS_API_KEY。",
+    envKey: "ELEVENLABS_API_KEY",
+    configKeys: ["tts.elevenlabs.voice_id", "tts.elevenlabs.model_id"],
+  },
+  neutts: {
+    id: "neutts",
+    label: "NeuTTS",
+    description: "本地语音合成，需要本机已安装 NeuTTS 依赖。",
+    local: true,
+    configKeys: ["tts.neutts.model", "tts.neutts.device", "tts.neutts.ref_audio", "tts.neutts.ref_text"],
+  },
+};
+
+export const VOICE_FIELD_LABELS: Record<string, string> = {
+  "stt.local.model": "本地识别模型",
+  "stt.local.language": "识别语言",
+  "stt.openai.model": "OpenAI 识别模型",
+  "stt.elevenlabs.model_id": "ElevenLabs STT 模型",
+  "stt.elevenlabs.language_code": "ElevenLabs 语言代码",
+  "stt.elevenlabs.tag_audio_events": "标记音频事件",
+  "stt.elevenlabs.diarize": "说话人区分",
+  "tts.edge.voice": "Edge 语音",
+  "tts.openai.model": "OpenAI TTS 模型",
+  "tts.openai.voice": "OpenAI 语音",
+  "tts.elevenlabs.voice_id": "ElevenLabs 语音",
+  "tts.elevenlabs.model_id": "ElevenLabs 模型",
+  "tts.neutts.model": "NeuTTS 模型",
+  "tts.neutts.device": "NeuTTS 设备",
+  "tts.neutts.ref_audio": "NeuTTS 参考音频",
+  "tts.neutts.ref_text": "NeuTTS 参考文本",
+};
+
+export const VOICE_FIELD_PLACEHOLDERS: Record<string, string> = {
+  "stt.local.model": "base",
+  "stt.local.language": "zh",
+  "stt.openai.model": "whisper-1",
+  "stt.elevenlabs.model_id": "scribe_v2",
+  "stt.elevenlabs.language_code": "zho",
+  "tts.edge.voice": "zh-CN-XiaoxiaoNeural",
+  "tts.openai.model": "gpt-4o-mini-tts",
+  "tts.openai.voice": "alloy",
+  "tts.elevenlabs.model_id": "eleven_multilingual_v2",
+  "tts.neutts.device": "cpu",
+};
+
+export const VOICE_SELECT_OPTIONS: Record<string, string[]> = {
+  "stt.local.model": ["tiny", "base", "small", "medium", "large-v3"],
+  "stt.openai.model": ["whisper-1", "gpt-4o-mini-transcribe", "gpt-4o-transcribe"],
+  "stt.elevenlabs.model_id": ["scribe_v2", "scribe_v1"],
+  "tts.openai.voice": ["alloy", "echo", "fable", "onyx", "nova", "shimmer"],
+};
+
+function asRecord(value: unknown): Record<string, unknown> | null {
+  return value && typeof value === "object" && !Array.isArray(value)
+    ? value as Record<string, unknown>
+    : null;
+}
+
+export function getVoiceConfigValue(config: Record<string, unknown> | null | undefined, path: string): unknown {
+  if (!config) return undefined;
+  return path.split(".").reduce<unknown>((current, key) => asRecord(current)?.[key], config);
+}
+
+function currentProvider(config: Record<string, unknown> | null | undefined, kind: VoiceConfigKind): string {
+  const key = kind === "stt" ? "stt.provider" : "tts.provider";
+  const fallback = kind === "stt" ? "local" : "edge";
+  const value = getVoiceConfigValue(config, key);
+  return typeof value === "string" && value.trim() ? value.trim() : fallback;
+}
+
+function providerMeta(kind: VoiceConfigKind, id: string): VoiceProviderMeta {
+  const catalog = kind === "stt" ? STT_PROVIDER_META : TTS_PROVIDER_META;
+  return catalog[id] ?? {
+    id,
+    label: id,
+    description: "当前 runtime schema 声明了此语音提供方，但桌面端还没有专门说明。",
+    configKeys: [],
+  };
+}
+
+export function voiceProviderEnvKey(kind: VoiceConfigKind, provider: string): string | undefined {
+  return providerMeta(kind, provider).envKey;
+}
+
+export function voiceProviderOptions(
+  kind: VoiceConfigKind,
+  schema: ConfigSchemaResponse | null | undefined,
+  current: string,
+): VoiceProviderMeta[] {
+  const schemaKey = kind === "stt" ? "stt.provider" : "tts.provider";
+  const schemaOptions = schema?.fields[schemaKey]?.options ?? [];
+  const supported = kind === "stt"
+    ? schemaOptions.filter((id) => STT_PROVIDER_ALLOWLIST.has(id))
+    : schemaOptions;
+
+  const options = supported.map((id) => providerMeta(kind, id));
+  if (current && !supported.includes(current)) {
+    options.push({
+      ...providerMeta(kind, current),
+      label: `${providerMeta(kind, current).label}（当前配置）`,
+      description: "当前配置使用了这个提供方，但当前 runtime schema 未声明它；保存前建议切换到可用选项。",
+      unsupported: true,
+    });
+  }
+  return options;
+}
+
+function normalizeBoolean(value: unknown, fallback: boolean): boolean {
+  if (typeof value === "boolean") return value;
+  return fallback;
+}
+
+function normalizeNumber(value: unknown, fallback: number): number {
+  if (typeof value === "number" && Number.isFinite(value)) return value;
+  if (typeof value === "string" && value.trim()) {
+    const parsed = Number(value);
+    if (Number.isFinite(parsed)) return parsed;
+  }
+  return fallback;
+}
+
+export function voiceSettingsDraftFromConfig(
+  config: Record<string, unknown> | null | undefined,
+): VoiceSettingsDraft {
+  const sttProvider = currentProvider(config, "stt");
+  const ttsProvider = currentProvider(config, "tts");
+  const values: Record<string, string | boolean | number> = {};
+  for (const meta of [providerMeta("stt", sttProvider), providerMeta("tts", ttsProvider)]) {
+    for (const key of meta.configKeys) {
+      const value = getVoiceConfigValue(config, key);
+      if (typeof value === "boolean" || typeof value === "number" || typeof value === "string") {
+        values[key] = value;
+      } else {
+        values[key] = "";
+      }
+    }
+  }
+
+  return {
+    sttEnabled: normalizeBoolean(getVoiceConfigValue(config, "stt.enabled"), true),
+    sttProvider,
+    ttsProvider,
+    autoTts: normalizeBoolean(getVoiceConfigValue(config, "voice.auto_tts"), false),
+    maxRecordingSeconds: normalizeNumber(getVoiceConfigValue(config, "voice.max_recording_seconds"), 120),
+    values,
+    sttApiKey: "",
+    ttsApiKey: "",
+  };
+}
+
+function shouldPersistValue(value: string | boolean | number | undefined): value is string | boolean | number {
+  if (typeof value === "boolean" || typeof value === "number") return true;
+  return typeof value === "string" && value.trim().length > 0;
+}
+
+export function buildVoiceSaveConfig(
+  current: Record<string, unknown>,
+  draft: VoiceSettingsDraft,
+): Record<string, unknown> {
+  const sttMeta = providerMeta("stt", draft.sttProvider);
+  const ttsMeta = providerMeta("tts", draft.ttsProvider);
+  const patches: Record<string, unknown>[] = [
+    buildNestedConfigUpdate("stt.enabled", draft.sttEnabled),
+    buildNestedConfigUpdate("stt.provider", draft.sttProvider),
+    buildNestedConfigUpdate("tts.provider", draft.ttsProvider),
+    buildNestedConfigUpdate("voice.auto_tts", draft.autoTts),
+    buildNestedConfigUpdate("voice.max_recording_seconds", Math.max(1, Math.trunc(draft.maxRecordingSeconds || 120))),
+  ];
+
+  for (const key of [...sttMeta.configKeys, ...ttsMeta.configKeys]) {
+    const value = draft.values[key];
+    if (shouldPersistValue(value)) patches.push(buildNestedConfigUpdate(key, value));
+  }
+
+  return patches.reduce((next, patch) => mergeConfigUpdate(next, patch), current);
+}
+
+export function buildVoiceEnvUpdates(draft: VoiceSettingsDraft): VoiceEnvUpdate[] {
+  const updates = new Map<string, string>();
+  const sttEnv = voiceProviderEnvKey("stt", draft.sttProvider);
+  const ttsEnv = voiceProviderEnvKey("tts", draft.ttsProvider);
+  const sttKey = draft.sttApiKey.trim();
+  const ttsKey = draft.ttsApiKey.trim();
+  if (sttEnv && sttKey) updates.set(sttEnv, sttKey);
+  if (ttsEnv && ttsKey) updates.set(ttsEnv, ttsKey);
+  return Array.from(updates, ([key, value]) => ({ key, value }));
+}
+
+export function envConfigured(envVars: Record<string, EnvVarInfo> | undefined, key: string | undefined): boolean {
+  if (!key) return true;
+  return Boolean(envVars?.[key]?.is_set);
+}
+

--- a/web/src/lib/voice.test.ts
+++ b/web/src/lib/voice.test.ts
@@ -1,0 +1,68 @@
+import { describe, expect, it } from "vitest";
+
+import {
+  sanitizeTextForSpeech,
+  isVoiceSetupErrorMessage,
+  sttEnabledFromConfig,
+  voiceAutoTtsFromConfig,
+  voiceErrorMessage,
+  voiceMaxRecordingSecondsFromConfig,
+} from "./voice";
+
+describe("voice config helpers", () => {
+  it("reads voice settings from nested config", () => {
+    const config = {
+      stt: { enabled: true },
+      voice: { auto_tts: true, max_recording_seconds: 42 },
+    };
+
+    expect(sttEnabledFromConfig(config)).toBe(true);
+    expect(voiceAutoTtsFromConfig(config)).toBe(true);
+    expect(voiceMaxRecordingSecondsFromConfig(config)).toBe(42);
+  });
+
+  it("defaults STT to enabled and clamps recording length", () => {
+    expect(sttEnabledFromConfig({})).toBe(true);
+    expect(voiceMaxRecordingSecondsFromConfig({ voice: { max_recording_seconds: 9999 } })).toBe(600);
+    expect(voiceMaxRecordingSecondsFromConfig({ voice: { max_recording_seconds: "0" } })).toBe(1);
+  });
+});
+
+describe("sanitizeTextForSpeech", () => {
+  it("removes code, markdown wrappers, links and emoji before TTS", () => {
+    const text = sanitizeTextForSpeech([
+      "# 标题",
+      "请看 [文档](https://example.test/docs) 😄",
+      "```ts",
+      "const secret = 'do-not-read';",
+      "```",
+      "行内 `code` 保留为普通词。",
+      "图片 ![截图](https://example.test/a.png)",
+    ].join("\n"));
+
+    expect(text).toContain("标题");
+    expect(text).toContain("文档");
+    expect(text).toContain("code");
+    expect(text).toContain("截图");
+    expect(text).not.toContain("https://example.test");
+    expect(text).not.toContain("do-not-read");
+    expect(text).not.toContain("😄");
+  });
+});
+
+describe("voiceErrorMessage", () => {
+  it("maps old runtime 404 to an update hint", () => {
+    expect(voiceErrorMessage(new Error("HTTP 404: Not Found"), "语音失败"))
+      .toBe("当前 Hermes runtime 不支持语音接口，请先更新 runtime。");
+  });
+
+  it("maps missing STT provider errors to a setup hint", () => {
+    const message = voiceErrorMessage(
+      new Error("HTTP 400: {\"detail\":\"No STT provider available. Install faster-whisper or set GROQ_API_KEY\"}"),
+      "语音转写失败",
+    );
+
+    expect(message).toContain("语音识别尚未配置可用提供方");
+    expect(isVoiceSetupErrorMessage(message)).toBe(true);
+  });
+});

--- a/web/src/lib/voice.ts
+++ b/web/src/lib/voice.ts
@@ -1,0 +1,195 @@
+import { AudioSpeakResponse, AudioTranscriptionResponse, ElevenLabsVoicesResponse } from "@hermes/protocol";
+import { fetchJSON, postJSON } from "@/lib/transport";
+
+const DEFAULT_MAX_RECORDING_SECONDS = 120;
+const MIN_RECORDING_SECONDS = 1;
+const MAX_RECORDING_SECONDS = 600;
+
+const EMOJI_RE = /(?:[\u{1F000}-\u{1FAFF}\u{2600}-\u{27BF}]|[\u{FE0F}\u{200D}]|[\u{E0020}-\u{E007F}])+/gu;
+const FENCED_CODE_RE = /```[\s\S]*?(?:```|$)/g;
+const INLINE_CODE_RE = /`([^`]+)`/g;
+const MARKDOWN_IMAGE_RE = /!\[([^\]]*)\]\([^)]+\)/g;
+const MARKDOWN_LINK_RE = /\[([^\]]+)\]\([^)]+\)/g;
+const PARAGRAPH_BREAK_RE = /[ \t]*\n{2,}[ \t]*/g;
+const SOFT_BREAK_RE = /[ \t]*\n[ \t]*/g;
+const THINKING_PREFIX_RE =
+  /^\s*(?:\([^\)\n]{1,48}\)\s*)?(?:processing|thinking|reasoning|analyzing|pondering|contemplating|musing|cogitating|ruminating|deliberating|mulling|reflecting|computing|synthesizing|formulating|brainstorming)\.{2,}\s*/i;
+const URL_RE = /\bhttps?:\/\/\S+/gi;
+
+function asRecord(value: unknown): Record<string, unknown> | null {
+  return value && typeof value === "object" && !Array.isArray(value)
+    ? value as Record<string, unknown>
+    : null;
+}
+
+function nestedValue(config: Record<string, unknown> | undefined | null, path: string): unknown {
+  if (!config) return undefined;
+  return path.split(".").reduce<unknown>((current, key) => asRecord(current)?.[key], config);
+}
+
+function clampRecordingSeconds(value: number): number {
+  return Math.max(
+    MIN_RECORDING_SECONDS,
+    Math.min(MAX_RECORDING_SECONDS, Math.trunc(value)),
+  );
+}
+
+export function voiceMaxRecordingSecondsFromConfig(
+  config: Record<string, unknown> | undefined | null,
+): number {
+  const value = nestedValue(config, "voice.max_recording_seconds");
+  if (typeof value === "number" && Number.isFinite(value)) {
+    return clampRecordingSeconds(value);
+  }
+  if (typeof value === "string" && value.trim()) {
+    const parsed = Number(value);
+    if (Number.isFinite(parsed)) return clampRecordingSeconds(parsed);
+  }
+  return DEFAULT_MAX_RECORDING_SECONDS;
+}
+
+export function voiceAutoTtsFromConfig(
+  config: Record<string, unknown> | undefined | null,
+): boolean {
+  return nestedValue(config, "voice.auto_tts") === true;
+}
+
+export function sttEnabledFromConfig(
+  config: Record<string, unknown> | undefined | null,
+): boolean {
+  return nestedValue(config, "stt.enabled") !== false;
+}
+
+function normalizeLineBreaks(text: string): string {
+  return text
+    .replace(/\r\n?/g, "\n")
+    .replace(/(\p{L})-\n(\p{L})/gu, "$1$2")
+    .replace(PARAGRAPH_BREAK_RE, "。 ")
+    .replace(SOFT_BREAK_RE, " ");
+}
+
+export function sanitizeTextForSpeech(text: string): string {
+  return normalizeLineBreaks(text)
+    .replace(FENCED_CODE_RE, " ")
+    .replace(THINKING_PREFIX_RE, " ")
+    .replace(MARKDOWN_IMAGE_RE, "$1")
+    .replace(MARKDOWN_LINK_RE, "$1")
+    .replace(INLINE_CODE_RE, "$1")
+    .replace(URL_RE, "链接")
+    .replace(EMOJI_RE, " ")
+    .replace(/^#{1,6}\s+/gm, "")
+    .replace(/[*_~>#]/g, "")
+    .replace(/^\s*[-+*]\s+/gm, "")
+    .replace(/\s+/g, " ")
+    .trim();
+}
+
+export function blobToDataUrl(blob: Blob): Promise<string> {
+  return new Promise((resolve, reject) => {
+    const reader = new FileReader();
+    reader.onerror = () => reject(new Error("无法读取录音数据"));
+    reader.onload = () => {
+      if (typeof reader.result === "string") {
+        resolve(reader.result);
+      } else {
+        reject(new Error("录音数据格式无效"));
+      }
+    };
+    reader.readAsDataURL(blob);
+  });
+}
+
+export async function transcribeAudioBlob(blob: Blob): Promise<AudioTranscriptionResponse> {
+  const dataUrl = await blobToDataUrl(blob);
+  return postJSON(
+    "/api/audio/transcribe",
+    {
+      data_url: dataUrl,
+      mime_type: blob.type || undefined,
+    },
+    AudioTranscriptionResponse,
+  );
+}
+
+export function speakText(text: string): Promise<AudioSpeakResponse> {
+  return postJSON(
+    "/api/audio/speak",
+    { text },
+    AudioSpeakResponse,
+  );
+}
+
+export function getElevenLabsVoices(): Promise<ElevenLabsVoicesResponse> {
+  return fetchJSON("/api/audio/elevenlabs/voices", undefined, ElevenLabsVoicesResponse);
+}
+
+export function isVoiceSetupErrorMessage(message: string): boolean {
+  const lower = message.toLowerCase();
+  return [
+    "no stt provider available",
+    "no tts provider available",
+    "groq_api_key",
+    "voice_tools_openai_key",
+    "openai_api_key",
+    "elevenlabs_api_key",
+    "xai_api_key",
+    "no xai credentials",
+    "edge-tts",
+    "faster-whisper",
+    "hermes_local_stt_command",
+    "语音识别尚未配置",
+    "回复朗读尚未配置",
+    "需要配置",
+  ].some((needle) => lower.includes(needle));
+}
+
+export function voiceErrorMessage(error: unknown, fallback: string): string {
+  const raw = error instanceof Error ? error.message : String(error || "");
+  const message = raw.trim();
+  if (!message) return fallback;
+
+  const lower = message.toLowerCase();
+  if (lower.includes("no stt provider available")) {
+    return "语音识别尚未配置可用提供方。请到“语音”设置选择本地识别，或填写 Groq、OpenAI、xAI、ElevenLabs 的 API Key。";
+  }
+  if (lower.includes("no tts provider available")) {
+    return "回复朗读尚未配置可用的语音合成提供方。请到“语音”设置选择 Edge TTS、OpenAI、ElevenLabs 或本地 TTS。";
+  }
+  if (lower.includes("groq_api_key")) {
+    return "Groq 语音识别需要配置 GROQ_API_KEY，请到“语音”设置填写 API Key。";
+  }
+  if (lower.includes("voice_tools_openai_key") || lower.includes("openai_api_key")) {
+    return "OpenAI 语音功能需要配置 VOICE_TOOLS_OPENAI_KEY，请到“语音”设置填写 API Key。";
+  }
+  if (lower.includes("elevenlabs_api_key")) {
+    return "ElevenLabs 语音功能需要配置 ELEVENLABS_API_KEY，请到“语音”设置填写 API Key。";
+  }
+  if (lower.includes("xai_api_key") || lower.includes("no xai credentials")) {
+    return "xAI 语音识别需要配置 XAI_API_KEY 或完成 xAI OAuth，请到“语音”设置填写 API Key。";
+  }
+  if (lower.includes("edge-tts")) {
+    return "Edge TTS 本地依赖不可用，请安装 edge-tts，或到“语音”设置切换其它朗读提供方。";
+  }
+  if (lower.includes("faster-whisper") || lower.includes("hermes_local_stt_command")) {
+    return "本地语音识别依赖不可用，请安装 faster-whisper、本地 whisper CLI，或到“语音”设置切换云端识别提供方。";
+  }
+  if (lower.includes("http 404") || lower.includes("not found")) {
+    return "当前 Hermes runtime 不支持语音接口，请先更新 runtime。";
+  }
+  if (lower.includes("audio recording is empty")) {
+    return "录音为空，请重新录制。";
+  }
+  if (lower.includes("audio recording is too large") || lower.includes("http 413")) {
+    return "录音过长或文件过大，请缩短录音后重试。";
+  }
+  if (lower.includes("payload must be an audio recording")) {
+    return "录音格式不受当前 runtime 支持，请换用系统默认麦克风后重试。";
+  }
+  if (lower.includes("text is required")) {
+    return "没有可朗读的文本。";
+  }
+  if (message.includes("麦克风") || message.includes("权限") || message.includes("录音")) {
+    return message;
+  }
+  return `${fallback}：${message}`;
+}

--- a/web/src/routes/detail.tsx
+++ b/web/src/routes/detail.tsx
@@ -42,6 +42,7 @@ import {
   subscribeSessionUiStateChanges,
 } from "@/lib/session-ui-state";
 import { uploadAttachmentFile } from "@/lib/transport";
+import { voiceAutoTtsFromConfig } from "@/lib/voice";
 import {
   rememberSessionWorkspace,
   rememberWorkspaceProject,
@@ -422,6 +423,7 @@ export function DetailRoute() {
     selectedContextMax,
     estimatedUsed: estimatedContextUsed,
   });
+  const autoTts = voiceAutoTtsFromConfig(config);
   const pageStyle = useMemo(
     () => {
       const font = conversationFontSizeVars(conversationFontSizeMode);
@@ -502,6 +504,7 @@ export function DetailRoute() {
             turnStartedAt={runtimeIsBusy ? runtime.turnStartedAt : undefined}
             sessionUsage={runtimeIsBusy ? sessionUsage : undefined}
             progressModel={runtimeIsBusy ? model || undefined : undefined}
+            autoTts={autoTts}
           />
           <div className={s.composerArea}>
             {runtimeIsBusy && stall.isStalled ? (
@@ -515,6 +518,7 @@ export function DetailRoute() {
               showMeta={false}
               loading={runtimeIsBusy}
               onStop={onStop}
+              voiceConfig={config ?? null}
               modelPicker={{
                 selected: contextSelection,
                 label: model || modelInfo?.model,
@@ -536,6 +540,7 @@ export function DetailRoute() {
         {subagentPanelOpen ? (
           <SubagentPanel subagents={subagents} onClose={() => setSubagentPanelOpen(false)} />
         ) : null}
+
       </div>
     </div>
   );

--- a/web/src/routes/voice.module.css
+++ b/web/src/routes/voice.module.css
@@ -1,0 +1,372 @@
+.page {
+  display: grid;
+  gap: 16px;
+  max-width: 1120px;
+  margin: 0 auto;
+  font-family: var(--h-font-cn);
+}
+
+.hero {
+  display: grid;
+  grid-template-columns: minmax(0, 1fr) auto;
+  gap: 18px;
+  align-items: start;
+  padding: 18px 20px;
+  border: 1px solid color-mix(in srgb, var(--h-accent) 24%, var(--h-line));
+  border-radius: 18px;
+  background:
+    radial-gradient(circle at 12% -20%, color-mix(in srgb, var(--h-accent) 14%, transparent), transparent 42%),
+    linear-gradient(180deg, color-mix(in srgb, var(--h-bg-pane) 96%, var(--h-bg-app)), var(--h-bg-app));
+  box-shadow: var(--h-shadow);
+}
+
+.hero h2,
+.card h3 {
+  margin: 0;
+  color: var(--h-text);
+}
+
+.hero h2 {
+  font-size: 20px;
+  font-weight: 680;
+  letter-spacing: -0.02em;
+}
+
+.hero p,
+.cardDesc,
+.fieldHint {
+  color: var(--h-text-2);
+  font-size: 12px;
+  line-height: 1.7;
+}
+
+.hero p {
+  margin: 7px 0 0;
+}
+
+.heroActions,
+.cardActions,
+.testActions,
+.inlineControls {
+  display: flex;
+  align-items: center;
+  flex-wrap: wrap;
+  gap: 8px;
+}
+
+.grid {
+  display: grid;
+  grid-template-columns: repeat(2, minmax(0, 1fr));
+  gap: 16px;
+}
+
+.card {
+  min-width: 0;
+  padding: 18px;
+  border: 1px solid var(--h-line);
+  border-radius: 16px;
+  background: var(--h-bg-app);
+}
+
+.card[data-wide="true"] {
+  grid-column: 1 / -1;
+}
+
+.cardHead {
+  display: flex;
+  align-items: flex-start;
+  justify-content: space-between;
+  gap: 14px;
+  min-width: 0;
+  margin-bottom: 14px;
+}
+
+.cardHead > div {
+  min-width: 0;
+}
+
+.cardTitle {
+  display: flex;
+  align-items: center;
+  gap: 8px;
+  min-width: 0;
+}
+
+.cardTitle svg {
+  color: var(--h-accent);
+}
+
+.card h3 {
+  font-size: 15px;
+  font-weight: 650;
+}
+
+.cardDesc {
+  margin: 4px 0 0;
+}
+
+.providerGrid {
+  display: grid;
+  grid-template-columns: repeat(auto-fit, minmax(170px, 1fr));
+  gap: 10px;
+  margin: 12px 0 16px;
+}
+
+.providerCard {
+  appearance: none;
+  min-width: 0;
+  padding: 12px;
+  border: 1px solid var(--h-line);
+  border-radius: 12px;
+  background: var(--h-bg-pane);
+  color: var(--h-text);
+  cursor: pointer;
+  font-family: var(--h-font-cn);
+  text-align: left;
+}
+
+.providerCard:hover {
+  border-color: color-mix(in srgb, var(--h-accent) 42%, var(--h-line));
+}
+
+.providerCard[data-active="true"] {
+  border-color: var(--h-accent);
+  background: color-mix(in srgb, var(--h-accent) 10%, var(--h-bg-pane));
+}
+
+.providerCard[data-unsupported="true"] {
+  border-style: dashed;
+  opacity: 0.8;
+}
+
+.providerName {
+  display: flex;
+  align-items: center;
+  justify-content: space-between;
+  gap: 8px;
+  min-width: 0;
+  font-size: 13px;
+  font-weight: 650;
+}
+
+.providerName > span:first-child {
+  min-width: 0;
+  overflow: hidden;
+  text-overflow: ellipsis;
+}
+
+.providerCard p {
+  margin: 7px 0 0;
+  color: var(--h-text-3);
+  font-size: 11px;
+  line-height: 1.55;
+}
+
+.badge {
+  display: inline-block;
+  flex: 0 1 auto;
+  min-width: 0;
+  max-width: min(100%, 190px);
+  box-sizing: border-box;
+  min-height: 20px;
+  overflow: hidden;
+  padding: 0 8px;
+  border-radius: 999px;
+  background: var(--h-bg-chip);
+  color: var(--h-text-3);
+  font-size: 10.5px;
+  line-height: 20px;
+  text-align: center;
+  text-overflow: ellipsis;
+  vertical-align: top;
+  white-space: nowrap;
+}
+
+.cardHead > .badge {
+  max-width: min(48%, 220px);
+}
+
+.providerName .badge {
+  max-width: min(62%, 190px);
+}
+
+.badge[data-tone="ok"] {
+  color: var(--h-ok);
+  background: var(--h-ok-soft);
+}
+
+.badge[data-tone="warn"] {
+  color: var(--h-warn);
+  background: var(--h-warn-soft);
+}
+
+.formGrid {
+  display: grid;
+  grid-template-columns: repeat(2, minmax(0, 1fr));
+  gap: 12px;
+}
+
+.fieldHint {
+  min-width: 0;
+  overflow-wrap: anywhere;
+}
+
+.field {
+  display: grid;
+  gap: 6px;
+  min-width: 0;
+}
+
+.field label {
+  color: var(--h-text-2);
+  font-size: 11px;
+}
+
+.input,
+.select,
+.textarea {
+  box-sizing: border-box;
+  width: 100%;
+  min-width: 0;
+  border: 1px solid var(--h-line);
+  border-radius: 8px;
+  background: var(--h-bg-input);
+  color: var(--h-text);
+  font-family: var(--h-font-cn);
+  font-size: 12px;
+  outline: none;
+}
+
+.input,
+.select {
+  height: 34px;
+  padding: 0 10px;
+}
+
+.textarea {
+  min-height: 78px;
+  padding: 9px 10px;
+  resize: vertical;
+  line-height: 1.6;
+}
+
+.switchRow {
+  display: flex;
+  align-items: center;
+  justify-content: space-between;
+  gap: 12px;
+  padding: 10px 0;
+  border-bottom: 1px solid var(--h-line-soft);
+}
+
+.switchRow:last-child {
+  border-bottom: 0;
+}
+
+.switchText strong {
+  display: block;
+  color: var(--h-text);
+  font-size: 13px;
+  margin-bottom: 3px;
+}
+
+.switchText span {
+  color: var(--h-text-3);
+  font-size: 11px;
+  line-height: 1.5;
+}
+
+.toggle {
+  width: 34px;
+  height: 19px;
+  border: 1px solid var(--h-line);
+  border-radius: 999px;
+  background: var(--h-bg-chip);
+  cursor: pointer;
+  padding: 0;
+  position: relative;
+}
+
+.toggle::after {
+  content: "";
+  position: absolute;
+  top: 2px;
+  left: 2px;
+  width: 13px;
+  height: 13px;
+  border-radius: 999px;
+  background: #fff;
+  transition: left 0.14s;
+}
+
+.toggle[data-on="true"] {
+  background: var(--h-text);
+  border-color: var(--h-text);
+}
+
+.toggle[data-on="true"]::after {
+  left: 17px;
+}
+
+.button,
+.primaryButton {
+  display: inline-flex;
+  align-items: center;
+  justify-content: center;
+  gap: 6px;
+  min-height: 32px;
+  padding: 0 13px;
+  border-radius: 8px;
+  font-family: var(--h-font-cn);
+  font-size: 12px;
+  cursor: pointer;
+}
+
+.button {
+  border: 1px solid var(--h-line);
+  background: transparent;
+  color: var(--h-text);
+}
+
+.primaryButton {
+  border: 1px solid var(--h-accent);
+  background: var(--h-accent);
+  color: #fff;
+}
+
+.button:disabled,
+.primaryButton:disabled {
+  cursor: not-allowed;
+  opacity: 0.58;
+}
+
+.feedback {
+  margin-top: 12px;
+  padding: 10px 12px;
+  border-radius: 10px;
+  border: 1px solid var(--h-line);
+  background: var(--h-bg-pane);
+  color: var(--h-text-2);
+  font-size: 12px;
+  line-height: 1.6;
+}
+
+.feedback[data-tone="ok"] {
+  color: var(--h-ok);
+  border-color: color-mix(in srgb, var(--h-ok) 36%, var(--h-line));
+  background: var(--h-ok-soft);
+}
+
+.feedback[data-tone="error"] {
+  color: var(--h-err);
+  border-color: color-mix(in srgb, var(--h-err) 36%, var(--h-line));
+  background: color-mix(in srgb, var(--h-err) 8%, var(--h-bg-pane));
+}
+
+@media (max-width: 980px) {
+  .hero,
+  .grid,
+  .formGrid {
+    grid-template-columns: 1fr;
+  }
+}

--- a/web/src/routes/voice.test.tsx
+++ b/web/src/routes/voice.test.tsx
@@ -1,0 +1,84 @@
+import ReactDOMServer from "react-dom/server";
+import { describe, expect, it } from "vitest";
+import type { ConfigSchemaResponse, EnvVarInfo } from "@hermes/protocol";
+
+import { voiceProviderOptions, voiceSettingsDraftFromConfig } from "@/lib/voice-config";
+import { VoiceSettingsView } from "./voice";
+
+const schema: ConfigSchemaResponse = {
+  category_order: ["stt", "tts", "voice"],
+  fields: {
+    "stt.provider": {
+      type: "select",
+      description: "Speech-to-text provider",
+      category: "stt",
+      options: ["local", "groq", "openai", "xai", "elevenlabs"],
+    },
+    "tts.provider": {
+      type: "select",
+      description: "Text-to-speech provider",
+      category: "tts",
+      options: ["edge", "openai", "elevenlabs", "neutts"],
+    },
+    "stt.openai.model": {
+      type: "string",
+      description: "OpenAI STT model",
+      category: "stt",
+    },
+    "tts.elevenlabs.voice_id": {
+      type: "string",
+      description: "ElevenLabs voice",
+      category: "tts",
+    },
+    "tts.elevenlabs.model_id": {
+      type: "string",
+      description: "ElevenLabs model",
+      category: "tts",
+    },
+  },
+};
+
+const envVars: Record<string, EnvVarInfo> = {
+  VOICE_TOOLS_OPENAI_KEY: {
+    is_set: true,
+    redacted_value: "sk-***",
+    description: "",
+    url: null,
+    category: "provider",
+    is_password: true,
+    tools: [],
+    advanced: false,
+  },
+};
+
+describe("VoiceSettingsView", () => {
+  it("renders STT, TTS and experience setup cards", () => {
+    const draft = voiceSettingsDraftFromConfig({
+      stt: { enabled: true, provider: "openai", openai: { model: "whisper-1" } },
+      tts: { provider: "elevenlabs", elevenlabs: { voice_id: "voice-1" } },
+      voice: { auto_tts: false, max_recording_seconds: 120 },
+    });
+    const html = ReactDOMServer.renderToStaticMarkup(
+      <VoiceSettingsView
+        draft={draft}
+        schema={schema}
+        envVars={envVars}
+        sttProviders={voiceProviderOptions("stt", schema, draft.sttProvider)}
+        ttsProviders={voiceProviderOptions("tts", schema, draft.ttsProvider)}
+        elevenLabsVoices={{
+          available: true,
+          voices: [{ voice_id: "voice-1", name: "Rachel", label: "Rachel (premade)" }],
+        }}
+      />,
+    );
+
+    expect(html).toContain("语音识别 STT");
+    expect(html).toContain("回复朗读 TTS");
+    expect(html).toContain("体验设置");
+    expect(html).toContain("VOICE_TOOLS_OPENAI_KEY 已配置");
+    expect(html).toContain("需要 ELEVENLABS_API_KEY");
+    expect(html).toContain("Rachel (premade)");
+    expect(html).toContain("保存配置");
+  });
+});
+

--- a/web/src/routes/voice.tsx
+++ b/web/src/routes/voice.tsx
@@ -1,0 +1,547 @@
+import { useEffect, useMemo, useRef, useState } from "react";
+import { useQuery } from "@tanstack/react-query";
+import { CheckCircle2, KeyRound, Loader2, Mic, Play, Save, Volume2 } from "lucide-react";
+import type { ConfigSchemaResponse, ElevenLabsVoicesResponse, EnvVarInfo } from "@hermes/protocol";
+import { useConfig, useConfigSchema, useSaveConfig } from "@/hooks/use-config";
+import { useEnvVars, useSetEnv } from "@/hooks/use-env";
+import { useMicRecorder } from "@/hooks/use-mic-recorder";
+import {
+  getElevenLabsVoices,
+  speakText,
+  transcribeAudioBlob,
+  voiceErrorMessage,
+} from "@/lib/voice";
+import {
+  VOICE_FIELD_LABELS,
+  VOICE_FIELD_PLACEHOLDERS,
+  VOICE_SELECT_OPTIONS,
+  buildVoiceEnvUpdates,
+  buildVoiceSaveConfig,
+  envConfigured,
+  getVoiceConfigValue,
+  voiceProviderEnvKey,
+  voiceProviderOptions,
+  voiceSettingsDraftFromConfig,
+  type VoiceProviderMeta,
+  type VoiceSettingsDraft,
+} from "@/lib/voice-config";
+import { SectionShell } from "./section-shell";
+import s from "./voice.module.css";
+
+type FeedbackTone = "info" | "ok" | "error";
+
+interface Feedback {
+  tone: FeedbackTone;
+  message: string;
+}
+
+interface VoiceSettingsViewProps {
+  draft: VoiceSettingsDraft;
+  schema: ConfigSchemaResponse;
+  envVars?: Record<string, EnvVarInfo>;
+  sttProviders: VoiceProviderMeta[];
+  ttsProviders: VoiceProviderMeta[];
+  elevenLabsVoices?: ElevenLabsVoicesResponse | null;
+  saving?: boolean;
+  sttTesting?: boolean;
+  ttsTesting?: boolean;
+  feedback?: Feedback | null;
+  ttsSampleText?: string;
+  onDraftChange?: (draft: VoiceSettingsDraft) => void;
+  onSave?: () => void;
+  onTestStt?: () => void;
+  onTestTts?: () => void;
+  onTtsSampleTextChange?: (value: string) => void;
+}
+
+function fieldValue(draft: VoiceSettingsDraft, key: string): string | boolean | number {
+  return draft.values[key] ?? "";
+}
+
+function fieldOptions(key: string, elevenLabsVoices?: ElevenLabsVoicesResponse | null): string[] | undefined {
+  if (key === "tts.elevenlabs.voice_id" && elevenLabsVoices?.available && elevenLabsVoices.voices.length > 0) {
+    return elevenLabsVoices.voices.map((voice) => voice.voice_id);
+  }
+  return VOICE_SELECT_OPTIONS[key];
+}
+
+function fieldOptionLabel(key: string, value: string, elevenLabsVoices?: ElevenLabsVoicesResponse | null): string {
+  if (key === "tts.elevenlabs.voice_id" && elevenLabsVoices?.voices.length) {
+    return elevenLabsVoices.voices.find((voice) => voice.voice_id === value)?.label ?? value;
+  }
+  return value;
+}
+
+function selectedProvider(providers: VoiceProviderMeta[], id: string): VoiceProviderMeta | undefined {
+  return providers.find((provider) => provider.id === id);
+}
+
+function EnvBadge({ envVars, envKey }: { envVars?: Record<string, EnvVarInfo>; envKey?: string }) {
+  if (!envKey) return <span className={s.badge} data-tone="ok">无需密钥</span>;
+  const configured = envConfigured(envVars, envKey);
+  const label = configured ? `${envKey} 已配置` : `需要 ${envKey}`;
+  return <span className={s.badge} data-tone={configured ? "ok" : "warn"} title={label}>{label}</span>;
+}
+
+function ProviderPicker({
+  kind,
+  value,
+  providers,
+  envVars,
+  onChange,
+}: {
+  kind: "stt" | "tts";
+  value: string;
+  providers: VoiceProviderMeta[];
+  envVars?: Record<string, EnvVarInfo>;
+  onChange?: (provider: string) => void;
+}) {
+  return (
+    <div className={s.providerGrid} data-kind={kind}>
+      {providers.map((provider) => (
+        <button
+          key={provider.id}
+          type="button"
+          className={s.providerCard}
+          data-active={provider.id === value ? "true" : undefined}
+          data-unsupported={provider.unsupported ? "true" : undefined}
+          onClick={() => onChange?.(provider.id)}
+        >
+          <span className={s.providerName}>
+            <span>{provider.label}</span>
+            <EnvBadge envVars={envVars} envKey={provider.envKey} />
+          </span>
+          <p>{provider.description}</p>
+        </button>
+      ))}
+    </div>
+  );
+}
+
+function ProviderFields({
+  provider,
+  draft,
+  schema,
+  elevenLabsVoices,
+  onDraftChange,
+}: {
+  provider?: VoiceProviderMeta;
+  draft: VoiceSettingsDraft;
+  schema: ConfigSchemaResponse;
+  elevenLabsVoices?: ElevenLabsVoicesResponse | null;
+  onDraftChange?: (draft: VoiceSettingsDraft) => void;
+}) {
+  if (!provider || provider.configKeys.length === 0) return null;
+
+  const updateValue = (key: string, value: string | boolean | number) => {
+    onDraftChange?.({
+      ...draft,
+      values: { ...draft.values, [key]: value },
+    });
+  };
+
+  return (
+    <div className={s.formGrid}>
+      {provider.configKeys.map((key) => {
+        const field = schema.fields[key];
+        const value = fieldValue(draft, key);
+        const options = fieldOptions(key, elevenLabsVoices);
+        const label = VOICE_FIELD_LABELS[key] ?? key;
+        if (field?.type === "boolean") {
+          return (
+            <div key={key} className={s.switchRow}>
+              <span className={s.switchText}>
+                <strong>{label}</strong>
+                <span>{key}</span>
+              </span>
+              <button
+                type="button"
+                className={s.toggle}
+                data-on={Boolean(value) ? "true" : undefined}
+                aria-label={label}
+                onClick={() => updateValue(key, !Boolean(value))}
+              />
+            </div>
+          );
+        }
+        return (
+          <div key={key} className={s.field}>
+            <label htmlFor={`voice-field-${key}`}>{label}</label>
+            {options ? (
+              <select
+                id={`voice-field-${key}`}
+                className={s.select}
+                value={String(value ?? "")}
+                onChange={(event) => updateValue(key, event.target.value)}
+              >
+                <option value="">使用 runtime 默认值</option>
+                {options.map((option) => (
+                  <option key={option} value={option}>{fieldOptionLabel(key, option, elevenLabsVoices)}</option>
+                ))}
+              </select>
+            ) : (
+              <input
+                id={`voice-field-${key}`}
+                className={s.input}
+                value={String(value ?? "")}
+                placeholder={VOICE_FIELD_PLACEHOLDERS[key] ?? "使用 runtime 默认值"}
+                onChange={(event) => {
+                  const nextValue = field?.type === "number" && event.target.value.trim()
+                    ? Number(event.target.value)
+                    : event.target.value;
+                  updateValue(key, nextValue);
+                }}
+              />
+            )}
+            <span className={s.fieldHint}>{key}</span>
+          </div>
+        );
+      })}
+    </div>
+  );
+}
+
+export function VoiceSettingsView({
+  draft,
+  schema,
+  envVars,
+  sttProviders,
+  ttsProviders,
+  elevenLabsVoices,
+  saving = false,
+  sttTesting = false,
+  ttsTesting = false,
+  feedback = null,
+  ttsSampleText = "你好，我是 Hermes。语音合成配置已经可以使用。",
+  onDraftChange,
+  onSave,
+  onTestStt,
+  onTestTts,
+  onTtsSampleTextChange,
+}: VoiceSettingsViewProps) {
+  const sttProvider = selectedProvider(sttProviders, draft.sttProvider);
+  const ttsProvider = selectedProvider(ttsProviders, draft.ttsProvider);
+  const sttEnvKey = voiceProviderEnvKey("stt", draft.sttProvider);
+  const ttsEnvKey = voiceProviderEnvKey("tts", draft.ttsProvider);
+
+  return (
+    <div className={s.page}>
+      <section className={s.hero}>
+        <div>
+          <h2>语音模型配置</h2>
+          <p>在这里配置 Composer 语音转文字和助手回复朗读。API Key 会写入当前档案的 .env，模型与开关写入 config.yaml。</p>
+        </div>
+        <div className={s.heroActions}>
+          <button type="button" className={s.primaryButton} onClick={onSave} disabled={saving}>
+            {saving ? <Loader2 size={14} /> : <Save size={14} />}
+            {saving ? "保存中…" : "保存配置"}
+          </button>
+        </div>
+      </section>
+
+      <div className={s.grid}>
+        <section className={s.card}>
+          <div className={s.cardHead}>
+            <div>
+              <div className={s.cardTitle}>
+                <Mic size={16} />
+                <h3>语音识别 STT</h3>
+              </div>
+              <p className={s.cardDesc}>选择录音转写提供方。当前 Composer 麦克风按钮会使用这里的配置。</p>
+            </div>
+            <EnvBadge envVars={envVars} envKey={sttEnvKey} />
+          </div>
+
+          <ProviderPicker
+            kind="stt"
+            value={draft.sttProvider}
+            providers={sttProviders}
+            envVars={envVars}
+            onChange={(provider) => onDraftChange?.({ ...draft, sttProvider: provider })}
+          />
+
+          {sttEnvKey ? (
+            <div className={s.field}>
+              <label htmlFor="voice-stt-api-key">API Key</label>
+              <input
+                id="voice-stt-api-key"
+                className={s.input}
+                type="password"
+                value={draft.sttApiKey}
+                placeholder={envConfigured(envVars, sttEnvKey) ? `已配置 ${sttEnvKey}，留空则保留` : `填写 ${sttEnvKey}`}
+                onChange={(event) => onDraftChange?.({ ...draft, sttApiKey: event.target.value })}
+              />
+              <span className={s.fieldHint}><KeyRound size={12} /> {sttEnvKey}</span>
+            </div>
+          ) : null}
+
+          <ProviderFields
+            provider={sttProvider}
+            draft={draft}
+            schema={schema}
+            onDraftChange={onDraftChange}
+          />
+
+          <div className={s.cardActions}>
+            <button type="button" className={s.button} onClick={onTestStt} disabled={sttTesting || !draft.sttEnabled}>
+              {sttTesting ? <Loader2 size={14} /> : <Mic size={14} />}
+              {sttTesting ? "录音测试中…" : "测试识别"}
+            </button>
+          </div>
+        </section>
+
+        <section className={s.card}>
+          <div className={s.cardHead}>
+            <div>
+              <div className={s.cardTitle}>
+                <Volume2 size={16} />
+                <h3>回复朗读 TTS</h3>
+              </div>
+              <p className={s.cardDesc}>选择助手回复朗读提供方。消息里的“朗读”按钮会使用这里的配置。</p>
+            </div>
+            <EnvBadge envVars={envVars} envKey={ttsEnvKey} />
+          </div>
+
+          <ProviderPicker
+            kind="tts"
+            value={draft.ttsProvider}
+            providers={ttsProviders}
+            envVars={envVars}
+            onChange={(provider) => onDraftChange?.({ ...draft, ttsProvider: provider })}
+          />
+
+          {ttsEnvKey ? (
+            <div className={s.field}>
+              <label htmlFor="voice-tts-api-key">API Key</label>
+              <input
+                id="voice-tts-api-key"
+                className={s.input}
+                type="password"
+                value={draft.ttsApiKey}
+                placeholder={envConfigured(envVars, ttsEnvKey) ? `已配置 ${ttsEnvKey}，留空则保留` : `填写 ${ttsEnvKey}`}
+                onChange={(event) => onDraftChange?.({ ...draft, ttsApiKey: event.target.value })}
+              />
+              <span className={s.fieldHint}><KeyRound size={12} /> {ttsEnvKey}</span>
+            </div>
+          ) : null}
+
+          <ProviderFields
+            provider={ttsProvider}
+            draft={draft}
+            schema={schema}
+            elevenLabsVoices={elevenLabsVoices}
+            onDraftChange={onDraftChange}
+          />
+
+          <div className={s.field}>
+            <label htmlFor="voice-tts-sample">朗读测试文本</label>
+            <textarea
+              id="voice-tts-sample"
+              className={s.textarea}
+              value={ttsSampleText}
+              onChange={(event) => onTtsSampleTextChange?.(event.target.value)}
+            />
+          </div>
+          <div className={s.cardActions}>
+            <button type="button" className={s.button} onClick={onTestTts} disabled={ttsTesting}>
+              {ttsTesting ? <Loader2 size={14} /> : <Play size={14} />}
+              {ttsTesting ? "朗读测试中…" : "测试朗读"}
+            </button>
+          </div>
+        </section>
+
+        <section className={s.card} data-wide="true">
+          <div className={s.cardHead}>
+            <div>
+              <div className={s.cardTitle}>
+                <CheckCircle2 size={16} />
+                <h3>体验设置</h3>
+              </div>
+              <p className={s.cardDesc}>这些设置会影响 Composer 录音体验和新完成助手回复的自动朗读行为。</p>
+            </div>
+          </div>
+
+          <div className={s.switchRow}>
+            <span className={s.switchText}>
+              <strong>启用语音识别</strong>
+              <span>关闭后 Composer 麦克风按钮不可用。</span>
+            </span>
+            <button
+              type="button"
+              className={s.toggle}
+              data-on={draft.sttEnabled ? "true" : undefined}
+              aria-label="启用语音识别"
+              onClick={() => onDraftChange?.({ ...draft, sttEnabled: !draft.sttEnabled })}
+            />
+          </div>
+          <div className={s.switchRow}>
+            <span className={s.switchText}>
+              <strong>自动朗读助手回复</strong>
+              <span>只朗读新完成的助手消息，不会朗读历史消息。</span>
+            </span>
+            <button
+              type="button"
+              className={s.toggle}
+              data-on={draft.autoTts ? "true" : undefined}
+              aria-label="自动朗读助手回复"
+              onClick={() => onDraftChange?.({ ...draft, autoTts: !draft.autoTts })}
+            />
+          </div>
+          <div className={s.switchRow}>
+            <span className={s.switchText}>
+              <strong>最长录音时长</strong>
+              <span>到达上限后自动停止并开始转写。</span>
+            </span>
+            <input
+              className={s.input}
+              type="number"
+              min={1}
+              max={600}
+              value={draft.maxRecordingSeconds}
+              onChange={(event) => onDraftChange?.({ ...draft, maxRecordingSeconds: Number(event.target.value) })}
+              aria-label="最长录音时长"
+              style={{ width: 120 }}
+            />
+          </div>
+        </section>
+      </div>
+
+      {feedback ? (
+        <div className={s.feedback} data-tone={feedback.tone === "info" ? undefined : feedback.tone}>
+          {feedback.message}
+        </div>
+      ) : null}
+    </div>
+  );
+}
+
+export function VoiceRoute() {
+  const { data: config, isLoading: configLoading } = useConfig();
+  const { data: schema, isLoading: schemaLoading } = useConfigSchema();
+  const { data: envVars } = useEnvVars();
+  const saveConfig = useSaveConfig();
+  const setEnv = useSetEnv();
+  const { handle: micRecorder } = useMicRecorder();
+  const [draft, setDraft] = useState<VoiceSettingsDraft | null>(null);
+  const [feedback, setFeedback] = useState<Feedback | null>(null);
+  const [sttTesting, setSttTesting] = useState(false);
+  const [ttsTesting, setTtsTesting] = useState(false);
+  const [ttsSampleText, setTtsSampleText] = useState("你好，我是 Hermes。语音合成配置已经可以使用。");
+  const audioRef = useRef<HTMLAudioElement | null>(null);
+
+  useEffect(() => {
+    if (config) setDraft(voiceSettingsDraftFromConfig(config));
+  }, [config]);
+
+  const elevenLabsVoices = useQuery({
+    queryKey: ["audio-elevenlabs-voices", draft?.ttsProvider],
+    queryFn: getElevenLabsVoices,
+    enabled: draft?.ttsProvider === "elevenlabs",
+    retry: false,
+  });
+
+  const sttProviders = useMemo(
+    () => draft && schema ? voiceProviderOptions("stt", schema, draft.sttProvider) : [],
+    [draft, schema],
+  );
+  const ttsProviders = useMemo(
+    () => draft && schema ? voiceProviderOptions("tts", schema, draft.ttsProvider) : [],
+    [draft, schema],
+  );
+
+  const save = async () => {
+    if (!config || !draft) return;
+    setFeedback(null);
+    try {
+      await saveConfig.mutateAsync(buildVoiceSaveConfig(config, draft));
+      for (const update of buildVoiceEnvUpdates(draft)) {
+        await setEnv.mutateAsync(update);
+      }
+      setDraft((current) => current ? { ...current, sttApiKey: "", ttsApiKey: "" } : current);
+      setFeedback({ tone: "ok", message: "语音配置已保存。API Key 已写入当前档案的 .env，语音模型设置已写入 config.yaml。" });
+    } catch (error) {
+      setFeedback({ tone: "error", message: voiceErrorMessage(error, "保存语音配置失败") });
+    }
+  };
+
+  const testStt = async () => {
+    if (!draft) return;
+    setSttTesting(true);
+    setFeedback({ tone: "info", message: `请开始说话，录音将在 ${Math.max(1, Math.trunc(draft.maxRecordingSeconds || 120))} 秒内自动停止。` });
+    try {
+      await micRecorder.start();
+      await new Promise((resolve) => window.setTimeout(resolve, Math.min(5, Math.max(1, draft.maxRecordingSeconds)) * 1000));
+      const recording = await micRecorder.stop();
+      if (!recording?.audio) throw new Error("录音为空，请重新测试。");
+      const result = await transcribeAudioBlob(recording.audio);
+      setFeedback({
+        tone: "ok",
+        message: result.transcript
+          ? `识别成功：${result.transcript}`
+          : "识别请求完成，但没有返回文字。请确认语音内容清晰或切换识别提供方。",
+      });
+    } catch (error) {
+      micRecorder.cancel();
+      setFeedback({ tone: "error", message: voiceErrorMessage(error, "语音识别测试失败") });
+    } finally {
+      setSttTesting(false);
+    }
+  };
+
+  const testTts = async () => {
+    const text = ttsSampleText.trim();
+    if (!text) {
+      setFeedback({ tone: "error", message: "请先填写朗读测试文本。" });
+      return;
+    }
+    setTtsTesting(true);
+    setFeedback(null);
+    try {
+      audioRef.current?.pause();
+      const result = await speakText(text);
+      const audio = new Audio(result.data_url);
+      audioRef.current = audio;
+      await audio.play();
+      setFeedback({ tone: "ok", message: "朗读测试已开始播放。" });
+    } catch (error) {
+      setFeedback({ tone: "error", message: voiceErrorMessage(error, "朗读测试失败") });
+    } finally {
+      setTtsTesting(false);
+    }
+  };
+
+  if (configLoading || schemaLoading || !config || !schema || !draft) {
+    return (
+      <SectionShell title="语音" sub="配置语音转文字和回复朗读。">
+        <div className={s.feedback}>正在加载语音配置…</div>
+      </SectionShell>
+    );
+  }
+
+  const existingStt = getVoiceConfigValue(config, "stt.provider");
+  const existingTts = getVoiceConfigValue(config, "tts.provider");
+  const sub = `当前 STT：${typeof existingStt === "string" ? existingStt : "local"} · 当前 TTS：${typeof existingTts === "string" ? existingTts : "edge"}`;
+
+  return (
+    <SectionShell title="语音" sub={sub}>
+      <VoiceSettingsView
+        draft={draft}
+        schema={schema}
+        envVars={envVars}
+        sttProviders={sttProviders}
+        ttsProviders={ttsProviders}
+        elevenLabsVoices={elevenLabsVoices.data ?? null}
+        saving={saveConfig.isPending || setEnv.isPending}
+        sttTesting={sttTesting}
+        ttsTesting={ttsTesting}
+        feedback={feedback}
+        ttsSampleText={ttsSampleText}
+        onDraftChange={setDraft}
+        onSave={() => void save()}
+        onTestStt={() => void testStt()}
+        onTestTts={() => void testTts()}
+        onTtsSampleTextChange={setTtsSampleText}
+      />
+    </SectionShell>
+  );
+}


### PR DESCRIPTION
## 变更内容

- 为 Composer 新增麦克风录音转写入口，复用 `/api/audio/transcribe`，并在缺少语音配置或旧 runtime 时给出中文可操作提示。
- 为助手完成回复新增手动朗读与停止朗读入口，复用 `/api/audio/speak`，并在朗读前清理 Markdown、代码块、链接和 emoji。
- 新增 `/voice` 语音配置向导，支持按 runtime schema 展示 STT/TTS provider，保存 config.yaml 与当前 profile `.env`，并提供识别和朗读测试。
- 补齐协议 schema、macOS 麦克风权限说明、桌面代理音频接口超时和 CSP media-src 配置。
- 顺手修复窄宽度下 Composer 底部按钮、顶部主导航和语音页密钥标签的响应式溢出问题。

## 影响

用户在遇到 “No STT provider available” 时可以直接从 Composer 跳转到语音配置页完成 API Key 或本地 provider 配置；完成回复后也可以手动朗读或停止朗读。本次不实现连续语音对话模式。

Closes #242

## 验证

- `pnpm typecheck`
- `pnpm test:unit`
- `cargo check`
- `pnpm --filter @hermes/web build`
- `git diff --check`