### PR TITLE
feat: add hideable rich-preview right rail to task detail (#233)

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -1304,6 +1304,16 @@ dependencies = [
 ]
 
 [[package]]
+name = "filetime"
+version = "0.2.29"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "5c287a33c7f0a620c38e641e7f60827713987b3c0f26e8ddc9462cc69cf75759"
+dependencies = [
+ "cfg-if",
+ "libc",
+]
+
+[[package]]
 name = "find-msvc-tools"
 version = "0.1.9"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -1381,6 +1391,15 @@ checksum = "9564fc758e15025b46aa6643b1b77d047d1a56a1aea6e01002ac0c7026876213"
 dependencies = [
  "libc",
  "winapi",
+]
+
+[[package]]
+name = "fsevent-sys"
+version = "4.1.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "76ee7a02da4d231650c7cea31349b889be2f45ddb3ef3032d2ec8185f6313fd2"
+dependencies = [
+ "libc",
 ]
 
 [[package]]
@@ -1865,6 +1884,7 @@ dependencies = [
  "getrandom 0.3.4",
  "libc",
  "log",
+ "notify",
  "objc2",
  "objc2-foundation",
  "open",
@@ -2212,6 +2232,26 @@ dependencies = [
 ]
 
 [[package]]
+name = "inotify"
+version = "0.9.6"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "f8069d3ec154eb856955c1c0fbffefbf5f3c40a104ec912d4797314c1801abff"
+dependencies = [
+ "bitflags 1.3.2",
+ "inotify-sys",
+ "libc",
+]
+
+[[package]]
+name = "inotify-sys"
+version = "0.1.5"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "e05c02b5e89bff3b946cedeca278abc628fe811e604f027c45a8aa3cf793d0eb"
+dependencies = [
+ "libc",
+]
+
+[[package]]
 name = "inout"
 version = "0.1.4"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -2401,6 +2441,26 @@ dependencies = [
  "bitflags 2.11.1",
  "serde",
  "unicode-segmentation",
+]
+
+[[package]]
+name = "kqueue"
+version = "1.2.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "273c0752728918e0ac4976f2b275b6fefb9ecd400585dec929419f3844cd87b5"
+dependencies = [
+ "kqueue-sys",
+ "libc",
+]
+
+[[package]]
+name = "kqueue-sys"
+version = "1.1.2"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "07293a4e297ac234359b510362495713f75ea345d5307140414f20c69ffeb087"
+dependencies = [
+ "bitflags 2.11.1",
+ "libc",
 ]
 
 [[package]]
@@ -2604,6 +2664,18 @@ dependencies = [
 
 [[package]]
 name = "mio"
+version = "0.8.11"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "a4a650543ca06a924e8b371db273b2756685faae30f8487da1b56505a8f78b0c"
+dependencies = [
+ "libc",
+ "log",
+ "wasi",
+ "windows-sys 0.48.0",
+]
+
+[[package]]
+name = "mio"
 version = "1.2.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "50b7e5b27aa02a74bac8c3f23f448f8d87ff11f92d3aac1a6ed369ee08cc56c1"
@@ -2674,6 +2746,25 @@ dependencies = [
  "cfg-if",
  "cfg_aliases 0.1.1",
  "libc",
+]
+
+[[package]]
+name = "notify"
+version = "6.1.1"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "6205bd8bb1e454ad2e27422015fb5e4f2bcc7e08fa8f27058670d208324a4d2d"
+dependencies = [
+ "bitflags 2.11.1",
+ "crossbeam-channel",
+ "filetime",
+ "fsevent-sys",
+ "inotify",
+ "kqueue",
+ "libc",
+ "log",
+ "mio 0.8.11",
+ "walkdir",
+ "windows-sys 0.48.0",
 ]
 
 [[package]]
@@ -4819,7 +4910,7 @@ checksum = "8fc7f01b389ac15039e4dc9531aa973a135d7a4135281b12d7c1bc79fd57fffe"
 dependencies = [
  "bytes",
  "libc",
- "mio",
+ "mio 1.2.0",
  "parking_lot",
  "pin-project-lite",
  "signal-hook-registry",
@@ -5797,6 +5888,15 @@ dependencies = [
 
 [[package]]
 name = "windows-sys"
+version = "0.48.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "677d2418bec65e3338edb076e806bc1ec15693c5d0104683f2efe857f61056a9"
+dependencies = [
+ "windows-targets 0.48.5",
+]
+
+[[package]]
+name = "windows-sys"
 version = "0.52.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "282be5f36a8ce781fad8c8ae18fa3f9beff57ec1b52cb3de0789201425d9a33d"
@@ -5844,6 +5944,21 @@ dependencies = [
  "windows_x86_64_gnu 0.42.2",
  "windows_x86_64_gnullvm 0.42.2",
  "windows_x86_64_msvc 0.42.2",
+]
+
+[[package]]
+name = "windows-targets"
+version = "0.48.5"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "9a2fa6e2155d7247be68c096456083145c183cbbbc2764150dda45a87197940c"
+dependencies = [
+ "windows_aarch64_gnullvm 0.48.5",
+ "windows_aarch64_msvc 0.48.5",
+ "windows_i686_gnu 0.48.5",
+ "windows_i686_msvc 0.48.5",
+ "windows_x86_64_gnu 0.48.5",
+ "windows_x86_64_gnullvm 0.48.5",
+ "windows_x86_64_msvc 0.48.5",
 ]
 
 [[package]]
@@ -5905,6 +6020,12 @@ checksum = "597a5118570b68bc08d8d59125332c54f1ba9d9adeedeef5b99b02ba2b0698f8"
 
 [[package]]
 name = "windows_aarch64_gnullvm"
+version = "0.48.5"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "2b38e32f0abccf9987a4e3079dfb67dcd799fb61361e53e2882c3cbaf0d905d8"
+
+[[package]]
+name = "windows_aarch64_gnullvm"
 version = "0.52.6"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "32a4622180e7a0ec044bb555404c800bc9fd9ec262ec147edd5989ccd0c02cd3"
@@ -5923,6 +6044,12 @@ checksum = "e08e8864a60f06ef0d0ff4ba04124db8b0fb3be5776a5cd47641e942e58c4d43"
 
 [[package]]
 name = "windows_aarch64_msvc"
+version = "0.48.5"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "dc35310971f3b2dbbf3f0690a219f40e2d9afcf64f9ab7cc1be722937c26b4bc"
+
+[[package]]
+name = "windows_aarch64_msvc"
 version = "0.52.6"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "09ec2a7bb152e2252b53fa7803150007879548bc709c039df7627cabbd05d469"
@@ -5938,6 +6065,12 @@ name = "windows_i686_gnu"
 version = "0.42.2"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "c61d927d8da41da96a81f029489353e68739737d3beca43145c8afec9a31a84f"
+
+[[package]]
+name = "windows_i686_gnu"
+version = "0.48.5"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "a75915e7def60c94dcef72200b9a8e58e5091744960da64ec734a6c6e9b3743e"
 
 [[package]]
 name = "windows_i686_gnu"
@@ -5971,6 +6104,12 @@ checksum = "44d840b6ec649f480a41c8d80f9c65108b92d89345dd94027bfe06ac444d1060"
 
 [[package]]
 name = "windows_i686_msvc"
+version = "0.48.5"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "8f55c233f70c4b27f66c523580f78f1004e8b5a8b659e05a4eb49d4166cca406"
+
+[[package]]
+name = "windows_i686_msvc"
 version = "0.52.6"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "240948bc05c5e7c6dabba28bf89d89ffce3e303022809e73deaefe4f6ec56c66"
@@ -5986,6 +6125,12 @@ name = "windows_x86_64_gnu"
 version = "0.42.2"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "8de912b8b8feb55c064867cf047dda097f92d51efad5b491dfb98f6bbb70cb36"
+
+[[package]]
+name = "windows_x86_64_gnu"
+version = "0.48.5"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "53d40abd2583d23e4718fddf1ebec84dbff8381c07cae67ff7768bbf19c6718e"
 
 [[package]]
 name = "windows_x86_64_gnu"
@@ -6007,6 +6152,12 @@ checksum = "26d41b46a36d453748aedef1486d5c7a85db22e56aff34643984ea85514e94a3"
 
 [[package]]
 name = "windows_x86_64_gnullvm"
+version = "0.48.5"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "0b7b52767868a23d5bab768e390dc5f5c55825b6d30b86c844ff2dc7414044cc"
+
+[[package]]
+name = "windows_x86_64_gnullvm"
 version = "0.52.6"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "24d5b23dc417412679681396f2b49f3de8c1473deb516bd34410872eff51ed0d"
@@ -6022,6 +6173,12 @@ name = "windows_x86_64_msvc"
 version = "0.42.2"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "9aec5da331524158c6d1a4ac0ab1541149c0b9505fde06423b02f5ef0106b9f0"
+
+[[package]]
+name = "windows_x86_64_msvc"
+version = "0.48.5"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "ed94fce61571a4006852b7389a063ab983c02eb1bb37b47f8272ce92d06d9538"
 
 [[package]]
 name = "windows_x86_64_msvc"

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -34,6 +34,10 @@ base64 = "0.22"
 url = "2"
 urlencoding = "2"
 open = "5"
+# Native filesystem watch powering the right-rail preview's "文件实时刷新"
+# (commands/preview.rs). Raw change events are emitted to the renderer, which
+# debounces before re-reading.
+notify = "6"
 futures-util = "0.3"
 # WebSocket relay to the runtime's native /api/ws (commands/ws_proxy.rs).
 # The relay also carries remote-mode connections (src/connection.rs), which

--- a/src/commands/mod.rs
+++ b/src/commands/mod.rs
@@ -11,6 +11,7 @@ pub mod im_onboarding;
 pub mod log_export;
 pub mod memory;
 pub mod notify;
+pub mod preview;
 pub mod profiles;
 pub mod restart;
 pub mod runtime_manager;

--- a/src/commands/preview.rs
+++ b/src/commands/preview.rs
@@ -332,7 +332,10 @@ mod tests {
             preview.text.as_ref().map(|t| t.len()),
             Some(TEXT_PREVIEW_MAX_BYTES as usize)
         );
-        assert_eq!(preview.byte_size, (TEXT_PREVIEW_MAX_BYTES as usize + 4096) as u64);
+        assert_eq!(
+            preview.byte_size,
+            (TEXT_PREVIEW_MAX_BYTES as usize + 4096) as u64
+        );
     }
 
     #[test]

--- a/src/commands/preview.rs
+++ b/src/commands/preview.rs
@@ -1,0 +1,407 @@
+// Right-rail rich preview backend (issue #233).
+//
+// Powers the task-detail right rail's file/code preview and "文件实时刷新"
+// (live file watch). Mirrors the Electron reference preload API
+// (apps/desktop right-rail: readFileText / watchPreviewFile /
+// onPreviewFileChanged) so the ported React component logic stays close.
+//
+// Two capabilities:
+// - `read_workspace_file`: read a single file from the session workspace,
+//   capped and binary-safe, with a containment guard so the renderer can't
+//   steer it outside the workspace root.
+// - `watch_preview_file` / `stop_preview_file_watch`: native fs watch that
+//   emits a `preview-file-changed` event on every change. The renderer
+//   debounces (matching the upstream 200ms FILE_RELOAD_DEBOUNCE_MS) before
+//   re-reading, so Rust stays a thin raw-event source.
+
+use std::collections::HashMap;
+use std::fs;
+use std::io::Read;
+use std::path::{Path, PathBuf};
+use std::sync::atomic::{AtomicU64, Ordering};
+use std::sync::{Mutex, OnceLock};
+
+use base64::Engine;
+use notify::{RecommendedWatcher, RecursiveMode, Watcher};
+use serde::{Deserialize, Serialize};
+use tauri::{AppHandle, Emitter};
+
+use crate::error::{AppError, AppResult};
+
+/// Tauri event emitted to the renderer whenever a watched file changes.
+const PREVIEW_FILE_CHANGED: &str = "preview-file-changed";
+
+/// Match the upstream `TEXT_PREVIEW_MAX_BYTES` (512 KB). Larger files are
+/// truncated for the text preview rather than streamed in full.
+const TEXT_PREVIEW_MAX_BYTES: u64 = 512 * 1024;
+/// Cap inline image data URLs so a giant asset can't balloon the IPC payload.
+const IMAGE_PREVIEW_MAX_BYTES: u64 = 8 * 1024 * 1024;
+/// Bytes sampled from the head of a file to decide text vs binary.
+const BINARY_SNIFF_BYTES: usize = 4096;
+
+#[derive(Deserialize)]
+#[serde(rename_all = "camelCase")]
+pub struct ReadWorkspaceFileInput {
+    /// File to read. Absolute or relative to `root`; must resolve inside `root`.
+    pub path: String,
+    /// Session workspace root. Reads are confined to this directory.
+    pub root: String,
+}
+
+#[derive(Debug, Default, Serialize)]
+#[serde(rename_all = "camelCase")]
+pub struct FilePreview {
+    /// UTF-8 (lossy) text content, when the file is textual.
+    #[serde(skip_serializing_if = "Option::is_none")]
+    pub text: Option<String>,
+    /// `data:<mime>;base64,...` for previewable images.
+    #[serde(skip_serializing_if = "Option::is_none")]
+    pub data_url: Option<String>,
+    /// Full size on disk in bytes (independent of how much was read).
+    pub byte_size: u64,
+    /// True when the content is binary (no text preview available).
+    pub binary: bool,
+    /// True when `text` was cut at `TEXT_PREVIEW_MAX_BYTES`.
+    pub truncated: bool,
+}
+
+#[derive(Deserialize)]
+#[serde(rename_all = "camelCase")]
+pub struct WatchPreviewFileInput {
+    pub path: String,
+}
+
+#[derive(Serialize)]
+#[serde(rename_all = "camelCase")]
+pub struct WatchPreviewFileResult {
+    pub watch_id: String,
+}
+
+#[derive(Deserialize)]
+#[serde(rename_all = "camelCase")]
+pub struct StopPreviewFileWatchInput {
+    pub watch_id: String,
+}
+
+#[derive(Clone, Serialize)]
+#[serde(rename_all = "camelCase")]
+struct PreviewFileChangedPayload {
+    watch_id: String,
+    path: String,
+}
+
+/// Resolve `path` against `root` and confirm the canonical target stays inside
+/// the canonical `root`. Rejects empty input, traversal (`..`), and symlinks
+/// that escape the workspace. Returns the canonical, existing path.
+fn resolve_within_root(root: &str, path: &str) -> AppResult<PathBuf> {
+    let raw = path.trim();
+    if raw.is_empty() {
+        return Err(AppError::InvalidRequest("Empty path".to_string()));
+    }
+    let root = root.trim();
+    if root.is_empty() {
+        return Err(AppError::InvalidRequest(
+            "Workspace root is required".to_string(),
+        ));
+    }
+
+    let root_real = PathBuf::from(root)
+        .canonicalize()
+        .map_err(|e| AppError::InvalidRequest(format!("Workspace root not accessible: {e}")))?;
+
+    let candidate = {
+        let pb = PathBuf::from(raw);
+        if pb.is_absolute() {
+            pb
+        } else {
+            root_real.join(pb)
+        }
+    };
+
+    let real = candidate
+        .canonicalize()
+        .map_err(|e| AppError::FileError(format!("Path not accessible: {e}")))?;
+
+    if !real.starts_with(&root_real) {
+        return Err(AppError::OriginViolation(format!(
+            "Path escapes workspace: {}",
+            real.display()
+        )));
+    }
+
+    Ok(real)
+}
+
+/// Map a lowercase file extension to an image MIME type, when previewable.
+fn image_mime(ext: &str) -> Option<&'static str> {
+    match ext {
+        "png" => Some("image/png"),
+        "jpg" | "jpeg" => Some("image/jpeg"),
+        "gif" => Some("image/gif"),
+        "webp" => Some("image/webp"),
+        "bmp" => Some("image/bmp"),
+        "ico" => Some("image/x-icon"),
+        "svg" => Some("image/svg+xml"),
+        _ => None,
+    }
+}
+
+/// Heuristic binary sniff over a head sample: any NUL byte, or a high ratio of
+/// non-text control characters, marks the content binary.
+fn looks_binary(sample: &[u8]) -> bool {
+    if sample.is_empty() {
+        return false;
+    }
+    if sample.contains(&0) {
+        return true;
+    }
+    let suspicious = sample
+        .iter()
+        .filter(|&&b| b < 0x09 || (b > 0x0d && b < 0x20))
+        .count();
+    suspicious * 100 / sample.len() > 30
+}
+
+/// Core, AppHandle-free read logic so it can be unit-tested directly.
+fn read_file_preview(root: &str, path: &str) -> AppResult<FilePreview> {
+    let resolved = resolve_within_root(root, path)?;
+    let meta = fs::metadata(&resolved)?;
+    if !meta.is_file() {
+        return Err(AppError::FileError("Not a regular file".to_string()));
+    }
+    let byte_size = meta.len();
+
+    let ext = resolved
+        .extension()
+        .and_then(|e| e.to_str())
+        .map(|s| s.to_ascii_lowercase());
+
+    if let Some(mime) = ext.as_deref().and_then(image_mime) {
+        if byte_size > IMAGE_PREVIEW_MAX_BYTES {
+            return Ok(FilePreview {
+                binary: true,
+                byte_size,
+                ..Default::default()
+            });
+        }
+        let bytes = fs::read(&resolved)?;
+        let b64 = base64::engine::general_purpose::STANDARD.encode(&bytes);
+        return Ok(FilePreview {
+            data_url: Some(format!("data:{mime};base64,{b64}")),
+            binary: true,
+            byte_size,
+            ..Default::default()
+        });
+    }
+
+    // Read at most the text cap + 1 byte (the extra byte only signals "there is
+    // more", it is never surfaced).
+    let file = fs::File::open(&resolved)?;
+    let mut buf = Vec::new();
+    file.take(TEXT_PREVIEW_MAX_BYTES + 1)
+        .read_to_end(&mut buf)?;
+
+    let sniff_len = buf.len().min(BINARY_SNIFF_BYTES);
+    if looks_binary(&buf[..sniff_len]) {
+        return Ok(FilePreview {
+            binary: true,
+            byte_size,
+            ..Default::default()
+        });
+    }
+
+    let keep = buf.len().min(TEXT_PREVIEW_MAX_BYTES as usize);
+    let text = String::from_utf8_lossy(&buf[..keep]).into_owned();
+    Ok(FilePreview {
+        text: Some(text),
+        byte_size,
+        truncated: byte_size > TEXT_PREVIEW_MAX_BYTES,
+        binary: false,
+        ..Default::default()
+    })
+}
+
+#[tauri::command]
+pub fn read_workspace_file(input: ReadWorkspaceFileInput) -> AppResult<FilePreview> {
+    read_file_preview(&input.root, &input.path)
+}
+
+/// Live watcher registry. Keeping the `RecommendedWatcher` alive is what keeps
+/// the OS watch active; dropping it (via stop / app exit) tears it down.
+fn watchers() -> &'static Mutex<HashMap<String, RecommendedWatcher>> {
+    static WATCHERS: OnceLock<Mutex<HashMap<String, RecommendedWatcher>>> = OnceLock::new();
+    WATCHERS.get_or_init(|| Mutex::new(HashMap::new()))
+}
+
+static WATCH_SEQ: AtomicU64 = AtomicU64::new(0);
+
+/// Build a non-recursive file watcher whose change events are routed to
+/// `on_change`. Split out from the command so tests can assert change
+/// detection without a Tauri `AppHandle`.
+fn spawn_file_watcher(
+    path: &Path,
+    on_change: impl Fn() + Send + 'static,
+) -> AppResult<RecommendedWatcher> {
+    let mut watcher = notify::recommended_watcher(move |res: notify::Result<notify::Event>| {
+        if let Ok(event) = res {
+            use notify::EventKind;
+            if matches!(
+                event.kind,
+                EventKind::Modify(_) | EventKind::Create(_) | EventKind::Remove(_)
+            ) {
+                on_change();
+            }
+        }
+    })
+    .map_err(|e| AppError::FileError(format!("Failed to create watcher: {e}")))?;
+
+    watcher
+        .watch(path, RecursiveMode::NonRecursive)
+        .map_err(|e| AppError::FileError(format!("Failed to watch path: {e}")))?;
+
+    Ok(watcher)
+}
+
+#[tauri::command]
+pub fn watch_preview_file(
+    app: AppHandle,
+    input: WatchPreviewFileInput,
+) -> AppResult<WatchPreviewFileResult> {
+    let path = PathBuf::from(input.path.trim());
+    if !path.exists() {
+        return Err(AppError::FileError(format!(
+            "Cannot watch missing path: {}",
+            path.display()
+        )));
+    }
+
+    let watch_id = format!("watch-{}", WATCH_SEQ.fetch_add(1, Ordering::Relaxed));
+    let emit_id = watch_id.clone();
+    let emit_path = path.to_string_lossy().to_string();
+
+    let watcher = spawn_file_watcher(&path, move || {
+        let _ = app.emit(
+            PREVIEW_FILE_CHANGED,
+            PreviewFileChangedPayload {
+                watch_id: emit_id.clone(),
+                path: emit_path.clone(),
+            },
+        );
+    })?;
+
+    watchers().lock()?.insert(watch_id.clone(), watcher);
+    Ok(WatchPreviewFileResult { watch_id })
+}
+
+#[tauri::command]
+pub fn stop_preview_file_watch(input: StopPreviewFileWatchInput) -> AppResult<bool> {
+    Ok(watchers().lock()?.remove(&input.watch_id).is_some())
+}
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+    use pretty_assertions::assert_eq;
+    use std::sync::mpsc;
+    use std::time::Duration;
+
+    #[test]
+    fn reads_small_text_file() {
+        let dir = tempfile::tempdir().unwrap();
+        let root = dir.path().to_string_lossy().to_string();
+        std::fs::write(dir.path().join("a.txt"), b"hello world").unwrap();
+
+        let preview = read_file_preview(&root, "a.txt").unwrap();
+        assert_eq!(preview.text.as_deref(), Some("hello world"));
+        assert!(!preview.binary);
+        assert!(!preview.truncated);
+        assert_eq!(preview.byte_size, 11);
+    }
+
+    #[test]
+    fn truncates_large_text_file() {
+        let dir = tempfile::tempdir().unwrap();
+        let root = dir.path().to_string_lossy().to_string();
+        let big = "x".repeat((TEXT_PREVIEW_MAX_BYTES as usize) + 4096);
+        std::fs::write(dir.path().join("big.txt"), big.as_bytes()).unwrap();
+
+        let preview = read_file_preview(&root, "big.txt").unwrap();
+        assert!(preview.truncated);
+        assert!(!preview.binary);
+        assert_eq!(
+            preview.text.as_ref().map(|t| t.len()),
+            Some(TEXT_PREVIEW_MAX_BYTES as usize)
+        );
+        assert_eq!(preview.byte_size, (TEXT_PREVIEW_MAX_BYTES as usize + 4096) as u64);
+    }
+
+    #[test]
+    fn detects_binary_content() {
+        let dir = tempfile::tempdir().unwrap();
+        let root = dir.path().to_string_lossy().to_string();
+        std::fs::write(dir.path().join("blob.bin"), [0u8, 1, 2, 3, 0, 9]).unwrap();
+
+        let preview = read_file_preview(&root, "blob.bin").unwrap();
+        assert!(preview.binary);
+        assert!(preview.text.is_none());
+        assert!(preview.data_url.is_none());
+    }
+
+    #[test]
+    fn encodes_small_image_as_data_url() {
+        let dir = tempfile::tempdir().unwrap();
+        let root = dir.path().to_string_lossy().to_string();
+        // 1x1 transparent PNG header bytes are enough to exercise the path.
+        std::fs::write(dir.path().join("pixel.png"), [0x89, 0x50, 0x4e, 0x47]).unwrap();
+
+        let preview = read_file_preview(&root, "pixel.png").unwrap();
+        assert!(preview.binary);
+        assert!(preview
+            .data_url
+            .as_deref()
+            .unwrap()
+            .starts_with("data:image/png;base64,"));
+    }
+
+    #[test]
+    fn rejects_path_escaping_root() {
+        let dir = tempfile::tempdir().unwrap();
+        let root = dir.path().join("ws");
+        std::fs::create_dir_all(&root).unwrap();
+        std::fs::write(dir.path().join("secret.txt"), b"nope").unwrap();
+
+        let err = read_file_preview(&root.to_string_lossy(), "../secret.txt").unwrap_err();
+        assert!(
+            matches!(err, AppError::OriginViolation(_)),
+            "expected OriginViolation, got {err:?}"
+        );
+    }
+
+    #[test]
+    fn rejects_empty_root() {
+        let err = read_file_preview("", "a.txt").unwrap_err();
+        assert!(matches!(err, AppError::InvalidRequest(_)));
+    }
+
+    #[test]
+    fn watcher_fires_on_modification() {
+        let dir = tempfile::tempdir().unwrap();
+        let file = dir.path().join("watched.txt");
+        std::fs::write(&file, b"v1").unwrap();
+
+        let (tx, rx) = mpsc::channel::<()>();
+        let _watcher = spawn_file_watcher(&file, move || {
+            let _ = tx.send(());
+        })
+        .unwrap();
+
+        // Give the watcher a moment to register before mutating.
+        std::thread::sleep(Duration::from_millis(200));
+        std::fs::write(&file, b"v2-changed").unwrap();
+
+        assert!(
+            rx.recv_timeout(Duration::from_secs(5)).is_ok(),
+            "watcher should fire on file modification"
+        );
+    }
+}

--- a/src/main.rs
+++ b/src/main.rs
@@ -406,6 +406,9 @@ fn main() {
             commands::terminal::terminal_write,
             commands::terminal::terminal_resize,
             commands::terminal::terminal_close,
+            commands::preview::read_workspace_file,
+            commands::preview::watch_preview_file,
+            commands::preview::stop_preview_file_watch,
         ])
         .on_window_event(move |window, event| match event {
             tauri::WindowEvent::CloseRequested { api, .. }

--- a/tauri.conf.json
+++ b/tauri.conf.json
@@ -21,7 +21,7 @@
       }
     ],
     "security": {
-      "csp": "default-src 'self'; script-src 'self' 'unsafe-inline'; style-src 'self' 'unsafe-inline'; connect-src 'self' http://127.0.0.1:* ws://127.0.0.1:* wss://127.0.0.1:*; img-src 'self' data: blob:; media-src 'self' data: blob:"
+      "csp": "default-src 'self'; script-src 'self' 'unsafe-inline'; style-src 'self' 'unsafe-inline'; connect-src 'self' http://127.0.0.1:* ws://127.0.0.1:* wss://127.0.0.1:*; img-src 'self' data: blob:; media-src 'self' data: blob:; frame-src 'self' http://localhost:* http://127.0.0.1:*"
     }
   },
   "bundle": {

--- a/web/src/components/chat/preview-rail/file-preview-tab.tsx
+++ b/web/src/components/chat/preview-rail/file-preview-tab.tsx
@@ -1,0 +1,206 @@
+import { useEffect, useMemo, useState } from "react";
+import { ChevronUp, File as FileIcon, Folder, RefreshCw } from "lucide-react";
+import { useFsList } from "@/hooks/use-fs-list";
+import type { FilePreview } from "@/lib/runtime";
+import {
+  detectLanguage,
+  fileExtension,
+  formatBytes,
+  isMarkdownPath,
+  toFencedMarkdown,
+} from "@/lib/preview-rail";
+import { MarkdownText } from "@/components/chat/markdown-renderer";
+import s from "./preview-rail.module.css";
+
+interface FilePreviewTabProps {
+  workspaceRoot: string;
+  filePath: string | null;
+  onSelectFile: (path: string | null) => void;
+}
+
+function basename(path: string): string {
+  return path.split(/[\\/]/).pop() ?? path;
+}
+
+// Debounced read so a burst of native file-change events (the upstream uses a
+// 200ms FILE_RELOAD_DEBOUNCE_MS) collapses into one re-read.
+const RELOAD_DEBOUNCE_MS = 200;
+
+export function FilePreviewTab({ workspaceRoot, filePath, onSelectFile }: FilePreviewTabProps) {
+  const [dir, setDir] = useState(workspaceRoot);
+
+  // Reset the browser to the workspace root whenever the session's workspace changes.
+  useEffect(() => {
+    setDir(workspaceRoot);
+  }, [workspaceRoot]);
+
+  const list = useFsList(dir, { enabled: Boolean(dir) });
+  const entries = useMemo(() => {
+    const items = list.data?.entries ?? [];
+    return [...items].sort((a, b) => {
+      if (a.is_dir !== b.is_dir) return a.is_dir ? -1 : 1;
+      return a.name.localeCompare(b.name);
+    });
+  }, [list.data?.entries]);
+  const canGoUp = Boolean(dir && workspaceRoot && dir !== workspaceRoot && list.data?.parent);
+
+  const [preview, setPreview] = useState<FilePreview | null>(null);
+  const [loadError, setLoadError] = useState<string | null>(null);
+  const [loading, setLoading] = useState(false);
+
+  useEffect(() => {
+    if (!filePath || !workspaceRoot) {
+      setPreview(null);
+      setLoadError(null);
+      return;
+    }
+
+    let cancelled = false;
+    let watchId: string | null = null;
+    let debounce: number | null = null;
+
+    const read = () => {
+      const bridge = window.hermesDesktop;
+      if (!bridge?.readWorkspaceFile) {
+        setLoadError("文件预览需要在桌面端中使用。");
+        return;
+      }
+      setLoading(true);
+      bridge
+        .readWorkspaceFile({ path: filePath, root: workspaceRoot })
+        .then((res) => {
+          if (cancelled) return;
+          setPreview(res);
+          setLoadError(null);
+        })
+        .catch((err) => {
+          if (cancelled) return;
+          setPreview(null);
+          setLoadError(err instanceof Error ? err.message : String(err));
+        })
+        .finally(() => {
+          if (!cancelled) setLoading(false);
+        });
+    };
+
+    read();
+
+    // Live watch: re-read (debounced) on every change to the selected file.
+    void window.hermesDesktop?.watchPreviewFile?.({ path: filePath })
+      .then((res) => {
+        if (cancelled) {
+          void window.hermesDesktop?.stopPreviewFileWatch?.({ watchId: res.watchId });
+          return;
+        }
+        watchId = res.watchId;
+      })
+      .catch(() => {});
+
+    const unsubscribe = window.hermesDesktop?.onPreviewFileChanged?.((payload) => {
+      if (payload.path !== filePath && payload.watchId !== watchId) return;
+      if (debounce !== null) window.clearTimeout(debounce);
+      debounce = window.setTimeout(read, RELOAD_DEBOUNCE_MS);
+    });
+
+    return () => {
+      cancelled = true;
+      if (debounce !== null) window.clearTimeout(debounce);
+      unsubscribe?.();
+      if (watchId) void window.hermesDesktop?.stopPreviewFileWatch?.({ watchId });
+    };
+  }, [filePath, workspaceRoot]);
+
+  if (!workspaceRoot) {
+    return (
+      <div className={s.empty}>
+        <Folder size={24} aria-hidden />
+        <p>本会话还没有绑定工作区，无法浏览文件。</p>
+      </div>
+    );
+  }
+
+  return (
+    <>
+      <div className={s.fileBrowser}>
+        <div className={s.crumb}>{dir}</div>
+        {canGoUp ? (
+          <button
+            type="button"
+            className={s.fileEntry}
+            onClick={() => list.data?.parent && setDir(list.data.parent)}
+          >
+            <ChevronUp size={14} className={s.fileEntryIcon} aria-hidden />
+            ..
+          </button>
+        ) : null}
+        {list.isLoading ? <div className={s.crumb}>加载目录中…</div> : null}
+        {entries.map((entry) => (
+          <button
+            key={entry.path}
+            type="button"
+            className={s.fileEntry}
+            data-active={entry.path === filePath ? "true" : undefined}
+            onClick={() => (entry.is_dir ? setDir(entry.path) : onSelectFile(entry.path))}
+            title={entry.path}
+          >
+            {entry.is_dir ? (
+              <Folder size={14} className={s.fileEntryIcon} aria-hidden />
+            ) : (
+              <FileIcon size={14} className={s.fileEntryIcon} aria-hidden />
+            )}
+            {entry.name}
+          </button>
+        ))}
+        {!list.isLoading && entries.length === 0 ? <div className={s.crumb}>空目录</div> : null}
+      </div>
+
+      {filePath ? (
+        <>
+          <div className={s.fileMeta}>
+            <span className={s.fileMetaName} title={filePath}>
+              {basename(filePath)}
+            </span>
+            {preview ? <span>{formatBytes(preview.byteSize)}</span> : null}
+            {preview?.truncated ? <span>· 已截断预览</span> : null}
+            {loading ? <RefreshCw size={12} aria-hidden /> : null}
+          </div>
+          <div className={s.fileContent}>
+            <FileContent path={filePath} preview={preview} error={loadError} loading={loading} />
+          </div>
+        </>
+      ) : (
+        <div className={s.empty}>
+          <FileIcon size={24} aria-hidden />
+          <p>从上方选择一个文件预览。修改磁盘上的文件后，这里会自动刷新。</p>
+        </div>
+      )}
+    </>
+  );
+}
+
+function FileContent({
+  path,
+  preview,
+  error,
+  loading,
+}: {
+  path: string;
+  preview: FilePreview | null;
+  error: string | null;
+  loading: boolean;
+}) {
+  if (error) return <div className={s.notice}>读取失败：{error}</div>;
+  if (!preview) return <div className={s.notice}>{loading ? "读取中…" : "暂无内容"}</div>;
+
+  if (preview.dataUrl) {
+    return <img className={s.fileImage} src={preview.dataUrl} alt={basename(path)} />;
+  }
+  if (preview.binary) {
+    return <div className={s.notice}>二进制文件（{formatBytes(preview.byteSize)}），暂不支持预览。</div>;
+  }
+  const text = preview.text ?? "";
+  if (isMarkdownPath(path)) {
+    return <MarkdownText text={text} />;
+  }
+  return <MarkdownText text={toFencedMarkdown(text, detectLanguage(path) ?? fileExtension(path))} />;
+}

--- a/web/src/components/chat/preview-rail/logs-tab.tsx
+++ b/web/src/components/chat/preview-rail/logs-tab.tsx
@@ -1,0 +1,87 @@
+import { useEffect, useMemo, useRef, useState } from "react";
+import { Search } from "lucide-react";
+import { useLogs } from "@/hooks/use-logs";
+import {
+  DEFAULT_LOGS_QUERY,
+  LOG_FILE_OPTIONS,
+  classifyLogLine,
+  filterLogLines,
+  type LogFileOption,
+} from "@/lib/logs-viewer";
+import s from "./preview-rail.module.css";
+
+const FILE_LABELS: Record<LogFileOption, string> = {
+  agent: "Agent",
+  errors: "Errors",
+  gateway: "Gateway",
+};
+
+// Compact, in-rail logs viewer. Reuses the data layer (useLogs) and the pure
+// filter/classify helpers from lib/logs-viewer with local state, so it doesn't
+// touch the detail URL. The standalone /logs route remains the full-featured
+// viewer (level/component filters, export, redaction).
+export function LogsTab() {
+  const [file, setFile] = useState<LogFileOption>(DEFAULT_LOGS_QUERY.file);
+  const [search, setSearch] = useState("");
+  const logs = useLogs(file, DEFAULT_LOGS_QUERY.lines);
+  const viewportRef = useRef<HTMLDivElement>(null);
+
+  const rawLines = logs.data?.lines ?? [];
+  const visible = useMemo(() => filterLogLines(rawLines, search), [rawLines, search]);
+  const signature = visible.join("\n");
+
+  // Poll for new logs while the tab is open.
+  useEffect(() => {
+    const timer = window.setInterval(() => void logs.refetch(), 5_000);
+    return () => window.clearInterval(timer);
+  }, [logs]);
+
+  // Auto-scroll to the newest line on update.
+  useEffect(() => {
+    const el = viewportRef.current;
+    if (el) el.scrollTop = el.scrollHeight;
+  }, [signature]);
+
+  return (
+    <>
+      <div className={s.bar}>
+        <div className={s.segmented}>
+          {LOG_FILE_OPTIONS.map((option) => (
+            <button
+              key={option}
+              type="button"
+              className={s.segmentButton}
+              data-active={option === file ? "true" : undefined}
+              onClick={() => setFile(option)}
+            >
+              {FILE_LABELS[option]}
+            </button>
+          ))}
+        </div>
+        <label className={s.input} style={{ display: "flex", alignItems: "center", gap: 6 }}>
+          <Search size={13} aria-hidden />
+          <input
+            value={search}
+            onChange={(e) => setSearch(e.target.value)}
+            placeholder="搜索…"
+            aria-label="搜索日志"
+            style={{ flex: 1, minWidth: 0, border: 0, background: "transparent", color: "inherit", outline: "none", font: "inherit" }}
+          />
+        </label>
+      </div>
+      <div ref={viewportRef} className={s.logViewport} role="log">
+        {visible.map((line, index) => (
+          <div key={`${index}-${line}`} className={s.logLine} data-tone={classifyLogLine(line)}>
+            <span className={s.lineNumber}>{index + 1}</span>
+            <span className={s.lineText}>{line}</span>
+          </div>
+        ))}
+        {logs.isLoading && visible.length === 0 ? <div className={s.crumb}>日志加载中…</div> : null}
+        {!logs.isLoading && rawLines.length === 0 ? <div className={s.crumb}>暂无日志。</div> : null}
+        {!logs.isLoading && rawLines.length > 0 && visible.length === 0 ? (
+          <div className={s.crumb}>没有匹配的日志。</div>
+        ) : null}
+      </div>
+    </>
+  );
+}

--- a/web/src/components/chat/preview-rail/preview-rail.module.css
+++ b/web/src/components/chat/preview-rail/preview-rail.module.css
@@ -1,0 +1,328 @@
+.panel {
+  width: 460px;
+  flex: 0 0 460px;
+  min-height: 0;
+  display: flex;
+  flex-direction: column;
+  border-left: 1px solid var(--h-line);
+  background: var(--h-bg-app);
+  overflow: hidden;
+}
+
+.header {
+  flex: 0 0 auto;
+  display: flex;
+  align-items: center;
+  justify-content: space-between;
+  gap: 8px;
+  padding: 8px 10px;
+  border-bottom: 1px solid var(--h-line-soft);
+}
+
+.tabs {
+  display: flex;
+  align-items: center;
+  gap: 3px;
+  flex-wrap: wrap;
+  min-width: 0;
+}
+
+.tab {
+  display: inline-flex;
+  align-items: center;
+  gap: 5px;
+  padding: 5px 9px;
+  border: 1px solid transparent;
+  border-radius: var(--h-r-sm);
+  background: transparent;
+  color: var(--h-text-3);
+  font-family: var(--h-font-cn);
+  font-size: 12px;
+  cursor: pointer;
+  white-space: nowrap;
+}
+
+.tab:hover:not(:disabled) {
+  background: var(--h-bg-soft);
+  color: var(--h-text);
+}
+
+.tab[data-active="true"] {
+  background: var(--h-bg-chip);
+  color: var(--h-text);
+  border-color: var(--h-line);
+}
+
+.tab:disabled {
+  opacity: 0.45;
+  cursor: not-allowed;
+}
+
+.close {
+  display: inline-flex;
+  align-items: center;
+  justify-content: center;
+  width: 24px;
+  height: 24px;
+  border: 0;
+  border-radius: var(--h-r-sm);
+  background: transparent;
+  color: var(--h-text-3);
+  cursor: pointer;
+  flex: 0 0 auto;
+}
+
+.close:hover {
+  background: var(--h-bg-soft);
+  color: var(--h-text);
+}
+
+.body {
+  flex: 1;
+  min-height: 0;
+  display: flex;
+  flex-direction: column;
+  overflow: hidden;
+}
+
+/* ── Shared bits ─────────────────────────────────────────────────────────── */
+
+.bar {
+  flex: 0 0 auto;
+  display: flex;
+  align-items: center;
+  gap: 6px;
+  padding: 8px 10px;
+  border-bottom: 1px solid var(--h-line-soft);
+}
+
+.input {
+  flex: 1;
+  min-width: 0;
+  height: 28px;
+  padding: 0 9px;
+  border: 1px solid var(--h-line);
+  border-radius: var(--h-r-sm);
+  background: var(--h-bg-input);
+  color: var(--h-text);
+  font-family: var(--h-font-mono);
+  font-size: 12px;
+}
+
+.iconBtn {
+  display: inline-flex;
+  align-items: center;
+  justify-content: center;
+  gap: 5px;
+  height: 28px;
+  padding: 0 9px;
+  border: 1px solid var(--h-line);
+  border-radius: var(--h-r-sm);
+  background: var(--h-bg-chip);
+  color: var(--h-text-2);
+  font-family: var(--h-font-cn);
+  font-size: 12px;
+  cursor: pointer;
+  flex: 0 0 auto;
+}
+
+.iconBtn:hover:not(:disabled) {
+  color: var(--h-text);
+  border-color: var(--h-accent-border);
+}
+
+.iconBtn:disabled {
+  opacity: 0.5;
+  cursor: not-allowed;
+}
+
+.empty {
+  flex: 1;
+  display: grid;
+  place-content: center;
+  justify-items: center;
+  gap: 8px;
+  padding: 28px 22px;
+  text-align: center;
+  color: var(--h-text-3);
+  font-size: 12.5px;
+  line-height: 1.6;
+}
+
+.notice {
+  margin: 10px;
+  padding: 10px 12px;
+  border: 1px solid var(--h-line-soft);
+  border-radius: var(--h-r-sm);
+  background: var(--h-bg-soft);
+  color: var(--h-text-2);
+  font-size: 12px;
+  line-height: 1.6;
+}
+
+/* ── Web preview ─────────────────────────────────────────────────────────── */
+
+.iframe {
+  flex: 1;
+  min-height: 0;
+  width: 100%;
+  border: 0;
+  background: #fff;
+}
+
+/* ── File preview ────────────────────────────────────────────────────────── */
+
+.fileBrowser {
+  flex: 0 0 auto;
+  max-height: 38%;
+  overflow-y: auto;
+  overscroll-behavior: contain;
+  border-bottom: 1px solid var(--h-line-soft);
+  padding: 4px;
+}
+
+.crumb {
+  display: flex;
+  align-items: center;
+  gap: 4px;
+  padding: 4px 6px;
+  color: var(--h-text-3);
+  font-family: var(--h-font-mono);
+  font-size: 11px;
+  word-break: break-all;
+}
+
+.fileEntry {
+  display: flex;
+  align-items: center;
+  gap: 7px;
+  width: 100%;
+  padding: 5px 7px;
+  border: 0;
+  border-radius: var(--h-r-sm);
+  background: transparent;
+  color: var(--h-text-2);
+  font-family: var(--h-font-cn);
+  font-size: 12.5px;
+  text-align: left;
+  cursor: pointer;
+}
+
+.fileEntry:hover {
+  background: var(--h-bg-soft);
+  color: var(--h-text);
+}
+
+.fileEntry[data-active="true"] {
+  background: var(--h-bg-chip);
+  color: var(--h-text);
+}
+
+.fileEntryIcon {
+  flex: 0 0 auto;
+  color: var(--h-text-4);
+}
+
+.fileMeta {
+  flex: 0 0 auto;
+  display: flex;
+  align-items: center;
+  gap: 8px;
+  padding: 6px 10px;
+  border-bottom: 1px solid var(--h-line-soft);
+  color: var(--h-text-3);
+  font-size: 11px;
+}
+
+.fileMetaName {
+  flex: 1;
+  min-width: 0;
+  overflow: hidden;
+  text-overflow: ellipsis;
+  white-space: nowrap;
+  font-family: var(--h-font-mono);
+  color: var(--h-text-2);
+}
+
+.fileContent {
+  flex: 1;
+  min-height: 0;
+  overflow: auto;
+  padding: 10px 12px;
+}
+
+.fileImage {
+  display: block;
+  max-width: 100%;
+  height: auto;
+  margin: 0 auto;
+}
+
+/* ── Logs ────────────────────────────────────────────────────────────────── */
+
+.segmented {
+  display: inline-flex;
+  gap: 2px;
+}
+
+.segmentButton {
+  padding: 4px 8px;
+  border: 1px solid var(--h-line);
+  border-radius: var(--h-r-sm);
+  background: transparent;
+  color: var(--h-text-3);
+  font-family: var(--h-font-cn);
+  font-size: 11.5px;
+  cursor: pointer;
+}
+
+.segmentButton[data-active="true"] {
+  background: var(--h-bg-chip);
+  color: var(--h-text);
+}
+
+.logViewport {
+  flex: 1;
+  min-height: 0;
+  overflow: auto;
+  padding: 8px 10px;
+  font-family: var(--h-font-mono);
+  font-size: 11.5px;
+  line-height: 1.55;
+}
+
+.logLine {
+  display: flex;
+  gap: 8px;
+  white-space: pre-wrap;
+  word-break: break-word;
+}
+
+.logLine[data-tone="error"] .lineText {
+  color: var(--h-err, #d76f54);
+}
+
+.logLine[data-tone="warning"] .lineText {
+  color: var(--h-warn);
+}
+
+.lineNumber {
+  flex: 0 0 auto;
+  width: 34px;
+  text-align: right;
+  color: var(--h-text-4);
+  user-select: none;
+}
+
+.lineText {
+  flex: 1;
+  min-width: 0;
+  color: var(--h-text-2);
+}
+
+/* Terminal tab fills the body; the surface paints its own dark theme. */
+.terminalSurface {
+  flex: 1;
+  min-height: 0;
+  padding: 8px;
+}

--- a/web/src/components/chat/preview-rail/preview-rail.tsx
+++ b/web/src/components/chat/preview-rail/preview-rail.tsx
@@ -1,0 +1,121 @@
+import { useAtom } from "jotai";
+import { useSearchParams } from "react-router-dom";
+import {
+  FileText,
+  GitCompare,
+  Globe,
+  Package,
+  ScrollText,
+  TerminalSquare,
+  X,
+} from "lucide-react";
+import {
+  PREVIEW_PANEL_QUERY_KEY,
+  normalizePreviewPanel,
+  type PreviewPanel,
+} from "@/lib/preview-rail";
+import {
+  EMPTY_PREVIEW_RAIL_SELECTION,
+  previewRailSelectionMapAtom,
+  type PreviewRailSelection,
+} from "@/stores/preview-rail";
+import { WebPreviewTab } from "./web-preview-tab";
+import { FilePreviewTab } from "./file-preview-tab";
+import { TerminalTab } from "./terminal-tab";
+import { LogsTab } from "./logs-tab";
+import s from "./preview-rail.module.css";
+
+interface PreviewRailProps {
+  /** Resolved session id; scopes the per-session selection. */
+  sessionId: string;
+  /** Session workspace root for file reads (may be empty). */
+  workspaceRoot: string;
+  onClose: () => void;
+}
+
+const TABS: Array<{ key: PreviewPanel; label: string; icon: typeof Globe }> = [
+  { key: "web", label: "网页", icon: Globe },
+  { key: "files", label: "文件", icon: FileText },
+  { key: "terminal", label: "终端", icon: TerminalSquare },
+  { key: "logs", label: "日志", icon: ScrollText },
+];
+
+// Tabs planned but blocked on backend (PRD §5 P0: session change audit log /
+// artifact manifest). Shown disabled so the layout matches the target spec.
+const PENDING_TABS: Array<{ key: string; label: string; icon: typeof Globe }> = [
+  { key: "diff", label: "Diff", icon: GitCompare },
+  { key: "artifacts", label: "产物", icon: Package },
+];
+
+export function PreviewRail({ sessionId, workspaceRoot, onClose }: PreviewRailProps) {
+  const [searchParams, setSearchParams] = useSearchParams();
+  const active = normalizePreviewPanel(searchParams.get(PREVIEW_PANEL_QUERY_KEY));
+
+  const setActive = (panel: PreviewPanel) => {
+    const next = new URLSearchParams(searchParams);
+    next.set(PREVIEW_PANEL_QUERY_KEY, panel);
+    setSearchParams(next, { replace: true });
+  };
+
+  const [selectionMap, setSelectionMap] = useAtom(previewRailSelectionMapAtom);
+  const selection = selectionMap[sessionId] ?? EMPTY_PREVIEW_RAIL_SELECTION;
+  const patchSelection = (patch: Partial<PreviewRailSelection>) => {
+    setSelectionMap((map) => ({
+      ...map,
+      [sessionId]: { ...(map[sessionId] ?? EMPTY_PREVIEW_RAIL_SELECTION), ...patch },
+    }));
+  };
+
+  return (
+    <aside className={s.panel} aria-label="预览面板">
+      <header className={s.header}>
+        <div className={s.tabs} role="tablist">
+          {TABS.map(({ key, label, icon: Icon }) => (
+            <button
+              key={key}
+              type="button"
+              role="tab"
+              aria-selected={active === key}
+              className={s.tab}
+              data-active={active === key ? "true" : undefined}
+              onClick={() => setActive(key)}
+            >
+              <Icon size={13} aria-hidden />
+              {label}
+            </button>
+          ))}
+          {PENDING_TABS.map(({ key, label, icon: Icon }) => (
+            <button
+              key={key}
+              type="button"
+              className={s.tab}
+              disabled
+              title="依赖后端能力，后续提供"
+            >
+              <Icon size={13} aria-hidden />
+              {label}
+            </button>
+          ))}
+        </div>
+        <button className={s.close} type="button" onClick={onClose} aria-label="关闭预览面板">
+          <X size={14} aria-hidden />
+        </button>
+      </header>
+
+      <div className={s.body}>
+        {active === "web" ? (
+          <WebPreviewTab url={selection.webUrl} onUrlChange={(url) => patchSelection({ webUrl: url })} />
+        ) : null}
+        {active === "files" ? (
+          <FilePreviewTab
+            workspaceRoot={workspaceRoot}
+            filePath={selection.filePath}
+            onSelectFile={(path) => patchSelection({ filePath: path })}
+          />
+        ) : null}
+        {active === "terminal" ? <TerminalTab /> : null}
+        {active === "logs" ? <LogsTab /> : null}
+      </div>
+    </aside>
+  );
+}

--- a/web/src/components/chat/preview-rail/terminal-tab.tsx
+++ b/web/src/components/chat/preview-rail/terminal-tab.tsx
@@ -1,0 +1,11 @@
+import { EmbeddedTerminal } from "@/components/console/embedded-terminal";
+import s from "./preview-rail.module.css";
+
+// Reuses the shared xterm widget. Mounting/unmounting with the tab means a
+// fresh terminal each time the tab is opened, which is fine for the rail.
+export function TerminalTab() {
+  if (!window.hermesDesktop?.terminalStart) {
+    return <div className={s.empty}>终端需要在桌面端中使用。</div>;
+  }
+  return <EmbeddedTerminal purpose="shell" className={s.terminalSurface} />;
+}

--- a/web/src/components/chat/preview-rail/web-preview-tab.tsx
+++ b/web/src/components/chat/preview-rail/web-preview-tab.tsx
@@ -1,0 +1,76 @@
+import { useEffect, useState } from "react";
+import { Globe, RotateCw } from "lucide-react";
+import { isPreviewableUrl } from "@/lib/preview-rail";
+import s from "./preview-rail.module.css";
+
+interface WebPreviewTabProps {
+  /** Committed URL loaded in the iframe (persisted per session by the rail). */
+  url: string;
+  onUrlChange: (url: string) => void;
+}
+
+// Sandboxed web preview. `frame-src` in tauri.conf.json must allow the target
+// origin (local dev servers: http://localhost:* / http://127.0.0.1:*).
+export function WebPreviewTab({ url, onUrlChange }: WebPreviewTabProps) {
+  const [draft, setDraft] = useState(url);
+  const [reloadKey, setReloadKey] = useState(0);
+
+  useEffect(() => {
+    setDraft(url);
+  }, [url]);
+
+  const valid = isPreviewableUrl(draft);
+
+  const load = () => {
+    if (!valid) return;
+    onUrlChange(draft.trim());
+    setReloadKey((k) => k + 1);
+  };
+
+  return (
+    <>
+      <div className={s.bar}>
+        <input
+          className={s.input}
+          value={draft}
+          onChange={(e) => setDraft(e.target.value)}
+          onKeyDown={(e) => {
+            if (e.key === "Enter") load();
+          }}
+          placeholder="http://127.0.0.1:5173"
+          aria-label="预览网址"
+          spellCheck={false}
+        />
+        <button type="button" className={s.iconBtn} onClick={load} disabled={!valid}>
+          <Globe size={13} aria-hidden />
+          打开
+        </button>
+        <button
+          type="button"
+          className={s.iconBtn}
+          onClick={() => setReloadKey((k) => k + 1)}
+          disabled={!url}
+          title="刷新"
+          aria-label="刷新预览"
+        >
+          <RotateCw size={13} aria-hidden />
+        </button>
+      </div>
+      {url ? (
+        <iframe
+          key={`${url}#${reloadKey}`}
+          className={s.iframe}
+          src={url}
+          title="网页预览"
+          sandbox="allow-scripts allow-same-origin allow-forms allow-popups"
+          referrerPolicy="no-referrer"
+        />
+      ) : (
+        <div className={s.empty}>
+          <Globe size={24} aria-hidden />
+          <p>输入一个本地预览地址（如开发服务器 http://127.0.0.1:5173），在右栏内嵌打开。</p>
+        </div>
+      )}
+    </>
+  );
+}

--- a/web/src/components/console/embedded-terminal.tsx
+++ b/web/src/components/console/embedded-terminal.tsx
@@ -1,0 +1,242 @@
+import {
+  forwardRef,
+  useEffect,
+  useImperativeHandle,
+  useRef,
+  useState,
+} from "react";
+import { Terminal } from "@xterm/xterm";
+import { FitAddon } from "@xterm/addon-fit";
+import { WebLinksAddon } from "@xterm/addon-web-links";
+import "@xterm/xterm/css/xterm.css";
+import type { TerminalEventPayload, TerminalStartResult } from "@/lib/runtime";
+import { openExternalUrl } from "@/lib/external-links";
+
+export type TerminalStatus = "starting" | "ready" | "error" | "closed" | "unsupported";
+export type TerminalPurpose = "shell" | "gatewaySetup" | "gatewayStatus";
+
+export interface EmbeddedTerminalHandle {
+  /** Type a command into the live terminal (no-op until ready). */
+  runCommand: (command: string) => void;
+  /** Close the underlying terminal process. */
+  close: () => void;
+  /** Whether a terminal process is currently attached. */
+  hasTerminal: () => boolean;
+}
+
+interface EmbeddedTerminalProps {
+  purpose?: TerminalPurpose;
+  /** Applied to the terminal surface element. */
+  className?: string;
+  /** Write the intro banner on open (default true). */
+  showBanner?: boolean;
+  onStatusChange?: (status: TerminalStatus) => void;
+  onSession?: (session: TerminalStartResult) => void;
+  onError?: (message: string | null) => void;
+}
+
+/**
+ * Self-contained xterm.js terminal bound to the desktop terminal IPC bridge.
+ * Encapsulates the open → terminalStart → stream → cleanup lifecycle so both
+ * the standalone Console route and the task-detail right rail share one widget.
+ */
+export const EmbeddedTerminal = forwardRef<EmbeddedTerminalHandle, EmbeddedTerminalProps>(
+  function EmbeddedTerminal(
+    { purpose = "shell", className, showBanner = true, onStatusChange, onSession, onError },
+    ref,
+  ) {
+    const containerRef = useRef<HTMLDivElement | null>(null);
+    const terminalRef = useRef<Terminal | null>(null);
+    const terminalIdRef = useRef<string | null>(null);
+    const pendingEventsRef = useRef<TerminalEventPayload[]>([]);
+    const [status, setStatus] = useState<TerminalStatus>("starting");
+    const [armed, setArmed] = useState(false);
+
+    // Notify the consumer of status transitions without coupling its render.
+    useEffect(() => {
+      onStatusChange?.(status);
+    }, [status, onStatusChange]);
+
+    useImperativeHandle(ref, () => ({
+      runCommand: (command: string) => {
+        const id = terminalIdRef.current;
+        const term = terminalRef.current;
+        if (!id || !term) return;
+        term.focus();
+        void window.hermesDesktop?.terminalWrite?.({ terminalId: id, data: `${command}\r` });
+      },
+      close: () => {
+        const id = terminalIdRef.current;
+        if (!id) return;
+        terminalIdRef.current = null;
+        void window.hermesDesktop?.terminalClose?.({ terminalId: id });
+        setStatus("closed");
+      },
+      hasTerminal: () => terminalIdRef.current !== null,
+    }));
+
+    // Delay mount briefly so the container has a measured size before xterm fits.
+    useEffect(() => {
+      const timer = window.setTimeout(() => setArmed(true), 250);
+      return () => window.clearTimeout(timer);
+    }, []);
+
+    useEffect(() => {
+      if (!armed || !containerRef.current) return;
+
+      if (!window.hermesDesktop?.terminalStart) {
+        setStatus("unsupported");
+        onError?.("Hermes 终端需要在桌面端中打开。");
+        return;
+      }
+
+      let disposed = false;
+      const term = new Terminal({
+        cursorBlink: true,
+        cursorStyle: "bar",
+        fontFamily: "JetBrains Mono, SFMono-Regular, Menlo, Monaco, Consolas, monospace",
+        fontSize: 13.5,
+        lineHeight: 1.22,
+        letterSpacing: 0.1,
+        scrollback: 4000,
+        convertEol: true,
+        theme: {
+          background: "#080807",
+          foreground: "#f5efe5",
+          cursor: "#ffb35c",
+          selectionBackground: "#5a3b22",
+          black: "#191714",
+          red: "#d76f54",
+          green: "#7fc083",
+          yellow: "#d7a84d",
+          blue: "#7aa7d9",
+          magenta: "#b989d6",
+          cyan: "#74b8c4",
+          white: "#f3eee6",
+          brightBlack: "#6f675d",
+          brightRed: "#ff8b6e",
+          brightGreen: "#9fe1a5",
+          brightYellow: "#ffd074",
+          brightBlue: "#9cc9ff",
+          brightMagenta: "#d9a9ff",
+          brightCyan: "#9be7ef",
+          brightWhite: "#fffaf1",
+        },
+      });
+      const fit = new FitAddon();
+      term.loadAddon(fit);
+      term.loadAddon(
+        new WebLinksAddon((_event, uri) => {
+          void openExternalUrl(uri);
+        }),
+      );
+      term.open(containerRef.current);
+      fit.fit();
+      term.focus();
+      terminalRef.current = term;
+
+      if (showBanner) {
+        term.writeln("\x1b[38;5;214mHermes\x1b[0m \x1b[38;5;81mConsole\x1b[0m");
+        term.writeln(
+          "这里是真实终端。你可以直接输入 Hermes 命令，也可以点常用操作自动填入。推荐先运行 hermes。",
+        );
+        if (purpose === "gatewaySetup") {
+          term.writeln("正在为你打开消息平台接入向导\r\n");
+        } else if (purpose === "gatewayStatus") {
+          term.writeln("正在为你查看消息平台接入状态\r\n");
+        } else {
+          term.writeln("");
+        }
+      }
+
+      const writeEvent = (event: TerminalEventPayload) => {
+        const id = terminalIdRef.current;
+        if (!id) {
+          pendingEventsRef.current.push(event);
+          return;
+        }
+        if (event.terminalId !== id) return;
+        if (event.kind === "data" && event.data) {
+          term.write(event.data);
+        } else if (event.kind === "error") {
+          term.writeln(`\r\n\x1b[31m终端错误：${event.message ?? "未知错误"}\x1b[0m`);
+          onError?.(event.message ?? "终端错误");
+          setStatus("error");
+        } else if (event.kind === "exit") {
+          const suffix = typeof event.exitCode === "number" ? `，退出码 ${event.exitCode}` : "";
+          term.writeln(`\r\n\x1b[90m终端已结束${suffix}。\x1b[0m`);
+          setStatus("closed");
+        }
+      };
+
+      const unlisten = window.hermesDesktop?.onTerminalOutput?.(writeEvent);
+      const disposable = term.onData((data) => {
+        const id = terminalIdRef.current;
+        if (!id) return;
+        void window.hermesDesktop?.terminalWrite?.({ terminalId: id, data }).catch((err) => {
+          onError?.(err instanceof Error ? err.message : String(err));
+          setStatus("error");
+        });
+      });
+
+      const resize = () => {
+        if (disposed) return;
+        try {
+          fit.fit();
+          const id = terminalIdRef.current;
+          if (id) {
+            void window.hermesDesktop?.terminalResize?.({ terminalId: id, cols: term.cols, rows: term.rows });
+          }
+        } catch {
+          // xterm fit may throw while the container is hidden; the next resize fixes it.
+        }
+      };
+      const scheduleResize = () => {
+        window.requestAnimationFrame(() => {
+          resize();
+          window.requestAnimationFrame(resize);
+        });
+        window.setTimeout(resize, 160);
+      };
+      const observer = new ResizeObserver(resize);
+      observer.observe(containerRef.current);
+      scheduleResize();
+
+      window.hermesDesktop
+        ?.terminalStart?.({ purpose, cols: term.cols, rows: term.rows })
+        .then((result) => {
+          if (disposed) return;
+          terminalIdRef.current = result.terminalId;
+          onSession?.(result);
+          setStatus("ready");
+          const pending = pendingEventsRef.current.splice(0);
+          pending.forEach(writeEvent);
+          scheduleResize();
+        })
+        .catch((err) => {
+          if (disposed) return;
+          const message = err instanceof Error ? err.message : String(err);
+          term.writeln(`\r\n\x1b[31m${message}\x1b[0m`);
+          onError?.(message);
+          setStatus("error");
+        });
+
+      return () => {
+        disposed = true;
+        observer.disconnect();
+        disposable.dispose();
+        unlisten?.();
+        const id = terminalIdRef.current;
+        terminalIdRef.current = null;
+        if (id) void window.hermesDesktop?.terminalClose?.({ terminalId: id });
+        term.dispose();
+        terminalRef.current = null;
+      };
+      // onStatusChange/onError/onSession are intentionally excluded — they would
+      // re-create the whole terminal on every parent render.
+      // eslint-disable-next-line react-hooks/exhaustive-deps
+    }, [armed, purpose, showBanner]);
+
+    return <div ref={containerRef} className={className} />;
+  },
+);

--- a/web/src/lib/preview-rail.test.ts
+++ b/web/src/lib/preview-rail.test.ts
@@ -1,0 +1,93 @@
+import { describe, expect, it } from "vitest";
+import {
+  DEFAULT_PREVIEW_PANEL,
+  detectLanguage,
+  fileExtension,
+  formatBytes,
+  isMarkdownPath,
+  isPreviewableUrl,
+  normalizePreviewPanel,
+  toFencedMarkdown,
+} from "./preview-rail";
+
+describe("normalizePreviewPanel", () => {
+  it("passes through valid panels", () => {
+    expect(normalizePreviewPanel("web")).toBe("web");
+    expect(normalizePreviewPanel("files")).toBe("files");
+    expect(normalizePreviewPanel("terminal")).toBe("terminal");
+    expect(normalizePreviewPanel("logs")).toBe("logs");
+  });
+
+  it("falls back to the default for unknown/empty values", () => {
+    expect(normalizePreviewPanel(null)).toBe(DEFAULT_PREVIEW_PANEL);
+    expect(normalizePreviewPanel("nope")).toBe(DEFAULT_PREVIEW_PANEL);
+    expect(normalizePreviewPanel(undefined)).toBe(DEFAULT_PREVIEW_PANEL);
+  });
+});
+
+describe("fileExtension", () => {
+  it("extracts the lowercased extension", () => {
+    expect(fileExtension("/a/b/Main.TSX")).toBe("tsx");
+    expect(fileExtension("file.tar.gz")).toBe("gz");
+    expect(fileExtension("C:\\x\\y.JSON")).toBe("json");
+  });
+
+  it("returns empty for dotfiles and extensionless names", () => {
+    expect(fileExtension("/a/.gitignore")).toBe("");
+    expect(fileExtension("README")).toBe("");
+  });
+});
+
+describe("detectLanguage / isMarkdownPath", () => {
+  it("maps common extensions to highlight languages", () => {
+    expect(detectLanguage("a.ts")).toBe("ts");
+    expect(detectLanguage("a.py")).toBe("python");
+    expect(detectLanguage("a.rs")).toBe("rust");
+    expect(detectLanguage("a.unknownext")).toBeUndefined();
+  });
+
+  it("detects markdown files", () => {
+    expect(isMarkdownPath("notes.md")).toBe(true);
+    expect(isMarkdownPath("doc.MARKDOWN")).toBe(true);
+    expect(isMarkdownPath("a.ts")).toBe(false);
+  });
+});
+
+describe("toFencedMarkdown", () => {
+  it("wraps content in a fenced block with the language", () => {
+    expect(toFencedMarkdown("const x = 1;", "ts")).toBe("```ts\nconst x = 1;\n```");
+  });
+
+  it("uses a longer fence when content contains backtick runs", () => {
+    const content = "outer\n```\ninner\n```\nend";
+    const fenced = toFencedMarkdown(content, "md");
+    // longest run inside is 3, so the wrapping fence must be at least 4 backticks
+    expect(fenced.startsWith("````md\n")).toBe(true);
+    expect(fenced.endsWith("\n````")).toBe(true);
+    expect(fenced).toContain(content);
+  });
+});
+
+describe("formatBytes", () => {
+  it("formats byte sizes", () => {
+    expect(formatBytes(0)).toBe("0 B");
+    expect(formatBytes(512)).toBe("512 B");
+    expect(formatBytes(1024)).toBe("1.0 KB");
+    expect(formatBytes(1536)).toBe("1.5 KB");
+    expect(formatBytes(5 * 1024 * 1024)).toBe("5.0 MB");
+  });
+});
+
+describe("isPreviewableUrl", () => {
+  it("accepts http(s) URLs", () => {
+    expect(isPreviewableUrl("http://127.0.0.1:5173")).toBe(true);
+    expect(isPreviewableUrl("https://example.com/path")).toBe(true);
+  });
+
+  it("rejects non-http(s) and malformed values", () => {
+    expect(isPreviewableUrl("")).toBe(false);
+    expect(isPreviewableUrl("file:///etc/passwd")).toBe(false);
+    expect(isPreviewableUrl("javascript:alert(1)")).toBe(false);
+    expect(isPreviewableUrl("not a url")).toBe(false);
+  });
+});

--- a/web/src/lib/preview-rail.ts
+++ b/web/src/lib/preview-rail.ts
@@ -1,0 +1,126 @@
+// Pure helpers for the task-detail right rail (issue #233). Kept free of React
+// so the panel routing, language detection, and content framing are unit
+// testable in isolation.
+
+export const PREVIEW_PANELS = ["web", "files", "terminal", "logs"] as const;
+export type PreviewPanel = (typeof PREVIEW_PANELS)[number];
+export const DEFAULT_PREVIEW_PANEL: PreviewPanel = "files";
+
+/** The `?panel=` query key used to deep-link the active rail tab. */
+export const PREVIEW_PANEL_QUERY_KEY = "panel";
+
+export function normalizePreviewPanel(value: unknown): PreviewPanel {
+  return PREVIEW_PANELS.includes(value as PreviewPanel)
+    ? (value as PreviewPanel)
+    : DEFAULT_PREVIEW_PANEL;
+}
+
+// Extension → fenced-code language id (Streamdown/Shiki). Only the common cases
+// the preview needs; unknown extensions fall back to no language (plain mono).
+const LANGUAGE_BY_EXT: Record<string, string> = {
+  ts: "ts",
+  tsx: "tsx",
+  js: "js",
+  jsx: "jsx",
+  mjs: "js",
+  cjs: "js",
+  json: "json",
+  jsonc: "json",
+  css: "css",
+  scss: "scss",
+  html: "html",
+  htm: "html",
+  xml: "xml",
+  svg: "xml",
+  py: "python",
+  rs: "rust",
+  go: "go",
+  java: "java",
+  kt: "kotlin",
+  c: "c",
+  h: "c",
+  cpp: "cpp",
+  cc: "cpp",
+  hpp: "cpp",
+  cs: "csharp",
+  rb: "ruby",
+  php: "php",
+  swift: "swift",
+  sh: "bash",
+  bash: "bash",
+  zsh: "bash",
+  fish: "bash",
+  yaml: "yaml",
+  yml: "yaml",
+  toml: "toml",
+  ini: "ini",
+  sql: "sql",
+  graphql: "graphql",
+  gql: "graphql",
+  vue: "vue",
+  svelte: "svelte",
+  lua: "lua",
+  dockerfile: "dockerfile",
+};
+
+const MARKDOWN_EXT = new Set(["md", "markdown", "mdx", "mdc"]);
+
+export function fileExtension(path: string): string {
+  const name = path.split(/[\\/]/).pop() ?? "";
+  const dot = name.lastIndexOf(".");
+  if (dot <= 0) return "";
+  return name.slice(dot + 1).toLowerCase();
+}
+
+export function detectLanguage(path: string): string | undefined {
+  return LANGUAGE_BY_EXT[fileExtension(path)];
+}
+
+export function isMarkdownPath(path: string): boolean {
+  return MARKDOWN_EXT.has(fileExtension(path));
+}
+
+/**
+ * Wrap raw file content in a markdown fenced code block for the existing
+ * `MarkdownText` renderer (Streamdown handles fence highlighting + a copy
+ * button). The fence is made one backtick longer than the longest backtick
+ * run in the content so embedded fences can't break out of the block.
+ */
+export function toFencedMarkdown(text: string, language?: string): string {
+  let longestRun = 0;
+  let current = 0;
+  for (const ch of text) {
+    if (ch === "`") {
+      current += 1;
+      if (current > longestRun) longestRun = current;
+    } else {
+      current = 0;
+    }
+  }
+  const fence = "`".repeat(Math.max(3, longestRun + 1));
+  return `${fence}${language ?? ""}\n${text}\n${fence}`;
+}
+
+export function formatBytes(bytes: number): string {
+  if (!Number.isFinite(bytes) || bytes <= 0) return "0 B";
+  const units = ["B", "KB", "MB", "GB"];
+  let value = bytes;
+  let index = 0;
+  while (value >= 1024 && index < units.length - 1) {
+    value /= 1024;
+    index += 1;
+  }
+  return `${value.toFixed(index === 0 ? 0 : 1)} ${units[index]}`;
+}
+
+/** Best-effort check that a string is an http(s) URL safe for the preview iframe. */
+export function isPreviewableUrl(value: string): boolean {
+  const trimmed = value.trim();
+  if (!trimmed) return false;
+  try {
+    const url = new URL(trimmed);
+    return url.protocol === "http:" || url.protocol === "https:";
+  } catch {
+    return false;
+  }
+}

--- a/web/src/lib/runtime.ts
+++ b/web/src/lib/runtime.ts
@@ -223,6 +223,37 @@ export interface TerminalEventPayload {
   message?: string | null;
 }
 
+// Right-rail rich preview (issue #233). Mirrors the Rust commands in
+// src/commands/preview.rs and the upstream Electron preload API.
+export interface ReadWorkspaceFileInput {
+  /** Absolute path, or relative to `root`. Must resolve inside `root`. */
+  path: string;
+  /** Session workspace root; reads are confined to this directory. */
+  root: string;
+}
+
+export interface FilePreview {
+  /** UTF-8 text content, when the file is textual. */
+  text?: string;
+  /** `data:<mime>;base64,...` for previewable images. */
+  dataUrl?: string;
+  /** Full size on disk in bytes. */
+  byteSize: number;
+  /** True when the content is binary (no text preview). */
+  binary: boolean;
+  /** True when `text` was cut at the 512 KB cap. */
+  truncated: boolean;
+}
+
+export interface WatchPreviewFileResult {
+  watchId: string;
+}
+
+export interface PreviewFileChangedPayload {
+  watchId: string;
+  path: string;
+}
+
 declare global {
   interface Window {
     __HERMES_SESSION_TOKEN__?: string;
@@ -295,6 +326,10 @@ declare global {
       terminalResize?(input: { terminalId: string; cols: number; rows: number }): Promise<boolean>;
       terminalClose?(input: { terminalId: string }): Promise<boolean>;
       onTerminalOutput?(handler: (event: TerminalEventPayload) => void): () => void;
+      readWorkspaceFile?(input: ReadWorkspaceFileInput): Promise<FilePreview>;
+      watchPreviewFile?(input: { path: string }): Promise<WatchPreviewFileResult>;
+      stopPreviewFileWatch?(input: { watchId: string }): Promise<boolean>;
+      onPreviewFileChanged?(handler: (payload: PreviewFileChangedPayload) => void): () => void;
       onSystemResume?(handler: () => void): () => void;
     };
   }

--- a/web/src/lib/tauri-bridge.ts
+++ b/web/src/lib/tauri-bridge.ts
@@ -45,6 +45,9 @@ import type {
 import type {
   DesktopNotifyInput,
   DesktopNotifyResult,
+  FilePreview,
+  PreviewFileChangedPayload,
+  ReadWorkspaceFileInput,
   SkillMarkdownResult,
   ExportDebugBundleInput,
   ExportDebugBundleResult,
@@ -56,6 +59,7 @@ import type {
   UiEventInput,
   UiStoreSnapshot,
   UiTurnStats,
+  WatchPreviewFileResult,
 } from "./runtime";
 import { BUILD_COMMIT, DESKTOP_VERSION, versionLabel } from "./build-info";
 import hermesLogoSvg from "../../../icons/icon.svg?raw";
@@ -377,6 +381,32 @@ const tauriBridge = {
     let unlisten: (() => void) | null = null;
     import("@tauri-apps/api/event").then(({ listen }) => {
       listen<TerminalEventPayload>("terminal-output", (event) => {
+        handler(event.payload);
+      }).then((fn) => {
+        unlisten = fn;
+      });
+    });
+    return () => {
+      unlisten?.();
+    };
+  },
+
+  async readWorkspaceFile(input: ReadWorkspaceFileInput): Promise<FilePreview> {
+    return invokeCommand("read_workspace_file", { input });
+  },
+
+  async watchPreviewFile(input: { path: string }): Promise<WatchPreviewFileResult> {
+    return invokeCommand("watch_preview_file", { input });
+  },
+
+  async stopPreviewFileWatch(input: { watchId: string }): Promise<boolean> {
+    return invokeCommand("stop_preview_file_watch", { input });
+  },
+
+  onPreviewFileChanged(handler: (payload: PreviewFileChangedPayload) => void): () => void {
+    let unlisten: (() => void) | null = null;
+    import("@tauri-apps/api/event").then(({ listen }) => {
+      listen<PreviewFileChangedPayload>("preview-file-changed", (event) => {
         handler(event.payload);
       }).then((fn) => {
         unlisten = fn;

--- a/web/src/routes/console.tsx
+++ b/web/src/routes/console.tsx
@@ -1,17 +1,15 @@
-import { useEffect, useMemo, useRef, useState } from "react";
+import { useMemo, useRef, useState } from "react";
 import { useLocation } from "react-router-dom";
-import { Terminal } from "@xterm/xterm";
-import { FitAddon } from "@xterm/addon-fit";
-import { WebLinksAddon } from "@xterm/addon-web-links";
-import "@xterm/xterm/css/xterm.css";
 import { ExternalLink, Play, Power, RotateCcw, TerminalSquare } from "lucide-react";
-import type { TerminalEventPayload, TerminalStartResult } from "@/lib/runtime";
-import { openExternalUrl } from "@/lib/external-links";
-import { runtime } from "@/lib/runtime";
+import type { TerminalStartResult } from "@/lib/runtime";
+import {
+  EmbeddedTerminal,
+  type EmbeddedTerminalHandle,
+  type TerminalPurpose,
+  type TerminalStatus,
+} from "@/components/console/embedded-terminal";
 import { SectionShell } from "./section-shell";
 import s from "./console.module.css";
-
-type ConsoleStatus = "starting" | "ready" | "error" | "closed" | "unsupported";
 
 interface CommandAction {
   label: string;
@@ -50,32 +48,21 @@ function normalizePath(path?: string | null) {
 
 export function ConsoleRoute() {
   const location = useLocation();
-  const containerRef = useRef<HTMLDivElement | null>(null);
-  const terminalRef = useRef<Terminal | null>(null);
-  const fitRef = useRef<FitAddon | null>(null);
-  const terminalIdRef = useRef<string | null>(null);
-  const pendingEventsRef = useRef<TerminalEventPayload[]>([]);
-  const [status, setStatus] = useState<ConsoleStatus>("starting");
+  const terminalRef = useRef<EmbeddedTerminalHandle | null>(null);
+  const [status, setStatus] = useState<TerminalStatus>("starting");
   const [error, setError] = useState<string | null>(null);
   const [session, setSession] = useState<TerminalStartResult | null>(null);
   const [lastCommand, setLastCommand] = useState<string | null>(null);
   const [externalOpening, setExternalOpening] = useState(false);
   const [externalOpened, setExternalOpened] = useState<string | null>(null);
-  const [armed, setArmed] = useState(false);
 
-  useEffect(() => {
-    const timer = window.setTimeout(() => setArmed(true), 250);
-    return () => window.clearTimeout(timer);
-  }, []);
-
-  const isDesktopTerminalAvailable = Boolean(window.hermesDesktop?.terminalStart);
   const isExternalTerminalAvailable = Boolean(window.hermesDesktop?.terminalOpenExternal);
-  const autoPurpose = useMemo(() => {
+  const autoPurpose = useMemo<TerminalPurpose>(() => {
     const params = new URLSearchParams(location.search);
     const run = params.get("run") ?? params.get("command") ?? "";
-    if (["gateway-setup", "gatewaySetup", "gateway_setup"].includes(run)) return "gatewaySetup" as const;
-    if (["gateway-status", "gatewayStatus", "gateway_status"].includes(run)) return "gatewayStatus" as const;
-    return "shell" as const;
+    if (["gateway-setup", "gatewaySetup", "gateway_setup"].includes(run)) return "gatewaySetup";
+    if (["gateway-status", "gatewayStatus", "gateway_status"].includes(run)) return "gatewayStatus";
+    return "shell";
   }, [location.search]);
 
   const statusText = useMemo(() => {
@@ -86,166 +73,10 @@ export function ConsoleRoute() {
     return "终端不可用";
   }, [status]);
 
-  useEffect(() => {
-    if (!armed || !containerRef.current) return;
-
-    if (!isDesktopTerminalAvailable) {
-      setStatus("unsupported");
-      setError("Hermes Console 需要在桌面端中打开。浏览器预览只能查看页面，不能启动本地终端。");
-      return;
-    }
-
-    let disposed = false;
-    const term = new Terminal({
-      cursorBlink: true,
-      cursorStyle: "bar",
-      fontFamily: "JetBrains Mono, SFMono-Regular, Menlo, Monaco, Consolas, monospace",
-      fontSize: 13.5,
-      lineHeight: 1.22,
-      letterSpacing: 0.1,
-      scrollback: 4000,
-      convertEol: true,
-      theme: {
-        background: "#080807",
-        foreground: "#f5efe5",
-        cursor: "#ffb35c",
-        selectionBackground: "#5a3b22",
-        black: "#191714",
-        red: "#d76f54",
-        green: "#7fc083",
-        yellow: "#d7a84d",
-        blue: "#7aa7d9",
-        magenta: "#b989d6",
-        cyan: "#74b8c4",
-        white: "#f3eee6",
-        brightBlack: "#6f675d",
-        brightRed: "#ff8b6e",
-        brightGreen: "#9fe1a5",
-        brightYellow: "#ffd074",
-        brightBlue: "#9cc9ff",
-        brightMagenta: "#d9a9ff",
-        brightCyan: "#9be7ef",
-        brightWhite: "#fffaf1",
-      },
-    });
-    const fit = new FitAddon();
-    term.loadAddon(fit);
-    term.loadAddon(new WebLinksAddon((_event, uri) => {
-      void openExternalUrl(uri);
-    }));
-    term.open(containerRef.current);
-    fit.fit();
-    term.focus();
-    terminalRef.current = term;
-    fitRef.current = fit;
-
-    const writeBanner = () => {
-      term.writeln("\x1b[38;5;214mHermes\x1b[0m \x1b[38;5;81mConsole\x1b[0m");
-      term.writeln("这里是真实终端。你可以直接输入 Hermes 命令，也可以点下方常用操作自动填入。推荐先运行 hermes。");
-      if (autoPurpose === "gatewaySetup") {
-        term.writeln("正在为你打开消息平台接入向导\r\n");
-      } else if (autoPurpose === "gatewayStatus") {
-        term.writeln("正在为你查看消息平台接入状态\r\n");
-      } else {
-        term.writeln("");
-      }
-    };
-    writeBanner();
-
-    const writeEvent = (event: TerminalEventPayload) => {
-      const id = terminalIdRef.current;
-      if (!id) {
-        pendingEventsRef.current.push(event);
-        return;
-      }
-      if (event.terminalId !== id) return;
-      if (event.kind === "data" && event.data) {
-        term.write(event.data);
-      } else if (event.kind === "error") {
-        term.writeln(`\r\n\x1b[31m终端错误：${event.message ?? "未知错误"}\x1b[0m`);
-        setError(event.message ?? "终端错误");
-        setStatus("error");
-      } else if (event.kind === "exit") {
-        const suffix = typeof event.exitCode === "number" ? `，退出码 ${event.exitCode}` : "";
-        term.writeln(`\r\n\x1b[90m终端已结束${suffix}。\x1b[0m`);
-        setStatus("closed");
-      }
-    };
-
-    const unlisten = window.hermesDesktop?.onTerminalOutput?.(writeEvent);
-    const disposable = term.onData((data) => {
-      const id = terminalIdRef.current;
-      if (!id) return;
-      void window.hermesDesktop?.terminalWrite?.({ terminalId: id, data }).catch((err) => {
-        setError(err instanceof Error ? err.message : String(err));
-        setStatus("error");
-      });
-    });
-
-    const resize = () => {
-      if (disposed) return;
-      try {
-        fit.fit();
-        const id = terminalIdRef.current;
-        if (id) {
-          void window.hermesDesktop?.terminalResize?.({ terminalId: id, cols: term.cols, rows: term.rows });
-        }
-      } catch {
-        // xterm fit may throw while the container is being mounted or hidden; the next resize fixes it.
-      }
-    };
-
-    const scheduleResize = () => {
-      window.requestAnimationFrame(() => {
-        resize();
-        window.requestAnimationFrame(resize);
-      });
-      window.setTimeout(resize, 160);
-    };
-    const observer = new ResizeObserver(resize);
-    observer.observe(containerRef.current);
-    scheduleResize();
-
-    window.hermesDesktop
-      ?.terminalStart?.({ purpose: autoPurpose, cols: term.cols, rows: term.rows })
-      .then((result) => {
-        if (disposed) return;
-        terminalIdRef.current = result.terminalId;
-        setSession(result);
-        setStatus("ready");
-        const pending = pendingEventsRef.current.splice(0);
-        pending.forEach(writeEvent);
-        scheduleResize();
-      })
-      .catch((err) => {
-        if (disposed) return;
-        const message = err instanceof Error ? err.message : String(err);
-        term.writeln(`\r\n\x1b[31m${message}\x1b[0m`);
-        setError(message);
-        setStatus("error");
-      });
-
-    return () => {
-      disposed = true;
-      observer.disconnect();
-      disposable.dispose();
-      unlisten?.();
-      const id = terminalIdRef.current;
-      terminalIdRef.current = null;
-      if (id) void window.hermesDesktop?.terminalClose?.({ terminalId: id });
-      term.dispose();
-      terminalRef.current = null;
-      fitRef.current = null;
-    };
-  }, [armed, autoPurpose, isDesktopTerminalAvailable]);
-
   const runCommand = (command: string) => {
-    const id = terminalIdRef.current;
-    const term = terminalRef.current;
-    if (!id || !term || status !== "ready") return;
+    if (status !== "ready") return;
     setLastCommand(command);
-    term.focus();
-    void window.hermesDesktop?.terminalWrite?.({ terminalId: id, data: `${command}\r` });
+    terminalRef.current?.runCommand(command);
   };
 
   const restartTerminal = () => {
@@ -253,11 +84,7 @@ export function ConsoleRoute() {
   };
 
   const closeTerminal = () => {
-    const id = terminalIdRef.current;
-    if (!id) return;
-    terminalIdRef.current = null;
-    void window.hermesDesktop?.terminalClose?.({ terminalId: id });
-    setStatus("closed");
+    terminalRef.current?.close();
   };
 
   const openExternalTerminal = () => {
@@ -295,7 +122,7 @@ export function ConsoleRoute() {
             <RotateCcw size={13} />
             重新打开
           </button>
-          <button type="button" className={s.dangerButton} onClick={closeTerminal} disabled={!terminalIdRef.current}>
+          <button type="button" className={s.dangerButton} onClick={closeTerminal} disabled={status !== "ready"}>
             <Power size={13} />
             关闭终端
           </button>
@@ -335,7 +162,14 @@ export function ConsoleRoute() {
                 {statusText}
               </div>
             </div>
-            <div ref={containerRef} className={s.terminalSurface} />
+            <EmbeddedTerminal
+              ref={terminalRef}
+              purpose={autoPurpose}
+              className={s.terminalSurface}
+              onStatusChange={setStatus}
+              onSession={setSession}
+              onError={setError}
+            />
           </div>
 
           {error && <div className={s.errorBox}>{error}</div>}

--- a/web/src/routes/detail.tsx
+++ b/web/src/routes/detail.tsx
@@ -1,13 +1,14 @@
 import { useEffect, useMemo, useCallback, useRef, useState, type CSSProperties } from "react";
 import { useAtom, useAtomValue, useSetAtom } from "jotai";
-import { useNavigate, useParams } from "react-router-dom";
-import { Bot, Check, Copy } from "lucide-react";
+import { useNavigate, useParams, useSearchParams } from "react-router-dom";
+import { Bot, Check, Copy, PanelRight } from "lucide-react";
 import {
   activeSessionIdAtom,
   conversationFontSizeAtom,
   conversationFontSizeVars,
   conversationWidthMaxWidth,
   conversationWidthModeAtom,
+  rightRailVisibleAtom,
 } from "@/stores/ui";
 import {
   appendNoticeAtom,
@@ -58,6 +59,8 @@ import type {
 import { MessageTimeline } from "@/components/chat/message-timeline";
 import { StallNotice } from "@/components/chat/stall-notice";
 import { SubagentPanel, useSessionSubagents } from "@/components/chat/subagent-panel";
+import { PreviewRail } from "@/components/chat/preview-rail/preview-rail";
+import { PREVIEW_PANEL_QUERY_KEY } from "@/lib/preview-rail";
 import { activeSubagentCount } from "@/stores/subagents";
 import { ConversationWidthControl } from "@/components/chat/conversation-width-control";
 import {
@@ -79,6 +82,8 @@ export function DetailRoute() {
   const [activeSessionId, setActiveId] = useAtom(activeSessionIdAtom);
   const [conversationWidthMode, setConversationWidthMode] = useAtom(conversationWidthModeAtom);
   const conversationFontSizeMode = useAtomValue(conversationFontSizeAtom);
+  const [rightRailVisible, setRightRailVisible] = useAtom(rightRailVisibleAtom);
+  const [searchParams] = useSearchParams();
   const taskId = activeSessionId ?? urlTaskId;
   const turnStats = useSessionTurnStats(taskId);
 
@@ -160,6 +165,32 @@ export function DetailRoute() {
   useEffect(() => {
     if (urlTaskId && urlTaskId !== activeSessionId) setActiveId(urlTaskId);
   }, [urlTaskId, activeSessionId, setActiveId]);
+
+  // ⌘B / Ctrl+B toggles the rich-preview right rail (issue #233). A ref holds
+  // the latest visibility so the listener stays attached once.
+  const railVisibleRef = useRef(rightRailVisible);
+  railVisibleRef.current = rightRailVisible;
+  useEffect(() => {
+    const onKey = (event: KeyboardEvent) => {
+      if ((event.metaKey || event.ctrlKey) && !event.altKey && !event.shiftKey && event.key.toLowerCase() === "b") {
+        event.preventDefault();
+        setRightRailVisible(!railVisibleRef.current);
+      }
+    };
+    window.addEventListener("keydown", onKey);
+    return () => window.removeEventListener("keydown", onKey);
+  }, [setRightRailVisible]);
+
+  // Deep link: arriving with ?panel=… opens the rail to that tab. Runs once so
+  // a later manual close isn't fought by this effect.
+  const didAutoOpenRail = useRef(false);
+  useEffect(() => {
+    if (didAutoOpenRail.current) return;
+    didAutoOpenRail.current = true;
+    if (searchParams.has(PREVIEW_PANEL_QUERY_KEY) && !railVisibleRef.current) {
+      setRightRailVisible(true);
+    }
+  }, [searchParams, setRightRailVisible]);
 
 
   // Reset the user-selected model whenever the route changes to a different
@@ -482,6 +513,16 @@ export function DetailRoute() {
                 </span>
               ) : null}
             </TopBarActionButton>
+            <TopBarActionButton
+              onClick={() => setRightRailVisible(!rightRailVisible)}
+              data-active={rightRailVisible ? "true" : undefined}
+              title="预览面板（⌘B）"
+              aria-label="预览面板"
+              aria-pressed={rightRailVisible}
+            >
+              <PanelRight size={12} aria-hidden="true" />
+              <span>预览</span>
+            </TopBarActionButton>
             <TopBarActions />
           </>
         }
@@ -537,6 +578,13 @@ export function DetailRoute() {
             />
           </div>
         </div>
+        {rightRailVisible && taskId ? (
+          <PreviewRail
+            sessionId={taskId}
+            workspaceRoot={sessionWorkspace}
+            onClose={() => setRightRailVisible(false)}
+          />
+        ) : null}
         {subagentPanelOpen ? (
           <SubagentPanel subagents={subagents} onClose={() => setSubagentPanelOpen(false)} />
         ) : null}

--- a/web/src/stores/preview-rail.ts
+++ b/web/src/stores/preview-rail.ts
@@ -1,0 +1,19 @@
+import { atom } from "jotai";
+
+// Per-session selection for the task-detail right rail (issue #233). Kept in a
+// map keyed by session id so toggling the rail (or switching tabs) preserves
+// the chosen file / entered URL within a session. Ephemeral by design — not
+// persisted to the UI store for the MVP.
+export interface PreviewRailSelection {
+  /** URL entered in the Web preview tab. */
+  webUrl: string;
+  /** Absolute path of the file selected in the Files tab. */
+  filePath: string | null;
+}
+
+export const EMPTY_PREVIEW_RAIL_SELECTION: PreviewRailSelection = {
+  webUrl: "",
+  filePath: null,
+};
+
+export const previewRailSelectionMapAtom = atom<Record<string, PreviewRailSelection>>({});

--- a/web/src/stores/ui.ts
+++ b/web/src/stores/ui.ts
@@ -104,6 +104,19 @@ export const showReasoningAtom = atom(
   },
 );
 
+// Task-detail right rail (issue #233): rich preview panel visibility. Persisted
+// so the user's last choice survives reload; ⌘B toggles it. The active tab
+// lives in the `?panel=` query, not here (see lib/preview-rail.ts).
+const RIGHT_RAIL_VISIBLE_KEY = "hermes.right-rail-visible";
+const rightRailVisibleBaseAtom = atom<boolean>(readUiValue<unknown>(RIGHT_RAIL_VISIBLE_KEY, false) === true);
+export const rightRailVisibleAtom = atom(
+  (get) => get(rightRailVisibleBaseAtom),
+  (_get, set, next: boolean) => {
+    set(rightRailVisibleBaseAtom, next === true);
+    writeUiValue(RIGHT_RAIL_VISIBLE_KEY, next === true);
+  },
+);
+
 const COMPOSER_SUBMIT_SHORTCUT_KEY = "hermes.composer-submit-shortcut";
 
 function normalizeComposerSubmitShortcut(value: unknown): ComposerSubmitShortcut {


### PR DESCRIPTION
## 背景 / 为什么
Closes #233。官方桌面端（Core `apps/desktop`）的会话详情是三栏布局、右栏富预览（网页沙箱 iframe、文件/代码、工具输出、磁盘文件实时刷新）；我们 Tauri 端此前是单栏时间线，只有独立的 `console.tsx` / `logs.tsx` 页。本 PR 补上**可隐藏的右栏（MVP）**，对齐 PRD §5.1 / 原型 03–06。

## 交付范围（MVP，已与需求方确认）
- **三栏外壳**：`detail.tsx` 的 `.workArea` 内并排 `PreviewRail`；`⌘B` 切换、顶栏「预览」按钮；活动 Tab 进 `?panel=web|files|terminal|logs`，支持深链自动展开。
- **网页预览**：sandbox `<iframe>` + 刷新；`tauri.conf.json` CSP 增加 `frame-src` 放行本地预览源（`http://localhost:* http://127.0.0.1:*`）。
- **文件/代码预览 + 实时刷新**：新增 Rust 命令 `read_workspace_file`（512KB 截断、二进制嗅探、图片→dataURL、**workspace 根目录越界防护**）与 `watch_preview_file`/`stop_preview_file_watch`（`notify` 原生 watch → `preview-file-changed` 事件，前端 200ms 去抖后自动重读，对齐上游 `FILE_RELOAD_DEBOUNCE_MS`）。代码渲染**复用现有 `MarkdownText`** 代码围栏，未引入额外高亮库。
- **终端**：把 `console.tsx` 的 xterm 生命周期抽成可复用的 `EmbeddedTerminal`，console 路由与右栏 Tab 共用（消除重复）。
- **日志**：复用 `lib/logs-viewer` + `useLogs` 的紧凑视图（本地状态，不污染详情 URL；完整 `/logs` 页保持不变）。
- 桥接/类型：`tauri-bridge.ts` + `runtime.ts` 暴露 `readWorkspaceFile`/`watchPreviewFile`/`stopPreviewFileWatch`/`onPreviewFileChanged`，镜像上游 Electron preload API。

## 暂不做（后续，依赖后端）
- **文件 Diff / 产物** 两个 Tab 仅占位禁用：需 Core 端 `GET /api/sessions/{id}/changes` / artifact manifest（PRD §5 P0 gap）。后续单开任务，并按需开 Core worktree。
- 左侧会话上下文栏、右栏拖拽调宽：均非本 issue 重点，另议。

## 测试
- ✅ web `tsc --noEmit` 通过；✅ `web/src/lib/preview-rail.test.ts` 11/11；新增 `src/commands/preview.rs` 7 个 Rust 单测。
- ✅ 提交前在开发机已跑过 `cargo check` 与 `cargo clippy -D warnings`（干净）。
- ⏳ 待在构建机补跑：`cargo test preview`、全量 `pnpm test:unit`、`pnpm tauri:dev -- --source ../Hermes-CN-Core` 路线 A 冒烟（⌘B 开关 / 文件实时刷新 / iframe CSP / `?panel=` 深链）。

## ⚠️ 基线说明（需 rebase）
本分支基于 `18fbba5`，其后 main 已合入 #256 / #257 / #258。**与本 PR 改动重叠的文件**：`tauri.conf.json`、`web/src/lib/runtime.ts`、`web/src/routes/detail.tsx`、`web/src/stores/ui.ts`。合并前请先 rebase 到最新 main 并解决冲突（大多为“双方各自新增”，保留两侧即可），随后在构建机复验。

🤖 Generated with [Claude Code](https://claude.com/claude-code)
