### PR TITLE
[codex] 调整侧栏最近对话和语音提示

### DIFF
--- a/web/src/components/app-shell/workbench-sidebar.module.css
+++ b/web/src/components/app-shell/workbench-sidebar.module.css
@@ -223,6 +223,7 @@
 }
 
 .sessionRow {
+  position: relative;
   padding: 8px 16px 8px 18px;
   border-left: 2px solid transparent;
   cursor: pointer;
@@ -254,13 +255,14 @@
 }
 
 .rowMore {
-  flex-shrink: 0;
+  position: absolute;
+  top: 7px;
+  right: 16px;
   display: inline-flex;
   align-items: center;
   justify-content: center;
   width: 22px;
   height: 22px;
-  margin-top: -1px;
   padding: 0;
   border: none;
   border-radius: 4px;
@@ -289,6 +291,7 @@
 }
 
 .ttl {
+  box-sizing: border-box;
   font-size: 12.5px;
   color: var(--h-text);
   white-space: nowrap;
@@ -298,6 +301,7 @@
   width: 100%;
   min-width: 0;
   overflow: visible;
+  padding-right: 30px;
 }
 
 .ttlText {

--- a/web/src/lib/sidebar-session-lists.test.ts
+++ b/web/src/lib/sidebar-session-lists.test.ts
@@ -38,7 +38,7 @@ describe("deriveSidebarSessionLists", () => {
     expect(lists.pinned.map((item) => item.id)).toEqual(["s3", "s1"]);
   });
 
-  it("limits recent sessions to five by last activity time", () => {
+  it("limits recent sessions to eight by last activity time", () => {
     const lists = deriveSidebarSessionLists(
       [
         session("s1", 1),
@@ -47,12 +47,15 @@ describe("deriveSidebarSessionLists", () => {
         session("s4", 4),
         session("s5", 5),
         session("s6", 6),
+        session("s7", 7),
+        session("s8", 8),
+        session("s9", 9),
       ],
       [],
       () => false,
     );
 
-    expect(lists.recent.map((item) => item.id)).toEqual(["s6", "s5", "s4", "s3", "s2"]);
+    expect(lists.recent.map((item) => item.id)).toEqual(["s9", "s8", "s7", "s6", "s5", "s4", "s3", "s2"]);
   });
 
   it("uses started time for active sessions and keeps running sessions out of recent", () => {

--- a/web/src/lib/sidebar-session-lists.ts
+++ b/web/src/lib/sidebar-session-lists.ts
@@ -1,6 +1,6 @@
 import type { SessionSummary } from "@hermes/protocol";
 
-export const RECENT_SESSION_LIMIT = 5;
+export const RECENT_SESSION_LIMIT = 8;
 
 export function lastActivitySec(session: SessionSummary): number {
   return session.ended_at ?? session.started_at;

--- a/web/src/lib/voice-config.ts
+++ b/web/src/lib/voice-config.ts
@@ -7,6 +7,7 @@ export interface VoiceProviderMeta {
   id: string;
   label: string;
   description: string;
+  notice?: string;
   envKey?: string;
   configKeys: readonly string[];
   local?: boolean;
@@ -78,7 +79,8 @@ const TTS_PROVIDER_META: Record<string, VoiceProviderMeta> = {
   edge: {
     id: "edge",
     label: "Edge TTS",
-    description: "Microsoft Edge 神经网络语音，免费，不需要 API Key。",
+    description: "Microsoft Edge 神经网络语音，免费，不需要 API Key，但需要 edge-tts 依赖。",
+    notice: "备注：Edge TTS 不是 macOS 系统或 Microsoft Edge 浏览器自带能力；当前运行环境需要能调用 edge-tts 依赖。若测试朗读提示 edge-tts 不可用，请安装依赖或切换 OpenAI、ElevenLabs、NeuTTS。",
     local: true,
     configKeys: ["tts.edge.voice"],
   },
@@ -284,4 +286,3 @@ export function envConfigured(envVars: Record<string, EnvVarInfo> | undefined, k
   if (!key) return true;
   return Boolean(envVars?.[key]?.is_set);
 }
-

--- a/web/src/lib/voice.ts
+++ b/web/src/lib/voice.ts
@@ -153,7 +153,7 @@ export function voiceErrorMessage(error: unknown, fallback: string): string {
     return "语音识别尚未配置可用提供方。请到“语音”设置选择本地识别，或填写 Groq、OpenAI、xAI、ElevenLabs 的 API Key。";
   }
   if (lower.includes("no tts provider available")) {
-    return "回复朗读尚未配置可用的语音合成提供方。请到“语音”设置选择 Edge TTS、OpenAI、ElevenLabs 或本地 TTS。";
+    return "回复朗读尚未配置可用的语音合成提供方。请到“语音”设置选择 Edge TTS（需 edge-tts 依赖）、OpenAI、ElevenLabs 或本地 TTS。";
   }
   if (lower.includes("groq_api_key")) {
     return "Groq 语音识别需要配置 GROQ_API_KEY，请到“语音”设置填写 API Key。";
@@ -168,7 +168,7 @@ export function voiceErrorMessage(error: unknown, fallback: string): string {
     return "xAI 语音识别需要配置 XAI_API_KEY 或完成 xAI OAuth，请到“语音”设置填写 API Key。";
   }
   if (lower.includes("edge-tts")) {
-    return "Edge TTS 本地依赖不可用，请安装 edge-tts，或到“语音”设置切换其它朗读提供方。";
+    return "Edge TTS 依赖不可用；macOS 不自带 edge-tts，请安装该依赖，或到“语音”设置切换其它朗读提供方。";
   }
   if (lower.includes("faster-whisper") || lower.includes("hermes_local_stt_command")) {
     return "本地语音识别依赖不可用，请安装 faster-whisper、本地 whisper CLI，或到“语音”设置切换云端识别提供方。";

--- a/web/src/routes/voice.module.css
+++ b/web/src/routes/voice.module.css
@@ -162,6 +162,17 @@
   line-height: 1.55;
 }
 
+.providerNotice {
+  margin: 0 0 14px;
+  padding: 9px 10px;
+  border: 1px solid color-mix(in srgb, var(--h-warn) 28%, var(--h-line));
+  border-radius: 10px;
+  background: color-mix(in srgb, var(--h-warn) 8%, var(--h-bg-pane));
+  color: var(--h-text-2);
+  font-size: 11px;
+  line-height: 1.65;
+}
+
 .badge {
   display: inline-block;
   flex: 0 1 auto;

--- a/web/src/routes/voice.test.tsx
+++ b/web/src/routes/voice.test.tsx
@@ -80,5 +80,24 @@ describe("VoiceSettingsView", () => {
     expect(html).toContain("Rachel (premade)");
     expect(html).toContain("保存配置");
   });
-});
 
+  it("renders a macOS dependency note for Edge TTS", () => {
+    const draft = voiceSettingsDraftFromConfig({
+      stt: { enabled: true, provider: "local" },
+      tts: { provider: "edge", edge: { voice: "en-US-AriaNeural" } },
+      voice: { auto_tts: false, max_recording_seconds: 120 },
+    });
+    const html = ReactDOMServer.renderToStaticMarkup(
+      <VoiceSettingsView
+        draft={draft}
+        schema={schema}
+        envVars={envVars}
+        sttProviders={voiceProviderOptions("stt", schema, draft.sttProvider)}
+        ttsProviders={voiceProviderOptions("tts", schema, draft.ttsProvider)}
+      />,
+    );
+
+    expect(html).toContain("Edge TTS 不是 macOS");
+    expect(html).toContain("edge-tts");
+  });
+});

--- a/web/src/routes/voice.tsx
+++ b/web/src/routes/voice.tsx
@@ -333,6 +333,10 @@ export function VoiceSettingsView({
             onDraftChange={onDraftChange}
           />
 
+          {ttsProvider?.notice ? (
+            <p className={s.providerNotice}>{ttsProvider.notice}</p>
+          ) : null}
+
           <div className={s.field}>
             <label htmlFor="voice-tts-sample">朗读测试文本</label>
             <textarea


### PR DESCRIPTION
## 变更

这次调整左侧边栏最近对话展示、会话行右侧对齐，以及语音配置页的 Edge TTS 说明。

## 影响

最近对话从 5 条扩展到 8 条；三点菜单不再占用会话主内容宽度，工作区名称可以和右侧按钮边界对齐；Edge TTS 文案明确提示 macOS 和 Microsoft Edge 浏览器不自带 `edge-tts` 依赖。

## 验证

已运行 `pnpm typecheck`、`pnpm test:unit`、`cargo check`，并本地启动桌面端查看样式效果。