### PR TITLE
fix: local provider context guidance and desktop doc links

### DIFF
--- a/docs/gateway-connection-overhaul.md
+++ b/docs/gateway-connection-overhaul.md
@@ -30,8 +30,8 @@
 **关键事实**:`/api/ws`(原生)和 `/api/v2/*`(我们的补丁)由同一个 dashboard 进程提供。官方 WS 端点
 本来就在,SSE 是我们多加的,不是替代品。官方代码里**零个** EventSource / api/v2 消费者。
 
-我们仓库里 `web/src/lib/gateway-client.ts`(~607 行)已经是一个完整的 WS 客户端
-(心跳 30s/10s、指数退避+jitter、唤醒看门狗、online/visibility 触发),线协议与官方
+我们仓库里 `web/src/lib/gateway-client.ts` 已经是一个完整的 WS 客户端
+(指数退避+jitter、唤醒看门狗、online/visibility 触发),线协议与官方
 `JsonRpcGatewayClient` 完全一致(JSON-RPC 2.0、`{method:'event'}` 事件帧、15s 连接超时、120s 请求超时),
 但 `pickTransport()` 因一句已被证伪的「WS 被 P-003 闸门挡住」注释在 Tauri 上强制走 SSE,成了死代码。
 实际上:运行时原生在 `/api/ws` 提供服务、`tauri.conf.json` CSP 已放行 `ws://127.0.0.1:*`、dev 模式已在用。
@@ -40,7 +40,7 @@
 
 | 症状 | 根因 | 处置 |
 |---|---|---|
-| 掉线 / 重连失败 | SSE 路径无心跳;上游 #177 已补退避/宽限,但属于在错误架构上打补丁 | **切 WS**(自带 30s/10s 心跳 + 指数退避) |
+| 掉线 / 重连失败 | SSE 路径无重连恢复;上游 #177 已补退避/宽限,但属于在错误架构上打补丁 | **切 WS**(官方一致:无主动 ping,靠 close/error/RPC timeout + 指数退避) |
 | 回复要切走再切回才可见 | 重连后**不重发 `session.resume`**,服务端事件只发给会话绑定的 transport | **C2**:重连后重发 `session.resume` |
 | 全链路延迟高 | 每 RPC 经 Rust 代理 + `res.text()` 整包缓冲;慢 turn 再走 SSE 第二跳(异步 ack) | **切 WS**:RPC 与事件同一条 socket,一帧到达 |
 | 401 风暴 | dashboard 重启即轮换 token;SSE 流建立时才发现 | WS 路径 `scheduleReconnect` 已在每次重试前 `refreshGatewayUrl()` |
@@ -54,8 +54,8 @@
 - 事件只路由给会话当前绑定的 transport;重新绑定靠 `session.resume` 或 `prompt.submit`。
 - → 重连后**必须**重发 `session.resume`,这是客户端的责任(官方也这么做:
   `apps/desktop` 的 `use-route-resume.ts` 在 gateway 重新 open 时 resume)。
-- 服务端**没有 `ping` RPC 方法**:我方心跳的「pong」实际是 unknown-method 错误回显,客户端把任意
-  入站帧当 pong(`lastPongAt`),功能正常。可选的 Core 跟进:注册 trivial `ping` 方法去掉这个 wart。
+- 服务端**没有 `ping` RPC 方法**;客户端对齐官方桌面端,不再发 synthetic `ping`。半开连接由
+  WebSocket close/error、RPC timeout、OS 唤醒后的强制重连兜住,避免本地慢推理场景误判 `Heartbeat timeout`。
 
 ---
 
@@ -67,7 +67,7 @@
 | 数据路径跳数 | 0 代理 | 2(IPC+reqwest),整包缓冲 | 0(直连)/ 1(中继,逐帧转发不缓冲) |
 | RPC 结果 | 同 socket 一帧 | 异步 ack → 另走 SSE 第二跳 | 同 socket 一帧 |
 | 重连退避 | `min(15s, 1s·2^min(n,4))` + 唤醒/online/visibility 触发 | #177:1→30s(SSE) | **对齐官方:15s 封顶**,触发器同官方(已内置于 `GatewayClient`) |
-| 心跳/半开检测 | 无(靠 close + 连接超时) | 无 | 30s/10s ping(保留,比官方多一层保护,见 §1 服务端语义) |
+| 心跳/半开检测 | 无(靠 close + 连接超时) | 无 | 官方一致:无主动 ping,靠 close/error/RPC timeout + 唤醒强制重连 |
 | 重连→恢复 | `session.resume` on reopen | **无** | `gateway.disconnected` arm → 下次 open 重发 `session.resume`(C2) |
 | Token | spawn 时 env 注入 `HERMES_DASHBOARD_SESSION_TOKEN`,WS `?token=` | 同左(main 已实现)+ 接管外部 dashboard 时 HTML 抓取(legacy) | 不变 |
 | 自造 Rust 行数 | n/a | `sse_proxy.rs` ~350 + `api_proxy` RPC 半 | `sse_proxy.rs` **删除**;`ws_proxy.rs` ~260(仅兜底);`api_proxy` 仅 REST |
@@ -109,7 +109,6 @@
 - `FORK_NOTES.md`(+zh-CN):P-009 标 **deprecated**——新桌面端(≥0.4)用官方 `/api/ws`;
   端点**必须保留**至老外壳(≤0.3.x)EOL(外壳无自更新而 runtime 热更新,新 runtime 必须继续服务老外壳)。
 - 可选:`/api/v2/events` 处理器加一行弃用使用日志,量化残留用量。
-- 可选:`tui_gateway/server.py` 注册 trivial `ping` 方法(标新 P-NNN)。
 - 必须保留:P-002 上传、P-004 fs/list、P-005 mcp-servers、P-008 profiles 兼容、P-011 slug_filter/probe
   (均与传输无关,本桌面端在用);P-006/P-010 国内 provider、P-014/P-015 冻结运行时打包。
 
@@ -143,7 +142,7 @@
 2. `?wspath=relay` 强制中继:完整对话回合、审批、打断。
 3. 睡眠 ≥2min 中途唤醒:≤15s 重连,在途回合续流到同一条消息(不再「切走再切回才可见」)。
 4. dashboard 重启(YOLO 切换 / kill -9):token 轮换后正常重连,无 401 风暴。
-5. ≥10min 长回合流式:顺序正确、无心跳误杀(重 markdown 渲染时看门狗误报检查)。
+5. ≥10min 长回合流式:顺序正确、无主动心跳误杀(重 markdown 渲染时看门狗误报检查)。
 6. 老外壳兼容:v0.3.2 外壳连 Core main 构建的新 runtime(P-009 SSE 端点仍可用)。
 
 ## 6. 风险与已知限制
@@ -154,7 +153,7 @@
    `detail.tsx` 的 `ensureGatewaySession` 懒恢复(内容不丢,转录可从历史重建)。后续增强:遍历
    `streamStatus === "connecting"` 的会话逐个 resume。
 3. **`session.resume` 慢**(分钟级 agent 重建):`reattachInFlight` 防叠加 + 瞬态文案 + 长超时。
-4. 心跳依赖 unknown-method 回显 —— 已注释说明;可选 Core `ping` 方法消除。
+4. 无主动 heartbeat 后,极端半开 socket 会等到下一次 RPC timeout 或 OS 唤醒强制重连才暴露;这是对齐官方桌面端以避免本地慢推理误杀的取舍。
 5. 接管外部已运行 dashboard 时无法 env 注入 token —— HTML 抓取保留为显式 legacy 路径。
 
 ## 7. 关键文件索引

--- a/web/src/lib/gateway-client.test.ts
+++ b/web/src/lib/gateway-client.test.ts
@@ -549,8 +549,8 @@ describe("GatewayClient", () => {
     });
   });
 
-  describe("heartbeat", () => {
-    it("sends ping every 30s after connection opens", async () => {
+  describe("idle connection liveness", () => {
+    it("does not send synthetic ping frames during long idle periods", async () => {
       vi.useFakeTimers();
       const client = new GatewayClient();
       const connected = client.connect();
@@ -560,19 +560,14 @@ describe("GatewayClient", () => {
       const ws = MockWebSocket.instances[0];
       expect(ws.sent).toHaveLength(0);
 
-      await vi.advanceTimersByTimeAsync(30_000);
-      expect(ws.sent).toHaveLength(1);
-      expect(JSON.parse(ws.sent[0])).toEqual({ jsonrpc: "2.0", method: "ping" });
-
-      ws.onmessage?.({ data: JSON.stringify({ jsonrpc: "2.0", result: {} }) });
-
-      await vi.advanceTimersByTimeAsync(30_000);
-      expect(ws.sent).toHaveLength(2);
+      await vi.advanceTimersByTimeAsync(120_000);
+      expect(ws.sent).toHaveLength(0);
+      expect(client.state).toBe("open");
 
       client.close();
     });
 
-    it("detects stale connection after 30s+10s with no message", async () => {
+    it("keeps an idle open socket instead of failing after the old 40s heartbeat window", async () => {
       vi.useFakeTimers();
       const client = new GatewayClient();
       const disconnects: string[] = [];
@@ -584,17 +579,14 @@ describe("GatewayClient", () => {
 
       expect(client.state).toBe("open");
 
-      await vi.advanceTimersByTimeAsync(30_000);
+      await vi.advanceTimersByTimeAsync(40_000);
       expect(client.state).toBe("open");
-
-      await vi.advanceTimersByTimeAsync(10_000);
-      expect(client.state).toBe("closed");
-      expect(disconnects).toHaveLength(1);
+      expect(disconnects).toHaveLength(0);
 
       client.close();
     });
 
-    it("incoming message prevents heartbeat failure", async () => {
+    it("pending requests are rejected by RPC timeout, not heartbeat timeout", async () => {
       vi.useFakeTimers();
       const client = new GatewayClient();
 
@@ -602,62 +594,22 @@ describe("GatewayClient", () => {
       MockWebSocket.instances[0].open();
       await connected;
 
-      const ws = MockWebSocket.instances[0];
-
-      await vi.advanceTimersByTimeAsync(30_000);
-
-      ws.onmessage?.({
-        data: JSON.stringify({
-          method: "event",
-          params: { type: "status.update", session_id: "s1", payload: {} },
-        }),
-      });
-
-      await vi.advanceTimersByTimeAsync(10_000);
-      expect(client.state).toBe("open");
-
-      client.close();
-    });
-
-    it("rejects pending requests with heartbeat timeout error", async () => {
-      vi.useFakeTimers();
-      const client = new GatewayClient();
-
-      const connected = client.connect();
-      MockWebSocket.instances[0].open();
-      await connected;
-
+      let settled = false;
       const result = client.request("some.method", {}, { timeoutMs: 120_000 })
         .then(() => null)
+        .finally(() => { settled = true; })
         .catch((err: Error) => err);
       await vi.advanceTimersByTimeAsync(0);
 
-      await vi.advanceTimersByTimeAsync(30_000);
-      await vi.advanceTimersByTimeAsync(10_000);
+      await vi.advanceTimersByTimeAsync(40_000);
+      expect(settled).toBe(false);
+      expect(client.state).toBe("open");
+
+      await vi.advanceTimersByTimeAsync(80_000);
 
       const error = await result;
       expect(error).toBeInstanceOf(Error);
-      expect(error!.message).toBe("Heartbeat timeout");
-      client.close();
-    });
-
-    it("heartbeat failure triggers auto-reconnect", async () => {
-      vi.useFakeTimers();
-      vi.spyOn(Math, "random").mockReturnValue(0);
-      const client = new GatewayClient();
-      client.enableAutoReconnect();
-
-      const connected = client.connect();
-      MockWebSocket.instances[0].open();
-      await connected;
-
-      await vi.advanceTimersByTimeAsync(30_000);
-      await vi.advanceTimersByTimeAsync(10_000);
-      expect(client.state).toBe("closed");
-
-      await vi.advanceTimersByTimeAsync(1_000);
-      expect(MockWebSocket.instances.length).toBeGreaterThanOrEqual(2);
-
+      expect(error!.message).toBe("RPC timeout: some.method");
       client.close();
     });
   });

--- a/web/src/lib/gateway-client.ts
+++ b/web/src/lib/gateway-client.ts
@@ -14,9 +14,6 @@ const RECONNECT_MAX_DELAY_MS = 15_000;
 const RECONNECT_EXP_CAP = 4;
 const RECONNECT_MAX_ATTEMPTS = Infinity;
 
-const HEARTBEAT_INTERVAL_MS = 30_000;
-const HEARTBEAT_TIMEOUT_MS = 10_000;
-
 const WAKE_WATCHDOG_INTERVAL_MS = 2_000;
 // 比 watchdog 间隔大得多——正常 tick 间隔约 2s，超过这个值基本只有
 // 进程被冻结过（macOS 睡眠 / OS 节流 / 标签页 background）才会出现。
@@ -63,10 +60,6 @@ export class GatewayClient {
   private reconnectAttempts = 0;
   private reconnectTimer: ReturnType<typeof setTimeout> | null = null;
   private intentionalClose = false;
-
-  private heartbeatInterval: ReturnType<typeof setInterval> | null = null;
-  private heartbeatTimeout: ReturnType<typeof setTimeout> | null = null;
-  private lastPongAt = 0;
 
   private wakeWatchdogTimer: ReturnType<typeof setInterval> | null = null;
   private lastWakeTickAt = 0;
@@ -131,7 +124,6 @@ export class GatewayClient {
         clearConnectState();
         this.reconnectAttempts = 0;
         this.setState("open");
-        this.startHeartbeat();
         resolve();
       };
       const settleConnectError = (err: Error, state: ConnectionState) => {
@@ -181,7 +173,6 @@ export class GatewayClient {
         if (!isCurrentSocket()) return;
 
         this.ws = null;
-        this.stopHeartbeat();
 
         if (!settled) {
           settleConnectError(new Error("WebSocket closed"), "closed");
@@ -200,7 +191,6 @@ export class GatewayClient {
       ws.onerror = () => {
         if (!isCurrentSocket()) return;
         this.ws = null;
-        this.stopHeartbeat();
         if (!settled) {
           settleConnectError(new Error("WebSocket connection failed"), "error");
         } else {
@@ -216,7 +206,6 @@ export class GatewayClient {
 
       ws.onmessage = (ev) => {
         if (!isCurrentSocket()) return;
-        this.lastPongAt = Date.now();
         try {
           this.handleFrame(JSON.parse(ev.data));
         } catch {
@@ -268,64 +257,6 @@ export class GatewayClient {
       clearTimeout(this.reconnectTimer);
       this.reconnectTimer = null;
     }
-  }
-
-  private startHeartbeat() {
-    this.stopHeartbeat();
-    this.lastPongAt = Date.now();
-
-    this.heartbeatInterval = setInterval(() => {
-      if (!this.ws || this.ws.readyState !== WebSocket.OPEN) {
-        this.stopHeartbeat();
-        return;
-      }
-
-      try {
-        // 服务端没有注册 "ping" 方法——这一帧会换回一个 unknown-method 错误
-        // 响应。这正是我们要的:onmessage 把任意入站帧都当 pong(lastPongAt),
-        // 所以错误回显足以证明链路活着。别给这帧加 id,否则会进 pending 表。
-        this.ws.send(JSON.stringify({ jsonrpc: "2.0", method: "ping" }));
-      } catch {
-        this.handleHeartbeatFailure();
-        return;
-      }
-
-      this.heartbeatTimeout = setTimeout(() => {
-        this.heartbeatTimeout = null;
-        if (Date.now() - this.lastPongAt >= HEARTBEAT_INTERVAL_MS + HEARTBEAT_TIMEOUT_MS) {
-          this.handleHeartbeatFailure();
-        }
-      }, HEARTBEAT_TIMEOUT_MS);
-    }, HEARTBEAT_INTERVAL_MS);
-  }
-
-  private stopHeartbeat() {
-    if (this.heartbeatInterval) {
-      clearInterval(this.heartbeatInterval);
-      this.heartbeatInterval = null;
-    }
-    if (this.heartbeatTimeout) {
-      clearTimeout(this.heartbeatTimeout);
-      this.heartbeatTimeout = null;
-    }
-  }
-
-  private handleHeartbeatFailure() {
-    this.stopHeartbeat();
-    this.pending.forEach(({ reject, timer }) => {
-      clearTimeout(timer);
-      reject(new Error("Heartbeat timeout"));
-    });
-    this.pending.clear();
-    const ws = this.ws;
-    this.ws = null;
-    this.connectPromise = null;
-    if (ws) {
-      try { ws.close(); } catch {}
-    }
-    this.setState("closed");
-    this.emitDisconnect();
-    this.scheduleReconnect();
   }
 
   private handleFrame(frame: any) {
@@ -492,8 +423,9 @@ export class GatewayClient {
     if (!this.autoReconnect || this.intentionalClose) return;
 
     // forceful=false 是 "提示" 路径（visibility/online）——已经 OPEN 的连接
-    // 没必要 tear down。半开 socket 会被 heartbeat（30s+10s 内）或下一次 RPC
-    // 失败兜住，不至于让窗口每次切回前台都闪 "连接已断开"。
+    // 没必要 tear down。对齐官方桌面端，不主动发 synthetic ping；
+    // 半开 socket 由下一次 RPC timeout / WebSocket close-error 兜住，
+    // 不至于让窗口每次切回前台都闪 "连接已断开"。
     if (!forceful && this.ws?.readyState === WebSocket.OPEN) {
       return;
     }
@@ -509,7 +441,6 @@ export class GatewayClient {
     if (hadSocket || hadInflight) {
       this.ws = null;
       this.connectPromise = null;
-      this.stopHeartbeat();
       // 拒绝挂在旧 socket 上的 RPC——不然要等 120s RPC timeout，UI 卡住。
       this.pending.forEach(({ reject, timer }) => {
         clearTimeout(timer);
@@ -531,7 +462,6 @@ export class GatewayClient {
   close() {
     this.intentionalClose = true;
     this.cancelReconnect();
-    this.stopHeartbeat();
     this.removeWakeListeners();
     this.abortConnect?.();
     this.pending.forEach(({ reject, timer }) => {

--- a/web/src/lib/gateway-result.test.ts
+++ b/web/src/lib/gateway-result.test.ts
@@ -75,7 +75,11 @@ describe("humanizeGatewayError", () => {
   });
 
   it("localizes timeout errors", () => {
-    expect(humanizeGatewayError(new Error("RPC timeout: session.resume"))).toContain("超时");
+    const message = humanizeGatewayError(new Error("RPC timeout: session.resume"));
+    expect(message).toContain("超时");
+    expect(message).toContain("LM Studio");
+    expect(message).toContain("64K");
+    expect(message).toContain("OOM");
   });
 
   it("localizes connection-closed errors", () => {

--- a/web/src/lib/gateway-result.ts
+++ b/web/src/lib/gateway-result.ts
@@ -99,7 +99,7 @@ export function humanizeGatewayError(error: unknown): string {
 
   const lower = message.toLowerCase();
   if (lower.includes("timeout") || message.includes("超时")) {
-    return "请求超时，请检查网络或重启 Hermes 后重试。";
+    return "请求超时。如果正在使用 LM Studio、Ollama 等本地模型，请确认本地服务已启动、模型已加载、上下文窗口已设为至少 64K，且显存/内存没有因上下文过大而 OOM；也可以重启 Hermes 后重试。";
   }
   if (
     lower.includes("connection closed") ||

--- a/web/src/lib/local-provider-context.test.ts
+++ b/web/src/lib/local-provider-context.test.ts
@@ -1,0 +1,68 @@
+import { describe, expect, it } from "vitest";
+import {
+  getLocalContextWarning,
+  MINIMUM_LOCAL_CONTEXT_LENGTH,
+  parseLocalContextWindow,
+  RECOMMENDED_LOCAL_CONTEXT_LENGTH,
+} from "./local-provider-context";
+
+describe("local provider context helpers", () => {
+  it("parses empty and invalid context windows as unset", () => {
+    expect(parseLocalContextWindow("")).toBeUndefined();
+    expect(parseLocalContextWindow("   ")).toBeUndefined();
+    expect(parseLocalContextWindow("abc")).toBeUndefined();
+    expect(parseLocalContextWindow("128k")).toBeUndefined();
+    expect(parseLocalContextWindow("-5")).toBeUndefined();
+  });
+
+  it("parses positive numeric context windows", () => {
+    expect(parseLocalContextWindow(String(RECOMMENDED_LOCAL_CONTEXT_LENGTH))).toBe(65_536);
+    expect(parseLocalContextWindow("64000")).toBe(64_000);
+    expect(parseLocalContextWindow("100.9")).toBe(100);
+  });
+
+  it("does not warn for empty, 64K, or recommended context values", () => {
+    expect(getLocalContextWarning({ isLocalProvider: true, configuredContextWindow: "" })).toBeNull();
+    expect(getLocalContextWarning({
+      isLocalProvider: true,
+      configuredContextWindow: String(MINIMUM_LOCAL_CONTEXT_LENGTH),
+    })).toBeNull();
+    expect(getLocalContextWarning({
+      isLocalProvider: true,
+      configuredContextWindow: String(RECOMMENDED_LOCAL_CONTEXT_LENGTH),
+    })).toBeNull();
+  });
+
+  it("warns when the configured context is below the minimum", () => {
+    const warning = getLocalContextWarning({
+      isLocalProvider: true,
+      configuredContextWindow: "63999",
+    });
+    expect(warning).toMatchObject({
+      length: 63_999,
+      source: "configured",
+    });
+    expect(warning?.message).toContain("64,000");
+    expect(warning?.message).toContain("65,536");
+  });
+
+  it("warns when the current detected local context is below the minimum", () => {
+    const warning = getLocalContextWarning({
+      isLocalProvider: true,
+      configuredContextWindow: "",
+      effectiveContextLength: 4_096,
+    });
+    expect(warning).toMatchObject({
+      length: 4_096,
+      source: "detected",
+    });
+  });
+
+  it("ignores local-only warnings for remote providers", () => {
+    expect(getLocalContextWarning({
+      isLocalProvider: false,
+      configuredContextWindow: "4096",
+      effectiveContextLength: 4_096,
+    })).toBeNull();
+  });
+});

--- a/web/src/lib/local-provider-context.test.ts
+++ b/web/src/lib/local-provider-context.test.ts
@@ -1,12 +1,23 @@
 import { describe, expect, it } from "vitest";
 import {
   getLocalContextWarning,
+  HERMES_CONTEXT_REQUIREMENTS_URL,
+  HERMES_PROVIDER_CONTEXT_URL,
   MINIMUM_LOCAL_CONTEXT_LENGTH,
   parseLocalContextWindow,
   RECOMMENDED_LOCAL_CONTEXT_LENGTH,
 } from "./local-provider-context";
 
 describe("local provider context helpers", () => {
+  it("exports stable documentation URLs for local provider onboarding", () => {
+    expect(HERMES_CONTEXT_REQUIREMENTS_URL).toBe(
+      "https://hermesagent.org.cn/en/docs/getting-started/quickstart",
+    );
+    expect(HERMES_PROVIDER_CONTEXT_URL).toBe(
+      "https://hermes-agent.nousresearch.com/docs/integrations/providers",
+    );
+  });
+
   it("parses empty and invalid context windows as unset", () => {
     expect(parseLocalContextWindow("")).toBeUndefined();
     expect(parseLocalContextWindow("   ")).toBeUndefined();

--- a/web/src/lib/local-provider-context.ts
+++ b/web/src/lib/local-provider-context.ts
@@ -1,0 +1,51 @@
+export const MINIMUM_LOCAL_CONTEXT_LENGTH = 64_000;
+export const RECOMMENDED_LOCAL_CONTEXT_LENGTH = 65_536;
+
+export const HERMES_CONTEXT_REQUIREMENTS_URL =
+  "https://hermesagent.org.cn/en/docs/getting-started/quickstart";
+export const HERMES_PROVIDER_CONTEXT_URL =
+  "https://hermes-agent.nousresearch.com/docs/integrations/providers";
+
+export type LocalContextWarningSource = "configured" | "detected";
+
+export interface LocalContextWarning {
+  length: number;
+  source: LocalContextWarningSource;
+  message: string;
+}
+
+function positiveInteger(value: unknown): number | undefined {
+  const number = typeof value === "number" ? value : Number(value);
+  return Number.isFinite(number) && number > 0 ? Math.floor(number) : undefined;
+}
+
+export function parseLocalContextWindow(raw: string | number | null | undefined): number | undefined {
+  if (raw == null) return undefined;
+  if (typeof raw === "string" && !raw.trim()) return undefined;
+  return positiveInteger(raw);
+}
+
+function formatTokens(value: number): string {
+  return value.toLocaleString("en-US");
+}
+
+export function getLocalContextWarning(input: {
+  isLocalProvider: boolean;
+  configuredContextWindow?: string | number | null;
+  effectiveContextLength?: number | null;
+}): LocalContextWarning | null {
+  if (!input.isLocalProvider) return null;
+
+  const configured = parseLocalContextWindow(input.configuredContextWindow);
+  const detected = positiveInteger(input.effectiveContextLength);
+  const length = configured ?? detected;
+  if (length == null || length >= MINIMUM_LOCAL_CONTEXT_LENGTH) return null;
+
+  const source: LocalContextWarningSource = configured != null ? "configured" : "detected";
+  const sourceText = source === "configured" ? "当前填写" : "当前探测";
+  return {
+    length,
+    source,
+    message: `${sourceText}上下文约 ${formatTokens(length)} tokens，低于 Hermes 要求的 ${formatTokens(MINIMUM_LOCAL_CONTEXT_LENGTH)}。建议将本地运行时和桌面端覆盖都设为 ${formatTokens(RECOMMENDED_LOCAL_CONTEXT_LENGTH)}，否则启动或运行时可能被拒绝。`,
+  };
+}

--- a/web/src/lib/local-provider-context.ts
+++ b/web/src/lib/local-provider-context.ts
@@ -1,6 +1,11 @@
 export const MINIMUM_LOCAL_CONTEXT_LENGTH = 64_000;
 export const RECOMMENDED_LOCAL_CONTEXT_LENGTH = 65_536;
 
+export const HERMES_CONTEXT_REQUIREMENTS_URL =
+  "https://hermesagent.org.cn/en/docs/getting-started/quickstart";
+export const HERMES_PROVIDER_CONTEXT_URL =
+  "https://hermes-agent.nousresearch.com/docs/integrations/providers";
+
 export type LocalContextWarningSource = "configured" | "detected";
 
 export interface LocalContextWarning {

--- a/web/src/lib/local-provider-context.ts
+++ b/web/src/lib/local-provider-context.ts
@@ -1,11 +1,6 @@
 export const MINIMUM_LOCAL_CONTEXT_LENGTH = 64_000;
 export const RECOMMENDED_LOCAL_CONTEXT_LENGTH = 65_536;
 
-export const HERMES_CONTEXT_REQUIREMENTS_URL =
-  "https://hermesagent.org.cn/en/docs/getting-started/quickstart";
-export const HERMES_PROVIDER_CONTEXT_URL =
-  "https://hermes-agent.nousresearch.com/docs/integrations/providers";
-
 export type LocalContextWarningSource = "configured" | "detected";
 
 export interface LocalContextWarning {

--- a/web/src/routes/settings-models-section.tsx
+++ b/web/src/routes/settings-models-section.tsx
@@ -46,8 +46,6 @@ import { rememberLastUsedModel } from "@/lib/last-used-model";
 import { fetchExternalJSON } from "@/lib/transport";
 import {
   getLocalContextWarning,
-  HERMES_CONTEXT_REQUIREMENTS_URL,
-  HERMES_PROVIDER_CONTEXT_URL,
   RECOMMENDED_LOCAL_CONTEXT_LENGTH,
 } from "@/lib/local-provider-context";
 import type { EnvVarInfo } from "@hermes/protocol";
@@ -1717,10 +1715,7 @@ export function ModelsSection() {
                       </div>
                       {selectedLocalContextWarning && (
                         <div className={s.localContextWarning} role="alert">
-                          {selectedLocalContextWarning.message}{" "}
-                          <a href={HERMES_CONTEXT_REQUIREMENTS_URL} target="_blank" rel="noreferrer" className={s.link}>
-                            64K 要求说明 ↗
-                          </a>
+                          {selectedLocalContextWarning.message}
                         </div>
                       )}
                       {selectedProviderIsCurrent && modelInfo && (
@@ -1903,15 +1898,6 @@ export function ModelsSection() {
                       Hermes Agent 会拒绝低于 64,000 tokens 的模型上下文。建议在本地运行时和下方「上下文窗口」中都设为{" "}
                       {RECOMMENDED_LOCAL_CONTEXT_LENGTH.toLocaleString()}，并在 LM Studio / Ollama / vLLM / llama.cpp 中重新加载模型。
                     </p>
-                    <div>
-                      <a href={HERMES_CONTEXT_REQUIREMENTS_URL} target="_blank" rel="noreferrer" className={s.link}>
-                        Quickstart 说明 ↗
-                      </a>
-                      {" · "}
-                      <a href={HERMES_PROVIDER_CONTEXT_URL} target="_blank" rel="noreferrer" className={s.link}>
-                        Providers 指引 ↗
-                      </a>
-                    </div>
                   </div>
                   <div className={s.localProviderGuide} aria-label="常用本地部署端点">
                     {LOCAL_PROVIDER_PRESETS.map((preset) => (
@@ -1977,10 +1963,7 @@ export function ModelsSection() {
                   </div>
                   {customLocalContextWarning && (
                     <div className={s.localContextWarning} role="alert">
-                      {customLocalContextWarning.message}{" "}
-                      <a href={HERMES_CONTEXT_REQUIREMENTS_URL} target="_blank" rel="noreferrer" className={s.link}>
-                        查看说明 ↗
-                      </a>
+                      {customLocalContextWarning.message}
                     </div>
                   )}
                 </>

--- a/web/src/routes/settings-models-section.tsx
+++ b/web/src/routes/settings-models-section.tsx
@@ -44,11 +44,15 @@ import { ModelCombobox } from "@/components/settings/model-combobox";
 import { translateEnvCategory, translateEnvVar } from "@/lib/env-translations";
 import { rememberLastUsedModel } from "@/lib/last-used-model";
 import { fetchExternalJSON } from "@/lib/transport";
+import { openExternalUrl } from "@/lib/external-links";
 import {
   getLocalContextWarning,
+  HERMES_CONTEXT_REQUIREMENTS_URL,
+  HERMES_PROVIDER_CONTEXT_URL,
   RECOMMENDED_LOCAL_CONTEXT_LENGTH,
 } from "@/lib/local-provider-context";
 import type { EnvVarInfo } from "@hermes/protocol";
+import { CopyButton } from "@/components/ui/copy-button";
 import { Alert, Button, Field, Input, Select, Textarea } from "@hermes/shared-ui";
 import { OAuthProvidersSection } from "./settings-oauth-section";
 import s from "./settings.module.css";
@@ -333,6 +337,38 @@ const LOCAL_PROVIDER_PRESETS: LocalProviderPreset[] = [
     tutorial: "启动 llama-server 的 OpenAI 兼容接口时使用 --ctx-size 65536；未启用鉴权时 API Key 留空即可。",
   },
 ];
+
+const LOCAL_PROVIDER_DOC_LINKS = [
+  { label: "Quickstart 说明", url: HERMES_CONTEXT_REQUIREMENTS_URL },
+  { label: "Providers 指引", url: HERMES_PROVIDER_CONTEXT_URL },
+] as const;
+
+function LocalProviderDocLinks() {
+  return (
+    <div className={s.localProviderDocLinks}>
+      {LOCAL_PROVIDER_DOC_LINKS.map((item) => (
+        <div key={item.url} className={s.localProviderDocLinkRow}>
+          <a
+            className={s.link}
+            href={item.url}
+            target="_blank"
+            rel="noopener noreferrer"
+            onClick={(event) => {
+              event.preventDefault();
+              void openExternalUrl(item.url);
+            }}
+          >
+            {item.label} ↗
+          </a>
+          <code className={s.localProviderDocUrl}>{item.url}</code>
+          <CopyButton className={s.localProviderDocCopy} text={item.url} showStatusIcon={false}>
+            复制
+          </CopyButton>
+        </div>
+      ))}
+    </div>
+  );
+}
 
 const AUXILIARY_TASK_BY_ID = Object.fromEntries(
   AUXILIARY_TASKS.map((task) => [task.id, task]),
@@ -1898,6 +1934,7 @@ export function ModelsSection() {
                       Hermes Agent 会拒绝低于 64,000 tokens 的模型上下文。建议在本地运行时和下方「上下文窗口」中都设为{" "}
                       {RECOMMENDED_LOCAL_CONTEXT_LENGTH.toLocaleString()}，并在 LM Studio / Ollama / vLLM / llama.cpp 中重新加载模型。
                     </p>
+                    <LocalProviderDocLinks />
                   </div>
                   <div className={s.localProviderGuide} aria-label="常用本地部署端点">
                     {LOCAL_PROVIDER_PRESETS.map((preset) => (

--- a/web/src/routes/settings-models-section.tsx
+++ b/web/src/routes/settings-models-section.tsx
@@ -44,6 +44,12 @@ import { ModelCombobox } from "@/components/settings/model-combobox";
 import { translateEnvCategory, translateEnvVar } from "@/lib/env-translations";
 import { rememberLastUsedModel } from "@/lib/last-used-model";
 import { fetchExternalJSON } from "@/lib/transport";
+import {
+  getLocalContextWarning,
+  HERMES_CONTEXT_REQUIREMENTS_URL,
+  HERMES_PROVIDER_CONTEXT_URL,
+  RECOMMENDED_LOCAL_CONTEXT_LENGTH,
+} from "@/lib/local-provider-context";
 import type { EnvVarInfo } from "@hermes/protocol";
 import { Alert, Button, Field, Input, Select, Textarea } from "@hermes/shared-ui";
 import { OAuthProvidersSection } from "./settings-oauth-section";
@@ -120,6 +126,16 @@ interface LocalProviderPreset {
   baseUrl: string;
   model: string;
   tutorial: string;
+}
+
+function initialCustomProviderForm(mode: CustomProviderMode) {
+  return {
+    name: "",
+    baseUrl: "",
+    apiKey: "",
+    model: "",
+    contextWindow: mode === "local" ? String(RECOMMENDED_LOCAL_CONTEXT_LENGTH) : "",
+  };
 }
 
 function buildChatCompletionsUrl(baseUrl: string): string {
@@ -298,25 +314,25 @@ const LOCAL_PROVIDER_PRESETS: LocalProviderPreset[] = [
     name: "LM Studio",
     baseUrl: "http://127.0.0.1:1234/v1",
     model: "local-model",
-    tutorial: "打开 Developer / Local Server，加载模型后点击 Start Server；模型名以 /v1/models 返回为准。",
+    tutorial: "打开 Developer / Local Server，模型设置里将 Context Length 调到 ≥65536，重新加载模型后点击 Start Server。",
   },
   {
     name: "Ollama",
     baseUrl: "http://127.0.0.1:11434/v1",
     model: "qwen2.5-coder:7b",
-    tutorial: "先运行 ollama pull qwen2.5-coder:7b，并确认 ollama serve 正在运行；API Key 通常留空。",
+    tutorial: "先运行 ollama pull，并用 ollama run <model> -c 65536 或 Modelfile 设置上下文；API Key 通常留空。",
   },
   {
     name: "vLLM",
     baseUrl: "http://127.0.0.1:8000/v1",
     model: "Qwen/Qwen2.5-Coder-7B-Instruct",
-    tutorial: "启动 OpenAI-compatible server，建议用 --served-model-name 固定一个容易填写的模型名。",
+    tutorial: "启动 OpenAI-compatible server，带上 --max-model-len 64k，并用 --served-model-name 固定模型名。",
   },
   {
     name: "llama.cpp",
     baseUrl: "http://127.0.0.1:8080/v1",
     model: "local-model",
-    tutorial: "启动 llama-server 的 OpenAI 兼容接口；未启用鉴权时 API Key 留空即可。",
+    tutorial: "启动 llama-server 的 OpenAI 兼容接口时使用 --ctx-size 65536；未启用鉴权时 API Key 留空即可。",
   },
 ];
 
@@ -669,12 +685,7 @@ export function ModelsSection() {
   const [providerSearch, setProviderSearch] = useState("");
   const [showCustomForm, setShowCustomForm] = useState(false);
   const [customProviderMode, setCustomProviderMode] = useState<CustomProviderMode>("custom");
-  const [customForm, setCustomForm] = useState({
-    name: "",
-    baseUrl: "",
-    apiKey: "",
-    model: "",
-  });
+  const [customForm, setCustomForm] = useState(() => initialCustomProviderForm("custom"));
   const [selectedAuxTask, setSelectedAuxTask] = useState<AuxiliaryTaskId>("vision");
   const [auxForm, setAuxForm] = useState<AuxiliaryTaskForm>(() =>
     auxiliaryFormFromConfig(config, "vision"));
@@ -706,12 +717,12 @@ export function ModelsSection() {
   const closeCustomForm = useCallback(() => {
     setShowCustomForm(false);
     setCustomProviderMode("custom");
-    setCustomForm({ name: "", baseUrl: "", apiKey: "", model: "" });
+    setCustomForm(initialCustomProviderForm("custom"));
   }, []);
 
   const openCustomProviderForm = useCallback((mode: CustomProviderMode) => {
     setCustomProviderMode(mode);
-    setCustomForm({ name: "", baseUrl: "", apiKey: "", model: "" });
+    setCustomForm(initialCustomProviderForm(mode));
     setShowCustomForm(true);
   }, []);
 
@@ -721,6 +732,7 @@ export function ModelsSection() {
       name: preset.name,
       baseUrl: preset.baseUrl,
       model: preset.model,
+      contextWindow: String(RECOMMENDED_LOCAL_CONTEXT_LENGTH),
     }));
   }, []);
   useEffect(() => {
@@ -826,9 +838,10 @@ export function ModelsSection() {
   const selectedProviderCredentialPreview = selectedProvider
     ? getProviderCredentialPreview(config, resolvedEnvVars, selectedProvider)
     : undefined;
-  const selectedProviderCanOmitApiKey = selectedProvider
+  const selectedProviderIsLocal = selectedProvider
     ? isLocalProviderBaseUrl(providerForm.baseUrl || selectedProvider.baseUrl)
     : false;
+  const selectedProviderCanOmitApiKey = selectedProviderIsLocal;
   const customBaseUrl = customForm.baseUrl.trim();
   const customBaseUrlValid = !customBaseUrl || isValidProviderBaseUrl(customBaseUrl);
   const duplicateBaseUrlProvider = useMemo(() => {
@@ -1004,6 +1017,11 @@ export function ModelsSection() {
     currentProviderId === selectedProvider.id &&
     modelInfo?.model === selectedProviderModel,
   );
+  const selectedLocalContextWarning = getLocalContextWarning({
+    isLocalProvider: selectedProviderIsLocal,
+    configuredContextWindow: providerForm.contextWindow,
+    effectiveContextLength: selectedProviderIsCurrent ? modelInfo?.effective_context_length : undefined,
+  });
 
   // Deep-link from the picker's "去设置" CTA: /models#provider-<slug> selects
   // and scrolls to that provider so the user lands on the right key field.
@@ -1273,6 +1291,7 @@ export function ModelsSection() {
     const baseUrl = customForm.baseUrl.trim();
     const model = customForm.model.trim();
     const apiKey = customForm.apiKey.trim();
+    const contextWindow = customProviderMode === "local" ? customForm.contextWindow.trim() : "";
     if (!name || !baseUrl || !model) return;
     if (!isValidProviderBaseUrl(baseUrl)) {
       setProviderSaveError("Base URL 必须是 http 或 https 地址");
@@ -1300,7 +1319,7 @@ export function ModelsSection() {
       isCustom: true,
     };
     const nextConfig = buildProviderOrderUpdate(
-      buildProviderConfigUpdate(config, preset, { apiKey, baseUrl, model }),
+      buildProviderConfigUpdate(config, preset, { apiKey, baseUrl, model, contextWindow }),
       [candidate, ...orderedProviders.map((provider) => provider.id)],
     );
     saveConfig.mutate(
@@ -1309,7 +1328,7 @@ export function ModelsSection() {
         onSuccess: () => {
           selectProvider(candidate);
           closeCustomForm();
-          setProviderForm({ apiKey: "", baseUrl, model, contextWindow: "" });
+          setProviderForm({ apiKey: "", baseUrl, model, contextWindow });
         },
       },
     );
@@ -1438,7 +1457,7 @@ export function ModelsSection() {
   const customProviderIsLocal = customProviderMode === "local";
   const customProviderTitle = customProviderIsLocal ? "添加本地部署服务商" : "添加自定义服务商";
   const customProviderHint = customProviderIsLocal
-    ? "适合 LM Studio、Ollama、vLLM、llama.cpp 等本地 OpenAI 兼容服务。先启动本地服务并加载模型，再选择下面的端点或手动填写。"
+    ? "适合 LM Studio、Ollama、vLLM、llama.cpp 等本地 OpenAI 兼容服务。先启动本地服务、加载模型并把上下文窗口设到至少 64K，再选择下面的端点或手动填写。"
     : "添加任意 OpenAI Chat Completions 兼容服务（百度千帆 / 腾讯混元 / SiliconFlow / 私有部署等）。提交后可在左侧列表里随时切换。";
   const customProviderPlaceholders = customProviderIsLocal
     ? {
@@ -1446,13 +1465,19 @@ export function ModelsSection() {
         baseUrl: "http://127.0.0.1:1234/v1",
         model: "qwen2.5-coder:7b",
         apiKey: "本地服务一般可留空，启用鉴权时再填写",
+        contextWindow: String(RECOMMENDED_LOCAL_CONTEXT_LENGTH),
       }
     : {
         name: "例如：Deepseek",
         baseUrl: "https://api.example.com/v1",
         model: "deepseek-v4-flash",
         apiKey: "可选，先建后填也可以",
+        contextWindow: "自动",
       };
+  const customLocalContextWarning = getLocalContextWarning({
+    isLocalProvider: customProviderIsLocal,
+    configuredContextWindow: customForm.contextWindow,
+  });
 
   return (
     <div className={s.modelsSettings}>
@@ -1690,6 +1715,14 @@ export function ModelsSection() {
                         留空或填 0 使用该模型自动探测到的上下文窗口；本地 / 自建模型探测不准时可手动指定（单位 token）。
                         {!selectedProviderIsCurrent && " 该值会在「设为当前模型」时生效。"}
                       </div>
+                      {selectedLocalContextWarning && (
+                        <div className={s.localContextWarning} role="alert">
+                          {selectedLocalContextWarning.message}{" "}
+                          <a href={HERMES_CONTEXT_REQUIREMENTS_URL} target="_blank" rel="noreferrer" className={s.link}>
+                            64K 要求说明 ↗
+                          </a>
+                        </div>
+                      )}
                       {selectedProviderIsCurrent && modelInfo && (
                         <div className={s.modelPickerHint}>
                           自动探测 {(modelInfo.auto_context_length ?? 0).toLocaleString()}
@@ -1863,20 +1896,38 @@ export function ModelsSection() {
                 {customProviderHint}
               </p>
               {customProviderIsLocal && (
-                <div className={s.localProviderGuide} aria-label="常用本地部署端点">
-                  {LOCAL_PROVIDER_PRESETS.map((preset) => (
-                    <button
-                      key={preset.name}
-                      type="button"
-                      className={s.localProviderCard}
-                      onClick={() => applyLocalProviderPreset(preset)}
-                    >
-                      <strong>{preset.name}</strong>
-                      <code>{preset.baseUrl}</code>
-                      <span>{preset.tutorial}</span>
-                    </button>
-                  ))}
-                </div>
+                <>
+                  <div className={s.localProviderContextNotice}>
+                    <strong>本地模型上下文需要 ≥64K</strong>
+                    <p>
+                      Hermes Agent 会拒绝低于 64,000 tokens 的模型上下文。建议在本地运行时和下方「上下文窗口」中都设为{" "}
+                      {RECOMMENDED_LOCAL_CONTEXT_LENGTH.toLocaleString()}，并在 LM Studio / Ollama / vLLM / llama.cpp 中重新加载模型。
+                    </p>
+                    <div>
+                      <a href={HERMES_CONTEXT_REQUIREMENTS_URL} target="_blank" rel="noreferrer" className={s.link}>
+                        Quickstart 说明 ↗
+                      </a>
+                      {" · "}
+                      <a href={HERMES_PROVIDER_CONTEXT_URL} target="_blank" rel="noreferrer" className={s.link}>
+                        Providers 指引 ↗
+                      </a>
+                    </div>
+                  </div>
+                  <div className={s.localProviderGuide} aria-label="常用本地部署端点">
+                    {LOCAL_PROVIDER_PRESETS.map((preset) => (
+                      <button
+                        key={preset.name}
+                        type="button"
+                        className={s.localProviderCard}
+                        onClick={() => applyLocalProviderPreset(preset)}
+                      >
+                        <strong>{preset.name}</strong>
+                        <code>{preset.baseUrl}</code>
+                        <span>{preset.tutorial}</span>
+                      </button>
+                    ))}
+                  </div>
+                </>
               )}
               <Field label="名称" className={s.fieldRow}>
                 <Input
@@ -1910,6 +1961,30 @@ export function ModelsSection() {
                   onChange={(e) => setCustomForm((p) => ({ ...p, model: e.target.value }))}
                 />
               </Field>
+              {customProviderIsLocal && (
+                <>
+                  <Field label="上下文窗口" className={s.fieldRow}>
+                    <Input
+                      mono
+                      inputMode="numeric"
+                      value={customForm.contextWindow}
+                      placeholder={customProviderPlaceholders.contextWindow}
+                      onChange={(e) => setCustomForm((p) => ({ ...p, contextWindow: e.target.value }))}
+                    />
+                  </Field>
+                  <div className={s.modelPickerHint}>
+                    保存时会写入桌面端的模型上下文覆盖；请同步确认本地服务实际加载的模型也已使用同样或更大的上下文。
+                  </div>
+                  {customLocalContextWarning && (
+                    <div className={s.localContextWarning} role="alert">
+                      {customLocalContextWarning.message}{" "}
+                      <a href={HERMES_CONTEXT_REQUIREMENTS_URL} target="_blank" rel="noreferrer" className={s.link}>
+                        查看说明 ↗
+                      </a>
+                    </div>
+                  )}
+                </>
+              )}
               <Field label="API Key" className={s.fieldRow}>
                 <Input
                   mono

--- a/web/src/routes/settings.module.css
+++ b/web/src/routes/settings.module.css
@@ -437,6 +437,18 @@
   font-family: var(--h-font-cn);
 }
 
+.localContextWarning {
+  margin-top: 8px;
+  border: 1px solid color-mix(in srgb, var(--h-warn, #c8782a) 42%, var(--h-line));
+  border-radius: 10px;
+  background: var(--h-warn-soft);
+  color: var(--h-text-2);
+  padding: 9px 10px;
+  font-size: 11.5px;
+  line-height: 1.55;
+  font-family: var(--h-font-cn);
+}
+
 .btn, .btnPrimary, .btnDanger {
   display: inline-flex;
   align-items: center;
@@ -1739,6 +1751,30 @@
   line-height: 1.55;
   color: var(--h-text-3);
   font-family: var(--h-font-cn);
+}
+
+.localProviderContextNotice {
+  border: 1px solid color-mix(in srgb, var(--h-warn, #c8782a) 42%, var(--h-line));
+  border-radius: 14px;
+  background:
+    radial-gradient(circle at 8% -10%, color-mix(in srgb, var(--h-warn, #c8782a) 16%, transparent), transparent 42%),
+    var(--h-warn-soft);
+  color: var(--h-text-2);
+  padding: 12px;
+  font-size: 12px;
+  line-height: 1.6;
+  font-family: var(--h-font-cn);
+}
+
+.localProviderContextNotice strong {
+  display: block;
+  margin-bottom: 4px;
+  color: var(--h-text);
+  font-size: 13px;
+}
+
+.localProviderContextNotice p {
+  margin: 0 0 6px;
 }
 
 .localProviderGuide {

--- a/web/src/routes/settings.module.css
+++ b/web/src/routes/settings.module.css
@@ -1777,6 +1777,60 @@
   margin: 0 0 6px;
 }
 
+.localProviderDocLinks {
+  display: grid;
+  gap: 6px;
+}
+
+.localProviderDocLinkRow {
+  display: flex;
+  flex-wrap: wrap;
+  align-items: center;
+  gap: 8px;
+}
+
+.localProviderDocUrl {
+  flex: 1 1 220px;
+  min-width: 0;
+  font-family: var(--h-font-mono);
+  font-size: 11px;
+  color: var(--h-text-3);
+  line-height: 1.45;
+  word-break: break-all;
+  -webkit-user-select: text;
+  user-select: text;
+}
+
+.localProviderDocCopy {
+  display: inline-flex;
+  align-items: center;
+  justify-content: center;
+  height: 19px;
+  padding: 0 7px;
+  border: 1px solid var(--h-line-soft);
+  border-radius: 6px;
+  background: transparent;
+  color: var(--h-text-2);
+  font-size: 11px;
+  cursor: pointer;
+}
+
+.localProviderDocCopy:hover {
+  border-color: color-mix(in srgb, var(--h-accent) 38%, var(--h-line));
+  color: var(--h-accent);
+}
+
+.localProviderDocCopy[data-copy-state="copied"] {
+  border-color: color-mix(in srgb, var(--h-ok) 42%, var(--h-line));
+  background: var(--h-ok-soft);
+  color: var(--h-ok);
+}
+
+.localProviderDocCopy[data-copy-state="error"] {
+  border-color: color-mix(in srgb, var(--h-err) 42%, var(--h-line));
+  color: var(--h-err);
+}
+
 .localProviderGuide {
   display: grid;
   grid-template-columns: repeat(2, minmax(0, 1fr));


### PR DESCRIPTION
## Summary

本地模型服务商配置向导补充 64K 上下文要求说明，并修复文档链接在 Tauri WebView 中无法打开的问题。

- 自定义本地服务商弹窗展示 ≥64K 上下文要求、常用端点预设（LM Studio / Ollama / vLLM / llama.cpp）与上下文校验警告
- 恢复 **Quickstart 说明** 与 **Providers 指引** 两个文档链接，点击时显式调用 `openExternalUrl` 走桌面端系统浏览器
- 每条链接下方附带完整 URL +「复制」按钮，WebView 打不开时仍可手动粘贴访问

## Test plan

- [x] `pnpm typecheck`
- [x] `pnpm test:unit`
- [ ] 手动：桌面端打开「模型 → 添加自定义服务商 → 本地部署」，点击两个文档链接应在系统浏览器打开
- [ ] 手动：复制按钮可粘贴完整 URL