### PR TITLE
[codex] 支持侧栏会话拖入 Composer 生成 @session 引用

### DIFF
--- a/web/src/components/app-shell/workbench-sidebar.tsx
+++ b/web/src/components/app-shell/workbench-sidebar.tsx
@@ -27,6 +27,7 @@ import {
   unpinSessions,
 } from "@/lib/session-ui-state";
 import { deriveSidebarSessionLists } from "@/lib/sidebar-session-lists";
+import { writeSessionDrag } from "@/lib/session-inline-ref";
 import {
   SessionDeleteModal,
   SessionRenameModal,
@@ -79,6 +80,7 @@ interface SessionRowProps {
   state: "live" | "ok" | "err" | "idle";
   active: boolean;
   meta: string;
+  profile: string;
   projectName?: string;
   pinned: boolean;
   actions: UseSessionRowActions;
@@ -91,6 +93,7 @@ function SessionRow({
   state,
   active,
   meta,
+  profile,
   projectName,
   pinned,
   actions,
@@ -115,6 +118,16 @@ function SessionRow({
       }}
       onMouseEnter={onHover}
       onFocus={onHover}
+      draggable
+      onDragStart={(event) => {
+        if (!writeSessionDrag(event.dataTransfer, {
+          id: session.id,
+          profile,
+          title,
+        })) {
+          event.preventDefault();
+        }
+      }}
       title={title}
     >
       <div className={s.rowMain}>
@@ -350,6 +363,7 @@ export function WorkbenchSidebar() {
                 state="live"
                 active={sessionIdMatches(sess.id, activeSessionId)}
                 meta={`${modelShort(sess.model)} · ${elapsed(sess.started_at, now)}`}
+                profile={profile}
                 projectName={projectNameBySessionId.get(sess.id)}
                 pinned={pinnedSessionIds.has(sess.id)}
                 actions={rowActions}
@@ -382,6 +396,7 @@ export function WorkbenchSidebar() {
                   state={state}
                   active={sessionIdMatches(sess.id, activeSessionId)}
                   meta={running ? `${modelShort(sess.model)} · ${elapsed(sess.started_at, now)}` : relTime(ts, now)}
+                  profile={profile}
                   projectName={projectNameBySessionId.get(sess.id)}
                   pinned={pinnedSessionIds.has(sess.id)}
                   actions={rowActions}
@@ -450,6 +465,7 @@ export function WorkbenchSidebar() {
                   state={state}
                   active={sessionIdMatches(sess.id, activeSessionId)}
                   meta={meta}
+                  profile={profile}
                   projectName={projectNameBySessionId.get(sess.id)}
                   pinned={pinnedSessionIds.has(sess.id)}
                   actions={rowActions}

--- a/web/src/components/chat/composer-types.ts
+++ b/web/src/components/chat/composer-types.ts
@@ -4,6 +4,7 @@ import type { ReasoningEffort } from "@/lib/reasoning-effort";
 export type ComposerAttachmentKind = "image" | "file" | "directory";
 export type ComposerAttachmentSource = "browser" | "path" | "uploaded";
 export type ComposerAttachmentStatus = "ready" | "uploading" | "processing" | "done" | "error";
+export type ComposerSessionRefStatus = "ready" | "processing" | "done" | "error";
 
 export interface ComposerAttachment {
   id: string;
@@ -19,6 +20,15 @@ export interface ComposerAttachment {
   uploadedPath?: string;
   uploadedName?: string;
   progress?: number;
+  error?: string;
+}
+
+export interface ComposerSessionRef {
+  id: string;
+  sessionId: string;
+  profile: string;
+  title: string;
+  status: ComposerSessionRefStatus;
   error?: string;
 }
 
@@ -41,6 +51,7 @@ export interface ComposerContextUsage {
 export interface ComposerSubmitPayload {
   text: string;
   attachments: ComposerAttachment[];
+  sessionRefs?: ComposerSessionRef[];
   workspacePath?: string;
   modelSelection?: ComposerModelSelection;
   skillCommandNames?: string[];
@@ -48,6 +59,7 @@ export interface ComposerSubmitPayload {
 
 export interface ComposerSubmitControls {
   updateAttachment(id: string, patch: Partial<ComposerAttachment>): void;
+  updateSessionRef?(id: string, patch: Partial<ComposerSessionRef>): void;
 }
 
 export interface ComposerModelPickerProps {

--- a/web/src/components/chat/goose-composer.module.css
+++ b/web/src/components/chat/goose-composer.module.css
@@ -56,6 +56,79 @@
   color: var(--h-err);
 }
 
+.sessionRefTray {
+  display: flex;
+  flex-wrap: wrap;
+  gap: 8px;
+  margin: 0 0 10px;
+}
+
+.sessionRefChip {
+  display: inline-grid;
+  grid-template-columns: auto auto minmax(0, 1fr) auto auto;
+  align-items: center;
+  gap: 7px;
+  max-width: min(360px, 100%);
+  min-height: 34px;
+  border: 1px solid color-mix(in srgb, var(--h-accent) 32%, var(--h-line));
+  border-radius: 999px;
+  background:
+    linear-gradient(135deg,
+      color-mix(in srgb, var(--h-accent-soft) 70%, var(--h-bg-input)),
+      color-mix(in srgb, var(--h-bg-chip) 84%, var(--h-accent-soft)));
+  color: var(--h-text);
+  font-size: 12px;
+  line-height: 1;
+  padding: 5px 5px 5px 9px;
+}
+
+.sessionRefChip[data-status="processing"] {
+  opacity: 0.7;
+}
+
+.sessionRefChip[data-status="error"] {
+  border-color: var(--h-err);
+  color: var(--h-err);
+}
+
+.sessionRefChip svg {
+  width: 13px;
+  height: 13px;
+  color: var(--h-accent);
+  stroke-width: 2.2;
+}
+
+.sessionRefKicker {
+  border-radius: 999px;
+  background: color-mix(in srgb, var(--h-accent) 14%, transparent);
+  color: var(--h-accent);
+  font-size: 10px;
+  font-weight: 700;
+  letter-spacing: 0.04em;
+  padding: 3px 6px;
+  text-transform: uppercase;
+}
+
+.sessionRefName,
+.sessionRefDetail {
+  min-width: 0;
+  overflow: hidden;
+  text-overflow: ellipsis;
+  white-space: nowrap;
+}
+
+.sessionRefName {
+  color: var(--h-text);
+  font-size: 12.5px;
+  font-weight: 650;
+}
+
+.sessionRefDetail {
+  color: var(--h-text-3);
+  font-family: var(--h-font-mono);
+  font-size: 10.5px;
+}
+
 .attachmentIcon,
 .attachmentPreview {
   width: 30px;
@@ -136,6 +209,7 @@
 }
 
 .attachmentChip button,
+.sessionRefChip button,
 .modelClose,
 .modelModalClose {
   display: inline-flex;
@@ -156,7 +230,26 @@
   line-height: 1;
 }
 
-.attachmentChip button:disabled {
+.sessionRefChip button {
+  width: 20px;
+  height: 20px;
+  border-radius: 999px;
+  padding: 0;
+}
+
+.sessionRefChip button:hover:not(:disabled) {
+  background: color-mix(in srgb, var(--h-accent) 13%, transparent);
+  color: var(--h-text);
+}
+
+.sessionRefChip button svg {
+  width: 13px;
+  height: 13px;
+  color: currentColor;
+}
+
+.attachmentChip button:disabled,
+.sessionRefChip button:disabled {
   cursor: default;
   opacity: 0.45;
 }
@@ -626,6 +719,11 @@
 }
 
 .box[data-variant="big"] .attachmentTray {
+  padding: 12px 18px 0;
+  margin-bottom: 0;
+}
+
+.box[data-variant="big"] .sessionRefTray {
   padding: 12px 18px 0;
   margin-bottom: 0;
 }

--- a/web/src/components/chat/goose-composer.tsx
+++ b/web/src/components/chat/goose-composer.tsx
@@ -11,7 +11,7 @@ import {
 } from "react";
 import { useAtomValue } from "jotai";
 import { useNavigate } from "react-router-dom";
-import { Cpu, Folder, Loader2, Mic, Plus, Sparkles, Square, X } from "lucide-react";
+import { Cpu, Folder, Loader2, MessageSquare, Mic, Plus, Sparkles, Square, X } from "lucide-react";
 import type { ModelOptionsResult } from "@hermes/protocol";
 import { fileNameFromPath } from "@/lib/composer-prompt";
 import {
@@ -49,12 +49,21 @@ import {
   writeWorkspacePath,
 } from "@/lib/workspaces";
 import {
+  dragHasSession,
+  readSessionDrag,
+  sessionRefIdentity,
+  sessionRefLabel,
+  normalizeSessionProfile,
+  type SessionDragPayload,
+} from "@/lib/session-inline-ref";
+import {
   ComposerAttachmentError,
   type ComposerAttachment,
   type ComposerContextUsage,
   type ComposerModelPickerProps,
   type ComposerModelSelection,
   type ComposerReasoningPickerProps,
+  type ComposerSessionRef,
   type ComposerSkillPickerProps,
   type ComposerSubmitControls,
   type ComposerSubmitPayload,
@@ -147,6 +156,74 @@ export function ComposerErrorMessage({
   );
 }
 
+type ComposerDragKind = "files" | "session" | null;
+
+function createSessionRefId(index: number): string {
+  return `session-ref-${Date.now()}-${index}-${Math.random().toString(16).slice(2)}`;
+}
+
+function createSessionRef(payload: SessionDragPayload, index: number): ComposerSessionRef {
+  return {
+    id: createSessionRefId(index),
+    sessionId: payload.id,
+    profile: normalizeSessionProfile(payload.profile),
+    title: sessionRefLabel(payload),
+    status: "ready",
+  };
+}
+
+function isSessionRefBusy(ref: ComposerSessionRef): boolean {
+  return ref.status === "processing";
+}
+
+function shortSessionId(sessionId: string): string {
+  return sessionId.length > 10 ? `${sessionId.slice(0, 8)}…` : sessionId;
+}
+
+function sessionRefDetail(ref: ComposerSessionRef): string {
+  if (ref.error) return ref.error;
+  if (ref.status === "processing") return "处理中";
+  if (ref.status === "done") return "已引用";
+  return `@session:${ref.profile}/${shortSessionId(ref.sessionId)}`;
+}
+
+function SessionRefTray({
+  sessionRefs,
+  onRemove,
+}: {
+  sessionRefs: ComposerSessionRef[];
+  onRemove: (id: string) => void;
+}) {
+  if (!sessionRefs.length) return null;
+
+  return (
+    <div className={s.sessionRefTray}>
+      {sessionRefs.map((ref) => (
+        <span
+          key={ref.id}
+          className={s.sessionRefChip}
+          data-status={ref.status}
+          title={`@session:${ref.profile}/${ref.sessionId}`}
+        >
+          <MessageSquare aria-hidden="true" />
+          <span className={s.sessionRefKicker}>Session</span>
+          <span className={s.sessionRefName}>{ref.title}</span>
+          <span className={s.sessionRefDetail}>{sessionRefDetail(ref)}</span>
+          <button
+            type="button"
+            onClick={() => onRemove(ref.id)}
+            disabled={isSessionRefBusy(ref)}
+            aria-label={`移除会话引用 ${ref.title}`}
+            title="移除引用"
+          >
+            <X aria-hidden="true" />
+          </button>
+        </span>
+      ))}
+    </div>
+  );
+}
+
 export function GooseComposer({
   onSend,
   onStop,
@@ -177,6 +254,7 @@ export function GooseComposer({
   const isBig = variant === "big";
   const [value, setValue] = useState(initial);
   const [attachments, setAttachments] = useState<ComposerAttachment[]>([]);
+  const [sessionRefs, setSessionRefs] = useState<ComposerSessionRef[]>([]);
   const [selectionStart, setSelectionStart] = useState(initial.length);
   const [selectionEnd, setSelectionEnd] = useState(initial.length);
   const [workspacePath, setWorkspacePath] = useState(
@@ -195,7 +273,7 @@ export function GooseComposer({
   const [selectedSkill, setSelectedSkill] = useState<ComposerSkillCandidate | null>(null);
   const [skillActiveIndex, setSkillActiveIndex] = useState(0);
   const [dismissedSlashToken, setDismissedSlashToken] = useState("");
-  const [dragActive, setDragActive] = useState(false);
+  const [dragKind, setDragKind] = useState<ComposerDragKind>(null);
   const [voiceStatus, setVoiceStatus] = useState<"idle" | "recording" | "transcribing">("idle");
   const [voiceElapsedSeconds, setVoiceElapsedSeconds] = useState(0);
   const { handle: micRecorder, level: voiceLevel } = useMicRecorder();
@@ -211,6 +289,7 @@ export function GooseComposer({
   const voiceIntervalRef = useRef<number | null>(null);
   const voiceTimeoutRef = useRef<number | null>(null);
   const hasProcessingAttachment = attachments.some(isAttachmentBusy);
+  const hasProcessingSessionRef = sessionRefs.some(isSessionRefBusy);
   const sttEnabled = sttEnabledFromConfig(voiceConfig);
   const maxRecordingSeconds = voiceMaxRecordingSecondsFromConfig(voiceConfig);
   const contextRisk = contextUsageRisk(contextUsage);
@@ -222,9 +301,10 @@ export function GooseComposer({
     : value.trim();
   const displayedTextLength = value.length;
   const canSend =
-    (submitText.length > 0 || attachments.length > 0) &&
+    (submitText.length > 0 || attachments.length > 0 || sessionRefs.length > 0) &&
     !controlsDisabled &&
-    !hasProcessingAttachment;
+    !hasProcessingAttachment &&
+    !hasProcessingSessionRef;
   const slashToken = useMemo(
     () => selectedSkill ? null : getLeadingSlashToken(value, selectionStart, selectionEnd),
     [selectionEnd, selectionStart, selectedSkill, value],
@@ -441,7 +521,7 @@ export function GooseComposer({
     setWorkspacePickerOpen(false);
     setModelOpen(false);
     setDismissedSlashToken("");
-    setDragActive(false);
+    setDragKind(null);
     dragDepthRef.current = 0;
   }, [controlsDisabled]);
 
@@ -501,6 +581,17 @@ export function GooseComposer({
     appendAttachmentDrafts(accepted.map((file, index) => createFileAttachment(file, index)));
   };
 
+  const addSessionRef = (payload: SessionDragPayload) => {
+    const draft = createSessionRef(payload, sessionRefs.length);
+    const identity = sessionRefIdentity(draft);
+    if (!identity) return;
+    setSubmitError("");
+    setSessionRefs((current) => {
+      const existing = new Set(current.map(sessionRefIdentity));
+      return existing.has(identity) ? current : [...current, draft];
+    });
+  };
+
   const pickFiles = async () => {
     if (controlsDisabled) return;
     setSubmitError("");
@@ -554,6 +645,10 @@ export function GooseComposer({
     });
   };
 
+  const removeSessionRef = (id: string) => {
+    setSessionRefs((current) => current.filter((item) => item.id !== id));
+  };
+
   const markAttachmentsProcessing = () => {
     setAttachments((current) =>
       current.map((item) => ({
@@ -561,6 +656,26 @@ export function GooseComposer({
         status: isAttachmentBusy(item) ? item.status : "processing",
         error: undefined,
         progress: item.status === "uploading" ? item.progress : undefined,
+      })),
+    );
+  };
+
+  const markSessionRefsProcessing = () => {
+    setSessionRefs((current) =>
+      current.map((item) => ({
+        ...item,
+        status: isSessionRefBusy(item) ? item.status : "processing",
+        error: undefined,
+      })),
+    );
+  };
+
+  const restoreSessionRefState = () => {
+    setSessionRefs((current) =>
+      current.map((item) => ({
+        ...item,
+        status: "ready",
+        error: undefined,
       })),
     );
   };
@@ -587,6 +702,12 @@ export function GooseComposer({
 
   const updateAttachment: ComposerSubmitControls["updateAttachment"] = (id, patch) => {
     setAttachments((current) =>
+      current.map((item) => (item.id === id ? { ...item, ...patch } : item)),
+    );
+  };
+
+  const updateSessionRef: ComposerSubmitControls["updateSessionRef"] = (id, patch) => {
+    setSessionRefs((current) =>
       current.map((item) => (item.id === id ? { ...item, ...patch } : item)),
     );
   };
@@ -651,6 +772,7 @@ export function GooseComposer({
     const payload: ComposerSubmitPayload = {
       text: submitText,
       attachments,
+      sessionRefs,
       workspacePath: workspacePath.trim() || undefined,
       modelSelection: selectedModelRef.current ?? undefined,
       skillCommandNames: skillPicker?.skills.map((skill) => skill.name),
@@ -658,18 +780,21 @@ export function GooseComposer({
 
     setSubmitError("");
     markAttachmentsProcessing();
+    markSessionRefsProcessing();
     try {
-      await onSend?.(payload, { updateAttachment });
+      await onSend?.(payload, { updateAttachment, updateSessionRef });
       setValue("");
       setSelectedSkill(null);
       setSelectionStart(0);
       setSelectionEnd(0);
       setDismissedSlashToken("");
+      setSessionRefs([]);
       setAttachments((current) => {
         current.forEach(revokeAttachmentPreview);
         return [];
       });
     } catch (error) {
+      restoreSessionRefState();
       restoreAttachmentState(error);
     }
   };
@@ -741,29 +866,34 @@ export function GooseComposer({
     addBrowserFiles(files);
   };
 
-  const hasDroppableData = (event: DragEvent<HTMLDivElement>): boolean => {
+  const dragKindOf = (event: DragEvent<HTMLDivElement>): ComposerDragKind => {
+    if (dragHasSession(event.dataTransfer)) return "session";
     const types = Array.from(event.dataTransfer.types);
-    return types.includes("Files") || types.includes("text/plain") || types.includes("text/uri-list");
+    if (types.includes("Files") || types.includes("text/plain") || types.includes("text/uri-list")) {
+      return "files";
+    }
+    return null;
   };
 
   const handleDragEnter = (event: DragEvent<HTMLDivElement>) => {
-    if (controlsDisabled || !hasDroppableData(event)) return;
+    const nextDragKind = controlsDisabled ? null : dragKindOf(event);
+    if (!nextDragKind) return;
     event.preventDefault();
     dragDepthRef.current += 1;
-    setDragActive(true);
+    setDragKind(nextDragKind);
   };
 
   const handleDragLeave = (event: DragEvent<HTMLDivElement>) => {
-    if (!dragActive) return;
+    if (!dragKind) return;
     event.preventDefault();
     dragDepthRef.current = Math.max(0, dragDepthRef.current - 1);
     if (dragDepthRef.current === 0) {
-      setDragActive(false);
+      setDragKind(null);
     }
   };
 
   const handleDragOver = (event: DragEvent<HTMLDivElement>) => {
-    if (controlsDisabled || !hasDroppableData(event)) return;
+    if (controlsDisabled || !dragKindOf(event)) return;
     event.preventDefault();
     event.dataTransfer.dropEffect = "copy";
   };
@@ -771,8 +901,14 @@ export function GooseComposer({
   const handleDrop = (event: DragEvent<HTMLDivElement>) => {
     event.preventDefault();
     dragDepthRef.current = 0;
-    setDragActive(false);
+    setDragKind(null);
     if (controlsDisabled) return;
+
+    const session = readSessionDrag(event.dataTransfer);
+    if (session) {
+      addSessionRef(session);
+      return;
+    }
 
     const paths: string[] = [];
     const text = event.dataTransfer.getData("text/uri-list") || event.dataTransfer.getData("text/plain");
@@ -888,7 +1024,8 @@ export function GooseComposer({
       <div
         className={s.box}
         data-disabled={disabled}
-        data-drag-active={dragActive}
+        data-drag-active={dragKind ? "true" : undefined}
+        data-drag-kind={dragKind ?? undefined}
         data-variant={variant}
         onDrop={handleDrop}
         onDragEnter={handleDragEnter}
@@ -903,7 +1040,11 @@ export function GooseComposer({
           onChange={handleFileInputChange}
           tabIndex={-1}
         />
-        {dragActive ? <div className={s.dropOverlay}>释放以添加到当前消息</div> : null}
+        {dragKind ? (
+          <div className={s.dropOverlay}>
+            {dragKind === "session" ? "释放以引用该会话" : "释放以添加到当前消息"}
+          </div>
+        ) : null}
 
         {isBig ? (
           <div className={s.bigHeader}>
@@ -924,6 +1065,7 @@ export function GooseComposer({
         ) : null}
 
         <AttachmentTray attachments={attachments} onRemove={removeAttachment} />
+        <SessionRefTray sessionRefs={sessionRefs} onRemove={removeSessionRef} />
 
         {selectedSkill ? (
           <div className={s.selectedSkillRow}>

--- a/web/src/components/panel/panel-composer.tsx
+++ b/web/src/components/panel/panel-composer.tsx
@@ -150,7 +150,7 @@ export function PanelComposer() {
         headerLabel="新任务"
         hints={[
           { kbd: "/", label: "选择 Skill" },
-          { label: "把文件拖入此处直接附加" },
+          { label: "把文件或侧栏会话拖入此处" },
         ]}
         showMeta={false}
         loading={sending}

--- a/web/src/hooks/use-create-and-send-session.ts
+++ b/web/src/hooks/use-create-and-send-session.ts
@@ -44,7 +44,9 @@ export function useCreateAndSendSession() {
     const submittedAt = Date.now();
     const workspacePath = payload.workspacePath?.trim() || undefined;
     const sessionId = await (options?.createSession ?? createSession)({ cwd: workspacePath });
-    const title = titleFromPrompt(payload.text || payload.attachments[0]?.name || "");
+    const title = titleFromPrompt(
+      payload.text || payload.attachments[0]?.name || payload.sessionRefs?.[0]?.title || "",
+    );
     const optimisticDisplayText = buildComposerDisplayText(payload);
     const optimisticDisplayImages = payload.attachments
       .filter((attachment) => attachment.kind === "image")
@@ -104,6 +106,7 @@ export function useCreateAndSendSession() {
           detectDroppedPath,
           uploadFile: uploadAttachmentFile,
           onAttachmentUpdate: controls.updateAttachment,
+          onSessionRefUpdate: controls.updateSessionRef,
         }, { transportText });
         await sendPrompt(sessionId, prepared.promptText, {
           displayText: prepared.displayText,

--- a/web/src/lib/composer-prompt.test.ts
+++ b/web/src/lib/composer-prompt.test.ts
@@ -65,6 +65,32 @@ describe("composer prompt preparation", () => {
     expect(stripHermesUiWorkspaceContext(storedPrompt)).toBe("看一下这张图里面是什么内容\n\n附件：ga.png");
   });
 
+
+  it("includes session refs in the transport prompt while keeping display text friendly", async () => {
+    const result = await prepareComposerPrompt(
+      "s1",
+      {
+        text: "继续总结这段上下文",
+        attachments: [],
+        sessionRefs: [{
+          id: "ref-1",
+          sessionId: "session-id",
+          profile: "default",
+          title: "架构讨论",
+          status: "ready",
+        }],
+      },
+      {
+        attachImage: vi.fn(),
+        detectDroppedPath: vi.fn(),
+      },
+    );
+
+    expect(result.promptText).toContain("@session:`default/session-id`");
+    expect(result.promptText.endsWith("继续总结这段上下文")).toBe(true);
+    expect(result.displayText).toBe("继续总结这段上下文\n\n引用会话：架构讨论");
+  });
+
   it("uses a dispatched skill invocation as transport text without changing display text", async () => {
     const result = await prepareComposerPrompt(
       "s1",

--- a/web/src/lib/composer-prompt.ts
+++ b/web/src/lib/composer-prompt.ts
@@ -1,8 +1,10 @@
 import {
   ComposerAttachmentError,
   type ComposerAttachment,
+  type ComposerSessionRef,
   type ComposerSubmitPayload,
 } from "@/components/chat/composer-types";
+import { formatSessionInlineRef, sessionRefLabel } from "@/lib/session-inline-ref";
 import type { AttachmentUploadResult, ImageAttachResult, InputDetectDropResult } from "@hermes/protocol";
 
 const WORKSPACE_BLOCK_START = "[Hermes UI Workspace]";
@@ -43,6 +45,10 @@ export function fileNameFromPath(path: string): string {
 
 function attachmentSuffix(labels: string[]): string {
   return `附件：${labels.join("、")}`;
+}
+
+function sessionRefSuffix(labels: string[]): string {
+  return `引用会话：${labels.join("、")}`;
 }
 
 function sanitizeContextValue(value: string): string {
@@ -123,8 +129,13 @@ async function imageDisplayUrl(attachment: ComposerAttachment, path: string): Pr
 export function buildComposerDisplayText(payload: ComposerSubmitPayload): string {
   const text = payload.text.trim();
   const attachments = payload.attachments.map(attachmentDisplayName);
-  if (attachments.length === 0) return text;
-  const suffix = `附件：${attachments.join("、")}`;
+  const sessionRefs = (payload.sessionRefs ?? []).map(sessionRefLabel);
+  const suffixes = [
+    sessionRefs.length ? sessionRefSuffix(sessionRefs) : "",
+    attachments.length ? attachmentSuffix(attachments) : "",
+  ].filter(Boolean);
+  if (suffixes.length === 0) return text;
+  const suffix = suffixes.join("\n");
   return text ? `${text}\n\n${suffix}` : suffix;
 }
 
@@ -140,6 +151,7 @@ export async function prepareComposerPrompt(
     attachImage(sessionId: string, path: string): Promise<ImageAttachResult>;
     detectDroppedPath(sessionId: string, path: string): Promise<InputDetectDropResult>;
     onAttachmentUpdate?(id: string, patch: Partial<ComposerAttachment>): void;
+    onSessionRefUpdate?(id: string, patch: Partial<ComposerSessionRef>): void;
   },
   options: {
     transportText?: string;
@@ -163,6 +175,15 @@ export async function prepareComposerPrompt(
     name?: string;
     mimeType?: string;
   }> = [];
+
+  const sessionRefParts: string[] = [];
+  for (const ref of payload.sessionRefs ?? []) {
+    helpers.onSessionRefUpdate?.(ref.id, { status: "processing", error: undefined });
+    const formatted = formatSessionInlineRef(ref);
+    if (formatted) sessionRefParts.push(formatted);
+    helpers.onSessionRefUpdate?.(ref.id, { status: "done" });
+  }
+  if (sessionRefParts.length) parts.push(sessionRefParts.join(" "));
 
   for (const attachment of payload.attachments) {
     try {

--- a/web/src/lib/session-inline-ref.test.ts
+++ b/web/src/lib/session-inline-ref.test.ts
@@ -1,0 +1,65 @@
+import { describe, expect, it } from "vitest";
+import {
+  HERMES_SESSION_MIME,
+  dragHasSession,
+  formatSessionInlineRef,
+  readSessionDrag,
+  sessionRefIdentity,
+  writeSessionDrag,
+} from "./session-inline-ref";
+
+class FakeDataTransfer {
+  effectAllowed = "";
+  types: string[] = [];
+  private values = new Map<string, string>();
+
+  setData(type: string, value: string) {
+    if (!this.types.includes(type)) this.types.push(type);
+    this.values.set(type, value);
+  }
+
+  getData(type: string) {
+    return this.values.get(type) ?? "";
+  }
+}
+
+describe("session-inline-ref", () => {
+  it("formats @session refs with the profile/id payload expected by session_search", () => {
+    expect(formatSessionInlineRef({ profile: "default", sessionId: "session-id" })).toBe(
+      "@session:`default/session-id`",
+    );
+  });
+
+  it("writes and reads the in-app session drag payload", () => {
+    const transfer = new FakeDataTransfer() as unknown as DataTransfer;
+
+    expect(writeSessionDrag(transfer, {
+      id: " session-1 ",
+      profile: " work ",
+      title: " 架构讨论 ",
+    })).toBe(true);
+
+    expect(dragHasSession(transfer)).toBe(true);
+    expect(transfer.effectAllowed).toBe("copy");
+    expect(transfer.getData("text/plain")).toBe("@session:`work/session-1`");
+    expect(readSessionDrag(transfer)).toEqual({
+      id: "session-1",
+      profile: "work",
+      title: "架构讨论",
+    });
+  });
+
+  it("returns null for malformed drag payloads", () => {
+    const transfer = new FakeDataTransfer() as unknown as DataTransfer;
+    transfer.setData(HERMES_SESSION_MIME, "{not-json");
+
+    expect(dragHasSession(transfer)).toBe(true);
+    expect(readSessionDrag(transfer)).toBeNull();
+  });
+
+  it("normalizes identities so duplicate refs can be skipped", () => {
+    expect(sessionRefIdentity({ profile: "", sessionId: "s1" })).toBe("default/s1");
+    expect(sessionRefIdentity({ profile: " default ", id: " s1 " })).toBe("default/s1");
+    expect(sessionRefIdentity({ profile: "default", sessionId: "" })).toBe("");
+  });
+});

--- a/web/src/lib/session-inline-ref.ts
+++ b/web/src/lib/session-inline-ref.ts
@@ -1,0 +1,86 @@
+export const HERMES_SESSION_MIME = "application/x-hermes-session";
+
+export interface SessionDragPayload {
+  id: string;
+  profile: string;
+  title: string;
+}
+
+export interface SessionRefIdentityLike {
+  id?: string | null;
+  sessionId?: string | null;
+  profile?: string | null;
+}
+
+function normalizeSessionId(value: string | null | undefined): string {
+  return (value ?? "").trim();
+}
+
+export function normalizeSessionProfile(value: string | null | undefined): string {
+  const profile = (value ?? "").trim();
+  return profile || "default";
+}
+
+export function sessionRefIdentity(ref: SessionRefIdentityLike): string {
+  const sessionId = normalizeSessionId(ref.sessionId ?? ref.id);
+  if (!sessionId) return "";
+  return `${normalizeSessionProfile(ref.profile)}/${sessionId}`;
+}
+
+export function sessionRefLabel(ref: { id?: string | null; sessionId?: string | null; title?: string | null }): string {
+  const title = (ref.title ?? "").trim();
+  if (title) return title;
+  const sessionId = normalizeSessionId(ref.sessionId ?? ref.id);
+  return sessionId ? `chat ${sessionId.slice(0, 8)}` : "会话";
+}
+
+function quoteRefValue(value: string): string {
+  if (!value.includes("`")) return `\`${value}\``;
+  if (!value.includes('"')) return `"${value}"`;
+  if (!value.includes("'")) return `'${value}'`;
+  return `\`${value.replace(/`/g, "") || "session"}\``;
+}
+
+export function formatSessionInlineRef(ref: { profile?: string | null; sessionId: string }): string {
+  const sessionId = normalizeSessionId(ref.sessionId);
+  if (!sessionId) return "";
+  return `@session:${quoteRefValue(`${normalizeSessionProfile(ref.profile)}/${sessionId}`)}`;
+}
+
+export function normalizeSessionDragPayload(value: Partial<SessionDragPayload> | null | undefined): SessionDragPayload | null {
+  const id = normalizeSessionId(value?.id);
+  if (!id) return null;
+  return {
+    id,
+    profile: normalizeSessionProfile(value?.profile),
+    title: (value?.title ?? "").trim(),
+  };
+}
+
+export function writeSessionDrag(transfer: DataTransfer, payload: Partial<SessionDragPayload>): boolean {
+  const normalized = normalizeSessionDragPayload(payload);
+  if (!normalized) return false;
+  transfer.setData(HERMES_SESSION_MIME, JSON.stringify(normalized));
+  transfer.setData("text/plain", formatSessionInlineRef({
+    profile: normalized.profile,
+    sessionId: normalized.id,
+  }));
+  transfer.effectAllowed = "copy";
+  return true;
+}
+
+export function dragHasSession(transfer: DataTransfer | null): boolean {
+  if (!transfer) return false;
+  return Array.from(transfer.types || []).includes(HERMES_SESSION_MIME);
+}
+
+export function readSessionDrag(transfer: DataTransfer | null): SessionDragPayload | null {
+  const raw = transfer?.getData(HERMES_SESSION_MIME);
+  if (!raw) return null;
+
+  try {
+    return normalizeSessionDragPayload(JSON.parse(raw) as Partial<SessionDragPayload>);
+  } catch {
+    return null;
+  }
+}

--- a/web/src/routes/detail.tsx
+++ b/web/src/routes/detail.tsx
@@ -311,6 +311,7 @@ export function DetailRoute() {
       detectDroppedPath,
       uploadFile: uploadAttachmentFile,
       onAttachmentUpdate: controls.updateAttachment,
+      onSessionRefUpdate: controls.updateSessionRef,
     });
     await sendPrompt(gatewaySessionId, prepared.promptText, {
       displayText: prepared.displayText,


### PR DESCRIPTION
## 变更说明

本 PR 轻量实现 issue #240：支持从工作台侧栏拖拽会话到现有 textarea Composer，生成可移除的 session 引用 chip，并在发送时把引用编码为 `@session:\`profile/sessionId\`` 的 transport prompt 片段。

## 主要内容

- 新增 session inline ref 工具，统一处理拖拽 MIME、payload 解析、去重 identity 和 `@session` 格式化。
- 工作台侧栏进行中、置顶和最近会话行支持拖拽，拖拽 payload 包含 session id、当前 profile 和展示标题。
- Composer drop 后维护 `sessionRefs`，展示 session chip，并在提交期间标记处理中。
- `prepareComposerPrompt` 会把 session 引用写入真实 prompt，display text 只显示“引用会话：标题”的友好摘要。
- 增加 Vitest 覆盖引用格式化、拖拽 payload 解析兜底、去重和 prompt 生成行为。

关联 #240。

## 验证

- `pnpm --filter @hermes/web exec vitest run src/lib/composer-prompt.test.ts src/lib/session-inline-ref.test.ts`
- `pnpm typecheck`
- `pnpm test:unit`
- `cargo check`
