### PR TITLE
[codex] fix: 支持拖拽添加聊天附件

### DIFF
--- a/web/src/components/chat/goose-composer.tsx
+++ b/web/src/components/chat/goose-composer.tsx
@@ -570,7 +570,7 @@ export function GooseComposer({
   // recommended / more) from the catalog + usage log. Composer just hands it
   // the raw model.options payload and stays out of the way.
 
-  const appendAttachmentDrafts = (drafts: ComposerAttachment[]) => {
+  const appendAttachmentDrafts = useCallback((drafts: ComposerAttachment[]) => {
     if (!drafts.length) return;
     setAttachments((current) => {
       const existing = new Set(current.map(attachmentIdentity));
@@ -586,16 +586,16 @@ export function GooseComposer({
       }
       return additions.length ? [...current, ...additions] : current;
     });
-  };
+  }, []);
 
-  const addPathAttachments = (paths: string[]) => {
+  const addPathAttachments = useCallback((paths: string[]) => {
     const nextPaths = uniquePaths(paths);
     if (!nextPaths.length) return;
     setSubmitError("");
     appendAttachmentDrafts(nextPaths.map((path, index) => createPathAttachment(path, index)));
-  };
+  }, [appendAttachmentDrafts]);
 
-  const addBrowserFiles = (files: File[] | FileList) => {
+  const addBrowserFiles = useCallback((files: File[] | FileList) => {
     const accepted: File[] = [];
     const rejected: string[] = [];
     for (const file of Array.from(files)) {
@@ -616,7 +616,41 @@ export function GooseComposer({
       setSubmitError("");
     }
     appendAttachmentDrafts(accepted.map((file, index) => createFileAttachment(file, index)));
-  };
+  }, [appendAttachmentDrafts]);
+
+  useEffect(() => {
+    const onFileDrop = window.hermesDesktop?.onFileDrop;
+    if (!onFileDrop) return;
+
+    return onFileDrop((payload) => {
+      if (payload.phase === "leave") {
+        dragDepthRef.current = 0;
+        setDragActive(false);
+        return;
+      }
+
+      if (controlsDisabled) {
+        dragDepthRef.current = 0;
+        setDragActive(false);
+        return;
+      }
+
+      if (payload.phase === "enter" || payload.phase === "over") {
+        setDragActive(true);
+        return;
+      }
+
+      if (payload.phase === "drop") {
+        dragDepthRef.current = 0;
+        setDragActive(false);
+        if (payload.paths.length) {
+          addPathAttachments(payload.paths);
+        } else {
+          setSubmitError("未能读取拖拽文件路径，请使用 + 按钮添加附件。");
+        }
+      }
+    });
+  }, [addPathAttachments, controlsDisabled]);
 
   const pickFiles = async () => {
     if (controlsDisabled) return;

--- a/web/src/lib/runtime.ts
+++ b/web/src/lib/runtime.ts
@@ -254,6 +254,15 @@ export interface PreviewFileChangedPayload {
   path: string;
 }
 
+export interface DesktopFileDropPayload {
+  phase: "enter" | "over" | "drop" | "leave";
+  paths: string[];
+  position?: {
+    x: number;
+    y: number;
+  };
+}
+
 declare global {
   interface Window {
     __HERMES_SESSION_TOKEN__?: string;
@@ -330,6 +339,7 @@ declare global {
       watchPreviewFile?(input: { path: string }): Promise<WatchPreviewFileResult>;
       stopPreviewFileWatch?(input: { watchId: string }): Promise<boolean>;
       onPreviewFileChanged?(handler: (payload: PreviewFileChangedPayload) => void): () => void;
+      onFileDrop?(handler: (payload: DesktopFileDropPayload) => void): () => void;
       onSystemResume?(handler: () => void): () => void;
     };
   }

--- a/web/src/lib/tauri-bridge.test.ts
+++ b/web/src/lib/tauri-bridge.test.ts
@@ -7,13 +7,34 @@ import {
 } from "./tauri-bridge";
 
 const mockInvoke = vi.fn();
+const mockFileDropUnlisten = vi.fn();
+let fileDropHandler: ((event: {
+  payload: {
+    type: "enter" | "over" | "drop" | "leave";
+    paths?: string[];
+    position?: { x: number; y: number };
+  };
+}) => void) | null = null;
+const mockOnDragDropEvent = vi.fn((handler: NonNullable<typeof fileDropHandler>) => {
+  fileDropHandler = handler;
+  return Promise.resolve(mockFileDropUnlisten);
+});
 
 vi.mock("@tauri-apps/api/core", () => ({
   invoke: mockInvoke,
 }));
 
+vi.mock("@tauri-apps/api/webview", () => ({
+  getCurrentWebview: () => ({
+    onDragDropEvent: mockOnDragDropEvent,
+  }),
+}));
+
 beforeEach(() => {
   mockInvoke.mockReset();
+  mockFileDropUnlisten.mockReset();
+  mockOnDragDropEvent.mockClear();
+  fileDropHandler = null;
   mockInvoke.mockImplementation((command: string, args?: unknown) => {
     if (command === "get_runtime_config") {
       return Promise.resolve({
@@ -129,6 +150,41 @@ describe("isTauriDevMode", () => {
     expect(mockInvoke).toHaveBeenCalledWith("terminal_open_external", {
       input: { purpose: "gatewaySetup" },
     });
+  });
+
+  it("exposes native Tauri file drop events through the desktop bridge", async () => {
+    await installTauriBridge();
+
+    const received: unknown[] = [];
+    const unsubscribe = window.hermesDesktop?.onFileDrop?.((payload) => {
+      received.push(payload);
+    });
+    await new Promise((resolve) => setTimeout(resolve, 0));
+
+    expect(mockOnDragDropEvent).toHaveBeenCalledTimes(1);
+
+    fileDropHandler?.({
+      payload: { type: "enter", paths: ["/Users/alice/a.txt"], position: { x: 10, y: 20 } },
+    });
+    fileDropHandler?.({
+      payload: { type: "over", position: { x: 11, y: 21 } },
+    });
+    fileDropHandler?.({
+      payload: { type: "drop", paths: ["/Users/alice/a.txt"], position: { x: 12, y: 22 } },
+    });
+    fileDropHandler?.({
+      payload: { type: "leave" },
+    });
+
+    expect(received).toEqual([
+      { phase: "enter", paths: ["/Users/alice/a.txt"], position: { x: 10, y: 20 } },
+      { phase: "over", paths: [], position: { x: 11, y: 21 } },
+      { phase: "drop", paths: ["/Users/alice/a.txt"], position: { x: 12, y: 22 } },
+      { phase: "leave", paths: [], position: undefined },
+    ]);
+
+    unsubscribe?.();
+    expect(mockFileDropUnlisten).toHaveBeenCalledTimes(1);
   });
 
   it("normalizes structured Tauri IPC errors while preserving code and kind", () => {

--- a/web/src/lib/tauri-bridge.ts
+++ b/web/src/lib/tauri-bridge.ts
@@ -45,6 +45,7 @@ import type {
 import type {
   DesktopNotifyInput,
   DesktopNotifyResult,
+  DesktopFileDropPayload,
   FilePreview,
   PreviewFileChangedPayload,
   ReadWorkspaceFileInput,
@@ -72,6 +73,17 @@ export function isTauriDevMode(envDev = import.meta.env.DEV): boolean {
 
 const BASE64_CHUNK_SIZE = 0x8000;
 const BOOTSTRAP_LOGO_BLUE_RGB = "0,95,249";
+
+type TauriFileDropPosition = {
+  x: number;
+  y: number;
+};
+
+type TauriFileDropEventPayload =
+  | { type: "enter"; paths?: string[]; position?: TauriFileDropPosition }
+  | { type: "over"; position?: TauriFileDropPosition }
+  | { type: "drop"; paths?: string[]; position?: TauriFileDropPosition }
+  | { type: "leave" };
 
 interface BootstrapVersionLine {
   label: "界面";
@@ -150,6 +162,16 @@ async function invokeCommand<T = any>(command: string, args?: Record<string, unk
   }
 }
 
+function normalizeFileDropPayload(payload: TauriFileDropEventPayload): DesktopFileDropPayload {
+  return {
+    phase: payload.type,
+    paths: "paths" in payload && Array.isArray(payload.paths) ? payload.paths : [],
+    position: "position" in payload && payload.position
+      ? { x: payload.position.x, y: payload.position.y }
+      : undefined,
+  };
+}
+
 const tauriBridge = {
   windowType: "tauri" as const,
 
@@ -183,6 +205,32 @@ const tauriBridge = {
 
   async createWorkspaceProject(): Promise<FilePickerResult> {
     return invokeCommand("create_workspace_project");
+  },
+
+  onFileDrop(handler: (payload: DesktopFileDropPayload) => void): () => void {
+    let unlisten: (() => void) | null = null;
+    let disposed = false;
+
+    import("@tauri-apps/api/webview")
+      .then(({ getCurrentWebview }) =>
+        getCurrentWebview().onDragDropEvent((event) => {
+          handler(normalizeFileDropPayload(event.payload as TauriFileDropEventPayload));
+        }))
+      .then((fn) => {
+        if (disposed) {
+          fn();
+        } else {
+          unlisten = fn;
+        }
+      })
+      .catch((error) => {
+        console.warn("Failed to register Tauri file drop handler", error);
+      });
+
+    return () => {
+      disposed = true;
+      unlisten?.();
+    };
   },
 
   async openWorkspacePath(input: { path: string }): Promise<ApiRequestResult> {


### PR DESCRIPTION
## 变更

修复 macOS 社区桌面端聊天窗口无法通过 Finder 拖拽添加文件的问题。Tauri 桥接层现在会订阅原生 webview 文件拖拽事件，并把文件路径转成统一的 `onFileDrop` 回调；聊天输入框收到 drop 后复用现有 path 附件逻辑，因此与点击 `+` 选择文件走同一条发送处理链路。

## 原因

Tauri 默认会接管系统文件拖拽，Finder 拖入窗口时前端 HTML5 `drop` 事件在打包/桌面环境下无法稳定拿到文件路径，导致已有 DOM drop 逻辑没有可附加的附件。

## 验证

- `pnpm typecheck`
- `pnpm test:unit`
- `cargo check`

Fixes #186