### PR TITLE
[codex] 修复 Tauri 打包资源路径解析

### DIFF
--- a/web/vite.config.ts
+++ b/web/vite.config.ts
@@ -255,6 +255,9 @@ function hermesSessionArchivePlugin(): Plugin {
 }
 
 export default defineConfig({
+  // Packaged Tauri builds load web/dist through a custom protocol, so asset
+  // URLs must stay relative instead of resolving to tauri://localhost/assets/*.
+  base: "./",
   plugins: [react(), hermesTokenPlugin(), hermesSessionLogPlugin(), hermesSessionArchivePlugin()],
   define: {
     "import.meta.env.VITE_HERMES_BUILD_COMMIT": JSON.stringify(gitShortCommit()),


### PR DESCRIPTION
## 变更说明

修复 Tauri 打包后的前端资源路径解析问题，在 Vite 配置中统一设置 `base: "./"`，让生产构建生成相对路径资源引用，避免 WebView 在自定义协议下请求 `tauri://localhost/assets/*` 造成白屏。

## 根因

Vite 默认 `base` 为 `/`，打包出的 `index.html` 会使用根路径资源引用。Tauri 生产环境通过自定义协议加载 `web/dist`，根路径资源在该协议下可能无法正确解析，导致 JS bundle 未加载、React 无法 mount。

## 验证

- `pnpm --filter @hermes/web build`
- 确认 `web/dist/index.html` 中脚本和样式引用为 `./assets/...`，不存在 `src="/` 或 `href="/` 的根路径引用
- `pnpm typecheck`
- `pnpm test:unit`
- `cargo check`

Closes #269.
