### PR TITLE
fix(workspace): use dvh and remove hardcoded max-height for list container

### DIFF
--- a/web/src/components/composer/workspace-picker/workspace-picker-modal.module.css
+++ b/web/src/components/composer/workspace-picker/workspace-picker-modal.module.css
@@ -13,7 +13,7 @@
   display: flex;
   flex-direction: column;
   width: min(640px, calc(100vw - 32px));
-  max-height: min(680px, calc(100vh - 48px));
+  max-height: min(680px, calc(100dvh - 48px));
   border: 1px solid var(--h-line);
   border-radius: 18px;
   background: var(--h-bg-input);
@@ -197,8 +197,7 @@
   flex: 1;
   overflow-y: auto;
   padding: 6px 6px;
-  min-height: 200px;
-  max-height: 360px;
+  min-height: 0;
 }
 
 .wpEntry {


### PR DESCRIPTION
## Summary

Fix #45921: The "Select" button becomes invisible when the directory list has many entries. Root causes:
- `.wpModal` used `100vh` which includes browser chrome area on Windows, causing the modal to exceed the visible viewport
- `.wpList` had a hardcoded `max-height: 360px` preventing it from filling available space within the modal
- Changed `min-height: 200px` to `0` on `.wpList` to allow proper flex shrinking

**File changed:** `web/src/components/composer/workspace-picker/workspace-picker-modal.module.css`
- `.wpModal`: `100vh` → `100dvh`
- `.wpList`: removed `max-height: 360px`, changed `min-height: 200px` → `0`

## Test Plan

- [ ] Open workspace picker on Windows with a deeply nested directory (many subdirectories)
- [ ] Verify the list scrolls and the footer with "选择此目录" / "取消" buttons remains visible
- [ ] Verify the modal does not extend beyond the viewport on small screens
- [ ] Verify behavior on macOS/Linux is unchanged

## Notes

- N/A