### PR TITLE
[codex] 支持清空新建对话默认工作区

### DIFF
--- a/web/src/components/chat/goose-composer.module.css
+++ b/web/src/components/chat/goose-composer.module.css
@@ -1326,6 +1326,37 @@
   opacity: 0.55;
 }
 
+.workspaceClearButton {
+  display: inline-flex;
+  align-items: center;
+  justify-content: center;
+  width: 22px;
+  height: 22px;
+  flex: 0 0 auto;
+  border: 0;
+  border-radius: 999px;
+  background: var(--h-bg-soft);
+  color: var(--h-text-3);
+  cursor: pointer;
+  padding: 0;
+}
+
+.workspaceClearButton:hover:not(:disabled) {
+  background: var(--h-bg-chip);
+  color: var(--h-text);
+}
+
+.workspaceClearButton:disabled {
+  cursor: not-allowed;
+  opacity: 0.55;
+}
+
+.workspaceClearButton svg {
+  width: 12px;
+  height: 12px;
+  stroke-width: 2.2;
+}
+
 .toolButton span,
 .toolButton small {
   min-width: 0;

--- a/web/src/components/chat/goose-composer.test.tsx
+++ b/web/src/components/chat/goose-composer.test.tsx
@@ -73,3 +73,20 @@ describe("GooseComposer slash hints", () => {
     expect(html).toContain("触发会话压缩");
   });
 });
+
+describe("GooseComposer workspace picker", () => {
+  it("renders a clear workspace action when a workspace is selected", () => {
+    const html = renderComposer(
+      <GooseComposer initialWorkspacePath="/Users/enzo/Project" />,
+    );
+
+    expect(html).toContain("Project");
+    expect(html).toContain("不指定默认工作区：/Users/enzo/Project");
+  });
+
+  it("does not render the clear workspace action without a selected workspace", () => {
+    const html = renderComposer(<GooseComposer />);
+
+    expect(html).not.toContain("不指定默认工作区：");
+  });
+});

--- a/web/src/components/chat/goose-composer.tsx
+++ b/web/src/components/chat/goose-composer.tsx
@@ -718,6 +718,14 @@ export function GooseComposer({
     rememberWorkspaceProject(nextPath);
   };
 
+  const clearWorkspacePath = () => {
+    if (controlsDisabled) return;
+    setSubmitError("");
+    setWorkspacePath("");
+    writeWorkspacePath("");
+    setWorkspacePickerOpen(false);
+  };
+
   const pickWorkspace = async () => {
     if (controlsDisabled) return;
     setSubmitError("");
@@ -1473,6 +1481,18 @@ export function GooseComposer({
               <span>工作区</span>
               {workspacePath ? <small>{fileNameFromPath(workspacePath)}</small> : null}
             </button>
+            {workspacePath ? (
+              <button
+                className={s.workspaceClearButton}
+                type="button"
+                onClick={clearWorkspacePath}
+                disabled={controlsDisabled}
+                title="不指定默认工作区"
+                aria-label={`不指定默认工作区：${workspacePath}`}
+              >
+                <X aria-hidden="true" />
+              </button>
+            ) : null}
             {modelPicker ? (
               <button
                 className={s.toolButton}


### PR DESCRIPTION
## 变更内容

在新建对话的工作区工具按钮后增加清空按钮，当用户已经选择工作区时可以一键取消默认工作区选择。

## 背景原因

此前新建对话会沿用已选择或最近使用的工作区，用户想创建不绑定工作区的对话时缺少明确入口。

## 影响

用户点击小叉号后会清空当前默认工作区，后续创建会话时不再传递工作区路径；原有选择工作区流程保持不变。

## 验证

- `pnpm typecheck`
- `pnpm test:unit`
- `cargo check`