### PR TITLE
[codex] 兼容压缩响应的结构化摘要

### DIFF
--- a/packages/protocol/src/hermes-api.test.ts
+++ b/packages/protocol/src/hermes-api.test.ts
@@ -9,6 +9,7 @@ import {
   CronRunsResponse,
   ElevenLabsVoicesResponse,
   SessionsResponse,
+  SessionCompressResult,
   SessionSummary,
 } from "./hermes-api";
 
@@ -260,6 +261,37 @@ describe("AnalyticsResponse", () => {
         },
       }),
     ).toThrow();
+  });
+});
+
+describe("SessionCompressResult", () => {
+  it("accepts current backend structured manual compression summaries", () => {
+    const parsed = SessionCompressResult.parse({
+      status: "compressed",
+      removed: 0,
+      before_messages: 0,
+      after_messages: 0,
+      before_tokens: 0,
+      after_tokens: 0,
+      summary: {
+        noop: true,
+        headline: "No changes from compression: 0 messages",
+        token_line: "Approx request size: ~0 tokens (unchanged)",
+        note: null,
+      },
+      usage: { total: 0, compressions: 0 },
+    });
+
+    expect(parsed.summary).toMatchObject({ noop: true });
+  });
+
+  it("keeps accepting older string summaries", () => {
+    const parsed = SessionCompressResult.parse({
+      status: "compressed",
+      summary: "Compressed: 20 → 8 messages",
+    });
+
+    expect(parsed.summary).toBe("Compressed: 20 → 8 messages");
   });
 });
 

--- a/packages/protocol/src/hermes-api.ts
+++ b/packages/protocol/src/hermes-api.ts
@@ -884,7 +884,12 @@ export const SessionCompressResult = z.object({
   after_messages: z.number().optional(),
   before_tokens: z.number().optional(),
   after_tokens: z.number().optional(),
-  summary: z.string().optional(),
+  // Core currently returns a structured manual-compression summary object
+  // ({ noop, headline, token_line, note }); older runtimes returned a string.
+  // The desktop UI derives its Chinese notice from the numeric before/after
+  // fields, so accept either shape instead of rejecting otherwise-successful
+  // /compress RPC results as "unrecognized".
+  summary: z.unknown().optional(),
   usage: SessionUsageResult.optional(),
 }).passthrough();
 export type SessionCompressResult = z.infer<typeof SessionCompressResult>;


### PR DESCRIPTION
## 变更内容

修复桌面端 composer 输入 `/compress` 后把成功的 `session.compress` 响应误判为“无法识别”的问题。

## 根因

当前 Core 返回的手动压缩 `summary` 已经是结构化对象，例如包含 `noop`、`headline`、`token_line` 和 `note` 字段；桌面端协议 schema 仍要求 `summary` 必须是字符串，导致 Zod 解析失败并展示通用的运行时不匹配错误。

## 影响

桌面端现在接受结构化或旧版字符串形式的 `summary`。中文提示仍由 before/after 消息数与 token 数生成，因此不会依赖后端英文摘要内容。

## 验证

已通过：

```bash
pnpm --filter @hermes/protocol test:unit -- hermes-api.test.ts
pnpm typecheck
pnpm test:unit
cargo check
```

并已启动 dev 桌面端供手动复测。