### PR TITLE
fix: read memory_char_limit and user_char_limit from config.yaml

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -1976,6 +1976,7 @@ dependencies = [
  "rusqlite",
  "serde",
  "serde_json",
+ "serde_yaml",
  "serial_test",
  "sha2",
  "tauri",
@@ -4244,6 +4245,19 @@ dependencies = [
 ]
 
 [[package]]
+name = "serde_yaml"
+version = "0.9.34+deprecated"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "6a8b1a1a2ebf674015cc02edccce75287f1a0130d394307b36743c2f5d504b47"
+dependencies = [
+ "indexmap 2.14.0",
+ "itoa",
+ "ryu",
+ "serde",
+ "unsafe-libyaml",
+]
+
+[[package]]
 name = "serial2"
 version = "0.2.37"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -5487,6 +5501,12 @@ name = "unicode-xid"
 version = "0.2.6"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "ebc1c04c71510c7f702b52b7c350734c9ff1295c464a03335b00bb84fc54f853"
+
+[[package]]
+name = "unsafe-libyaml"
+version = "0.2.11"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "673aac59facbab8a9007c7f6108d11f63b603f7cabff99fabf650fea5c32b861"
 
 [[package]]
 name = "untrusted"

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -15,6 +15,7 @@ tauri-plugin-dialog = "2"
 tauri-plugin-notification = "2"
 serde = { version = "1", features = ["derive"] }
 serde_json = "1"
+serde_yaml = "0.9"
 tokio = { version = "1", features = ["full"] }
 reqwest = { version = "0.12", default-features = false, features = [
     "json",

--- a/src/commands/memory.rs
+++ b/src/commands/memory.rs
@@ -2,7 +2,7 @@ use std::fs;
 use std::path::{Path, PathBuf};
 use std::time::UNIX_EPOCH;
 
-use serde::Serialize;
+use serde::{Deserialize, Serialize};
 use tauri::State;
 use tokio::task;
 
@@ -12,6 +12,35 @@ use crate::state::AppState;
 const ENTRY_DELIMITER: &str = "\n§\n";
 const MEMORY_CHAR_LIMIT: usize = 2200;
 const USER_CHAR_LIMIT: usize = 1375;
+
+#[derive(Debug, Deserialize)]
+struct MemoryConfig {
+    memory: Option<MemoryConfigSection>,
+}
+
+#[derive(Debug, Deserialize)]
+struct MemoryConfigSection {
+    #[serde(rename = "memory_char_limit")]
+    memory_char_limit: Option<usize>,
+    #[serde(rename = "user_char_limit")]
+    user_char_limit: Option<usize>,
+}
+
+fn load_memory_limits(home: &Path) -> (usize, usize) {
+    let config_path = home.join("config.yaml");
+    let limits = fs::read_to_string(&config_path)
+        .ok()
+        .and_then(|content| serde_yaml::from_str::<MemoryConfig>(&content).ok())
+        .and_then(|c| c.memory)
+        .map(|m| {
+            (
+                m.memory_char_limit.unwrap_or(MEMORY_CHAR_LIMIT),
+                m.user_char_limit.unwrap_or(USER_CHAR_LIMIT),
+            )
+        })
+        .unwrap_or((MEMORY_CHAR_LIMIT, USER_CHAR_LIMIT));
+    limits
+}
 
 #[derive(Debug, Clone, Serialize, PartialEq, Eq)]
 #[serde(rename_all = "camelCase")]
@@ -154,8 +183,9 @@ fn active_hermes_home(state: &State<'_, AppState>) -> AppResult<PathBuf> {
 }
 
 fn read_memory_from_home(home: &Path) -> MemoryInfo {
-    let mem_file = read_file_safe(&memory_path(home), MEMORY_CHAR_LIMIT);
-    let user_file = read_file_safe(&user_path(home), USER_CHAR_LIMIT);
+    let (memory_limit, user_limit) = load_memory_limits(home);
+    let mem_file = read_file_safe(&memory_path(home), memory_limit);
+    let user_file = read_file_safe(&user_path(home), user_limit);
     let entries = parse_memory_entries(&mem_file.content);
 
     MemoryInfo {
@@ -208,21 +238,22 @@ pub async fn add_memory_entry(
 
     let home = active_hermes_home(&state)?;
     run_memory_io(move || {
+        let (memory_limit, _) = load_memory_limits(&home);
         let path = memory_path(&home);
-        let existing = read_file_safe(&path, MEMORY_CHAR_LIMIT);
+        let existing = read_file_safe(&path, memory_limit);
         let mut entries = parse_memory_entries(&existing.content);
         entries.push(MemoryEntry {
             index: entries.len(),
             content: trimmed,
         });
         let next = serialize_entries(&entries);
-        if char_count(&next) > MEMORY_CHAR_LIMIT {
+        if char_count(&next) > memory_limit {
             return Ok(MemoryMutationResult {
                 success: false,
                 error: Some(format!(
                     "超过记忆上限（{} / {} 字符）",
                     char_count(&next),
-                    MEMORY_CHAR_LIMIT
+                    memory_limit
                 )),
             });
         }
@@ -245,8 +276,9 @@ pub async fn update_memory_entry(
     let next_content = content.trim().to_string();
     let home = active_hermes_home(&state)?;
     run_memory_io(move || {
+        let (memory_limit, _) = load_memory_limits(&home);
         let path = memory_path(&home);
-        let existing = read_file_safe(&path, MEMORY_CHAR_LIMIT);
+        let existing = read_file_safe(&path, memory_limit);
         let mut entries = parse_memory_entries(&existing.content);
 
         if index >= entries.len() {
@@ -258,13 +290,13 @@ pub async fn update_memory_entry(
 
         entries[index].content = next_content;
         let next = serialize_entries(&entries);
-        if char_count(&next) > MEMORY_CHAR_LIMIT {
+        if char_count(&next) > memory_limit {
             return Ok(MemoryMutationResult {
                 success: false,
                 error: Some(format!(
                     "超过记忆上限（{} / {} 字符）",
                     char_count(&next),
-                    MEMORY_CHAR_LIMIT
+                    memory_limit
                 )),
             });
         }
@@ -303,17 +335,18 @@ pub async fn write_user_profile(
     state: State<'_, AppState>,
 ) -> AppResult<MemoryMutationResult> {
     let count = char_count(&content);
-    if count > USER_CHAR_LIMIT {
+    let home = active_hermes_home(&state)?;
+    let (_, user_limit) = load_memory_limits(&home);
+    if count > user_limit {
         return Ok(MemoryMutationResult {
             success: false,
             error: Some(format!(
                 "超过用户画像上限（{} / {} 字符）",
-                count, USER_CHAR_LIMIT
+                count, user_limit
             )),
         });
     }
 
-    let home = active_hermes_home(&state)?;
     run_memory_io(move || {
         write_file_safe(&user_path(&home), &content)?;
         Ok(MemoryMutationResult {
@@ -369,5 +402,27 @@ mod tests {
     #[test]
     fn counts_unicode_characters_not_bytes() {
         assert_eq!(char_count("中文🙂"), 3);
+    }
+
+    #[test]
+    fn load_memory_limits_reads_from_config_yaml() {
+        let tmp = tempfile::TempDir::new().unwrap();
+        let config_yaml = tmp.path().join("config.yaml");
+        fs::write(
+            &config_yaml,
+            "memory:\n  memory_char_limit: 5000\n  user_char_limit: 3000\n",
+        )
+        .unwrap();
+        let (mem, user) = load_memory_limits(tmp.path());
+        assert_eq!(mem, 5000);
+        assert_eq!(user, 3000);
+    }
+
+    #[test]
+    fn load_memory_limits_falls_back_to_defaults_when_config_missing() {
+        let tmp = tempfile::TempDir::new().unwrap();
+        let (mem, user) = load_memory_limits(tmp.path());
+        assert_eq!(mem, MEMORY_CHAR_LIMIT);
+        assert_eq!(user, USER_CHAR_LIMIT);
     }
 }


### PR DESCRIPTION
## Summary

修复记忆配置页面显示上限偏小的问题。根因是 Rust 后端硬编码了 `MEMORY_CHAR_LIMIT=2200` 和 `USER_CHAR_LIMIT=1375`，从未读取用户在 `config.yaml` 中配置的自定义值。这导致前端 `CapacityBar` 组件永远基于默认值计算进度条和显示上限数字。

修复后在 `read_memory_from_home()` 中调用新增的 `load_memory_limits()` 读取 `hermes_home/config.yaml` 的 `memory.memory_char_limit` / `memory.user_char_limit` 字段，缺失或解析失败时安全回退到硬编码默认值。同时更新了 `add_memory_entry`、`update_memory_entry`、`write_user_profile` 的写入上限拦截逻辑，使其使用配置感知的上限值。

Closes #264

## Test Plan

- [x] 独立单元测试通过 5 个场景：缺失配置文件、正常读取、部分字段配置、YAML 格式错误、无 limit 键
- [x] `memory.rs` 内嵌单元测试新增 2 个用例覆盖 `load_memory_limits` 的 happy path 和 fallback
- [ ] 需在有 GTK 库的环境执行 `cargo test --all-features` 完整验证
- [ ] 手动验证：在 `config.yaml` 中设置 `memory.memory_char_limit: 5000`，重启应用后检查"配置 → 记忆"页面显示上限是否为 5000

## Notes

- 新增依赖 `serde_yaml = "0.9"`，与项目已有的 `serde` / `serde_json` 兼容
- 对用户可见行为：此前修改 config.yaml 内的 memory 上限值不生效，修复后即时生效
- 对配置的影响：无 schema 变更，仅新增对已有字段 `memory.memory_char_limit` / `memory.user_char_limit` 的读取
- 向下兼容：config.yaml 缺失或字段不存在时，行为与修复前完全一致（使用 2200/1375 默认值）