### PR TITLE
[codex] 补齐富链接和图片存图能力

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -130,6 +130,27 @@ dependencies = [
 ]
 
 [[package]]
+name = "arboard"
+version = "3.6.1"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "0348a1c054491f4bfe6ab86a7b6ab1e44e45d899005de92f58b3df180b36ddaf"
+dependencies = [
+ "clipboard-win",
+ "image",
+ "log",
+ "objc2",
+ "objc2-app-kit",
+ "objc2-core-foundation",
+ "objc2-core-graphics",
+ "objc2-foundation",
+ "parking_lot",
+ "percent-encoding",
+ "windows-sys 0.60.2",
+ "wl-clipboard-rs",
+ "x11rb",
+]
+
+[[package]]
 name = "assert-json-diff"
 version = "2.0.2"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -433,6 +454,12 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "1fd0f2584146f6f2ef48085050886acf353beff7305ebd1ae69500e27c67f64b"
 
 [[package]]
+name = "byteorder-lite"
+version = "0.1.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "8f1fe948ff07f4bd06c30984e69f5b4899c516a3ef74f34df92a2df2ab535495"
+
+[[package]]
 name = "bytes"
 version = "1.11.1"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -607,6 +634,15 @@ dependencies = [
 ]
 
 [[package]]
+name = "clipboard-win"
+version = "5.4.1"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "bde03770d3df201d4fb868f2c9c59e66a3e4e2bd06692a0fe701e7103c7e84d4"
+dependencies = [
+ "error-code",
+]
+
+[[package]]
 name = "colorchoice"
 version = "1.0.5"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -740,6 +776,12 @@ name = "crossbeam-utils"
 version = "0.8.21"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "d0a5c400df2834b80a4c3327b3aad3a4c4cd4de0629063962b03235697506a28"
+
+[[package]]
+name = "crunchy"
+version = "0.2.4"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "460fbee9c2c2f33933d720630a6a0bac33ba7053db5344fac858d4b8952d77d5"
 
 [[package]]
 name = "crypto-common"
@@ -1229,6 +1271,12 @@ dependencies = [
 ]
 
 [[package]]
+name = "error-code"
+version = "3.3.2"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "dea2df4cf52843e0452895c455a1a2cfbb842a1e7329671acf418fdc53ed4c59"
+
+[[package]]
 name = "event-listener"
 version = "5.4.1"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -1266,6 +1314,12 @@ name = "fastrand"
 version = "2.4.1"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "9f1f227452a390804cdb637b74a86990f2a7d7ba4b7d5693aac9b4dd6defd8d6"
+
+[[package]]
+name = "fax"
+version = "0.2.7"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "caf1079563223d5d59d83c85886a56e586cfd5c1a26292e971a0fa266531ac5a"
 
 [[package]]
 name = "fdeflate"
@@ -1318,6 +1372,12 @@ name = "find-msvc-tools"
 version = "0.1.9"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "5baebc0774151f905a1a2cc41989300b1e6fbb29aff0ceffa1064fdd3088d582"
+
+[[package]]
+name = "fixedbitset"
+version = "0.5.7"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "1d674e81391d1e1ab681a28d99df07927c6d4aa5b027d7da16ba32d1d21ecd99"
 
 [[package]]
 name = "flate2"
@@ -1613,6 +1673,16 @@ dependencies = [
 ]
 
 [[package]]
+name = "gethostname"
+version = "1.1.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "1bd49230192a3797a9a4d6abe9b3eed6f7fa4c8a8a4947977c6f80025f92cbd8"
+dependencies = [
+ "rustix",
+ "windows-link 0.2.1",
+]
+
+[[package]]
 name = "getrandom"
 version = "0.2.17"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -1820,6 +1890,17 @@ dependencies = [
 ]
 
 [[package]]
+name = "half"
+version = "2.7.1"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "6ea2d84b969582b4b1864a92dc5d27cd2b77b622a8d79306834f1be5ba20d84b"
+dependencies = [
+ "cfg-if",
+ "crunchy",
+ "zerocopy",
+]
+
+[[package]]
 name = "hashbrown"
 version = "0.12.3"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -1899,6 +1980,7 @@ dependencies = [
  "sha2",
  "tauri",
  "tauri-build",
+ "tauri-plugin-clipboard-manager",
  "tauri-plugin-dialog",
  "tauri-plugin-notification",
  "tempfile",
@@ -2197,6 +2279,20 @@ checksum = "cb68373c0d6620ef8105e855e7745e18b0d00d3bdb07fb532e434244cdb9a714"
 dependencies = [
  "icu_normalizer",
  "icu_properties",
+]
+
+[[package]]
+name = "image"
+version = "0.25.10"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "85ab80394333c02fe689eaf900ab500fbd0c2213da414687ebf995a65d5a6104"
+dependencies = [
+ "bytemuck",
+ "byteorder-lite",
+ "moxcms",
+ "num-traits",
+ "png 0.18.1",
+ "tiff",
 ]
 
 [[package]]
@@ -2686,6 +2782,16 @@ dependencies = [
 ]
 
 [[package]]
+name = "moxcms"
+version = "0.8.1"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "bb85c154ba489f01b25c0d36ae69a87e4a1c73a72631fc6c0eb6dde34a73e44b"
+dependencies = [
+ "num-traits",
+ "pxfm",
+]
+
+[[package]]
 name = "muda"
 version = "0.19.1"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -2746,6 +2852,15 @@ dependencies = [
  "cfg-if",
  "cfg_aliases 0.1.1",
  "libc",
+]
+
+[[package]]
+name = "nom"
+version = "8.0.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "df9761775871bdef83bee530e60050f7e54b1105350d6884eb0fb4f46c2f9405"
+dependencies = [
+ "memchr",
 ]
 
 [[package]]
@@ -2848,6 +2963,7 @@ dependencies = [
  "block2",
  "objc2",
  "objc2-core-foundation",
+ "objc2-core-graphics",
  "objc2-foundation",
 ]
 
@@ -3064,6 +3180,16 @@ dependencies = [
 ]
 
 [[package]]
+name = "os_pipe"
+version = "1.2.3"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "7d8fae84b431384b68627d0f9b3b1245fcf9f46f6c0e3dc902e9dce64edd1967"
+dependencies = [
+ "libc",
+ "windows-sys 0.61.2",
+]
+
+[[package]]
 name = "pango"
 version = "0.18.3"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -3147,6 +3273,17 @@ name = "percent-encoding"
 version = "2.3.2"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "9b4f627cb1b25917193a259e49bdad08f671f8d9708acfd5fe0a8c1455d87220"
+
+[[package]]
+name = "petgraph"
+version = "0.8.3"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "8701b58ea97060d5e5b155d383a69952a60943f0e6dfe30b04c287beb0b27455"
+dependencies = [
+ "fixedbitset",
+ "hashbrown 0.15.5",
+ "indexmap 2.14.0",
+]
 
 [[package]]
 name = "phf"
@@ -3434,6 +3571,18 @@ checksum = "8fd00f0bb2e90d81d1044c2b32617f68fcb9fa3bb7640c23e9c748e53fb30934"
 dependencies = [
  "unicode-ident",
 ]
+
+[[package]]
+name = "pxfm"
+version = "0.1.29"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "e0c5ccf5294c6ccd63a74f1565028353830a9c2f5eb0c682c355c471726a6e3f"
+
+[[package]]
+name = "quick-error"
+version = "2.0.1"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "a993555f31e5a609f617c12db6250dedcac1b0a85076912c436e6fc9b2c8e6a3"
 
 [[package]]
 name = "quick-xml"
@@ -4611,6 +4760,21 @@ dependencies = [
 ]
 
 [[package]]
+name = "tauri-plugin-clipboard-manager"
+version = "2.3.2"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "206dc20af4ed210748ba945c2774e60fd0acd52b9a73a028402caf809e9b6ecf"
+dependencies = [
+ "arboard",
+ "log",
+ "serde",
+ "serde_json",
+ "tauri",
+ "tauri-plugin",
+ "thiserror 2.0.18",
+]
+
+[[package]]
 name = "tauri-plugin-dialog"
 version = "2.7.1"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -4844,6 +5008,20 @@ dependencies = [
  "proc-macro2",
  "quote",
  "syn 2.0.117",
+]
+
+[[package]]
+name = "tiff"
+version = "0.11.3"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "b63feaf3343d35b6ca4d50483f94843803b0f51634937cc2ec519fc32232bc52"
+dependencies = [
+ "fax",
+ "flate2",
+ "half",
+ "quick-error",
+ "weezl",
+ "zune-jpeg",
 ]
 
 [[package]]
@@ -5185,6 +5363,17 @@ dependencies = [
  "serde",
  "thiserror 2.0.18",
  "windows-sys 0.61.2",
+]
+
+[[package]]
+name = "tree_magic_mini"
+version = "3.2.2"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "b8765b90061cba6c22b5831f675da109ae5561588290f9fa2317adab2714d5a6"
+dependencies = [
+ "memchr",
+ "nom",
+ "petgraph",
 ]
 
 [[package]]
@@ -5563,6 +5752,76 @@ dependencies = [
 ]
 
 [[package]]
+name = "wayland-backend"
+version = "0.3.15"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "2857dd20b54e916ec7253b3d6b4d5c4d7d4ca2c33c2e11c6c76a99bd8744755d"
+dependencies = [
+ "cc",
+ "downcast-rs",
+ "rustix",
+ "smallvec",
+ "wayland-sys",
+]
+
+[[package]]
+name = "wayland-client"
+version = "0.31.14"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "645c7c96bb74690c3189b5c9cb4ca1627062bb23693a4fad9d8c3de958260144"
+dependencies = [
+ "bitflags 2.11.1",
+ "rustix",
+ "wayland-backend",
+ "wayland-scanner",
+]
+
+[[package]]
+name = "wayland-protocols"
+version = "0.32.12"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "563a85523cade2429938e790815fd7319062103b9f4a2dc806e9b53b95982d8f"
+dependencies = [
+ "bitflags 2.11.1",
+ "wayland-backend",
+ "wayland-client",
+ "wayland-scanner",
+]
+
+[[package]]
+name = "wayland-protocols-wlr"
+version = "0.3.12"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "eb04e52f7836d7c7976c78ca0250d61e33873c34156a2a1fc9474828ec268234"
+dependencies = [
+ "bitflags 2.11.1",
+ "wayland-backend",
+ "wayland-client",
+ "wayland-protocols",
+ "wayland-scanner",
+]
+
+[[package]]
+name = "wayland-scanner"
+version = "0.31.10"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "9c324a910fd86ebdc364a3e61ec1f11737d3b1d6c273c0239ee8ff4bc0d24b4a"
+dependencies = [
+ "proc-macro2",
+ "quick-xml 0.39.4",
+ "quote",
+]
+
+[[package]]
+name = "wayland-sys"
+version = "0.31.11"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "d8eab23fefc9e41f8e841df4a9c707e8a8c4ed26e944ef69297184de2785e3be"
+dependencies = [
+ "pkg-config",
+]
+
+[[package]]
 name = "web-sys"
 version = "0.3.98"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -5691,6 +5950,12 @@ dependencies = [
  "windows",
  "windows-core 0.61.2",
 ]
+
+[[package]]
+name = "weezl"
+version = "0.1.12"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "a28ac98ddc8b9274cb41bb4d9d4d5c425b6020c50c46f25559911905610b4a88"
 
 [[package]]
 name = "winapi"
@@ -6353,6 +6618,24 @@ dependencies = [
 ]
 
 [[package]]
+name = "wl-clipboard-rs"
+version = "0.9.3"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "e9651471a32e87d96ef3a127715382b2d11cc7c8bb9822ded8a7cc94072eb0a3"
+dependencies = [
+ "libc",
+ "log",
+ "os_pipe",
+ "rustix",
+ "thiserror 2.0.18",
+ "tree_magic_mini",
+ "wayland-backend",
+ "wayland-client",
+ "wayland-protocols",
+ "wayland-protocols-wlr",
+]
+
+[[package]]
 name = "writeable"
 version = "0.6.3"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -6422,6 +6705,23 @@ dependencies = [
  "once_cell",
  "pkg-config",
 ]
+
+[[package]]
+name = "x11rb"
+version = "0.13.2"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "9993aa5be5a26815fe2c3eacfc1fde061fc1a1f094bf1ad2a18bf9c495dd7414"
+dependencies = [
+ "gethostname",
+ "rustix",
+ "x11rb-protocol",
+]
+
+[[package]]
+name = "x11rb-protocol"
+version = "0.13.2"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "ea6fc2961e4ef194dcbfe56bb845534d0dc8098940c7e5c012a258bfec6701bd"
 
 [[package]]
 name = "xz2"
@@ -6690,6 +6990,21 @@ checksum = "91e19ebc2adc8f83e43039e79776e3fda8ca919132d68a1fed6a5faca2683748"
 dependencies = [
  "cc",
  "pkg-config",
+]
+
+[[package]]
+name = "zune-core"
+version = "0.5.1"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "cb8a0807f7c01457d0379ba880ba6322660448ddebc890ce29bb64da71fb40f9"
+
+[[package]]
+name = "zune-jpeg"
+version = "0.5.15"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "27bc9d5b815bc103f142aa054f561d9187d191692ec7c2d1e2b4737f8dbd7296"
+dependencies = [
+ "zune-core",
 ]
 
 [[package]]

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -52,6 +52,7 @@ getrandom = "0.3"
 # Parse $HERMES_HOME/.env for per-spawn child env injection (src/env_file.rs).
 # Only from_path_iter is used — the desktop process env is never mutated.
 dotenvy = "0.15"
+tauri-plugin-clipboard-manager = "2.3.2"
 
 [target.'cfg(target_os = "windows")'.dependencies]
 windows-sys = { version = "0.61", features = [

--- a/capabilities/default.json
+++ b/capabilities/default.json
@@ -7,6 +7,7 @@
     "core:default",
     "core:window:allow-start-dragging",
     "dialog:default",
-    "dialog:allow-open"
+    "dialog:allow-open",
+    "clipboard-manager:allow-read-image"
   ]
 }

--- a/pnpm-lock.yaml
+++ b/pnpm-lock.yaml
@@ -94,6 +94,9 @@ importers:
       '@tanstack/react-query':
         specifier: ^5.100.5
         version: 5.100.10(react@19.2.6)
+      '@tauri-apps/plugin-clipboard-manager':
+        specifier: ^2.3.2
+        version: 2.3.2
       '@xterm/addon-fit':
         specifier: ^0.11.0
         version: 0.11.0
@@ -1041,6 +1044,9 @@ packages:
     resolution: {integrity: sha512-rpEbaJ/HzNb6fwsquwoAbq29/Vt4gADhS423A8fdkwL4edJ0wZmoB8ar7O6JPDL834MUKOCm/rrJ7c9oAaEaYQ==}
     engines: {node: '>= 10'}
     hasBin: true
+
+  '@tauri-apps/plugin-clipboard-manager@2.3.2':
+    resolution: {integrity: sha512-CUlb5Hqi2oZbcZf4VUyUH53XWPPdtpw43EUpCza5HWZJwxEoDowFzNUDt1tRUXA8Uq+XPn17Ysfptip33sG4eQ==}
 
   '@types/babel__core@7.20.5':
     resolution: {integrity: sha512-qoQprZvz5wQFJwMDqeseRXWv3rqMvhgpbXFfVyWhbx9X47POIA6i/+dXefEmZKoAgOaTdaIgNSMqMIU61yRyzA==}
@@ -3248,6 +3254,10 @@ snapshots:
       '@tauri-apps/cli-win32-arm64-msvc': 2.11.1
       '@tauri-apps/cli-win32-ia32-msvc': 2.11.1
       '@tauri-apps/cli-win32-x64-msvc': 2.11.1
+
+  '@tauri-apps/plugin-clipboard-manager@2.3.2':
+    dependencies:
+      '@tauri-apps/api': 2.11.0
 
   '@types/babel__core@7.20.5':
     dependencies:

--- a/src/commands/api_proxy.rs
+++ b/src/commands/api_proxy.rs
@@ -12,6 +12,7 @@ use std::net::IpAddr;
 use std::sync::LazyLock;
 use std::time::Duration;
 
+use futures_util::StreamExt;
 use serde::{Deserialize, Serialize};
 use tauri::State;
 
@@ -29,6 +30,8 @@ const DASHBOARD_AUDIO_PROXY_TIMEOUT: Duration = Duration::from_secs(180);
 const UPLOAD_TIMEOUT: Duration = Duration::from_secs(60);
 const MAX_UPLOAD_BYTES: usize = 100 * 1024 * 1024;
 const MAX_UPLOAD_BASE64_LEN: usize = MAX_UPLOAD_BYTES.div_ceil(3) * 4;
+const MAX_EXTERNAL_IMAGE_BYTES: usize = 20 * 1024 * 1024;
+const MAX_EXTERNAL_IMAGE_REDIRECTS: usize = 5;
 static DASHBOARD_PROXY_HTTP_CLIENT: LazyLock<reqwest::Client> = LazyLock::new(|| {
     reqwest::Client::builder()
         .timeout(DASHBOARD_PROXY_TIMEOUT)
@@ -77,6 +80,22 @@ pub struct ApiRequestResult {
     pub body: String,
 }
 
+#[derive(Clone, Debug, Deserialize)]
+#[serde(rename_all = "camelCase")]
+pub struct DownloadExternalImageInput {
+    pub url: String,
+}
+
+#[derive(Debug, Serialize)]
+#[serde(rename_all = "camelCase")]
+pub struct DownloadExternalImageResult {
+    pub final_url: String,
+    pub filename: String,
+    pub mime_type: String,
+    pub data_base64: String,
+    pub size: usize,
+}
+
 fn json_result(status: u16, status_text: &str, body: serde_json::Value) -> ApiRequestResult {
     let mut headers = HashMap::new();
     headers.insert("content-type".to_string(), "application/json".to_string());
@@ -106,6 +125,13 @@ fn upload_limit_error() -> AppError {
     AppError::InvalidRequest(format!(
         "upload_file exceeds {} MiB limit",
         MAX_UPLOAD_BYTES / 1024 / 1024
+    ))
+}
+
+fn external_image_limit_error() -> AppError {
+    AppError::InvalidRequest(format!(
+        "download_external_image exceeds {} MiB limit",
+        MAX_EXTERNAL_IMAGE_BYTES / 1024 / 1024
     ))
 }
 
@@ -590,6 +616,219 @@ pub async fn api_request(
 pub async fn external_request(input: ApiRequestInput) -> Result<ApiRequestResult, AppError> {
     let target_url = validate_external_url(&input.path).await?;
     external_request_impl(input, target_url).await
+}
+
+fn image_mime_from_magic(bytes: &[u8]) -> Option<&'static str> {
+    if bytes.starts_with(&[0x89, b'P', b'N', b'G', b'\r', b'\n', 0x1a, b'\n']) {
+        return Some("image/png");
+    }
+    if bytes.starts_with(&[0xff, 0xd8, 0xff]) {
+        return Some("image/jpeg");
+    }
+    if bytes.starts_with(b"GIF87a") || bytes.starts_with(b"GIF89a") {
+        return Some("image/gif");
+    }
+    if bytes.len() >= 12 && bytes.starts_with(b"RIFF") && &bytes[8..12] == b"WEBP" {
+        return Some("image/webp");
+    }
+    if bytes.starts_with(b"BM") {
+        return Some("image/bmp");
+    }
+    if bytes.starts_with(b"II*\0") || bytes.starts_with(b"MM\0*") {
+        return Some("image/tiff");
+    }
+    None
+}
+
+fn image_extension(mime: &str) -> &'static str {
+    match mime
+        .split(';')
+        .next()
+        .unwrap_or("")
+        .trim()
+        .to_ascii_lowercase()
+        .as_str()
+    {
+        "image/jpeg" | "image/jpg" => "jpg",
+        "image/gif" => "gif",
+        "image/webp" => "webp",
+        "image/bmp" => "bmp",
+        "image/tiff" => "tiff",
+        "image/svg+xml" => "svg",
+        "image/avif" => "avif",
+        _ => "png",
+    }
+}
+
+fn content_type_mime(headers: &reqwest::header::HeaderMap) -> Option<String> {
+    headers
+        .get(reqwest::header::CONTENT_TYPE)
+        .and_then(|value| value.to_str().ok())
+        .map(|value| {
+            value
+                .split(';')
+                .next()
+                .unwrap_or("")
+                .trim()
+                .to_ascii_lowercase()
+        })
+        .filter(|value| !value.is_empty())
+}
+
+fn filename_from_url(url: &url::Url, mime_type: &str) -> String {
+    let ext = image_extension(mime_type);
+    let candidate = url
+        .path_segments()
+        .and_then(|mut segments| segments.next_back())
+        .map(str::trim)
+        .filter(|segment| !segment.is_empty())
+        .unwrap_or("external-image");
+    let safe: String = candidate
+        .chars()
+        .map(|ch| {
+            if ch.is_ascii_alphanumeric() || matches!(ch, '.' | '-' | '_') {
+                ch
+            } else {
+                '_'
+            }
+        })
+        .collect();
+    let safe = safe.trim_matches('.').trim_matches('_');
+    if safe.is_empty() {
+        return format!("external-image.{ext}");
+    }
+    if safe.rsplit_once('.').is_some_and(|(_, suffix)| {
+        (2..=8).contains(&suffix.len()) && suffix.chars().all(|ch| ch.is_ascii_alphanumeric())
+    }) {
+        safe.to_string()
+    } else {
+        format!("{safe}.{ext}")
+    }
+}
+
+async fn read_response_limited(
+    response: reqwest::Response,
+    limit: usize,
+) -> Result<Vec<u8>, AppError> {
+    if response
+        .content_length()
+        .is_some_and(|length| length > limit as u64)
+    {
+        return Err(external_image_limit_error());
+    }
+
+    let mut bytes = Vec::new();
+    let mut stream = response.bytes_stream();
+    while let Some(chunk) = stream.next().await {
+        let chunk = chunk.map_err(|e| {
+            AppError::InvalidRequest(format!("download_external_image failed: {}", e))
+        })?;
+        if bytes.len() + chunk.len() > limit {
+            return Err(external_image_limit_error());
+        }
+        bytes.extend_from_slice(&chunk);
+    }
+    Ok(bytes)
+}
+
+async fn next_redirect_url(
+    current: &url::Url,
+    response: &reqwest::Response,
+) -> Result<url::Url, AppError> {
+    let location = response
+        .headers()
+        .get(reqwest::header::LOCATION)
+        .and_then(|value| value.to_str().ok())
+        .ok_or_else(|| {
+            AppError::InvalidRequest(
+                "download_external_image redirect missing Location".to_string(),
+            )
+        })?;
+    let next = current.join(location)?;
+    validate_external_url(next.as_str()).await
+}
+
+pub async fn download_external_image_impl(
+    input: DownloadExternalImageInput,
+    mut target_url: url::Url,
+) -> Result<DownloadExternalImageResult, AppError> {
+    use base64::Engine;
+
+    for redirect_count in 0..=MAX_EXTERNAL_IMAGE_REDIRECTS {
+        let response = EXTERNAL_HTTP_CLIENT
+            .get(target_url.clone())
+            .header(
+                reqwest::header::ACCEPT,
+                "image/avif,image/webp,image/png,image/jpeg,image/gif,image/*;q=0.8,*/*;q=0.3",
+            )
+            .send()
+            .await
+            .map_err(|e| {
+                AppError::InvalidRequest(format!(
+                    "download_external_image failed for {}: {}",
+                    input.url, e
+                ))
+            })?;
+
+        if response.status().is_redirection() {
+            if redirect_count >= MAX_EXTERNAL_IMAGE_REDIRECTS {
+                return Err(AppError::InvalidRequest(
+                    "download_external_image followed too many redirects".to_string(),
+                ));
+            }
+            target_url = next_redirect_url(&target_url, &response).await?;
+            continue;
+        }
+
+        if !response.status().is_success() {
+            return Err(AppError::InvalidRequest(format!(
+                "download_external_image returned HTTP {}",
+                response.status().as_u16()
+            )));
+        }
+
+        let header_mime = content_type_mime(response.headers());
+        let bytes = read_response_limited(response, MAX_EXTERNAL_IMAGE_BYTES).await?;
+        let magic_mime = image_mime_from_magic(&bytes).map(str::to_string);
+        let mime_type = match (header_mime, magic_mime) {
+            // Trust explicit image/* for formats not covered by the small magic
+            // table (for example avif), but still reject empty bodies below.
+            (Some(header), _) if header.starts_with("image/") => header,
+            (_, Some(magic)) => magic,
+            _ => {
+                return Err(AppError::InvalidRequest(
+                    "download_external_image URL did not return image content".to_string(),
+                ));
+            }
+        };
+        if bytes.is_empty() {
+            return Err(AppError::InvalidRequest(
+                "download_external_image returned an empty image".to_string(),
+            ));
+        }
+        let filename = filename_from_url(&target_url, &mime_type);
+        return Ok(DownloadExternalImageResult {
+            final_url: target_url.to_string(),
+            filename,
+            mime_type,
+            data_base64: base64::engine::general_purpose::STANDARD.encode(bytes.as_slice()),
+            size: bytes.len(),
+        });
+    }
+
+    Err(AppError::InvalidRequest(
+        "download_external_image followed too many redirects".to_string(),
+    ))
+}
+
+/// Download a public image URL for use as a composer attachment. URL validation
+/// intentionally mirrors `external_request` and every redirect is revalidated.
+#[tauri::command]
+pub async fn download_external_image(
+    input: DownloadExternalImageInput,
+) -> Result<DownloadExternalImageResult, AppError> {
+    let target_url = validate_external_url(&input.url).await?;
+    download_external_image_impl(input, target_url).await
 }
 
 /// Core implementation of `external_request` with validation already handled by

--- a/src/main.rs
+++ b/src/main.rs
@@ -116,6 +116,7 @@ fn main() {
     let app = tauri::Builder::default()
         .plugin(tauri_plugin_dialog::init())
         .plugin(tauri_plugin_notification::init())
+        .plugin(tauri_plugin_clipboard_manager::init())
         .manage(app_state)
         .setup(move |app| {
             use tauri::Manager;
@@ -377,6 +378,7 @@ fn main() {
             commands::api_proxy::api_request,
             commands::api_proxy::external_request,
             commands::api_proxy::upload_file,
+            commands::api_proxy::download_external_image,
             commands::runtime_manager::runtime_info,
             commands::runtime_manager::runtime_check_update,
             commands::runtime_manager::runtime_install_update,

--- a/tests/api_proxy.rs
+++ b/tests/api_proxy.rs
@@ -21,8 +21,9 @@ use std::time::Duration;
 
 use base64::Engine;
 use hermes_agent_cn::commands::api_proxy::{
-    api_request_impl, api_request_impl_with_home_base, external_request, external_request_impl,
-    upload_file_impl, ApiRequestInput, UploadFileInput,
+    api_request_impl, api_request_impl_with_home_base, download_external_image_impl,
+    external_request, external_request_impl, upload_file_impl, ApiRequestInput,
+    DownloadExternalImageInput, UploadFileInput,
 };
 use hermes_agent_cn::error::AppError;
 use hermes_agent_cn::ui_store;
@@ -483,6 +484,159 @@ async fn external_request_command_allows_loopback_http() {
     assert_eq!(result.status, 200);
     assert_eq!(result.body, r#"{"data":[{"id":"local"}]}"#);
     assert!(result.ok);
+}
+
+// --- download_external_image -----------------------------------------------
+
+const TINY_PNG: &[u8] = &[
+    0x89, b'P', b'N', b'G', b'\r', b'\n', 0x1a, b'\n', 0, 0, 0, 0,
+];
+
+#[tokio::test]
+async fn download_external_image_succeeds_against_mock_server() {
+    let server = MockServer::start().await;
+    Mock::given(method("GET"))
+        .and(path("/img/logo.png"))
+        .respond_with(
+            ResponseTemplate::new(200)
+                .insert_header("content-type", "image/png")
+                .set_body_bytes(TINY_PNG),
+        )
+        .mount(&server)
+        .await;
+
+    let url = format!("{}/img/logo.png", server.uri());
+    let result = download_external_image_impl(
+        DownloadExternalImageInput { url: url.clone() },
+        url.parse().expect("valid URL"),
+    )
+    .await
+    .expect("ok");
+
+    assert_eq!(result.final_url, url);
+    assert_eq!(result.filename, "logo.png");
+    assert_eq!(result.mime_type, "image/png");
+    assert_eq!(result.size, TINY_PNG.len());
+    assert_eq!(
+        result.data_base64,
+        base64::engine::general_purpose::STANDARD.encode(TINY_PNG)
+    );
+}
+
+#[tokio::test]
+async fn download_external_image_rejects_non_image_content() {
+    let server = MockServer::start().await;
+    Mock::given(method("GET"))
+        .and(path("/page"))
+        .respond_with(
+            ResponseTemplate::new(200)
+                .insert_header("content-type", "text/html")
+                .set_body_string("<html>not image</html>"),
+        )
+        .mount(&server)
+        .await;
+
+    let url = format!("{}/page", server.uri());
+    let err = download_external_image_impl(
+        DownloadExternalImageInput { url: url.clone() },
+        url.parse().expect("valid URL"),
+    )
+    .await
+    .expect_err("non-image should be rejected");
+
+    assert!(
+        matches!(err, AppError::InvalidRequest(ref msg) if msg.contains("image content")),
+        "got {:?}",
+        err
+    );
+}
+
+#[tokio::test]
+async fn download_external_image_rejects_declared_oversize_content() {
+    let server = MockServer::start().await;
+    let mut huge = Vec::with_capacity((20 * 1024 * 1024) + 1);
+    huge.extend_from_slice(TINY_PNG);
+    huge.resize((20 * 1024 * 1024) + 1, 0);
+    Mock::given(method("GET"))
+        .and(path("/huge.png"))
+        .respond_with(
+            ResponseTemplate::new(200)
+                .insert_header("content-type", "image/png")
+                .set_body_bytes(huge),
+        )
+        .mount(&server)
+        .await;
+
+    let url = format!("{}/huge.png", server.uri());
+    let err = download_external_image_impl(
+        DownloadExternalImageInput { url: url.clone() },
+        url.parse().expect("valid URL"),
+    )
+    .await
+    .expect_err("oversize should be rejected");
+
+    assert!(
+        matches!(err, AppError::InvalidRequest(ref msg) if msg.contains("20 MiB")),
+        "got {:?}",
+        err
+    );
+}
+
+#[tokio::test]
+async fn download_external_image_follows_and_revalidates_redirects() {
+    let server = MockServer::start().await;
+    Mock::given(method("GET"))
+        .and(path("/start"))
+        .respond_with(ResponseTemplate::new(302).insert_header("location", "/final.webp"))
+        .mount(&server)
+        .await;
+    Mock::given(method("GET"))
+        .and(path("/final.webp"))
+        .respond_with(
+            ResponseTemplate::new(200)
+                .insert_header("content-type", "application/octet-stream")
+                .set_body_bytes(b"RIFF\x04\x00\x00\x00WEBP"),
+        )
+        .mount(&server)
+        .await;
+
+    let url = format!("{}/start", server.uri());
+    let result = download_external_image_impl(
+        DownloadExternalImageInput { url },
+        format!("{}/start", server.uri())
+            .parse()
+            .expect("valid URL"),
+    )
+    .await
+    .expect("redirected image should succeed");
+
+    assert_eq!(result.final_url, format!("{}/final.webp", server.uri()));
+    assert_eq!(result.mime_type, "image/webp");
+    assert_eq!(result.filename, "final.webp");
+}
+
+#[tokio::test]
+async fn download_external_image_reports_network_errors_readably() {
+    let port = {
+        let l = std::net::TcpListener::bind(("127.0.0.1", 0)).expect("bind ephemeral port");
+        let p = l.local_addr().unwrap().port();
+        drop(l);
+        p
+    };
+    let url = format!("http://127.0.0.1:{}/image.png", port);
+
+    let err = download_external_image_impl(
+        DownloadExternalImageInput { url: url.clone() },
+        url.parse().expect("valid URL"),
+    )
+    .await
+    .expect_err("unreachable target should fail");
+
+    assert!(
+        matches!(err, AppError::InvalidRequest(ref msg) if msg.contains("download_external_image failed")),
+        "got {:?}",
+        err
+    );
 }
 
 // --- upload_file -----------------------------------------------------------

--- a/web/package.json
+++ b/web/package.json
@@ -22,6 +22,7 @@
     "@streamdown/math": "^1.0.2",
     "@streamdown/mermaid": "^1.0.2",
     "@tanstack/react-query": "^5.100.5",
+    "@tauri-apps/plugin-clipboard-manager": "^2.3.2",
     "@xterm/addon-fit": "^0.11.0",
     "@xterm/addon-web-links": "^0.12.0",
     "@xterm/xterm": "^6.0.0",

--- a/web/src/components/chat/goose-composer.tsx
+++ b/web/src/components/chat/goose-composer.tsx
@@ -18,6 +18,7 @@ import {
   GitBranch,
   Globe,
   Folder,
+  ImagePlus,
   Loader2,
   MessageSquare,
   Mic,
@@ -101,6 +102,8 @@ import {
 import { WorkspacePickerModal } from "@/components/composer/workspace-picker";
 import { UrlDialog } from "@/components/composer/url-dialog";
 import { isSingleUrl, urlReferenceText } from "@/lib/composer-url";
+import { imageFileFromClipboardData, readClipboardImageAsFile } from "@/lib/clipboard-image";
+import { downloadExternalImageFile } from "@/lib/transport";
 import { ReasoningEffortMenu } from "@/components/composer/reasoning-effort-menu";
 import s from "./goose-composer.module.css";
 
@@ -674,6 +677,29 @@ export function GooseComposer({
     event.target.value = "";
   };
 
+  const attachClipboardImage = async () => {
+    if (controlsDisabled) return;
+    setSubmitError("");
+    try {
+      const file = await readClipboardImageAsFile();
+      if (!file) {
+        setSubmitError("剪贴板中没有可读取的图片。");
+        return;
+      }
+      addBrowserFiles([file]);
+    } catch (error) {
+      setSubmitError(messageFromError(error));
+    }
+  };
+
+  const attachImageFromUrl = async (imageUrl: string) => {
+    if (controlsDisabled) return;
+    setSubmitError("");
+    const file = await downloadExternalImageFile(imageUrl);
+    addBrowserFiles([file]);
+    setUrlDialog(null);
+  };
+
   const applyWorkspacePath = (path: string) => {
     const nextPath = normalizeWorkspacePath(path);
     if (!nextPath) return;
@@ -933,16 +959,25 @@ export function GooseComposer({
 
   const handlePaste = (event: ClipboardEvent<HTMLTextAreaElement>) => {
     if (controlsDisabled) return;
-    const files = Array.from(event.clipboardData.files);
-    if (files.length) {
+    const clipboardData = event.clipboardData;
+    const text = clipboardData.getData("text/plain");
+    const pastedImage = imageFileFromClipboardData(clipboardData);
+    if (pastedImage) {
       event.preventDefault();
-      addBrowserFiles(files);
+      addBrowserFiles([pastedImage]);
+      return;
+    }
+    if (!text) {
+      event.preventDefault();
+      void readClipboardImageAsFile(null).then((file) => {
+        if (!file) return;
+        addBrowserFiles([file]);
+      });
       return;
     }
     // A bare-URL paste offers to attach it as an `@url:` reference (only where
     // backend ref expansion is wired, i.e. a mention source is present).
     if (mentionPicker && !mentionPicker.disabled) {
-      const text = event.clipboardData.getData("text/plain");
       if (text && isSingleUrl(text)) {
         event.preventDefault();
         setUrlDialog({ url: text.trim(), start: selectionStart, end: selectionEnd });
@@ -1389,6 +1424,16 @@ export function GooseComposer({
             <button
               className={s.iconButton}
               type="button"
+              onClick={() => void attachClipboardImage()}
+              disabled={controlsDisabled}
+              title="添加剪贴板图片"
+              aria-label="添加剪贴板图片"
+            >
+              <ImagePlus className={s.toolIcon} aria-hidden="true" />
+            </button>
+            <button
+              className={s.iconButton}
+              type="button"
               onClick={toggleVoiceRecording}
               disabled={voiceButtonDisabled}
               data-active={voiceStatus !== "idle"}
@@ -1531,6 +1576,7 @@ export function GooseComposer({
         url={urlDialog?.url ?? ""}
         onInsertReference={() => applyUrlInsertion(urlReferenceText(urlDialog?.url ?? ""))}
         onInsertPlain={() => applyUrlInsertion(urlDialog?.url ?? "")}
+        onAttachImage={(imageUrl) => attachImageFromUrl(imageUrl)}
         onCancel={() => setUrlDialog(null)}
       />
     </div>

--- a/web/src/components/composer/url-dialog.module.css
+++ b/web/src/components/composer/url-dialog.module.css
@@ -92,16 +92,95 @@
   padding: 8px 10px;
 }
 
+.previewCard {
+  display: flex;
+  gap: 12px;
+  border: 1px solid var(--h-line-soft);
+  border-radius: 12px;
+  background: var(--h-bg-soft);
+  padding: 10px;
+  min-width: 0;
+}
+
+.previewImage,
+.previewIcon {
+  flex: 0 0 auto;
+  width: 72px;
+  height: 72px;
+  border-radius: 10px;
+  overflow: hidden;
+  background: var(--h-bg);
+  border: 1px solid var(--h-line-soft);
+}
+
+.previewImage img,
+.previewIcon img {
+  display: block;
+  width: 100%;
+  height: 100%;
+  object-fit: cover;
+}
+
+.previewIcon {
+  display: inline-flex;
+  align-items: center;
+  justify-content: center;
+  color: var(--h-text-2);
+}
+
+.previewIcon svg {
+  width: 22px;
+  height: 22px;
+}
+
+.previewMeta {
+  display: flex;
+  flex: 1;
+  min-width: 0;
+  flex-direction: column;
+  justify-content: center;
+  gap: 4px;
+}
+
+.previewSite {
+  color: var(--h-text-3, var(--h-text-2));
+  font-size: 11px;
+  font-weight: 650;
+  overflow: hidden;
+  text-overflow: ellipsis;
+  white-space: nowrap;
+}
+
 .titlePreview {
   font-size: 14px;
   font-weight: 600;
   color: var(--h-text);
   line-height: 1.4;
+  display: -webkit-box;
+  overflow: hidden;
+  -webkit-line-clamp: 2;
+  -webkit-box-orient: vertical;
 }
 
 .titlePreview[data-muted] {
   color: var(--h-text-2);
   font-weight: 400;
+}
+
+.previewDescription {
+  display: -webkit-box;
+  overflow: hidden;
+  color: var(--h-text-2);
+  font-size: 12px;
+  line-height: 1.45;
+  -webkit-line-clamp: 2;
+  -webkit-box-orient: vertical;
+}
+
+.errorText {
+  color: var(--h-danger, #dc2626);
+  font-size: 12px;
+  line-height: 1.45;
 }
 
 .hint {
@@ -148,6 +227,17 @@
 .secondary:hover {
   background: var(--h-bg-soft);
   color: var(--h-text);
+}
+
+.secondary:disabled {
+  cursor: not-allowed;
+  opacity: 0.58;
+}
+
+.secondary svg {
+  width: 15px;
+  height: 15px;
+  stroke-width: 2;
 }
 
 .primary {

--- a/web/src/components/composer/url-dialog.tsx
+++ b/web/src/components/composer/url-dialog.tsx
@@ -1,7 +1,12 @@
 import { useEffect, useId, useRef, useState } from "react";
 import { createPortal } from "react-dom";
-import { Globe, Link2, X } from "lucide-react";
-import { fetchUrlTitle } from "@/lib/composer-url";
+import { Globe, ImagePlus, Link2, X } from "lucide-react";
+import {
+  fetchLinkMetadata,
+  isLikelyImageUrl,
+  type LinkMetadata,
+} from "@/lib/composer-url";
+import { downloadExternalImageFile } from "@/lib/transport";
 import s from "./url-dialog.module.css";
 
 interface UrlDialogProps {
@@ -11,6 +16,8 @@ interface UrlDialogProps {
   onInsertReference: () => void;
   /** Insert the raw URL as plain text. */
   onInsertPlain: () => void;
+  /** Download the URL or rich preview image and add it as a composer attachment. */
+  onAttachImage?: (url: string) => void | Promise<void>;
   onCancel: () => void;
 }
 
@@ -19,26 +26,65 @@ interface UrlDialogProps {
  * (best-effort) and lets the user attach it as an `@url:` reference or drop it
  * in as plain text.
  */
-export function UrlDialog({ open, url, onInsertReference, onInsertPlain, onCancel }: UrlDialogProps) {
+export function UrlDialog({
+  open,
+  url,
+  onInsertReference,
+  onInsertPlain,
+  onAttachImage,
+  onCancel,
+}: UrlDialogProps) {
   const titleId = useId();
-  const [title, setTitle] = useState("");
-  const [loadingTitle, setLoadingTitle] = useState(false);
+  const [metadata, setMetadata] = useState<LinkMetadata | null>(null);
+  const [loadingMetadata, setLoadingMetadata] = useState(false);
+  const [previewObjectUrl, setPreviewObjectUrl] = useState("");
+  const [attachError, setAttachError] = useState("");
+  const [attachingImage, setAttachingImage] = useState(false);
   const insertRef = useRef<HTMLButtonElement>(null);
+  const previewSource = metadata?.imageUrl || (isLikelyImageUrl(url) ? url : metadata?.faviconUrl);
 
   useEffect(() => {
     if (!open || !url) return;
     let cancelled = false;
-    setTitle("");
-    setLoadingTitle(true);
-    void fetchUrlTitle(url).then((value) => {
+    setMetadata(null);
+    setAttachError("");
+    setLoadingMetadata(true);
+    void fetchLinkMetadata(url).then((value) => {
       if (cancelled) return;
-      setTitle(value);
-      setLoadingTitle(false);
+      setMetadata(value);
+    }).finally(() => {
+      if (cancelled) return;
+      setLoadingMetadata(false);
     });
     return () => {
       cancelled = true;
     };
   }, [open, url]);
+
+  useEffect(() => {
+    if (!open || !previewSource || typeof URL === "undefined") {
+      setPreviewObjectUrl("");
+      return;
+    }
+
+    let cancelled = false;
+    let objectUrl = "";
+    setPreviewObjectUrl("");
+    void downloadExternalImageFile(previewSource)
+      .then((file) => {
+        if (cancelled) return;
+        objectUrl = URL.createObjectURL(file);
+        setPreviewObjectUrl(objectUrl);
+      })
+      .catch(() => {
+        if (!cancelled) setPreviewObjectUrl("");
+      });
+
+    return () => {
+      cancelled = true;
+      if (objectUrl) URL.revokeObjectURL(objectUrl);
+    };
+  }, [open, previewSource]);
 
   useEffect(() => {
     if (!open) return;
@@ -57,6 +103,29 @@ export function UrlDialog({ open, url, onInsertReference, onInsertPlain, onCance
   }, [open, onCancel, onInsertReference]);
 
   if (!open || typeof document === "undefined") return null;
+
+  const imageCandidate = isLikelyImageUrl(url) ? url : metadata?.imageUrl;
+  const displayTitle = metadata?.title || (loadingMetadata ? "读取链接信息…" : "未能读取页面标题");
+  const displayHost = metadata?.siteName || (() => {
+    try {
+      return new URL(metadata?.canonicalUrl || url).host;
+    } catch {
+      return "";
+    }
+  })();
+
+  const attachImage = async () => {
+    if (!imageCandidate || !onAttachImage) return;
+    setAttachingImage(true);
+    setAttachError("");
+    try {
+      await onAttachImage(imageCandidate);
+    } catch (error) {
+      setAttachError(error instanceof Error ? error.message : String(error || "添加图片失败"));
+    } finally {
+      setAttachingImage(false);
+    }
+  };
 
   return createPortal(
     <div
@@ -83,9 +152,27 @@ export function UrlDialog({ open, url, onInsertReference, onInsertPlain, onCance
         </div>
         <div className={s.body}>
           <div className={s.urlText}>{url}</div>
-          <div className={s.titlePreview} data-muted={!title || undefined}>
-            {loadingTitle ? "读取标题…" : title || "（未能读取页面标题）"}
+          <div className={s.previewCard}>
+            {previewObjectUrl ? (
+              <div className={s.previewImage} aria-hidden="true">
+                <img src={previewObjectUrl} alt="" />
+              </div>
+            ) : (
+              <div className={s.previewIcon} aria-hidden="true">
+                <Globe />
+              </div>
+            )}
+            <div className={s.previewMeta}>
+              {displayHost ? <div className={s.previewSite}>{displayHost}</div> : null}
+              <div className={s.titlePreview} data-muted={!metadata?.title || undefined}>
+                {displayTitle}
+              </div>
+              {metadata?.description ? (
+                <div className={s.previewDescription}>{metadata.description}</div>
+              ) : null}
+            </div>
           </div>
+          {attachError ? <div className={s.errorText}>{attachError}</div> : null}
           <p className={s.hint}>
             插入为 <code>@url:</code> 引用后，发送时会自动抓取网页正文作为上下文。
           </p>
@@ -94,6 +181,17 @@ export function UrlDialog({ open, url, onInsertReference, onInsertPlain, onCance
           <button type="button" className={s.secondary} onClick={onInsertPlain}>
             作为纯文本
           </button>
+          {imageCandidate && onAttachImage ? (
+            <button
+              type="button"
+              className={s.secondary}
+              onClick={() => void attachImage()}
+              disabled={attachingImage}
+            >
+              <ImagePlus aria-hidden="true" />
+              {attachingImage ? "添加中…" : isLikelyImageUrl(url) ? "添加图片" : "添加预览图"}
+            </button>
+          ) : null}
           <button ref={insertRef} type="button" className={s.primary} onClick={onInsertReference}>
             <Link2 aria-hidden="true" />
             插入引用

--- a/web/src/lib/clipboard-image.test.ts
+++ b/web/src/lib/clipboard-image.test.ts
@@ -1,0 +1,69 @@
+import { describe, expect, it, vi } from "vitest";
+import {
+  imageFileFromClipboardData,
+  readClipboardImageAsFile,
+  type NativeClipboardImage,
+} from "./clipboard-image";
+
+function clipboardDataWithFile(file: File): DataTransfer {
+  return {
+    files: [file],
+    items: [],
+  } as unknown as DataTransfer;
+}
+
+function clipboardDataWithItem(file: File): DataTransfer {
+  return {
+    files: [],
+    items: [{
+      kind: "file",
+      type: file.type,
+      getAsFile: () => file,
+    }],
+  } as unknown as DataTransfer;
+}
+
+describe("clipboard image helpers", () => {
+  it("reads image files from paste event files", () => {
+    const file = new File(["png"], "clip.png", { type: "image/png" });
+    expect(imageFileFromClipboardData(clipboardDataWithFile(file))).toBe(file);
+  });
+
+  it("reads image files from paste event items", () => {
+    const file = new File(["jpg"], "clip.jpg", { type: "image/jpeg" });
+    expect(imageFileFromClipboardData(clipboardDataWithItem(file))).toBe(file);
+  });
+
+  it("ignores non-image paste files", () => {
+    const file = new File(["txt"], "note.txt", { type: "text/plain" });
+    expect(imageFileFromClipboardData(clipboardDataWithFile(file))).toBeNull();
+  });
+
+  it("falls back to native clipboard image when paste data has no image", async () => {
+    const nativeImage: NativeClipboardImage = {
+      size: vi.fn(async () => ({ width: 1, height: 1 })),
+      rgba: vi.fn(async () => new Uint8Array([255, 0, 0, 255])),
+      close: vi.fn(),
+    };
+    const encoded = new File(["png"], "encoded.png", { type: "image/png" });
+    const out = await readClipboardImageAsFile(null, {
+      readNativeImage: vi.fn(async () => nativeImage),
+      encodeRgbaToPngFile: vi.fn(async () => encoded),
+      now: () => new Date("2026-06-14T01:02:03.004Z"),
+    });
+
+    expect(out).toBe(encoded);
+    expect(nativeImage.close).toHaveBeenCalledOnce();
+  });
+
+  it("can disable native fallback for normal text paste handling", async () => {
+    const readNativeImage = vi.fn(async () => {
+      throw new Error("should not run");
+    });
+
+    await expect(
+      readClipboardImageAsFile(null, { nativeFallback: false, readNativeImage }),
+    ).resolves.toBeNull();
+    expect(readNativeImage).not.toHaveBeenCalled();
+  });
+});

--- a/web/src/lib/clipboard-image.ts
+++ b/web/src/lib/clipboard-image.ts
@@ -1,0 +1,111 @@
+import { isLikelyImageUrl } from "@/lib/composer-url";
+
+export interface NativeClipboardImage {
+  rgba(): Promise<Uint8Array>;
+  size(): Promise<{ width: number; height: number }>;
+  close?(): Promise<void> | void;
+}
+
+export interface ReadClipboardImageOptions {
+  nativeFallback?: boolean;
+  readNativeImage?: () => Promise<NativeClipboardImage>;
+  encodeRgbaToPngFile?: (
+    rgba: Uint8Array,
+    width: number,
+    height: number,
+    filename: string,
+  ) => Promise<File>;
+  now?: () => Date;
+}
+
+function timestampName(now: () => Date): string {
+  return `clipboard-${now().toISOString().replace(/[:.]/g, "-")}.png`;
+}
+
+function isImageFile(file: File): boolean {
+  return file.type.startsWith("image/") || isLikelyImageUrl(file.name);
+}
+
+export function imageFileFromClipboardData(clipboardData?: DataTransfer | null): File | null {
+  if (!clipboardData) return null;
+
+  for (const file of Array.from(clipboardData.files ?? [])) {
+    if (isImageFile(file)) return file;
+  }
+
+  for (const item of Array.from(clipboardData.items ?? [])) {
+    if (item.kind !== "file") continue;
+    if (item.type && !item.type.startsWith("image/")) continue;
+    const file = item.getAsFile();
+    if (file && isImageFile(file)) return file;
+  }
+
+  return null;
+}
+
+async function defaultReadNativeImage(): Promise<NativeClipboardImage> {
+  const { readImage } = await import("@tauri-apps/plugin-clipboard-manager");
+  return readImage();
+}
+
+function canvasToBlob(canvas: HTMLCanvasElement): Promise<Blob> {
+  return new Promise((resolve, reject) => {
+    canvas.toBlob((blob) => {
+      if (blob) {
+        resolve(blob);
+      } else {
+        reject(new Error("剪贴板图片转换失败"));
+      }
+    }, "image/png");
+  });
+}
+
+export async function encodeRgbaToPngFile(
+  rgba: Uint8Array,
+  width: number,
+  height: number,
+  filename: string,
+): Promise<File> {
+  if (typeof document === "undefined") {
+    throw new Error("当前环境不支持读取剪贴板图片");
+  }
+  if (width <= 0 || height <= 0 || rgba.length < width * height * 4) {
+    throw new Error("剪贴板图片数据无效");
+  }
+
+  const canvas = document.createElement("canvas");
+  canvas.width = width;
+  canvas.height = height;
+  const context = canvas.getContext("2d");
+  if (!context) throw new Error("当前环境不支持读取剪贴板图片");
+  context.putImageData(new ImageData(new Uint8ClampedArray(rgba), width, height), 0, 0);
+  const blob = await canvasToBlob(canvas);
+  return new File([blob], filename, { type: "image/png" });
+}
+
+export async function readClipboardImageAsFile(
+  clipboardData?: DataTransfer | null,
+  options: ReadClipboardImageOptions = {},
+): Promise<File | null> {
+  const fromPasteEvent = imageFileFromClipboardData(clipboardData);
+  if (fromPasteEvent) return fromPasteEvent;
+
+  if (options.nativeFallback === false) return null;
+
+  const readNativeImage = options.readNativeImage ?? defaultReadNativeImage;
+  const encode = options.encodeRgbaToPngFile ?? encodeRgbaToPngFile;
+  let image: NativeClipboardImage | null = null;
+  try {
+    image = await readNativeImage();
+    const [{ width, height }, rgba] = await Promise.all([image.size(), image.rgba()]);
+    return encode(rgba, width, height, timestampName(options.now ?? (() => new Date())));
+  } catch {
+    return null;
+  } finally {
+    try {
+      await image?.close?.();
+    } catch {
+      // Closing a Tauri resource is best-effort only.
+    }
+  }
+}

--- a/web/src/lib/composer-url.test.ts
+++ b/web/src/lib/composer-url.test.ts
@@ -1,5 +1,11 @@
 import { describe, expect, it } from "vitest";
-import { extractTitleFromHtml, isSingleUrl, urlReferenceText } from "./composer-url";
+import {
+  extractLinkMetadataFromHtml,
+  extractTitleFromHtml,
+  isLikelyImageUrl,
+  isSingleUrl,
+  urlReferenceText,
+} from "./composer-url";
 
 describe("isSingleUrl", () => {
   it("accepts a single http(s) URL", () => {
@@ -33,8 +39,68 @@ describe("extractTitleFromHtml", () => {
   });
 });
 
+describe("extractLinkMetadataFromHtml", () => {
+  it("extracts rich metadata and resolves relative URLs", () => {
+    const html = `
+      <head>
+        <title>Fallback</title>
+        <meta property="og:title" content="OG &amp; Title">
+        <meta name="description" content="Plain description">
+        <meta property="og:description" content="Rich &#x4E2D; description">
+        <meta property="og:site_name" content="Hermes">
+        <meta property="og:image" content="/cover.png">
+        <link rel="canonical" href="/article">
+        <link rel="icon" href="/favicon.ico">
+      </head>
+    `;
+
+    expect(extractLinkMetadataFromHtml(html, "https://example.com/posts/1")).toMatchObject({
+      url: "https://example.com/posts/1",
+      canonicalUrl: "https://example.com/article",
+      title: "OG & Title",
+      description: "Rich 中 description",
+      siteName: "Hermes",
+      imageUrl: "https://example.com/cover.png",
+      faviconUrl: "https://example.com/favicon.ico",
+    });
+  });
+
+  it("falls back to twitter metadata and title when Open Graph is absent", () => {
+    const html = `
+      <head>
+        <title>Plain   Title</title>
+        <meta name="twitter:description" content="Twitter description">
+        <meta name="twitter:image" content="https://cdn.example.com/x.webp">
+      </head>
+    `;
+
+    expect(extractLinkMetadataFromHtml(html, "https://example.com/a")).toMatchObject({
+      title: "Plain Title",
+      description: "Twitter description",
+      imageUrl: "https://cdn.example.com/x.webp",
+    });
+  });
+
+  it("returns minimal metadata when no tags are present", () => {
+    expect(extractLinkMetadataFromHtml("<main>hello</main>", "https://example.com")).toEqual({
+      url: "https://example.com",
+    });
+  });
+});
+
 describe("urlReferenceText", () => {
   it("builds an @url: reference token", () => {
     expect(urlReferenceText(" https://example.com ")).toBe("@url:https://example.com");
+  });
+});
+
+describe("isLikelyImageUrl", () => {
+  it("accepts common image URL extensions", () => {
+    expect(isLikelyImageUrl("https://example.com/a/image.png?size=2")).toBe(true);
+    expect(isLikelyImageUrl("photo.webp")).toBe(true);
+  });
+
+  it("rejects non-image URLs", () => {
+    expect(isLikelyImageUrl("https://example.com/article")).toBe(false);
   });
 });

--- a/web/src/lib/composer-url.ts
+++ b/web/src/lib/composer-url.ts
@@ -2,10 +2,21 @@ import { fetchExternalText } from "@/lib/transport";
 
 // URL-paste helper. When a bare URL is pasted into the composer we offer to
 // insert it as an `@url:<url>` reference (the backend fetches + summarises the
-// page at submit time) and preview the page <title> for confirmation. Title
+// page at submit time) and preview the page metadata for confirmation. Metadata
 // fetching is best-effort and purely cosmetic.
 
 const SINGLE_URL_RE = /^https?:\/\/\S+$/i;
+const IMAGE_URL_RE = /\.(?:png|jpe?g|gif|webp|bmp|tiff?|svg|avif)(?:$|[?#])/i;
+
+export interface LinkMetadata {
+  url: string;
+  canonicalUrl?: string;
+  title?: string;
+  description?: string;
+  siteName?: string;
+  imageUrl?: string;
+  faviconUrl?: string;
+}
 
 /**
  * True when the text is exactly one http(s) URL. The `^https?://\S+$` anchor
@@ -23,8 +34,95 @@ function decodeEntities(value: string): string {
     .replace(/&gt;/gi, ">")
     .replace(/&quot;/gi, '"')
     .replace(/&#39;|&apos;/gi, "'")
-    .replace(/&#(\d+);/g, (_, code) => String.fromCodePoint(Number(code)))
+    .replace(/&#(\d+);/g, (_, code) => safeCodePoint(Number(code)))
+    .replace(/&#x([0-9a-f]+);/gi, (_, code) => safeCodePoint(Number.parseInt(code, 16)))
     .replace(/&nbsp;/gi, " ");
+}
+
+function safeCodePoint(code: number): string {
+  try {
+    return Number.isFinite(code) ? String.fromCodePoint(code) : "";
+  } catch {
+    return "";
+  }
+}
+
+function normalizeText(value: string | undefined): string | undefined {
+  const text = decodeEntities(value ?? "").replace(/\s+/g, " ").trim();
+  return text || undefined;
+}
+
+function parseAttributes(tag: string): Record<string, string> {
+  const attrs: Record<string, string> = {};
+  const attrRe = /([:\w-]+)\s*=\s*(?:"([^"]*)"|'([^']*)'|([^\s"'=<>`]+))/g;
+  for (const match of tag.matchAll(attrRe)) {
+    const key = match[1]?.toLowerCase();
+    if (!key) continue;
+    attrs[key] = decodeEntities(match[2] ?? match[3] ?? match[4] ?? "");
+  }
+  return attrs;
+}
+
+function firstDefined(...values: Array<string | undefined>): string | undefined {
+  for (const value of values) {
+    const text = normalizeText(value);
+    if (text) return text;
+  }
+  return undefined;
+}
+
+function absoluteUrl(value: string | undefined, baseUrl: string): string | undefined {
+  const text = normalizeText(value);
+  if (!text) return undefined;
+  try {
+    return new URL(text, baseUrl).toString();
+  } catch {
+    return undefined;
+  }
+}
+
+function metaMapFromHtml(html: string): Map<string, string> {
+  const map = new Map<string, string>();
+  for (const match of html.matchAll(/<meta\b[^>]*>/gi)) {
+    const attrs = parseAttributes(match[0]);
+    const key = attrs.property || attrs.name || attrs.itemprop;
+    const content = attrs.content;
+    if (!key || !content) continue;
+    const normalizedKey = key.toLowerCase();
+    if (!map.has(normalizedKey)) map.set(normalizedKey, content);
+  }
+  return map;
+}
+
+function titleFromHtml(html: string): string | undefined {
+  return normalizeText(html.match(/<title\b[^>]*>([\s\S]*?)<\/title>/i)?.[1]);
+}
+
+function linkByRel(html: string, predicate: (rels: string[]) => boolean): string | undefined {
+  for (const match of html.matchAll(/<link\b[^>]*>/gi)) {
+    const attrs = parseAttributes(match[0]);
+    const rels = (attrs.rel || "")
+      .toLowerCase()
+      .split(/\s+/)
+      .filter(Boolean);
+    if (!attrs.href || !predicate(rels)) continue;
+    return attrs.href;
+  }
+  return undefined;
+}
+
+function canonicalFromHtml(html: string, baseUrl: string): string | undefined {
+  return absoluteUrl(
+    linkByRel(html, (rels) => rels.includes("canonical")),
+    baseUrl,
+  );
+}
+
+function faviconFromHtml(html: string, baseUrl: string): string | undefined {
+  return absoluteUrl(
+    linkByRel(html, (rels) => rels.includes("icon") || rels.includes("apple-touch-icon")),
+    baseUrl,
+  );
 }
 
 /**
@@ -32,13 +130,49 @@ function decodeEntities(value: string): string {
  * Returns an empty string when neither is present.
  */
 export function extractTitleFromHtml(html: string): string {
-  const og = html.match(
-    /<meta[^>]+property=["']og:title["'][^>]*content=["']([^"']+)["']/i,
-  ) ?? html.match(
-    /<meta[^>]+content=["']([^"']+)["'][^>]*property=["']og:title["']/i,
+  return extractLinkMetadataFromHtml(html, "https://example.invalid/").title ?? "";
+}
+
+export function extractLinkMetadataFromHtml(html: string, pageUrl: string): LinkMetadata {
+  const meta = metaMapFromHtml(html);
+  const canonicalUrl = canonicalFromHtml(html, pageUrl);
+  const metadata: LinkMetadata = {
+    url: pageUrl,
+    ...(canonicalUrl ? { canonicalUrl } : {}),
+  };
+
+  const title = firstDefined(
+    meta.get("og:title"),
+    meta.get("twitter:title"),
+    titleFromHtml(html),
   );
-  const raw = og?.[1] ?? html.match(/<title[^>]*>([\s\S]*?)<\/title>/i)?.[1] ?? "";
-  return decodeEntities(raw).replace(/\s+/g, " ").trim();
+  const description = firstDefined(
+    meta.get("og:description"),
+    meta.get("twitter:description"),
+    meta.get("description"),
+  );
+  const siteName = firstDefined(
+    meta.get("og:site_name"),
+    meta.get("application-name"),
+  );
+  const imageUrl = absoluteUrl(
+    firstDefined(
+      meta.get("og:image:secure_url"),
+      meta.get("og:image:url"),
+      meta.get("og:image"),
+      meta.get("twitter:image:src"),
+      meta.get("twitter:image"),
+    ),
+    pageUrl,
+  );
+  const faviconUrl = faviconFromHtml(html, pageUrl);
+
+  if (title) metadata.title = title;
+  if (description) metadata.description = description;
+  if (siteName) metadata.siteName = siteName;
+  if (imageUrl) metadata.imageUrl = imageUrl;
+  if (faviconUrl) metadata.faviconUrl = faviconUrl;
+  return metadata;
 }
 
 /** Build the `@url:<url>` reference token text inserted into the composer. */
@@ -46,15 +180,40 @@ export function urlReferenceText(url: string): string {
   return `@url:${url.trim()}`;
 }
 
+export function isLikelyImageUrl(url: string): boolean {
+  try {
+    const parsed = new URL(url);
+    return IMAGE_URL_RE.test(parsed.pathname);
+  } catch {
+    return IMAGE_URL_RE.test(url);
+  }
+}
+
+/**
+ * Best-effort fetch of a URL's metadata. Never throws — returns a minimal
+ * metadata object on any network/parse failure so the dialog can still offer
+ * to insert the reference.
+ */
+export async function fetchLinkMetadata(url: string): Promise<LinkMetadata> {
+  const normalizedUrl = url.trim();
+  const fallback: LinkMetadata = { url: normalizedUrl };
+  try {
+    const html = await fetchExternalText(normalizedUrl, {
+      headers: { Accept: "text/html,application/xhtml+xml,text/plain;q=0.8,*/*;q=0.5" },
+    });
+    return {
+      ...fallback,
+      ...extractLinkMetadataFromHtml(html, normalizedUrl),
+    };
+  } catch {
+    return fallback;
+  }
+}
+
 /**
  * Best-effort fetch of a URL's page title. Never throws — returns "" on any
  * network/parse failure so the dialog can still offer to insert the reference.
  */
 export async function fetchUrlTitle(url: string): Promise<string> {
-  try {
-    const html = await fetchExternalText(url);
-    return extractTitleFromHtml(html);
-  } catch {
-    return "";
-  }
+  return (await fetchLinkMetadata(url)).title ?? "";
 }

--- a/web/src/lib/runtime.ts
+++ b/web/src/lib/runtime.ts
@@ -58,6 +58,18 @@ export interface ElectronFilePickerResult {
   paths: string[];
 }
 
+export interface DownloadExternalImageInput {
+  url: string;
+}
+
+export interface DownloadedImageResult {
+  finalUrl: string;
+  filename: string;
+  mimeType: string;
+  dataBase64: string;
+  size: number;
+}
+
 export interface ElectronSimpleResult {
   ok: boolean;
   message?: string | null;
@@ -283,6 +295,7 @@ declare global {
       request(input: ElectronApiRequestInput): Promise<ElectronApiRequestResult>;
       externalRequest?(input: ElectronApiRequestInput): Promise<ElectronApiRequestResult>;
       uploadFile?(input: FileUploadInput): Promise<ElectronApiRequestResult>;
+      downloadExternalImage?(input: DownloadExternalImageInput): Promise<DownloadedImageResult>;
       pickFiles?(): Promise<ElectronFilePickerResult>;
       pickDirectory?(): Promise<ElectronFilePickerResult>;
       requestMicrophoneAccess?(): Promise<boolean>;

--- a/web/src/lib/tauri-bridge.ts
+++ b/web/src/lib/tauri-bridge.ts
@@ -46,6 +46,8 @@ import type {
   DesktopNotifyInput,
   DesktopNotifyResult,
   DesktopFileDropPayload,
+  DownloadExternalImageInput,
+  DownloadedImageResult,
   FilePreview,
   PreviewFileChangedPayload,
   ReadWorkspaceFileInput,
@@ -193,6 +195,10 @@ const tauriBridge = {
         data: base64,
       },
     });
+  },
+
+  async downloadExternalImage(input: DownloadExternalImageInput): Promise<DownloadedImageResult> {
+    return invokeCommand("download_external_image", { input });
   },
 
   async pickFiles(): Promise<FilePickerResult> {

--- a/web/src/lib/transport.test.ts
+++ b/web/src/lib/transport.test.ts
@@ -1,6 +1,11 @@
 import { afterAll, afterEach, beforeAll, beforeEach, describe, expect, it, vi, type MockInstance } from "vitest";
 import { debugBus } from "./debug-bus";
-import { fetchExternalJSON, fetchJSON, uploadAttachmentFile } from "./transport";
+import {
+  downloadExternalImageFile,
+  fetchExternalJSON,
+  fetchJSON,
+  uploadAttachmentFile,
+} from "./transport";
 
 type PushArg = Parameters<typeof debugBus.push>[0];
 
@@ -216,5 +221,28 @@ describe("transport · debug-bus integration", () => {
     expect(uploadInput.data).toBeInstanceOf(ArrayBuffer);
     expect(onProgress).toHaveBeenNthCalledWith(1, 0);
     expect(onProgress).toHaveBeenNthCalledWith(2, 100);
+  });
+
+  it("downloadExternalImageFile uses desktop downloadExternalImage capability", async () => {
+    const downloadExternalImage = vi.fn(async () => ({
+      finalUrl: "https://example.com/image.png",
+      filename: "image.png",
+      mimeType: "image/png",
+      dataBase64: btoa("png-bytes"),
+      size: 9,
+    }));
+    window.__HERMES_RUNTIME__ = { platform: "tauri" };
+    window.hermesDesktop = {
+      windowType: "tauri",
+      request: vi.fn(),
+      downloadExternalImage,
+    };
+
+    const file = await downloadExternalImageFile("https://example.com/image.png");
+
+    expect(downloadExternalImage).toHaveBeenCalledWith({ url: "https://example.com/image.png" });
+    expect(file.name).toBe("image.png");
+    expect(file.type).toBe("image/png");
+    expect(await file.text()).toBe("png-bytes");
   });
 });

--- a/web/src/lib/transport.ts
+++ b/web/src/lib/transport.ts
@@ -3,6 +3,7 @@ import { runtime } from "./runtime";
 import { debugBus } from "./debug-bus";
 import { activeProfileAtom } from "@/stores/ui";
 import { AttachmentUploadResult } from "@hermes/protocol";
+import type { DownloadExternalImageInput, DownloadedImageResult } from "./runtime";
 
 interface Parser<T> {
   parse(value: unknown): T;
@@ -230,6 +231,56 @@ export async function fetchExternalText(url: string, init?: RequestInit): Promis
   return res.text();
 }
 
+function base64ToArrayBuffer(value: string): ArrayBuffer {
+  const binary = atob(value);
+  const bytes = new Uint8Array(binary.length);
+  for (let i = 0; i < binary.length; i += 1) {
+    bytes[i] = binary.charCodeAt(i);
+  }
+  return bytes.buffer;
+}
+
+function filenameFromUrl(url: string, mimeType?: string): string {
+  const extFromMime = mimeType?.toLowerCase().includes("png")
+    ? "png"
+    : mimeType?.toLowerCase().includes("jpeg") || mimeType?.toLowerCase().includes("jpg")
+      ? "jpg"
+      : mimeType?.toLowerCase().includes("gif")
+        ? "gif"
+        : mimeType?.toLowerCase().includes("webp")
+          ? "webp"
+          : "png";
+  try {
+    const pathname = new URL(url).pathname;
+    const last = decodeURIComponent(pathname.split("/").filter(Boolean).pop() ?? "");
+    if (last && /\.[a-z0-9]{2,8}$/i.test(last)) return last;
+  } catch {
+    // Fall through to timestamped filename.
+  }
+  return `external-image-${Date.now()}.${extFromMime}`;
+}
+
+export async function downloadExternalImageFile(url: string): Promise<File> {
+  const input: DownloadExternalImageInput = { url };
+  const nativeDownload = window.hermesDesktop?.downloadExternalImage;
+  if (nativeDownload) {
+    const result: DownloadedImageResult = await nativeDownload(input);
+    const data = base64ToArrayBuffer(result.dataBase64);
+    return new File([data], result.filename, { type: result.mimeType });
+  }
+
+  const res = await fetch(url, {
+    headers: { Accept: "image/avif,image/webp,image/png,image/jpeg,image/gif,image/*;q=0.8,*/*;q=0.3" },
+    signal: timeoutSignal(),
+  });
+  if (!res.ok) throw new Error(`HTTP ${res.status}`);
+  const blob = await res.blob();
+  if (!blob.type.startsWith("image/")) {
+    throw new Error("URL 返回的不是图片内容");
+  }
+  return new File([blob], filenameFromUrl(url, blob.type), { type: blob.type });
+}
+
 export async function putJSON<T>(path: string, body: unknown, parser?: Parser<T>): Promise<T> {
   return fetchJSON<T>(path, { method: "PUT", body: JSON.stringify(body) }, parser);
 }
@@ -297,4 +348,3 @@ export function uploadAttachmentFile(
     xhr.send(form);
   });
 }
-


### PR DESCRIPTION
## 变更内容

补齐 Issue #244 的富链接元数据和图片存图能力：

- URL 粘贴弹窗升级为富链接卡片，支持标题、描述、站点、预览图和 favicon 元数据。
- 新增从图片 URL / og:image 添加图片附件的流程，继续复用现有上传和 image.attach 链路。
- 新增 Tauri `download_external_image` command，复用外部 URL 安全校验，限制 20 MiB，并逐跳校验重定向。
- 新增 Tauri clipboard-manager 依赖，只开放 read-image 权限，支持从剪贴板图片生成 Composer 附件。
- 补充富链接解析、剪贴板图片、外部图片下载相关测试。

## 验证

- `pnpm typecheck`
- `pnpm test:unit`
- `cargo check`
- `cargo test --all-features`
- `cargo clippy --all-targets --all-features -- -D warnings`

Closes #244