### PR TITLE
fix: disable session actions menu while task is running

### DIFF
--- a/web/src/components/app-shell/workbench-sidebar.tsx
+++ b/web/src/components/app-shell/workbench-sidebar.tsx
@@ -81,6 +81,7 @@ interface SessionRowProps {
   meta: string;
   projectName?: string;
   pinned: boolean;
+  menuDisabled?: boolean;
   actions: UseSessionRowActions;
   onClick: () => void;
   onHover?: () => void;
@@ -93,12 +94,14 @@ function SessionRow({
   meta,
   projectName,
   pinned,
+  menuDisabled = false,
   actions,
   onClick,
   onHover,
 }: SessionRowProps) {
   const title = sessionDisplayTitle(session);
   const dotState = state === "idle" ? undefined : state;
+  const actionMenuDisabled = menuDisabled || actions.isDeleting;
   return (
     // role=button (not a real <button>) so the "⋯" trigger can nest inside it.
     <div
@@ -132,15 +135,18 @@ function SessionRow({
         </div>
       </div>
       <Popover.Root
-        open={actions.openMenuId === session.id}
-        onOpenChange={(open) => actions.setOpenMenuId(open ? session.id : null)}
+        open={!actionMenuDisabled && actions.openMenuId === session.id}
+        onOpenChange={(open) => {
+          actions.setOpenMenuId(open && !actionMenuDisabled ? session.id : null);
+        }}
       >
         <Popover.Trigger asChild>
           <button
             type="button"
             className={s.rowMore}
             aria-label="会话操作"
-            disabled={actions.isDeleting}
+            title={menuDisabled ? "运行中任务暂不可操作" : "会话操作"}
+            disabled={actionMenuDisabled}
             onClick={(event) => event.stopPropagation()}
             onKeyDown={(event) => event.stopPropagation()}
           >
@@ -149,7 +155,7 @@ function SessionRow({
         </Popover.Trigger>
         <SessionRowMenu
           pinned={pinned}
-          disabled={actions.isDeleting}
+          disabled={actionMenuDisabled}
           onTogglePin={() => actions.togglePin(session.id)}
           onRename={() => actions.startRename(session)}
           onArchive={() => actions.handleArchive(session)}
@@ -352,6 +358,7 @@ export function WorkbenchSidebar() {
                 meta={`${modelShort(sess.model)} · ${elapsed(sess.started_at, now)}`}
                 projectName={projectNameBySessionId.get(sess.id)}
                 pinned={pinnedSessionIds.has(sess.id)}
+                menuDisabled
                 actions={rowActions}
                 onClick={() => goSession(sess)}
                 onHover={() => hoverSession(sess)}
@@ -384,6 +391,7 @@ export function WorkbenchSidebar() {
                   meta={running ? `${modelShort(sess.model)} · ${elapsed(sess.started_at, now)}` : relTime(ts, now)}
                   projectName={projectNameBySessionId.get(sess.id)}
                   pinned={pinnedSessionIds.has(sess.id)}
+                  menuDisabled={running}
                   actions={rowActions}
                   onClick={() => goSession(sess)}
                   onHover={() => hoverSession(sess)}

--- a/web/src/routes/history.tsx
+++ b/web/src/routes/history.tsx
@@ -725,6 +725,7 @@ export function HistoryRoute() {
                   const meta = getSourceMeta(session.source);
                   const selected = selectedSessionIds.has(session.id);
                   const pinned = pinnedSessionIds.has(session.id);
+                  const menuDisabled = live || deleteSessions.isPending;
                   const workspacePath = normalizeWorkspacePath(workspaceMap[session.id]);
                   const workspaceName = workspacePath
                     ? workspaceNameFromPath(workspacePath)
@@ -775,15 +776,18 @@ export function HistoryRoute() {
                       </span>
                       <span className={s.cellTimestamp}>{updatedDisplay}</span>
                       <Popover.Root
-                        open={openMenuId === session.id}
-                        onOpenChange={(open) => setOpenMenuId(open ? session.id : null)}
+                        open={!menuDisabled && openMenuId === session.id}
+                        onOpenChange={(open) => {
+                          setOpenMenuId(open && !menuDisabled ? session.id : null);
+                        }}
                       >
                         <Popover.Trigger asChild>
                           <button
                             type="button"
                             className={s.cellMore}
                             aria-label="会话操作"
-                            disabled={deleteSessions.isPending}
+                            title={live ? "运行中任务暂不可操作" : "会话操作"}
+                            disabled={menuDisabled}
                             onClick={(event) => event.stopPropagation()}
                           >
                             <MoreHorizontal size={14} />
@@ -791,7 +795,7 @@ export function HistoryRoute() {
                         </Popover.Trigger>
                         <SessionRowMenu
                           pinned={pinned}
-                          disabled={deleteSessions.isPending}
+                          disabled={menuDisabled}
                           onTogglePin={() => onTogglePinSession(session.id)}
                           onRename={() => startRename(session)}
                           onArchive={() => handleArchive(session)}


### PR DESCRIPTION
## Summary

运行中的任务在左侧边栏和对话历史页禁用三点菜单，避免在任务执行期间触发置顶、重命名、归档、删除等操作。

- 侧边栏「运行中」分区及历史列表中 `isSessionRunning` 为 true 的会话，禁用 ⋯ 按钮并显示提示「运行中任务暂不可操作」
- 若菜单在任务进入运行态时已打开，通过受控 `Popover` 强制关闭，防止继续操作

## Test plan

- [x] `pnpm typecheck`
- [x] `pnpm test:unit`
- [x] `cargo check`
- [ ] 手动：启动一个运行中会话，确认侧边栏与历史页 ⋯ 按钮禁用且已打开的菜单会关闭