### PR TITLE
[codex] 支持本地连接、助手个性化与会话显示修复

### DIFF
--- a/packages/protocol/src/channels.ts
+++ b/packages/protocol/src/channels.ts
@@ -501,14 +501,16 @@ export interface SetYoloModeResult {
   error?: string;
 }
 
-// --- Connection config: local managed runtime vs remote Hermes Agent -------
+// --- Connection config: managed runtime vs local/remote Hermes Agent -------
 // Mirrors the official desktop's connection IPC (token auth only). The token
 // value never crosses to the renderer — only presence/preview signals.
 
-export type ConnectionMode = "local" | "remote";
+export type ConnectionMode = "managed" | "local" | "remote";
 
 export interface ConnectionConfigInput {
   mode?: ConnectionMode;
+  /** Loopback CLI dashboard URL for local connection mode. Defaults to 127.0.0.1:9119. */
+  localUrl?: string;
   remoteUrl?: string;
   /** Empty/absent keeps the previously saved token. */
   remoteToken?: string;
@@ -517,6 +519,7 @@ export interface ConnectionConfigInput {
 export interface ConnectionConfigView {
   /** The saved (target) mode — may differ from effectiveMode until applied. */
   mode: ConnectionMode;
+  localUrl: string;
   remoteUrl: string;
   remoteTokenSet: boolean;
   /** "set" or "...XXXXXX" (last 6 chars); absent when no token is saved. */

--- a/packages/protocol/src/hermes-api.test.ts
+++ b/packages/protocol/src/hermes-api.test.ts
@@ -333,3 +333,24 @@ describe("SessionSummary cwd (#216)", () => {
     expect(parsed.sessions[0]?.cwd).toBe("/Users/claw/project-b");
   });
 });
+
+describe("OAuth schemas", () => {
+  it("accepts loopback providers and start responses", async () => {
+    const { OAuthProvider, OAuthStartResponse } = await import("./hermes-api");
+    const provider = OAuthProvider.parse({
+      id: "xai-oauth",
+      name: "xAI Grok OAuth",
+      flow: "loopback",
+      status: { logged_in: false },
+    });
+    expect(provider.flow).toBe("loopback");
+
+    const start = OAuthStartResponse.parse({
+      session_id: "sid",
+      flow: "loopback",
+      auth_url: "https://example.test/authorize",
+      expires_in: 900,
+    });
+    expect(start.flow).toBe("loopback");
+  });
+});

--- a/packages/protocol/src/hermes-api.ts
+++ b/packages/protocol/src/hermes-api.ts
@@ -678,7 +678,7 @@ export type OAuthProviderStatus = z.infer<typeof OAuthProviderStatus>;
 export const OAuthProvider = z.object({
   id: z.string(),
   name: z.string(),
-  flow: z.enum(["pkce", "device_code", "external"]).optional(),
+  flow: z.enum(["pkce", "device_code", "external", "loopback"]).optional(),
   cli_command: z.string().optional(),
   docs_url: z.string().optional(),
   status: OAuthProviderStatus,
@@ -706,9 +706,17 @@ const OAuthStartResponseDeviceCode = z.object({
   poll_interval: z.number(),
 });
 
+const OAuthStartResponseLoopback = z.object({
+  session_id: z.string(),
+  flow: z.literal("loopback"),
+  auth_url: z.string(),
+  expires_in: z.number(),
+});
+
 export const OAuthStartResponse = z.discriminatedUnion("flow", [
   OAuthStartResponsePkce,
   OAuthStartResponseDeviceCode,
+  OAuthStartResponseLoopback,
 ]);
 export type OAuthStartResponse = z.infer<typeof OAuthStartResponse>;
 

--- a/src/bootstrap.rs
+++ b/src/bootstrap.rs
@@ -6,15 +6,16 @@
 // sync → dashboard spawn) when flipping remote → local, including the
 // "no managed runtime on disk yet" first-install case.
 //
-// Two backend shapes come out of here:
-//   - local: a desktop-owned `hermes dashboard` subprocess (acquire_managed_dashboard)
-//   - remote: an attach-only handle to a remote Hermes Agent (connect_remote_backend)
+// Three backend shapes come out of here:
+//   - managed: a desktop-owned `hermes dashboard` subprocess (acquire_managed_dashboard)
+//   - local: an attach-only handle to a loopback Hermes Agent CLI dashboard
+//   - remote: an attach-only handle to a remote Hermes Agent
 
 use std::path::{Path, PathBuf};
 
 use tauri::Emitter;
 
-use crate::connection::{ConnectionMode, RemoteBackend};
+use crate::connection::{ConnectionMode, LocalBackend, RemoteBackend};
 use crate::environment;
 use crate::process::{dashboard, runtime};
 use crate::state::{AppState, DashboardHandle};
@@ -169,6 +170,36 @@ pub async fn connect_remote_backend(
     DashboardHandle::remote(remote.base_url.clone(), remote.token.clone())
 }
 
+/// Attach to a local Hermes Agent CLI dashboard. The URL is already validated
+/// as loopback by connection.rs; we best-effort fetch the current session token
+/// from the served HTML so users do not have to paste it manually.
+pub async fn connect_local_backend(
+    app: &tauri::AppHandle,
+    local: &LocalBackend,
+) -> DashboardHandle {
+    emit_runtime_status(
+        app,
+        "starting-dashboard",
+        "正在连接本地 Hermes Agent CLI...",
+    );
+    log::info!("Local connection mode: attaching to {}", local.base_url);
+    if !dashboard::probe_attached_dashboard(&local.base_url).await {
+        log::warn!(
+            "Local Hermes Agent CLI dashboard not reachable at {} during bootstrap; continuing — \
+             Settings → 连接 can fix the URL or switch back to managed runtime",
+            local.base_url
+        );
+    }
+    let token = dashboard::fetch_session_token(&local.base_url).await;
+    if token.is_none() {
+        log::warn!(
+            "Local Hermes Agent CLI dashboard at {} did not expose a session token",
+            local.base_url
+        );
+    }
+    DashboardHandle::local(local.base_url.clone(), token)
+}
+
 /// Finish bootstrap once a dashboard handle is available: fetch the session
 /// token, build the gateway URL, populate AppState, and emit the "ready"
 /// event the frontend waits on.
@@ -184,9 +215,8 @@ pub async fn finalize_bootstrap(
 
     let session_token = match handle.session_token.clone() {
         Some(token) => Some(token),
-        // Remote handles always carry their token, so this local-dashboard
-        // fallback chain (env override → scrape the dashboard HTML) only ever
-        // runs in local mode.
+        // Remote handles always carry their token, so this dashboard scrape
+        // fallback is only for managed or loopback-local dashboards.
         None => match std::env::var("HERMES_DESKTOP_SESSION_TOKEN")
             .ok()
             .or_else(|| std::env::var("HERMES_DASHBOARD_SESSION_TOKEN").ok())
@@ -196,21 +226,39 @@ pub async fn finalize_bootstrap(
         },
     };
     let gateway_url = dashboard::build_gateway_url(&handle.api_base_url, session_token.as_deref());
+    let (effective_home, effective_home_base, effective_profile) = if mode == ConnectionMode::Local
+    {
+        match dashboard::fetch_attached_dashboard_hermes_home(&handle.api_base_url)
+            .await
+            .filter(|h| !h.trim().is_empty())
+        {
+            Some(home) => (home.clone(), home, "default".to_string()),
+            None => {
+                log::warn!(
+                    "Local dashboard at {} did not return hermes_home; keeping bootstrap home until Settings reconnect succeeds",
+                    handle.api_base_url
+                );
+                (hermes_home, hermes_home_base, "default".to_string())
+            }
+        }
+    } else {
+        (hermes_home, hermes_home_base, profile)
+    };
 
     {
         let state = app.state::<AppState>();
         let mut inner = state.inner.lock().unwrap();
         inner.api_base_url = handle.api_base_url.clone();
         inner.gateway_url = gateway_url;
-        inner.hermes_home = hermes_home;
-        inner.hermes_home_base = hermes_home_base;
+        inner.hermes_home = effective_home;
+        inner.hermes_home_base = effective_home_base;
         inner.session_token = session_token;
-        inner.current_profile = profile;
+        inner.current_profile = effective_profile;
         inner.yolo_mode = match mode {
-            ConnectionMode::Local => dashboard::yolo_mode_effective(&inner.hermes_home),
+            ConnectionMode::Managed => dashboard::yolo_mode_effective(&inner.hermes_home),
             // YOLO is a managed-runtime launch flag; it has no meaning for a
             // backend this desktop doesn't own.
-            ConnectionMode::Remote => false,
+            ConnectionMode::Local | ConnectionMode::Remote => false,
         };
         inner.connection_mode = mode;
         inner.dashboard_handle = Some(handle);

--- a/src/commands/api_proxy.rs
+++ b/src/commands/api_proxy.rs
@@ -537,20 +537,20 @@ pub async fn api_request(
     input: ApiRequestInput,
     state: State<'_, AppState>,
 ) -> Result<ApiRequestResult, AppError> {
-    let (api_base_url, session_token, hermes_home, hermes_home_base, is_remote) = {
+    let (api_base_url, session_token, hermes_home, hermes_home_base, mode) = {
         let inner = state.inner.lock()?;
         (
             inner.api_base_url.clone(),
             inner.session_token.clone(),
             inner.hermes_home.clone(),
             inner.hermes_home_base.clone(),
-            inner.connection_mode == crate::connection::ConnectionMode::Remote,
+            inner.connection_mode,
         )
     };
 
-    // Remote mode: the runtime-update intercept below manages the LOCAL
-    // managed runtime, which is not what this desktop is connected to.
-    if is_remote
+    // Attached modes: the runtime-update intercept below manages the desktop
+    // managed runtime, which is not what this shell is connected to.
+    if mode != crate::connection::ConnectionMode::Managed
         && url_path(&input.path) == "/api/hermes/update"
         && input.method.as_deref().unwrap_or("GET").to_uppercase() == "POST"
     {
@@ -559,7 +559,7 @@ pub async fn api_request(
             "Conflict",
             serde_json::json!({
                 "ok": false,
-                "error": "当前连接的是远程 Hermes Agent，无法更新本地 runtime"
+                "error": "当前连接的不是本机内核，无法更新桌面端 managed runtime"
             }),
         ));
     }
@@ -574,8 +574,9 @@ pub async fn api_request(
     .await?;
     // Remote tokens are static (entered in Settings or via env); the
     // refresh-by-scraping-the-dashboard-HTML recovery below only applies to
-    // the local managed runtime, whose token rotates on restart.
-    if first.status != 401 || is_remote {
+    // managed runtime and loopback local CLI dashboards, whose token may
+    // rotate on restart.
+    if first.status != 401 || mode == crate::connection::ConnectionMode::Remote {
         return Ok(first);
     }
 

--- a/src/commands/connection.rs
+++ b/src/commands/connection.rs
@@ -1,16 +1,14 @@
-// Connection-config commands: local managed runtime vs remote Hermes Agent.
+// Connection-config commands: managed runtime vs local/remote Hermes Agent.
 //
 // IPC surface mirrors the official desktop (Hermes-CN-Core apps/desktop
 // preload: getConnectionConfig / saveConnectionConfig / applyConnectionConfig /
 // testConnectionConfig / probeConnectionConfig), token-auth only.
 //
 // `apply_connection_config` switches modes live, without an app restart:
-//   - local → remote: probe the remote FIRST (fail fast leaving the local
-//     dashboard untouched), then stop the owned dashboard and adopt the remote
-//     connection into AppState.
-//   - remote → local: run the full bootstrap acquire path (which can download
-//     a managed runtime on a machine that has never run local) and adopt the
-//     spawned dashboard.
+//   - managed → local/remote: probe the target FIRST, then stop the owned
+//     dashboard and adopt the attachment into AppState.
+//   - local/remote → managed: run the full bootstrap acquire path (which can
+//     download a managed runtime on a machine that has never run it).
 // Both directions hold the shared dashboard-restart guard so they cannot race
 // a profile switch or YOLO toggle. The frontend reloads the webview after a
 // successful apply, which rebuilds all JS-side state from get_runtime_config.
@@ -25,6 +23,7 @@ use crate::commands::restart;
 use crate::connection::{self, ConnectionConfig, ConnectionMode, SanitizedConnectionConfig};
 use crate::error::{AppError, AppResult};
 use crate::process::dashboard;
+use crate::process::runtime;
 use crate::state::{AppState, DashboardHandle};
 
 static CONNECTION_HTTP_CLIENT: LazyLock<reqwest::Client> = LazyLock::new(|| {
@@ -48,6 +47,7 @@ pub struct ConnectionConfigView {
 #[serde(rename_all = "camelCase")]
 pub struct ConnectionConfigInput {
     pub mode: Option<String>,
+    pub local_url: Option<String>,
     pub remote_url: Option<String>,
     /// Empty/absent keeps the previously saved token (so the user can edit the
     /// URL without re-entering the secret), matching the official desktop's
@@ -102,8 +102,9 @@ fn coerce_config(
     input: &ConnectionConfigInput,
 ) -> AppResult<ConnectionConfig> {
     let mode = match input.mode.as_deref() {
+        Some("managed") | None => ConnectionMode::Managed,
+        Some("local") => ConnectionMode::Local,
         Some("remote") => ConnectionMode::Remote,
-        Some("local") | None => ConnectionMode::Local,
         Some(other) => {
             return Err(AppError::InvalidRequest(format!(
                 "未知的连接模式: {}",
@@ -112,6 +113,11 @@ fn coerce_config(
         }
     };
 
+    let local_url = match input.local_url.as_deref().map(str::trim) {
+        Some(url) if !url.is_empty() => Some(connection::normalize_local_base_url(url)?),
+        Some(_) => Some(connection::DEFAULT_LOCAL_DASHBOARD_URL.to_string()),
+        None => existing.local_url.clone(),
+    };
     let remote_url = match input.remote_url.as_deref().map(str::trim) {
         Some(url) if !url.is_empty() => Some(connection::normalize_remote_base_url(url)?),
         // An explicitly empty URL clears the saved one; absent keeps it.
@@ -122,6 +128,12 @@ fn coerce_config(
         Some(token) if !token.is_empty() => Some(token.to_string()),
         // Empty or absent keeps the saved secret — the form never round-trips it.
         _ => existing.remote_token.clone(),
+    };
+
+    let local_url = if mode == ConnectionMode::Local {
+        Some(local_url.unwrap_or_else(|| connection::DEFAULT_LOCAL_DASHBOARD_URL.to_string()))
+    } else {
+        local_url
     };
 
     if mode == ConnectionMode::Remote {
@@ -139,6 +151,7 @@ fn coerce_config(
 
     Ok(ConnectionConfig {
         mode,
+        local_url,
         remote_url,
         remote_token,
     })
@@ -154,10 +167,41 @@ fn reject_env_override() -> AppResult<()> {
     Ok(())
 }
 
+enum TestTarget {
+    Local { base_url: String },
+    Remote { base_url: String, token: String },
+}
+
 /// Resolve the URL/token a test should run against: explicit form input wins,
 /// then the env override, then the saved config.
-fn test_target(input: &ConnectionConfigInput) -> AppResult<(String, String)> {
+fn test_target(input: &ConnectionConfigInput) -> AppResult<TestTarget> {
     let saved = connection::read_config();
+    let mode = match input.mode.as_deref() {
+        Some("local") => ConnectionMode::Local,
+        Some("remote") => ConnectionMode::Remote,
+        Some("managed") | None => saved.mode,
+        Some(other) => {
+            return Err(AppError::InvalidRequest(format!(
+                "未知的连接模式: {}",
+                other
+            )))
+        }
+    };
+
+    if mode == ConnectionMode::Local {
+        let raw_url = input
+            .local_url
+            .as_deref()
+            .map(str::trim)
+            .filter(|v| !v.is_empty())
+            .map(str::to_string)
+            .or(saved.local_url)
+            .unwrap_or_else(|| connection::DEFAULT_LOCAL_DASHBOARD_URL.to_string());
+        return Ok(TestTarget::Local {
+            base_url: connection::normalize_local_base_url(&raw_url)?,
+        });
+    }
+
     let env_url = std::env::var(connection::ENV_REMOTE_URL)
         .ok()
         .map(|v| v.trim().to_string())
@@ -190,7 +234,10 @@ fn test_target(input: &ConnectionConfigInput) -> AppResult<(String, String)> {
             AppError::InvalidRequest("没有可测试的 token：请先填写 session token".to_string())
         })?;
 
-    Ok((connection::normalize_remote_base_url(&raw_url)?, token))
+    Ok(TestTarget::Remote {
+        base_url: connection::normalize_remote_base_url(&raw_url)?,
+        token,
+    })
 }
 
 async fn fetch_status(
@@ -282,14 +329,21 @@ pub async fn probe_connection_config(
 pub async fn test_connection_config(
     input: ConnectionConfigInput,
 ) -> Result<TestConnectionResult, AppError> {
-    let (base_url, token) = test_target(&input)?;
+    let target = test_target(&input)?;
+    let (base_url, token, is_local) = match target {
+        TestTarget::Local { base_url } => {
+            let token = dashboard::fetch_session_token(&base_url).await;
+            (base_url, token, true)
+        }
+        TestTarget::Remote { base_url, token } => (base_url, Some(token), false),
+    };
 
     let mut result = TestConnectionResult {
         base_url: base_url.clone(),
         ..Default::default()
     };
 
-    match fetch_status(&base_url, Some(&token)).await {
+    match fetch_status(&base_url, token.as_deref()).await {
         Ok((status, body)) => {
             result.http_status = Some(status);
             result.http_ok = (200..300).contains(&status);
@@ -300,13 +354,18 @@ pub async fn test_connection_config(
                 .and_then(|v| v.as_str())
                 .map(str::to_string);
             if status == 401 {
-                result.error = Some("token 无效或已过期（HTTP 401）".to_string());
+                result.error = Some(if is_local {
+                    "无法自动读取本地 dashboard session token，或 token 已过期（HTTP 401）"
+                        .to_string()
+                } else {
+                    "token 无效或已过期（HTTP 401）".to_string()
+                });
             } else if !result.http_ok {
-                result.error = Some(format!("远程返回 HTTP {}", status));
+                result.error = Some(format!("目标网关返回 HTTP {}", status));
             }
         }
         Err(err) => {
-            result.error = Some(format!("无法连接远程地址: {}", err));
+            result.error = Some(format!("无法连接目标地址: {}", err));
             return Ok(result);
         }
     }
@@ -317,7 +376,12 @@ pub async fn test_connection_config(
         return Ok(result);
     }
 
-    result.ws_ok = dashboard::dashboard_supports_ws(&base_url, Some(&token)).await;
+    if token.is_none() {
+        result.error = Some("HTTP 可达，但无法自动读取 dashboard session token".to_string());
+        return Ok(result);
+    }
+
+    result.ws_ok = dashboard::dashboard_supports_ws(&base_url, token.as_deref()).await;
     if result.http_ok && !result.ws_ok {
         result.error = Some(
             "HTTP 可达但 WebSocket（/api/ws）握手失败：检查代理/防火墙是否放行 WS，以及 token 是否正确".to_string(),
@@ -351,12 +415,29 @@ pub async fn apply_connection_config(
     }
 
     let result = match config.mode {
+        ConnectionMode::Managed => apply_managed(&app, &state).await,
+        ConnectionMode::Local => apply_local_connection(&state, &config).await,
         ConnectionMode::Remote => apply_remote(&state, &config).await,
-        ConnectionMode::Local => apply_local(&app, &state).await,
     };
 
     restart::end_restart(&state);
     result
+}
+
+fn detach_current_backend(state: &State<'_, AppState>) -> Result<(), AppError> {
+    let mut inner = state.inner.lock()?;
+    if let Some(relay) = inner.gateway_ws.take() {
+        relay
+            .abort
+            .store(true, std::sync::atomic::Ordering::Relaxed);
+        relay.notify.notify_waiters();
+    }
+    let session_token = inner.session_token.clone();
+    if let Some(ref mut handle) = inner.dashboard_handle {
+        handle.stop_with_token(session_token.as_deref());
+    }
+    inner.dashboard_handle = None;
+    Ok(())
 }
 
 /// Switch the running desktop onto a remote Hermes Agent. The remote is probed
@@ -393,22 +474,7 @@ async fn apply_remote(
         });
     }
 
-    // Tear down the local side: stop the WS relay, then gracefully stop the
-    // owned dashboard (a no-op for remote/external handles).
-    {
-        let mut inner = state.inner.lock()?;
-        if let Some(relay) = inner.gateway_ws.take() {
-            relay
-                .abort
-                .store(true, std::sync::atomic::Ordering::Relaxed);
-            relay.notify.notify_waiters();
-        }
-        let session_token = inner.session_token.clone();
-        if let Some(ref mut handle) = inner.dashboard_handle {
-            handle.stop_with_token(session_token.as_deref());
-        }
-        inner.dashboard_handle = None;
-    }
+    detach_current_backend(state)?;
 
     let gateway_url = dashboard::build_gateway_url(&base_url, Some(&token));
     {
@@ -433,43 +499,158 @@ async fn apply_remote(
     })
 }
 
-/// Switch back to the local managed runtime. Runs the full bootstrap acquire
+/// Switch the running desktop onto a loopback Hermes Agent CLI dashboard. The
+/// session token is fetched from the dashboard HTML and never stored.
+async fn apply_local_connection(
+    state: &State<'_, AppState>,
+    config: &ConnectionConfig,
+) -> Result<ApplyConnectionResult, AppError> {
+    let base_url = config
+        .local_url
+        .clone()
+        .unwrap_or_else(|| connection::DEFAULT_LOCAL_DASHBOARD_URL.to_string());
+
+    if !dashboard::probe_attached_dashboard(&base_url).await {
+        return Ok(ApplyConnectionResult {
+            ok: false,
+            mode: "local".to_string(),
+            error: Some(format!(
+                "本地 Hermes Agent CLI 不可达（{}/api/status 无响应），已保存配置但未切换",
+                base_url
+            )),
+            ..Default::default()
+        });
+    }
+
+    let token = match dashboard::fetch_session_token(&base_url).await {
+        Some(token) => token,
+        None => {
+            return Ok(ApplyConnectionResult {
+                ok: false,
+                mode: "local".to_string(),
+                error: Some(
+                    "无法从本地 dashboard 页面自动读取 session token，请确认 Hermes Agent CLI dashboard 正常运行"
+                        .to_string(),
+                ),
+                ..Default::default()
+            })
+        }
+    };
+
+    if !dashboard::dashboard_supports_ws(&base_url, Some(&token)).await {
+        return Ok(ApplyConnectionResult {
+            ok: false,
+            mode: "local".to_string(),
+            error: Some(
+                "本地 WebSocket（/api/ws）握手失败：检查本机 dashboard 状态与 session token"
+                    .to_string(),
+            ),
+            ..Default::default()
+        });
+    }
+
+    let hermes_home = match dashboard::fetch_attached_dashboard_hermes_home(&base_url)
+        .await
+        .filter(|h| !h.trim().is_empty())
+    {
+        Some(home) => home,
+        None => {
+            return Ok(ApplyConnectionResult {
+                ok: false,
+                mode: "local".to_string(),
+                error: Some(
+                    "本地 dashboard 未返回 hermes_home，已保存配置但未切换，避免误读桌面端内置内核的 Memory"
+                        .to_string(),
+                ),
+                ..Default::default()
+            })
+        }
+    };
+    let gateway_url = dashboard::build_gateway_url(&base_url, Some(&token));
+    detach_current_backend(state)?;
+
+    {
+        let mut inner = state.inner.lock()?;
+        inner.api_base_url = base_url.clone();
+        inner.gateway_url = gateway_url.clone();
+        inner.session_token = Some(token.clone());
+        inner.hermes_home = hermes_home.clone();
+        inner.hermes_home_base = hermes_home;
+        inner.current_profile = "default".to_string();
+        inner.connection_mode = ConnectionMode::Local;
+        inner.yolo_mode = false;
+        inner.last_runtime_error = None;
+        inner.dashboard_handle = Some(DashboardHandle::local(
+            base_url.clone(),
+            Some(token.clone()),
+        ));
+    }
+
+    log::info!(
+        "Connection switched to local Hermes Agent CLI at {}",
+        base_url
+    );
+    Ok(ApplyConnectionResult {
+        ok: true,
+        mode: "local".to_string(),
+        api_base_url: Some(base_url),
+        gateway_url: Some(gateway_url),
+        session_token: Some(token),
+        error: None,
+    })
+}
+
+/// Switch back to the desktop managed runtime. Runs the full bootstrap acquire
 /// path — a remote-first install may not even have a managed runtime on disk
 /// yet, so this can download one (with runtime-status progress events).
-async fn apply_local(
+async fn apply_managed(
     app: &tauri::AppHandle,
     state: &State<'_, AppState>,
 ) -> Result<ApplyConnectionResult, AppError> {
-    let (hermes_home, already_local) = {
+    let (already_managed, api_base_url, gateway_url, session_token) = {
         let inner = state.inner.lock()?;
         (
-            inner.hermes_home.clone(),
-            inner.connection_mode == ConnectionMode::Local && inner.dashboard_handle.is_some(),
+            inner.connection_mode == ConnectionMode::Managed && inner.dashboard_handle.is_some(),
+            inner.api_base_url.clone(),
+            inner.gateway_url.clone(),
+            inner.session_token.clone(),
         )
     };
-    if already_local {
-        let inner = state.inner.lock()?;
+    if already_managed {
         return Ok(ApplyConnectionResult {
             ok: true,
-            mode: "local".to_string(),
-            api_base_url: Some(inner.api_base_url.clone()),
-            gateway_url: Some(inner.gateway_url.clone()),
-            session_token: inner.session_token.clone(),
+            mode: "managed".to_string(),
+            api_base_url: Some(api_base_url),
+            gateway_url: Some(gateway_url),
+            session_token,
             error: None,
         });
     }
 
-    // Drop the remote attachment (stop_with_token is a no-op for it).
-    {
-        let mut inner = state.inner.lock()?;
-        if let Some(relay) = inner.gateway_ws.take() {
-            relay
-                .abort
-                .store(true, std::sync::atomic::Ordering::Relaxed);
-            relay.notify.notify_waiters();
-        }
-        inner.dashboard_handle = None;
+    let hermes_home_base = runtime::hermes_home_dir().to_string_lossy().to_string();
+    let mut current_profile =
+        crate::commands::profiles::read_active_profile_sticky(&hermes_home_base);
+    let mut hermes_home = if current_profile == "default" {
+        runtime::hermes_home_dir()
+    } else {
+        runtime::hermes_home_dir()
+            .join("profiles")
+            .join(&current_profile)
+    };
+    if current_profile != "default" && !hermes_home.exists() {
+        log::warn!(
+            "saved managed profile {} points to missing {}; falling back to default",
+            current_profile,
+            hermes_home.display()
+        );
+        current_profile = "default".to_string();
+        hermes_home = runtime::hermes_home_dir();
+        let _ = std::fs::remove_file(runtime::hermes_home_dir().join("active_profile"));
     }
+    let hermes_home = hermes_home.to_string_lossy().to_string();
+
+    // Drop the attachment (stop_with_token is a no-op for it).
+    detach_current_backend(state)?;
 
     let (host, port) = restart::host_and_port();
     let options = dashboard::EnsureDashboardOptions {
@@ -487,7 +668,7 @@ async fn apply_local(
             Err(err) => {
                 return Ok(ApplyConnectionResult {
                     ok: false,
-                    mode: "local".to_string(),
+                    mode: "managed".to_string(),
                     error: Some(format!("本地内核启动失败：{}", err)),
                     ..Default::default()
                 })
@@ -512,16 +693,19 @@ async fn apply_local(
         inner.api_base_url = api_base_url.clone();
         inner.gateway_url = gateway_url.clone();
         inner.session_token = token.clone();
-        inner.connection_mode = ConnectionMode::Local;
+        inner.hermes_home = hermes_home.clone();
+        inner.hermes_home_base = hermes_home_base;
+        inner.current_profile = current_profile;
+        inner.connection_mode = ConnectionMode::Managed;
         inner.yolo_mode = dashboard::yolo_mode_effective(&hermes_home);
         inner.last_runtime_error = None;
         inner.dashboard_handle = Some(handle);
     }
 
-    log::info!("Connection switched back to local managed runtime");
+    log::info!("Connection switched back to desktop managed runtime");
     Ok(ApplyConnectionResult {
         ok: true,
-        mode: "local".to_string(),
+        mode: "managed".to_string(),
         api_base_url: Some(api_base_url),
         gateway_url: Some(gateway_url),
         session_token: token,
@@ -537,17 +721,46 @@ mod tests {
     fn remote_config() -> ConnectionConfig {
         ConnectionConfig {
             mode: ConnectionMode::Remote,
+            local_url: Some(connection::DEFAULT_LOCAL_DASHBOARD_URL.to_string()),
             remote_url: Some("http://host:9221".to_string()),
             remote_token: Some("saved-token".to_string()),
         }
     }
 
     #[test]
-    fn coerce_defaults_to_local_keeping_remote_fields() {
+    fn coerce_defaults_to_managed_keeping_saved_fields() {
         let coerced = coerce_config(&remote_config(), &ConnectionConfigInput::default()).unwrap();
-        assert_eq!(coerced.mode, ConnectionMode::Local);
+        assert_eq!(coerced.mode, ConnectionMode::Managed);
+        assert_eq!(
+            coerced.local_url.as_deref(),
+            Some(connection::DEFAULT_LOCAL_DASHBOARD_URL)
+        );
         assert_eq!(coerced.remote_url.as_deref(), Some("http://host:9221"));
         assert_eq!(coerced.remote_token.as_deref(), Some("saved-token"));
+    }
+
+    #[test]
+    fn coerce_local_defaults_to_loopback_cli_url() {
+        let input = ConnectionConfigInput {
+            mode: Some("local".to_string()),
+            ..Default::default()
+        };
+        let coerced = coerce_config(&ConnectionConfig::default(), &input).unwrap();
+        assert_eq!(coerced.mode, ConnectionMode::Local);
+        assert_eq!(
+            coerced.local_url.as_deref(),
+            Some(connection::DEFAULT_LOCAL_DASHBOARD_URL)
+        );
+    }
+
+    #[test]
+    fn coerce_local_rejects_non_loopback_url() {
+        let input = ConnectionConfigInput {
+            mode: Some("local".to_string()),
+            local_url: Some("http://192.168.1.10:9119".to_string()),
+            ..Default::default()
+        };
+        assert!(coerce_config(&ConnectionConfig::default(), &input).is_err());
     }
 
     #[test]
@@ -556,6 +769,7 @@ mod tests {
             mode: Some("remote".to_string()),
             remote_url: Some("http://new-host:9120/".to_string()),
             remote_token: Some("   ".to_string()),
+            ..Default::default()
         };
         let coerced = coerce_config(&remote_config(), &input).unwrap();
         assert_eq!(coerced.mode, ConnectionMode::Remote);
@@ -578,6 +792,7 @@ mod tests {
             mode: Some("remote".to_string()),
             remote_url: Some("http://host:9221".to_string()),
             remote_token: None,
+            ..Default::default()
         };
         assert!(coerce_config(&ConnectionConfig::default(), &input).is_err());
     }
@@ -594,6 +809,7 @@ mod tests {
             mode: Some("remote".to_string()),
             remote_url: Some("ftp://host".to_string()),
             remote_token: Some("tok".to_string()),
+            ..Default::default()
         };
         assert!(coerce_config(&ConnectionConfig::default(), &bad_url).is_err());
     }
@@ -601,9 +817,10 @@ mod tests {
     #[test]
     fn coerce_explicit_empty_url_clears_saved_value() {
         let input = ConnectionConfigInput {
-            mode: Some("local".to_string()),
+            mode: Some("managed".to_string()),
             remote_url: Some("".to_string()),
             remote_token: None,
+            ..Default::default()
         };
         let coerced = coerce_config(&remote_config(), &input).unwrap();
         assert_eq!(coerced.remote_url, None);

--- a/src/commands/gateway.rs
+++ b/src/commands/gateway.rs
@@ -12,8 +12,7 @@ pub struct RuntimeConfig {
     pub gateway_url: String,
     pub session_token: Option<String>,
     pub current_profile: String,
-    /// "local" or "remote" — whether the desktop runs its own managed runtime
-    /// or is attached to a remote Hermes Agent as a shell.
+    /// "managed", "local" or "remote".
     pub connection_mode: String,
 }
 
@@ -40,19 +39,19 @@ pub struct RefreshGatewayResult {
 pub async fn refresh_gateway_url(
     state: State<'_, AppState>,
 ) -> Result<RefreshGatewayResult, AppError> {
-    let (api_base_url, current_token, is_remote) = {
+    let (api_base_url, current_token, mode) = {
         let inner = state.inner.lock()?;
         (
             inner.api_base_url.clone(),
             inner.session_token.clone(),
-            inner.connection_mode == crate::connection::ConnectionMode::Remote,
+            inner.connection_mode,
         )
     };
 
     // Remote tokens are static (Settings or env), never rotated by a local
     // dashboard restart — return the current connection unchanged instead of
     // scraping the remote's HTML for a token it doesn't embed.
-    if is_remote {
+    if mode == crate::connection::ConnectionMode::Remote {
         let inner = state.inner.lock()?;
         return Ok(RefreshGatewayResult {
             gateway_url: inner.gateway_url.clone(),

--- a/src/commands/memory.rs
+++ b/src/commands/memory.rs
@@ -147,6 +147,11 @@ fn write_file_safe(path: &Path, content: &str) -> AppResult<()> {
 
 fn active_hermes_home(state: &State<'_, AppState>) -> AppResult<PathBuf> {
     let inner = state.inner.lock()?;
+    if inner.connection_mode == crate::connection::ConnectionMode::Remote {
+        return Err(AppError::InvalidRequest(
+            "远程记忆编辑需要远端 Hermes Agent 提供记忆读写 API；当前桌面端不会读取内置内核的 Memory。".to_string(),
+        ));
+    }
     if inner.hermes_home.trim().is_empty() {
         return Err(AppError::NotReady);
     }

--- a/src/commands/profiles.rs
+++ b/src/commands/profiles.rs
@@ -108,13 +108,13 @@ pub async fn switch_profile(
     let (base, current_profile, _owns_process, previous_home) = {
         let inner = state.inner.lock()?;
 
-        // Profiles are HERMES_HOME-scoped local state; a remote Hermes Agent
-        // owns its own home. (The owns_process check below would also catch
-        // this, but with a misleading "not the owner" message.)
-        if inner.connection_mode == crate::connection::ConnectionMode::Remote {
+        // Profile switching requires a desktop-owned managed dashboard so the
+        // shell can restart it with a different HERMES_HOME. Attached local or
+        // remote agents own their own process/lifecycle.
+        if inner.connection_mode != crate::connection::ConnectionMode::Managed {
             return Ok(SwitchProfileResult {
                 ok: false,
-                error: Some("当前连接的是远程 Hermes Agent，不支持切换 Profile".to_string()),
+                error: Some("当前连接的不是本机内核，不支持在桌面端切换 Profile".to_string()),
                 ..Default::default()
             });
         }

--- a/src/commands/yolo.rs
+++ b/src/commands/yolo.rs
@@ -60,9 +60,9 @@ pub struct SetYoloModeResult {
 #[tauri::command]
 pub fn get_yolo_mode(state: State<'_, AppState>) -> Result<YoloModeStatus, AppError> {
     let inner = state.inner.lock()?;
-    // YOLO is a launch flag of the desktop-owned managed runtime; a remote
-    // Hermes Agent decides its own approval policy.
-    if inner.connection_mode == crate::connection::ConnectionMode::Remote {
+    // YOLO is a launch flag of the desktop-owned managed runtime; attached
+    // local/remote agents decide their own approval policy.
+    if inner.connection_mode != crate::connection::ConnectionMode::Managed {
         return Ok(YoloModeStatus {
             enabled: false,
             effective: false,
@@ -85,15 +85,15 @@ pub async fn set_yolo_mode(
     // a restart regardless of what happens to the live process.
     let (hermes_home, owns_process) = {
         let inner = state.inner.lock()?;
-        // Don't persist a preference into the local HERMES_HOME while a remote
-        // agent is connected — it wouldn't affect the remote, and would
-        // surprise the user on the next local boot.
-        if inner.connection_mode == crate::connection::ConnectionMode::Remote {
+        // Don't persist a preference while attached to another agent — it
+        // wouldn't affect that process, and would surprise the user on the
+        // next managed-runtime boot.
+        if inner.connection_mode != crate::connection::ConnectionMode::Managed {
             return Ok(SetYoloModeResult {
                 ok: false,
                 enabled: false,
                 effective: false,
-                error: Some("当前连接的是远程 Hermes Agent，YOLO 模式由远程端自行配置".to_string()),
+                error: Some("当前连接的不是本机内核，YOLO 模式由当前后端自行配置".to_string()),
                 ..Default::default()
             });
         }

--- a/src/connection.rs
+++ b/src/connection.rs
@@ -1,4 +1,4 @@
-// Desktop connection config: local managed runtime vs remote Hermes Agent.
+// Desktop connection config: managed runtime vs local/remote Hermes Agent.
 //
 // Port of the official desktop's connection layer (Hermes-CN-Core
 // apps/desktop/electron/connection-config.cjs + the resolveRemoteBackend logic
@@ -14,10 +14,11 @@
 // Resolution precedence (first match wins), matching the official desktop:
 //   1. HERMES_DESKTOP_REMOTE_URL + HERMES_DESKTOP_REMOTE_TOKEN env override
 //      (URL without token is a hard error, not a silent fallback)
-//   2. connection.json with mode == "remote"
-//   3. local managed runtime
+//   2. connection.json with mode == "remote" or "local"
+//   3. desktop-managed runtime
 
 use std::fs;
+use std::net::IpAddr;
 use std::path::PathBuf;
 
 use serde::{Deserialize, Serialize};
@@ -27,12 +28,15 @@ use crate::process::runtime;
 
 pub const ENV_REMOTE_URL: &str = "HERMES_DESKTOP_REMOTE_URL";
 pub const ENV_REMOTE_TOKEN: &str = "HERMES_DESKTOP_REMOTE_TOKEN";
+pub const DEFAULT_LOCAL_DASHBOARD_URL: &str = "http://127.0.0.1:9119";
 const CONNECTION_FILE: &str = "connection.json";
+const CONNECTION_FILE_VERSION: u32 = 2;
 
 /// Effective connection mode of the running desktop.
 #[derive(Debug, Clone, Copy, PartialEq, Eq, Default)]
 pub enum ConnectionMode {
     #[default]
+    Managed,
     Local,
     Remote,
 }
@@ -40,6 +44,7 @@ pub enum ConnectionMode {
 impl ConnectionMode {
     pub fn as_str(&self) -> &'static str {
         match self {
+            ConnectionMode::Managed => "managed",
             ConnectionMode::Local => "local",
             ConnectionMode::Remote => "remote",
         }
@@ -62,6 +67,23 @@ impl RemoteSource {
     }
 }
 
+/// A local CLI dashboard the desktop should attach to instead of spawning the
+/// managed runtime. The session token is fetched from the dashboard at connect
+/// time, so it is never persisted.
+#[derive(Debug, Clone, PartialEq, Eq)]
+pub struct LocalBackend {
+    /// Normalized loopback base URL (no trailing slash, no query/hash).
+    pub base_url: String,
+}
+
+/// Effective backend selected for this boot.
+#[derive(Debug, Clone, PartialEq, Eq)]
+pub enum ConnectionBackend {
+    Managed,
+    Local(LocalBackend),
+    Remote(RemoteBackend),
+}
+
 /// A fully-resolved remote backend the desktop should attach to instead of
 /// spawning the managed runtime.
 #[derive(Debug, Clone, PartialEq, Eq)]
@@ -76,6 +98,7 @@ pub struct RemoteBackend {
 #[derive(Debug, Clone, Default, PartialEq, Eq)]
 pub struct ConnectionConfig {
     pub mode: ConnectionMode,
+    pub local_url: Option<String>,
     pub remote_url: Option<String>,
     pub remote_token: Option<String>,
 }
@@ -85,6 +108,7 @@ pub struct ConnectionConfig {
 #[serde(rename_all = "camelCase")]
 pub struct SanitizedConnectionConfig {
     pub mode: String,
+    pub local_url: String,
     pub remote_url: String,
     pub remote_token_set: bool,
     pub remote_token_preview: Option<String>,
@@ -98,7 +122,14 @@ struct ConnectionFile {
     version: u32,
     mode: String,
     #[serde(default, skip_serializing_if = "Option::is_none")]
+    local: Option<LocalFileEntry>,
+    #[serde(default, skip_serializing_if = "Option::is_none")]
     remote: Option<RemoteFileEntry>,
+}
+
+#[derive(Debug, Serialize, Deserialize)]
+struct LocalFileEntry {
+    url: String,
 }
 
 #[derive(Debug, Serialize, Deserialize)]
@@ -120,7 +151,7 @@ pub fn config_path() -> PathBuf {
 }
 
 /// Read the persisted connection config. Fails closed: a missing, unreadable,
-/// or malformed file yields the default local config rather than an error, so
+/// or malformed file yields the default managed config rather than an error, so
 /// a corrupt connection.json can never brick the desktop boot.
 pub fn read_config() -> ConnectionConfig {
     read_config_from(&config_path())
@@ -135,7 +166,7 @@ fn read_config_from(path: &PathBuf) -> ConnectionConfig {
         Ok(file) => file,
         Err(err) => {
             log::warn!(
-                "Malformed connection config at {}; falling back to local mode: {}",
+                "Malformed connection config at {}; falling back to managed mode: {}",
                 path.display(),
                 err
             );
@@ -143,11 +174,20 @@ fn read_config_from(path: &PathBuf) -> ConnectionConfig {
         }
     };
 
-    let mode = if file.mode == "remote" {
-        ConnectionMode::Remote
-    } else {
-        ConnectionMode::Local
+    let mode = match file.mode.as_str() {
+        "remote" => ConnectionMode::Remote,
+        // v1 used "local" for the desktop-managed runtime. Only v2+ can mean
+        // the new “local CLI connection” mode, so old files must migrate to
+        // managed to avoid unexpectedly attaching to 127.0.0.1:9119.
+        "local" if file.version >= CONNECTION_FILE_VERSION => ConnectionMode::Local,
+        "managed" | "local" => ConnectionMode::Managed,
+        _ => ConnectionMode::Managed,
     };
+    let local_url = file
+        .local
+        .as_ref()
+        .map(|r| r.url.trim().to_string())
+        .filter(|url| !url.is_empty());
     let remote_url = file
         .remote
         .as_ref()
@@ -163,6 +203,7 @@ fn read_config_from(path: &PathBuf) -> ConnectionConfig {
 
     ConnectionConfig {
         mode,
+        local_url,
         remote_url,
         remote_token,
     }
@@ -176,8 +217,12 @@ pub fn write_config(config: &ConnectionConfig) -> AppResult<()> {
 
 fn write_config_to(path: &PathBuf, config: &ConnectionConfig) -> AppResult<()> {
     let file = ConnectionFile {
-        version: 1,
+        version: CONNECTION_FILE_VERSION,
         mode: config.mode.as_str().to_string(),
+        local: config
+            .local_url
+            .as_ref()
+            .map(|url| LocalFileEntry { url: url.clone() }),
         remote: config.remote_url.as_ref().map(|url| RemoteFileEntry {
             url: url.clone(),
             token: config.remote_token.as_ref().map(|value| TokenFileEntry {
@@ -234,6 +279,52 @@ pub fn normalize_remote_base_url(raw: &str) -> AppResult<String> {
     Ok(parsed.to_string().trim_end_matches('/').to_string())
 }
 
+fn normalize_base_url(raw: &str, empty_message: &str, invalid_prefix: &str) -> AppResult<url::Url> {
+    let value = raw.trim();
+    if value.is_empty() {
+        return Err(AppError::InvalidRequest(empty_message.to_string()));
+    }
+
+    let mut parsed = url::Url::parse(value)
+        .map_err(|e| AppError::InvalidRequest(format!("{}无效: {}", invalid_prefix, e)))?;
+    if !matches!(parsed.scheme(), "http" | "https") {
+        return Err(AppError::InvalidRequest(format!(
+            "{}必须是 http:// 或 https://，当前为 {}://",
+            invalid_prefix,
+            parsed.scheme()
+        )));
+    }
+    parsed.set_fragment(None);
+    parsed.set_query(None);
+    let trimmed_path = parsed.path().trim_end_matches('/').to_string();
+    parsed.set_path(&trimmed_path);
+    Ok(parsed)
+}
+
+fn is_loopback_host(parsed: &url::Url) -> bool {
+    match parsed.host() {
+        Some(url::Host::Domain(host)) => {
+            let lower = host.to_ascii_lowercase();
+            lower == "localhost" || lower.ends_with(".localhost")
+        }
+        Some(url::Host::Ipv4(ip)) => ip.is_loopback(),
+        Some(url::Host::Ipv6(ip)) => IpAddr::V6(ip).is_loopback(),
+        None => false,
+    }
+}
+
+/// Normalize a local CLI dashboard URL. Unlike remote URLs, this must stay on
+/// loopback so the desktop never treats a LAN/Internet host as “local”.
+pub fn normalize_local_base_url(raw: &str) -> AppResult<String> {
+    let parsed = normalize_base_url(raw, "本地 Hermes Agent 地址不能为空", "本地地址")?;
+    if !is_loopback_host(&parsed) {
+        return Err(AppError::InvalidRequest(
+            "本地连接仅允许 localhost / 127.0.0.1 / ::1 地址".to_string(),
+        ));
+    }
+    Ok(parsed.to_string().trim_end_matches('/').to_string())
+}
+
 /// "…XXXXXX" preview of a stored token for display: short tokens collapse to
 /// "set" so the preview can never reconstruct a meaningful fraction of them.
 pub fn token_preview(token: &str) -> Option<String> {
@@ -265,12 +356,10 @@ pub fn env_override_active() -> bool {
 
 /// Resolve the effective backend for this boot.
 ///
-/// Returns `Ok(Some(remote))` when the desktop should attach to a remote
-/// agent, `Ok(None)` for the local managed runtime, and `Err(message)` when
-/// the configuration is unusable (env URL without token, or an invalid URL —
-/// the latter only for env; a bad *saved* URL falls back to local with a
-/// warning so the user can still reach Settings to fix it).
-pub fn resolve_remote_backend() -> Result<Option<RemoteBackend>, String> {
+/// Returns a managed/local/remote backend. Env remote misconfiguration is a
+/// hard error; invalid saved local/remote entries fall back to managed so the
+/// user can still reach Settings and repair them.
+pub fn resolve_connection_backend() -> Result<ConnectionBackend, String> {
     if let Some(raw_url) = env_non_empty(ENV_REMOTE_URL) {
         let token = env_non_empty(ENV_REMOTE_TOKEN).ok_or_else(|| {
             format!(
@@ -280,7 +369,7 @@ pub fn resolve_remote_backend() -> Result<Option<RemoteBackend>, String> {
         })?;
         let base_url = normalize_remote_base_url(&raw_url)
             .map_err(|e| format!("{} 无效: {}", ENV_REMOTE_URL, e))?;
-        return Ok(Some(RemoteBackend {
+        return Ok(ConnectionBackend::Remote(RemoteBackend {
             base_url,
             token,
             source: RemoteSource::Env,
@@ -288,27 +377,52 @@ pub fn resolve_remote_backend() -> Result<Option<RemoteBackend>, String> {
     }
 
     let config = read_config();
-    if config.mode != ConnectionMode::Remote {
-        return Ok(None);
-    }
-
-    let (Some(raw_url), Some(token)) = (config.remote_url, config.remote_token) else {
-        log::warn!("connection.json 选择了远程模式但缺少 URL 或 token；回退到本地模式");
-        return Ok(None);
-    };
-    match normalize_remote_base_url(&raw_url) {
-        Ok(base_url) => Ok(Some(RemoteBackend {
-            base_url,
-            token,
-            source: RemoteSource::Settings,
-        })),
-        Err(err) => {
-            log::warn!(
-                "connection.json 中的远程地址无效（{}）；回退到本地模式",
-                err
-            );
-            Ok(None)
+    match config.mode {
+        ConnectionMode::Managed => Ok(ConnectionBackend::Managed),
+        ConnectionMode::Local => {
+            let raw_url = config
+                .local_url
+                .as_deref()
+                .unwrap_or(DEFAULT_LOCAL_DASHBOARD_URL);
+            match normalize_local_base_url(raw_url) {
+                Ok(base_url) => Ok(ConnectionBackend::Local(LocalBackend { base_url })),
+                Err(err) => {
+                    log::warn!(
+                        "connection.json 中的本地连接地址无效（{}）；回退到本机内核",
+                        err
+                    );
+                    Ok(ConnectionBackend::Managed)
+                }
+            }
         }
+        ConnectionMode::Remote => {
+            let (Some(raw_url), Some(token)) = (config.remote_url, config.remote_token) else {
+                log::warn!("connection.json 选择了远程模式但缺少 URL 或 token；回退到本机内核");
+                return Ok(ConnectionBackend::Managed);
+            };
+            match normalize_remote_base_url(&raw_url) {
+                Ok(base_url) => Ok(ConnectionBackend::Remote(RemoteBackend {
+                    base_url,
+                    token,
+                    source: RemoteSource::Settings,
+                })),
+                Err(err) => {
+                    log::warn!(
+                        "connection.json 中的远程地址无效（{}）；回退到本机内核",
+                        err
+                    );
+                    Ok(ConnectionBackend::Managed)
+                }
+            }
+        }
+    }
+}
+
+/// Backward-compatible helper for older tests/callers.
+pub fn resolve_remote_backend() -> Result<Option<RemoteBackend>, String> {
+    match resolve_connection_backend()? {
+        ConnectionBackend::Remote(remote) => Ok(Some(remote)),
+        ConnectionBackend::Managed | ConnectionBackend::Local(_) => Ok(None),
     }
 }
 
@@ -320,6 +434,10 @@ pub fn sanitize(config: &ConnectionConfig) -> SanitizedConnectionConfig {
         let token = env_non_empty(ENV_REMOTE_TOKEN);
         return SanitizedConnectionConfig {
             mode: ConnectionMode::Remote.as_str().to_string(),
+            local_url: config
+                .local_url
+                .clone()
+                .unwrap_or_else(|| DEFAULT_LOCAL_DASHBOARD_URL.to_string()),
             remote_url: url,
             remote_token_set: token.is_some(),
             remote_token_preview: token.as_deref().and_then(token_preview),
@@ -329,6 +447,10 @@ pub fn sanitize(config: &ConnectionConfig) -> SanitizedConnectionConfig {
 
     SanitizedConnectionConfig {
         mode: config.mode.as_str().to_string(),
+        local_url: config
+            .local_url
+            .clone()
+            .unwrap_or_else(|| DEFAULT_LOCAL_DASHBOARD_URL.to_string()),
         remote_url: config.remote_url.clone().unwrap_or_default(),
         remote_token_set: config.remote_token.is_some(),
         remote_token_preview: config.remote_token.as_deref().and_then(token_preview),
@@ -435,6 +557,7 @@ mod tests {
         let path = dir.path().join("connection.json");
         let config = ConnectionConfig {
             mode: ConnectionMode::Remote,
+            local_url: Some(DEFAULT_LOCAL_DASHBOARD_URL.to_string()),
             remote_url: Some("http://host:9221".to_string()),
             remote_token: Some("tok-123".to_string()),
         };
@@ -443,18 +566,65 @@ mod tests {
     }
 
     #[test]
-    fn read_missing_file_falls_back_to_local() {
+    fn read_missing_file_falls_back_to_managed() {
         let dir = TempDir::new().unwrap();
         let path = dir.path().join("connection.json");
         assert_eq!(read_config_from(&path), ConnectionConfig::default());
     }
 
     #[test]
-    fn read_malformed_file_falls_back_to_local() {
+    fn read_malformed_file_falls_back_to_managed() {
         let dir = TempDir::new().unwrap();
         let path = dir.path().join("connection.json");
         fs::write(&path, "{ not json").unwrap();
         assert_eq!(read_config_from(&path), ConnectionConfig::default());
+    }
+
+    #[test]
+    fn read_v1_local_migrates_to_managed() {
+        let dir = TempDir::new().unwrap();
+        let path = dir.path().join("connection.json");
+        fs::write(
+            &path,
+            r#"{ "version": 1, "mode": "local",
+                 "local": { "url": "http://127.0.0.1:9119" } }"#,
+        )
+        .unwrap();
+        let config = read_config_from(&path);
+        assert_eq!(config.mode, ConnectionMode::Managed);
+        assert_eq!(
+            config.local_url.as_deref(),
+            Some(DEFAULT_LOCAL_DASHBOARD_URL)
+        );
+    }
+
+    #[test]
+    fn read_v2_local_keeps_local_cli_mode() {
+        let dir = TempDir::new().unwrap();
+        let path = dir.path().join("connection.json");
+        fs::write(
+            &path,
+            r#"{ "version": 2, "mode": "local",
+                 "local": { "url": "http://localhost:9119/" } }"#,
+        )
+        .unwrap();
+        let config = read_config_from(&path);
+        assert_eq!(config.mode, ConnectionMode::Local);
+        assert_eq!(config.local_url.as_deref(), Some("http://localhost:9119/"));
+    }
+
+    #[test]
+    fn normalize_local_allows_only_loopback() {
+        assert_eq!(
+            normalize_local_base_url(" http://127.0.0.1:9119/?x=1#frag ").unwrap(),
+            DEFAULT_LOCAL_DASHBOARD_URL
+        );
+        assert_eq!(
+            normalize_local_base_url("http://localhost:9119/").unwrap(),
+            "http://localhost:9119"
+        );
+        assert!(normalize_local_base_url("http://192.168.1.10:9119").is_err());
+        assert!(normalize_local_base_url("https://example.com").is_err());
     }
 
     #[test]
@@ -483,6 +653,7 @@ mod tests {
             &path,
             &ConnectionConfig {
                 mode: ConnectionMode::Remote,
+                local_url: None,
                 remote_url: Some("http://h:1".to_string()),
                 remote_token: Some("secret".to_string()),
             },
@@ -536,6 +707,7 @@ mod tests {
         clear_env();
         let config = ConnectionConfig {
             mode: ConnectionMode::Remote,
+            local_url: None,
             remote_url: Some("http://h:1".to_string()),
             remote_token: Some("supersecretvalue".to_string()),
         };

--- a/src/main.rs
+++ b/src/main.rs
@@ -12,12 +12,12 @@ use std::sync::atomic::{AtomicBool, Ordering};
 use std::sync::Arc;
 
 use hermes_agent_cn::bootstrap::{
-    acquire_managed_dashboard, connect_remote_backend, finalize_bootstrap,
+    acquire_managed_dashboard, connect_local_backend, connect_remote_backend, finalize_bootstrap,
     install_bundled_runtime_for_bootstrap, record_bootstrap_error,
 };
 use hermes_agent_cn::commands;
 use hermes_agent_cn::commands::profiles::read_active_profile_sticky;
-use hermes_agent_cn::connection::{self, ConnectionMode};
+use hermes_agent_cn::connection::{self, ConnectionBackend, ConnectionMode};
 use hermes_agent_cn::process::{dashboard, runtime};
 use hermes_agent_cn::state::{AppState, DashboardHandle};
 use hermes_agent_cn::tray;
@@ -190,10 +190,10 @@ fn main() {
             };
 
             // Resolve the backend for this boot: env override → connection.json
-            // remote mode → local managed runtime. An env URL without a token
+            // local/remote attachment → managed runtime. An env URL without a token
             // is the one fatal misconfiguration (matching the official desktop).
-            let remote_backend = match connection::resolve_remote_backend() {
-                Ok(remote) => remote,
+            let backend = match connection::resolve_connection_backend() {
+                Ok(backend) => backend,
                 Err(msg) => {
                     record_bootstrap_error(app.handle(), msg);
                     return Ok(());
@@ -210,27 +210,38 @@ fn main() {
                 let profile_for_task = current_profile.clone();
 
                 tauri::async_runtime::spawn(async move {
-                    let (handle, mode) = if let Some(remote) = remote_backend {
-                        (
+                    let (handle, mode) = match backend {
+                        ConnectionBackend::Remote(remote) => (
                             connect_remote_backend(&app_handle, &remote).await,
                             ConnectionMode::Remote,
-                        )
-                    } else if external_dev_dashboard {
-                        let api_base_url = dashboard::dashboard_base_url(&host_for_task, port);
-                        if !dashboard::probe_dashboard(&api_base_url).await {
-                            log::warn!(
-                                "External dev dashboard mode: dashboard not reachable at {}",
-                                api_base_url
-                            );
+                        ),
+                        ConnectionBackend::Local(local) => (
+                            connect_local_backend(&app_handle, &local).await,
+                            ConnectionMode::Local,
+                        ),
+                        ConnectionBackend::Managed if external_dev_dashboard => {
+                            let api_base_url = dashboard::dashboard_base_url(&host_for_task, port);
+                            if !dashboard::probe_dashboard(&api_base_url).await {
+                                log::warn!(
+                                    "External dev dashboard mode: dashboard not reachable at {}",
+                                    api_base_url
+                                );
+                            }
+                            (external_dev_handle(api_base_url), ConnectionMode::Managed)
                         }
-                        (external_dev_handle(api_base_url), ConnectionMode::Local)
-                    } else {
-                        match acquire_managed_dashboard(&app_handle, options, resource_dir, true)
+                        ConnectionBackend::Managed => {
+                            match acquire_managed_dashboard(
+                                &app_handle,
+                                options,
+                                resource_dir,
+                                true,
+                            )
                             .await
-                        {
-                            Ok(h) => (h, ConnectionMode::Local),
-                            // Error already surfaced to the UI via runtime-status.
-                            Err(_) => return,
+                            {
+                                Ok(h) => (h, ConnectionMode::Managed),
+                                // Error already surfaced to the UI via runtime-status.
+                                Err(_) => return,
+                            }
                         }
                     };
 
@@ -250,18 +261,36 @@ fn main() {
             }
 
             // --- Synchronous fallback (HERMES_DESKTOP_SYNC_BOOTSTRAP). ---
-            if let Some(remote) = remote_backend {
-                let handle =
-                    tauri::async_runtime::block_on(connect_remote_backend(app.handle(), &remote));
-                tauri::async_runtime::block_on(finalize_bootstrap(
-                    app.handle(),
-                    handle,
-                    boot_home_str,
-                    base_str,
-                    current_profile,
-                    ConnectionMode::Remote,
-                ));
-                return Ok(());
+            match backend {
+                ConnectionBackend::Remote(remote) => {
+                    let handle = tauri::async_runtime::block_on(connect_remote_backend(
+                        app.handle(),
+                        &remote,
+                    ));
+                    tauri::async_runtime::block_on(finalize_bootstrap(
+                        app.handle(),
+                        handle,
+                        boot_home_str,
+                        base_str,
+                        current_profile,
+                        ConnectionMode::Remote,
+                    ));
+                    return Ok(());
+                }
+                ConnectionBackend::Local(local) => {
+                    let handle =
+                        tauri::async_runtime::block_on(connect_local_backend(app.handle(), &local));
+                    tauri::async_runtime::block_on(finalize_bootstrap(
+                        app.handle(),
+                        handle,
+                        boot_home_str,
+                        base_str,
+                        current_profile,
+                        ConnectionMode::Local,
+                    ));
+                    return Ok(());
+                }
+                ConnectionBackend::Managed => {}
             }
 
             if external_dev_dashboard {
@@ -278,7 +307,7 @@ fn main() {
                     boot_home_str,
                     base_str,
                     current_profile,
-                    ConnectionMode::Local,
+                    ConnectionMode::Managed,
                 ));
                 return Ok(());
             }
@@ -317,7 +346,7 @@ fn main() {
                         boot_home_for_task,
                         base_for_task,
                         profile_for_task,
-                        ConnectionMode::Local,
+                        ConnectionMode::Managed,
                     )
                     .await;
                 });
@@ -346,7 +375,7 @@ fn main() {
                 boot_home_str,
                 base_str,
                 current_profile,
-                ConnectionMode::Local,
+                ConnectionMode::Managed,
             ));
             Ok(())
         })

--- a/src/process/dashboard.rs
+++ b/src/process/dashboard.rs
@@ -29,7 +29,8 @@ use crate::state::{DashboardHandle, DashboardJobHandle};
 // bootstrap has already failed. Keep a wider production-safe margin.
 const DASHBOARD_READY_TIMEOUT: Duration = Duration::from_secs(120);
 const PROBE_TIMEOUT: Duration = Duration::from_millis(900);
-const SESSION_TOKEN_TIMEOUT: Duration = Duration::from_millis(1200);
+const SESSION_TOKEN_TIMEOUT: Duration = Duration::from_secs(3);
+const ATTACHED_DASHBOARD_TIMEOUT: Duration = Duration::from_secs(5);
 const SHUTDOWN_HTTP_TIMEOUT: Duration = Duration::from_millis(800);
 const GRACEFUL_SHUTDOWN_TIMEOUT: Duration = Duration::from_millis(1800);
 const FORCE_SHUTDOWN_TIMEOUT: Duration = Duration::from_millis(1200);
@@ -50,6 +51,12 @@ static SESSION_TOKEN_HTTP_CLIENT: LazyLock<reqwest::Client> = LazyLock::new(|| {
         .timeout(SESSION_TOKEN_TIMEOUT)
         .build()
         .expect("valid dashboard session token HTTP client")
+});
+static ATTACHED_HTTP_CLIENT: LazyLock<reqwest::Client> = LazyLock::new(|| {
+    reqwest::Client::builder()
+        .timeout(ATTACHED_DASHBOARD_TIMEOUT)
+        .build()
+        .expect("valid attached dashboard HTTP client")
 });
 
 #[derive(Debug, Clone, Serialize, Deserialize)]
@@ -465,6 +472,53 @@ pub async fn probe_dashboard(api_base_url: &str) -> bool {
     }
 }
 
+/// More tolerant probe for an already-running local/remote dashboard we do not
+/// own. The normal readiness probe is intentionally short so managed startup
+/// loops remain responsive, but a user CLI dashboard can briefly spend more
+/// than 900ms in `/api/status` while spawning TUI sidecars or loading plugins.
+/// Treat that as transient instead of reporting "9119 unreachable".
+pub async fn probe_attached_dashboard(api_base_url: &str) -> bool {
+    let url = format!("{}/api/status", api_base_url);
+
+    for attempt in 0..3 {
+        match ATTACHED_HTTP_CLIENT
+            .get(&url)
+            .header("Accept", "application/json")
+            .send()
+            .await
+        {
+            Ok(res) if res.status().is_success() || res.status().as_u16() == 401 => {
+                return true;
+            }
+            Ok(res) => {
+                log::debug!(
+                    "Attached dashboard probe at {} returned HTTP {}",
+                    api_base_url,
+                    res.status()
+                );
+            }
+            Err(err) => {
+                log::debug!(
+                    "Attached dashboard probe attempt {} at {} failed: {}",
+                    attempt + 1,
+                    api_base_url,
+                    err
+                );
+            }
+        }
+        tokio::time::sleep(Duration::from_millis(250)).await;
+    }
+
+    if probe_dashboard_port(api_base_url) {
+        log::warn!(
+            "Attached dashboard port is listening at {}, but /api/status did not answer within {:?}",
+            api_base_url,
+            ATTACHED_DASHBOARD_TIMEOUT
+        );
+    }
+    false
+}
+
 async fn probe_dashboard_openapi(api_base_url: &str) -> bool {
     let url = format!("{}/openapi.json", api_base_url);
 
@@ -549,7 +603,7 @@ async fn has_openapi_path(api_base_url: &str, path: &str) -> bool {
 }
 
 /// Get the HERMES_HOME value from a running dashboard.
-async fn get_dashboard_hermes_home(api_base_url: &str) -> Option<String> {
+pub async fn fetch_dashboard_hermes_home(api_base_url: &str) -> Option<String> {
     let url = format!("{}/api/status", api_base_url);
 
     let res = PROBE_HTTP_CLIENT
@@ -564,9 +618,57 @@ async fn get_dashboard_hermes_home(api_base_url: &str) -> Option<String> {
         .map(|s| s.to_string())
 }
 
+/// Tolerant HERMES_HOME lookup for attached local dashboards. This mirrors
+/// `probe_attached_dashboard` so a busy CLI dashboard does not make the
+/// desktop fall back to its managed runtime data root.
+pub async fn fetch_attached_dashboard_hermes_home(api_base_url: &str) -> Option<String> {
+    let url = format!("{}/api/status", api_base_url);
+
+    for attempt in 0..3 {
+        match ATTACHED_HTTP_CLIENT
+            .get(&url)
+            .header("Accept", "application/json")
+            .send()
+            .await
+        {
+            Ok(res) => match res.json::<serde_json::Value>().await {
+                Ok(data) => {
+                    if let Some(home) = data
+                        .get("hermes_home")
+                        .and_then(|v| v.as_str())
+                        .map(str::to_string)
+                        .filter(|s| !s.trim().is_empty())
+                    {
+                        return Some(home);
+                    }
+                }
+                Err(err) => {
+                    log::debug!(
+                        "Attached dashboard hermes_home parse attempt {} at {} failed: {}",
+                        attempt + 1,
+                        api_base_url,
+                        err
+                    );
+                }
+            },
+            Err(err) => {
+                log::debug!(
+                    "Attached dashboard hermes_home attempt {} at {} failed: {}",
+                    attempt + 1,
+                    api_base_url,
+                    err
+                );
+            }
+        }
+        tokio::time::sleep(Duration::from_millis(250)).await;
+    }
+
+    None
+}
+
 /// Check whether an existing dashboard's hermes_home matches ours.
 async fn dashboard_matches_hermes_home(api_base_url: &str, hermes_home: &str) -> bool {
-    match get_dashboard_hermes_home(api_base_url).await {
+    match fetch_dashboard_hermes_home(api_base_url).await {
         Some(current) if !current.is_empty() => {
             let left = std::fs::canonicalize(&current).unwrap_or_else(|_| PathBuf::from(&current));
             let right =

--- a/src/state.rs
+++ b/src/state.rs
@@ -98,16 +98,30 @@ impl DashboardHandle {
     /// attaches to. `owns_process` is false, so app shutdown and restart paths
     /// never try to terminate or `/api/shutdown` the remote agent.
     pub fn remote(api_base_url: String, session_token: String) -> Self {
+        Self::attached(api_base_url, Some(session_token), "remote")
+    }
+
+    /// Build a handle for a loopback Hermes Agent CLI dashboard that the
+    /// desktop attaches to but does not own.
+    pub fn local(api_base_url: String, session_token: Option<String>) -> Self {
+        Self::attached(api_base_url, session_token, "local")
+    }
+
+    fn attached(
+        api_base_url: String,
+        session_token: Option<String>,
+        ownership_state: &str,
+    ) -> Self {
         Self {
             api_base_url,
-            session_token: Some(session_token),
+            session_token,
             owns_process: false,
             command_program: None,
             command_args: vec![],
             gateway_runtime_dir: None,
             gateway_lock_dir: None,
             ownership_marker_path: None,
-            ownership_state: Some("remote".to_string()),
+            ownership_state: Some(ownership_state.to_string()),
             job_handle: None,
             attached_pid: None,
             child: None,
@@ -177,10 +191,11 @@ pub struct AppStateInner {
     /// which can briefly differ from the persisted preference between a toggle
     /// and the runtime restart that applies it.
     pub yolo_mode: bool,
-    /// Whether the desktop is attached to a remote Hermes Agent (shell mode)
-    /// or running its own managed runtime. Set during bootstrap and by
-    /// `apply_connection_config`; commands consult it to skip local-only
-    /// behavior (token refresh, profile switch, YOLO, runtime updates).
+    /// Whether the desktop is running its own managed runtime, attached to a
+    /// loopback CLI dashboard, or attached to a remote Hermes Agent. Set
+    /// during bootstrap and by `apply_connection_config`; commands consult it
+    /// to decide ownership-only behavior (profile switch, YOLO, runtime
+    /// updates) and token refresh strategy.
     pub connection_mode: crate::connection::ConnectionMode,
 }
 
@@ -204,7 +219,7 @@ impl AppState {
                 dashboard_restart_in_flight: false,
                 last_runtime_error: None,
                 yolo_mode: false,
-                connection_mode: crate::connection::ConnectionMode::Local,
+                connection_mode: crate::connection::ConnectionMode::Managed,
             }),
         }
     }

--- a/web/src/components/chat/message-adapter.test.ts
+++ b/web/src/components/chat/message-adapter.test.ts
@@ -589,6 +589,50 @@ describe("message adapter", () => {
     expect(chat[0]?.stats?.finishReason).toBe("interrupted");
   });
 
+  it("hides stale interrupted live replies once a later stored assistant answer exists", () => {
+    const stored = legacySessionMessagesToHermesUIMessages([
+      sessionMessage({
+        id: 875,
+        role: "user",
+        content: "爱为何物？",
+        timestamp: 1_000,
+      }),
+      sessionMessage({
+        id: 910,
+        role: "user",
+        content:
+          '[IMPORTANT: Background process proc_99f1ebe876c0 matched watch pattern "Local:".\n' +
+          "Command: pnpm dev:web\n" +
+          "Matched output:\n" +
+          "\x1b[36m@acme/web:dev: \x1b[0m- Local:         http://localhost:3000]",
+        timestamp: 1_054,
+      }),
+      sessionMessage({
+        id: 911,
+        role: "assistant",
+        content: "爱是长期选择。\n\n顺便：你的 web dev server 已起来了，地址是 `http://localhost:3000`。",
+        timestamp: 1_069,
+      }),
+    ]);
+    const live = [
+      uiMessage({
+        id: "live-interrupted-turn",
+        createdAt: 1_025_000,
+        parts: [{ type: "text", text: "Operation interrupted: waiting for model response (45.4s elapsed)." }],
+        metadata: { finishReason: "interrupted" },
+      }),
+    ];
+
+    const merged = mergeHermesUIMessages(stored, live);
+    const chat = hermesUIMessagesToChatMessages(merged);
+
+    expect(merged.map((message) => message.id)).toEqual(["stored-875", "stored-910", "stored-911"]);
+    expect(chat.map((message) => message.role)).toEqual(["user", "system", "assistant"]);
+    expect(chat.map((message) => message.text).join("\n")).not.toContain("Operation interrupted");
+    expect(chat[1]?.text).toContain("后台进程通知：");
+    expect(chat[1]?.text).not.toContain("\x1b[36m");
+  });
+
   it("keeps persisted stats when a matching live message has no metadata", () => {
     const stored = [
       uiMessage({

--- a/web/src/components/chat/message-adapter.ts
+++ b/web/src/components/chat/message-adapter.ts
@@ -297,6 +297,16 @@ function legacyMetadata(msg: SessionMessage): HermesMessageMetadata | undefined 
   return metadata;
 }
 
+const PROCESS_NOTIFICATION_RE = /^\[IMPORTANT: Background process\s+([\s\S]*?)\]$/;
+const ANSI_RE = /\x1b\[[0-9;]*m/g;
+
+function normalizeProcessNotificationText(text: string): string | null {
+  const clean = text.replace(ANSI_RE, "").trim();
+  const match = clean.match(PROCESS_NOTIFICATION_RE);
+  if (!match) return null;
+  return `后台进程通知：${match[1]}`;
+}
+
 // Roles we know how to render. Hermes integrations (Feishu bridge etc.)
 // emit extra marker roles like "session_meta" into the persisted log —
 // the response schema accepts arbitrary strings so the row doesn't
@@ -332,6 +342,9 @@ export function legacySessionMessageToHermesUIMessage(msg: SessionMessage): Herm
 
   const content = textAndImagesFromStructuredContent(msg.content);
   const text = normalizeContent(content.text);
+  const processNotificationText = msg.role === "user"
+    ? normalizeProcessNotificationText(text ?? "")
+    : null;
   const reasoning = normalizeContent(
     normalizeReasoningText(msg.reasoning_content ?? msg.reasoning ?? undefined),
   );
@@ -352,10 +365,10 @@ export function legacySessionMessageToHermesUIMessage(msg: SessionMessage): Herm
   return {
     id: `stored-${msg.id}`,
     sessionId: msg.session_id,
-    role: msg.role as "user" | "assistant" | "system",
+    role: processNotificationText ? "system" : msg.role as "user" | "assistant" | "system",
     createdAt,
     status: msg.finish_reason === "error" ? "error" : "complete",
-    parts,
+    parts: processNotificationText ? [{ type: "notice", level: "system", text: processNotificationText }] : parts,
     metadata: legacyMetadata(msg),
   };
 }
@@ -857,6 +870,19 @@ function hasInterruptedCompletion(message: HermesUIMessage, canonicalMessageText
   return canonicalMessageText.toLowerCase().includes("operationinterrupted:");
 }
 
+function isStaleInterruptedLiveMessage(
+  live: HermesUIMessage,
+  storedMessages: HermesUIMessage[],
+): boolean {
+  if (live.role !== "assistant") return false;
+  if (!hasInterruptedCompletion(live, canonicalText(live))) return false;
+  return storedMessages.some((stored) =>
+    stored.role === "assistant" &&
+    stored.createdAt >= live.createdAt &&
+    !hasInterruptedCompletion(stored, canonicalText(stored)),
+  );
+}
+
 function isInterruptedLiveSuperset(
   stored: HermesUIMessage,
   live: HermesUIMessage,
@@ -992,7 +1018,9 @@ export function mergeHermesUIMessages(
   }
 
   consolidatedLive.forEach((liveMessage, index) => {
-    if (!usedLiveIndexes.has(index)) merged.push(liveMessage);
+    if (usedLiveIndexes.has(index)) return;
+    if (isStaleInterruptedLiveMessage(liveMessage, stored)) return;
+    merged.push(liveMessage);
   });
 
   // Issue #98: a live message that fails to match any stored row — typically

--- a/web/src/components/chat/message-timeline.module.css
+++ b/web/src/components/chat/message-timeline.module.css
@@ -128,7 +128,8 @@
 
 .systemNoticeIcon {
   flex-shrink: 0;
-  margin-top: 2px;
+  display: block;
+  margin-top: 5px;
   color: var(--h-text-3);
 }
 
@@ -170,6 +171,26 @@
   margin: 0 0 4px 2px;
   color: var(--h-text-2);
   font-size: 12px;
+}
+
+.assistantIdentity {
+  display: inline-flex;
+  align-items: center;
+  gap: 7px;
+  margin: 0 0 6px 0;
+  color: var(--h-text-2);
+  font-size: 12px;
+  font-weight: 550;
+}
+
+.assistantAvatar {
+  width: 24px;
+  height: 24px;
+  flex: 0 0 auto;
+  border-radius: 50%;
+  border: 1px solid var(--h-line);
+  background: var(--h-bg-chip);
+  object-fit: cover;
 }
 
 .bubble {

--- a/web/src/components/chat/message-timeline.tsx
+++ b/web/src/components/chat/message-timeline.tsx
@@ -2,7 +2,7 @@ import { useCallback, useEffect, useLayoutEffect, useMemo, useRef, useState } fr
 import type { ReactNode, WheelEvent } from "react";
 import { useAtomValue } from "jotai";
 import { AlertTriangle, ChevronRight, Info, Loader2, Volume2, VolumeX } from "lucide-react";
-import { showReasoningAtom } from "@/stores/ui";
+import { assistantAvatarDataUrlAtom, assistantDisplayNameAtom, showReasoningAtom } from "@/stores/ui";
 import type { AssistantMessageStats, ChatMessage, ChatToolItem } from "./chat-types";
 import { MessageImage } from "./message-image";
 import { MessageSkeleton } from "./message-skeleton";
@@ -636,6 +636,8 @@ interface MessageBubbleProps {
 
 function MessageBubble({ message, turnStartedAt, sessionUsage, progressModel, speech }: MessageBubbleProps) {
   const showReasoning = useAtomValue(showReasoningAtom);
+  const assistantDisplayName = useAtomValue(assistantDisplayNameAtom);
+  const assistantAvatarDataUrl = useAtomValue(assistantAvatarDataUrlAtom);
   const isUser = message.role === "user";
   const isToolOnly = message.role === "tool";
   const isSystem = message.role === "system";
@@ -685,7 +687,14 @@ function MessageBubble({ message, turnStartedAt, sessionUsage, progressModel, sp
   return (
     <div className={s.messageRow} data-role={isUser ? "user" : "assistant"}>
       <div className={s.messageContent}>
-        {!isUser ? <div className={s.assistantName}>Hermes</div> : null}
+        {!isUser ? (
+          <div className={assistantAvatarDataUrl ? s.assistantIdentity : s.assistantName}>
+            {assistantAvatarDataUrl ? (
+              <img className={s.assistantAvatar} src={assistantAvatarDataUrl} alt={`${assistantDisplayName} 头像`} />
+            ) : null}
+            <span>{assistantDisplayName}</span>
+          </div>
+        ) : null}
         <div className={s.bubble} data-role={isUser ? "user" : "assistant"}>
           {hasBlocks ? (
             <MessageBlocks

--- a/web/src/components/panel/health-grid.tsx
+++ b/web/src/components/panel/health-grid.tsx
@@ -20,12 +20,12 @@ import { useConfig, useModelInfo } from "@/hooks/use-config";
 import { useEnvVars } from "@/hooks/use-env";
 import { useSkills } from "@/hooks/use-skills";
 import { useMcpServers } from "@/hooks/use-mcp-servers";
+import { useOAuthProviders } from "@/hooks/use-oauth-providers";
 import { useLastUsedModel } from "@/lib/last-used-model";
 import { CopyButton } from "@/components/ui/copy-button";
 import { Dot } from "@/components/ui/pill";
 import s from "./health-grid.module.css";
 
-const DEFAULT_DESKTOP_DASHBOARD_ORIGIN = "127.0.0.1:9120";
 const TOKEN_KEYS = ["ANTHROPIC_API_KEY", "OPENAI_API_KEY", "GLM_API_KEY", "DEEPSEEK_API_KEY"];
 
 type Tone = "ok" | "warn" | "err";
@@ -64,13 +64,21 @@ function formatContextLength(n: number | undefined | null): string {
   return `${n} ctx`;
 }
 
-function originFromHealthUrl(url: string | null | undefined): string {
-  if (!url) return DEFAULT_DESKTOP_DASHBOARD_ORIGIN;
+function originFromUrl(url: string | null | undefined): string | null {
+  if (!url) return null;
   try {
-    return new URL(url).host || DEFAULT_DESKTOP_DASHBOARD_ORIGIN;
+    return new URL(url).host || null;
   } catch {
-    return DEFAULT_DESKTOP_DASHBOARD_ORIGIN;
+    return null;
   }
+}
+
+function currentDashboardOrigin(statusHealthUrl: string | null | undefined): string {
+  const runtimeConfig = typeof window !== "undefined" ? window.__HERMES_RUNTIME__ : undefined;
+  return originFromUrl(runtimeConfig?.dashboardApiBaseUrl)
+    ?? originFromUrl(runtimeConfig?.apiBaseUrl)
+    ?? originFromUrl(statusHealthUrl)
+    ?? "Dashboard";
 }
 
 function isRecord(value: unknown): value is Record<string, unknown> {
@@ -97,7 +105,7 @@ function groupTitle(group: HealthGroup): string {
 
 function groupSub(group: HealthGroup): string {
   if (group === "runtime") return "Dashboard、Gateway 与本地 Hermes 数据目录。";
-  if (group === "model") return "默认模型、API Token 与 provider 字段校验。";
+  if (group === "model") return "默认模型、模型凭证与 provider 字段校验。";
   return "Skills、MCP 以及会话扩展能力。";
 }
 
@@ -259,12 +267,14 @@ export function HealthGrid({ variant = "compact" }: HealthGridProps) {
   const envQuery = useEnvVars();
   const skillsQuery = useSkills();
   const mcpQuery = useMcpServers();
+  const oauthQuery = useOAuthProviders();
   const status = statusQuery.data;
   const modelInfo = modelInfoQuery.data;
   const config = configQuery.data;
   const env = envQuery.data;
   const skills = skillsQuery.data;
   const mcp = mcpQuery.data;
+  const oauthProviders = oauthQuery.data;
   const lastUsedModel = useLastUsedModel();
 
   const health = useMemo(() => {
@@ -276,12 +286,16 @@ export function HealthGrid({ variant = "compact" }: HealthGridProps) {
     const dashboardReachable = !!status;
     const daemonRunning = status?.gateway_running === true;
     const gatewayState = status?.gateway_state || (daemonRunning ? "running" : "stopped");
-    const dashboardOrigin = originFromHealthUrl(status?.gateway_health_url);
+    const dashboardOrigin = currentDashboardOrigin(status?.gateway_health_url);
 
     const setTokens = env ? TOKEN_KEYS.filter((key) => env[key]?.is_set) : [];
     const anyTokenSet = setTokens.length > 0;
 
     const modelName = lastUsedModel?.model || modelInfo?.model || "—";
+    const currentProviderId = modelInfo?.provider || lastUsedModel?.provider || "";
+    const currentOAuthProvider = oauthProviders?.find((provider) => provider.id === currentProviderId);
+    const currentOAuthLoggedIn = currentOAuthProvider?.status.logged_in === true;
+    const anyModelCredential = anyTokenSet || currentOAuthLoggedIn;
     const ctxLabel = formatContextLength(
       lastUsedModel?.contextWindow
         ?? modelInfo?.effective_context_length
@@ -296,7 +310,7 @@ export function HealthGrid({ variant = "compact" }: HealthGridProps) {
     const providers = providerMap(config);
     const invalidProviders = findInvalidProviderApiKeys(providers);
     const providerTotal = Object.keys(providers).length;
-    const providersOk = providerTotal > 0 && invalidProviders.length === 0;
+    const providersOk = currentOAuthLoggedIn || (providerTotal > 0 && invalidProviders.length === 0);
 
     const items: HealthItem[] = [
       {
@@ -347,37 +361,49 @@ export function HealthGrid({ variant = "compact" }: HealthGridProps) {
       {
         id: "token",
         group: "model",
-        label: "API Token",
-        tone: envQuery.isError ? "err" : env ? (anyTokenSet ? "ok" : "warn") : "warn",
-        value: envQuery.isError ? "读取失败" : env ? (anyTokenSet ? "已配置" : "未配置") : "检测中",
-        sub: anyTokenSet ? formatTokenNames(setTokens) : "模型调用需要至少一个可用 Token",
-        detail: anyTokenSet
-          ? "仅展示已设置的变量名称，不会暴露密钥内容。"
-          : "可在模型设置里补齐 Anthropic、OpenAI、GLM 或 DeepSeek 等服务商密钥。",
-        actionTo: anyTokenSet ? undefined : "/models",
-        actionLabel: "填写 Token",
+        label: "模型凭证",
+        tone: envQuery.isError ? "err" : env ? (anyModelCredential ? "ok" : "warn") : "warn",
+        value: envQuery.isError ? "读取失败" : env ? (anyModelCredential ? "已配置" : "未配置") : "检测中",
+        sub: currentOAuthLoggedIn
+          ? `${currentOAuthProvider?.name ?? currentProviderId} OAuth 已连接`
+          : anyTokenSet
+            ? formatTokenNames(setTokens)
+            : "模型调用需要 API Key 或 OAuth 凭证",
+        detail: currentOAuthLoggedIn
+          ? "当前主模型使用 OAuth 登录凭证，无需额外 API Token。"
+          : anyTokenSet
+            ? "仅展示已设置的变量名称，不会暴露密钥内容。"
+            : "可在模型设置里补齐 API Key，或完成支持 OAuth 的模型登录。",
+        actionTo: anyModelCredential ? undefined : "/models",
+        actionLabel: "配置凭证",
       },
       {
         id: "provider",
         group: "model",
         label: "Provider 配置",
         tone: providersOk ? "ok" : "warn",
-        value: providerTotal === 0
+        value: currentOAuthLoggedIn
+          ? "OAuth 有效"
+          : providerTotal === 0
           ? "未配置"
           : invalidProviders.length > 0
             ? `${invalidProviders.length} / ${providerTotal} 异常`
             : `${providerTotal} 个有效`,
-        sub: invalidProviders.length > 0
+        sub: currentOAuthLoggedIn
+          ? `${currentProviderId} 已通过 OAuth 提供模型凭证`
+          : invalidProviders.length > 0
           ? `api_key 是 URL：${invalidProviders.join(", ")}`
           : providerTotal === 0
             ? "缺少 providers 配置"
             : "api_key 字段形态正常",
-        detail: invalidProviders.length > 0
+        detail: currentOAuthLoggedIn
+          ? "当前后端 /api/model/info 与 OAuth 状态一致，健康检查不再要求 providers.api_key。"
+          : invalidProviders.length > 0
           ? "这些 provider 会把 URL 当作 Bearer token 发送，上游通常会返回 401。"
           : providerTotal === 0
             ? "选择服务商并保存模型后会自动写入 provider 配置。"
             : "已完成基础形态检查；真实额度与连通性仍以模型页探测结果为准。",
-        actionTo: providerTotal === 0 || invalidProviders.length > 0 ? "/models" : undefined,
+        actionTo: providersOk ? undefined : "/models",
         actionLabel: "修正配置",
       },
       {
@@ -434,12 +460,13 @@ export function HealthGrid({ variant = "compact" }: HealthGridProps) {
         { label: "活跃会话", value: String(status?.active_sessions ?? 0), sub: status ? `Dashboard v${status.version}` : "等待状态接口", tone: status ? "ok" as Tone : "warn" as Tone },
       ] satisfies HealthMetric[],
     };
-  }, [config, env, envQuery.isError, lastUsedModel, mcp, mcpQuery.isError, modelInfo, skills, skillsQuery.isError, status, statusQuery.isError]);
+  }, [config, env, envQuery.isError, lastUsedModel, mcp, mcpQuery.isError, modelInfo, oauthProviders, skills, skillsQuery.isError, status, statusQuery.isError]);
 
   const isRefreshing = statusQuery.isFetching
     || modelInfoQuery.isFetching
     || configQuery.isFetching
     || envQuery.isFetching
+    || oauthQuery.isFetching
     || skillsQuery.isFetching
     || mcpQuery.isFetching;
 
@@ -449,6 +476,7 @@ export function HealthGrid({ variant = "compact" }: HealthGridProps) {
       modelInfoQuery.refetch(),
       configQuery.refetch(),
       envQuery.refetch(),
+      oauthQuery.refetch(),
       skillsQuery.refetch(),
       mcpQuery.refetch(),
     ]);

--- a/web/src/components/panel/panel-top-chips.tsx
+++ b/web/src/components/panel/panel-top-chips.tsx
@@ -8,15 +8,21 @@ import { useLastUsedModel } from "@/lib/last-used-model";
 import { Dot } from "@/components/ui/pill";
 import s from "./panel-top-chips.module.css";
 
-const DEFAULT_DESKTOP_DASHBOARD_PORT = "9120";
-
-function portFromHealthUrl(url: string | null | undefined): string {
-  if (!url) return DEFAULT_DESKTOP_DASHBOARD_PORT;
+function portFromUrl(url: string | null | undefined): string | null {
+  if (!url) return null;
   try {
-    return new URL(url).port || DEFAULT_DESKTOP_DASHBOARD_PORT;
+    return new URL(url).port || null;
   } catch {
-    return DEFAULT_DESKTOP_DASHBOARD_PORT;
+    return null;
   }
+}
+
+function dashboardPort(statusHealthUrl: string | null | undefined): string {
+  const runtimeConfig = typeof window !== "undefined" ? window.__HERMES_RUNTIME__ : undefined;
+  return portFromUrl(runtimeConfig?.dashboardApiBaseUrl)
+    ?? portFromUrl(runtimeConfig?.apiBaseUrl)
+    ?? portFromUrl(statusHealthUrl)
+    ?? "—";
 }
 
 export function PanelTopChips() {
@@ -31,7 +37,7 @@ export function PanelTopChips() {
   // daemon 字段，与桌面端聊天链路无关（见 health-grid.tsx 注释）。
   const gatewayOk = connectionState === "open";
   const gatewayTone = gatewayOk ? "ok" : connectionState === "connecting" ? "warn" : "err";
-  const gatewayPort = portFromHealthUrl(status?.gateway_health_url);
+  const gatewayPort = dashboardPort(status?.gateway_health_url);
 
   // Match composer's "model that will be used" semantics: prefer user's last-used
   // selection, fall back to dashboard's effective default. Tag the source so the

--- a/web/src/components/sidebar/profile-selector.module.css
+++ b/web/src/components/sidebar/profile-selector.module.css
@@ -62,11 +62,20 @@
 }
 
 .triggerLabel {
+  display: inline-flex;
+  align-items: center;
+  gap: 4px;
   font-size: 9.5px;
   text-transform: uppercase;
   letter-spacing: 0.06em;
   color: var(--h-text-3);
   font-weight: 500;
+  line-height: 1;
+}
+
+.triggerLabel svg {
+  display: block;
+  flex: 0 0 auto;
 }
 
 .triggerName {
@@ -85,6 +94,10 @@
   font-size: 11px;
   letter-spacing: 0;
   text-transform: none;
+}
+
+.trigger[data-variant="topbar"] .triggerLabel svg {
+  transform: translateY(1px);
 }
 
 .trigger[data-variant="topbar"] .triggerName {

--- a/web/src/components/sidebar/profile-selector.tsx
+++ b/web/src/components/sidebar/profile-selector.tsx
@@ -1,6 +1,6 @@
 import { useState } from "react";
 import { useNavigate } from "react-router-dom";
-import { Check, ChevronsUpDown, Globe2, X } from "lucide-react";
+import { Cable, Check, ChevronsUpDown, Globe2, X } from "lucide-react";
 import { Popover } from "@hermes/shared-ui";
 import {
   useActiveProfileName,
@@ -50,9 +50,13 @@ export function ProfileSelector({ variant = "sidebar" }: ProfileSelectorProps) {
     navigate("/profiles");
   };
 
-  // Remote mode: profiles are HERMES_HOME-scoped local state, and the remote
-  // agent owns its own home — show a remote indicator instead of a switcher.
-  if (runtime.isRemote()) {
+  // Attached mode: profiles are HERMES_HOME-scoped local state, and the
+  // attached agent owns its own home/process — show an indicator instead of a
+  // switcher. The backend may still have its own active profile, but the
+  // desktop cannot restart it here.
+  if (!runtime.isManaged()) {
+    const isRemote = runtime.isRemote();
+    const Icon = isRemote ? Globe2 : Cable;
     return (
       <button
         type="button"
@@ -60,10 +64,10 @@ export function ProfileSelector({ variant = "sidebar" }: ProfileSelectorProps) {
         data-variant={variant}
         data-no-drag={variant === "topbar" ? true : undefined}
         disabled
-        title="已连接远程 Hermes Agent；远程模式下不支持切换档案（设置 → 连接 可切回本机内核）"
+        title={`已连接${isRemote ? "远程 Hermes Agent" : "本地 Hermes Agent CLI"}；当前连接模式下不支持由桌面端切换档案（设置 → 连接 可切回本机内核）`}
       >
         <span className={s.triggerLabel}>
-          <Globe2 size={11} aria-hidden="true" /> 远程
+          <Icon size={11} aria-hidden="true" /> {isRemote ? "远程" : "本地"}
         </span>
         <span className={s.triggerName}>Hermes Agent</span>
       </button>

--- a/web/src/hooks/use-oauth-providers.ts
+++ b/web/src/hooks/use-oauth-providers.ts
@@ -16,6 +16,8 @@ export function useOAuthProviders() {
       const res = await fetchJSON("/api/providers/oauth", { signal }, OAuthProvidersResponse);
       return res.providers;
     },
+    retry: 1,
+    staleTime: 30_000,
   });
 }
 

--- a/web/src/hooks/use-profiles.test.ts
+++ b/web/src/hooks/use-profiles.test.ts
@@ -59,6 +59,18 @@ describe("resolveBootstrapProfile", () => {
         }),
       ).toEqual({ next: null, hydrated: true });
     });
+
+    it("can force attached backends to the runtime profile", () => {
+      expect(
+        resolveBootstrapProfile({
+          alreadyHydrated: false,
+          current: "other",
+          electronProfile: "default",
+          queryData: undefined,
+          forceElectronProfile: true,
+        }),
+      ).toEqual({ next: "default", hydrated: true });
+    });
   });
 
   describe("web mode (first run)", () => {

--- a/web/src/hooks/use-profiles.ts
+++ b/web/src/hooks/use-profiles.ts
@@ -73,14 +73,19 @@ export function resolveBootstrapProfile(input: {
   current: string;
   electronProfile: string | undefined;
   queryData: string | undefined;
+  forceElectronProfile?: boolean;
 }): BootstrapDecision {
-  const { alreadyHydrated, current, electronProfile, queryData } = input;
+  const { alreadyHydrated, current, electronProfile, queryData, forceElectronProfile = false } = input;
   // 首次同步完成后，运行期的 profile 切换由 useSetActiveProfile 全权负责。
   if (alreadyHydrated) return { next: null, hydrated: true };
   // 桌面端：主进程已同步把权威 profile 推进 __HERMES_RUNTIME__，启动即可得。
   if (electronProfile) {
     const next =
-      current === "default" && electronProfile !== "default" ? electronProfile : null;
+      forceElectronProfile && current !== electronProfile
+        ? electronProfile
+        : current === "default" && electronProfile !== "default"
+          ? electronProfile
+          : null;
     return { next, hydrated: true };
   }
   // Web：等后端 sticky 到达再决定；未到达则先不标记 hydrated，待下次重试。
@@ -93,6 +98,7 @@ export function useBootstrapActiveProfile() {
   const setActive = useSetAtom(activeProfileAtom);
   const current = useAtomValue(activeProfileAtom);
   const electronProfile = runtime.getCurrentProfile();
+  const forceElectronProfile = runtime.isAttached();
   const query = useActiveProfile();
   const hydratedRef = useRef(false);
   useEffect(() => {
@@ -101,10 +107,11 @@ export function useBootstrapActiveProfile() {
       current,
       electronProfile,
       queryData: query.data,
+      forceElectronProfile,
     });
     if (decision.hydrated) hydratedRef.current = true;
     if (decision.next !== null) setActive(decision.next);
-  }, [electronProfile, query.data, current, setActive]);
+  }, [electronProfile, forceElectronProfile, query.data, current, setActive]);
 }
 
 // 切 profile 时需要 invalidate 的 query keys——和下面在 hook 里加 profileId

--- a/web/src/hooks/use-yolo-mode.ts
+++ b/web/src/hooks/use-yolo-mode.ts
@@ -9,13 +9,13 @@ import { PROFILE_AWARE_QUERY_KEYS } from "@/hooks/use-profiles";
 import type { YoloModeStatus } from "@hermes/protocol";
 
 /** YOLO mode is a desktop-only feature: it depends on (re)launching the managed
- * runtime, which only the Tauri/Electron shell can do. A remote Hermes Agent
- * decides its own approval policy, so remote mode reports unsupported. */
+ * runtime, which only the Tauri/Electron shell can do. Attached local/remote
+ * agents decide their own approval policy, so they report unsupported. */
 export function isYoloModeSupported(): boolean {
   return (
     typeof window !== "undefined" &&
     !!window.hermesDesktop?.setYoloMode &&
-    !runtime.isRemote()
+    runtime.isManaged()
   );
 }
 

--- a/web/src/lib/cn-provider-slugs.test.ts
+++ b/web/src/lib/cn-provider-slugs.test.ts
@@ -5,6 +5,7 @@ describe("CN backend provider slug filter", () => {
   it("keeps official direct providers and excludes deprecated or relay-only defaults", () => {
     expect(CN_BACKEND_PROVIDER_SLUGS).toContain("stepfun");
     expect(CN_BACKEND_PROVIDER_SLUGS).toContain("xiaomi");
+    expect(CN_BACKEND_PROVIDER_SLUGS).toContain("openai-codex");
     expect(CN_BACKEND_PROVIDER_SLUGS).toContain("openrouter");
     expect(CN_BACKEND_PROVIDER_SLUGS).not.toContain("qwen-oauth");
     expect(CN_BACKEND_PROVIDER_SLUGS).not.toContain("tencent-tokenhub");

--- a/web/src/lib/cn-provider-slugs.ts
+++ b/web/src/lib/cn-provider-slugs.ts
@@ -20,6 +20,7 @@ export const CN_BACKEND_PROVIDER_SLUGS = [
   "stepfun",
   "xiaomi",
   "anthropic",   // ANTHROPIC_API_KEY widely used even in CN edition
+  "openai-codex",
   "openrouter",  // kept as an explicit user-requested fallback aggregator
 ] as const;
 

--- a/web/src/lib/gateway-socket-path.test.ts
+++ b/web/src/lib/gateway-socket-path.test.ts
@@ -68,7 +68,7 @@ class MockNativeSocket {
 interface FakeWindow {
   location: { search: string; href: string };
   __TAURI_INTERNALS__?: unknown;
-  __HERMES_RUNTIME__?: { connectionMode?: "local" | "remote" };
+  __HERMES_RUNTIME__?: { connectionMode?: "managed" | "local" | "remote" };
 }
 
 let fakeWindow: FakeWindow;

--- a/web/src/lib/last-used-model.test.ts
+++ b/web/src/lib/last-used-model.test.ts
@@ -1,14 +1,30 @@
-import { beforeEach, describe, expect, it, vi } from "vitest";
+import { beforeEach, describe, expect, it } from "vitest";
 import {
   forgetLastUsedModel,
+  modelSelectionScopeKey,
   rememberLastUsedModel,
   readLastUsedModel,
 } from "./last-used-model";
 import { __resetUiStoreForTests, readUiValue, writeUiValue } from "./ui-store";
 
+function setRuntime(input: Partial<NonNullable<Window["__HERMES_RUNTIME__"]>> = {}) {
+  (globalThis as any).window = (globalThis as any).window ?? {};
+  window.__HERMES_RUNTIME__ = {
+    connectionMode: "managed",
+    apiBaseUrl: "http://127.0.0.1:9120",
+    currentProfile: "default",
+    ...input,
+  };
+}
+
+function scopedKey(): string {
+  return `hermes:last-used-model:${modelSelectionScopeKey()}`;
+}
+
 describe("last-used-model", () => {
   beforeEach(() => {
     __resetUiStoreForTests();
+    setRuntime();
   });
 
   it("returns null when nothing stored", () => {
@@ -30,6 +46,31 @@ describe("last-used-model", () => {
     });
   });
 
+  it("isolates selections by connection mode, api base, and profile", () => {
+    rememberLastUsedModel({ model: "k2.6", provider: "builtin" });
+    setRuntime({
+      connectionMode: "local",
+      apiBaseUrl: "http://127.0.0.1:9119",
+      dashboardApiBaseUrl: "http://127.0.0.1:9119",
+      currentProfile: "default",
+    });
+    expect(readLastUsedModel()).toBeNull();
+
+    rememberLastUsedModel({ model: "gpt-5.5", provider: "openai-codex" });
+    expect(readLastUsedModel()).toEqual({ model: "gpt-5.5", provider: "openai-codex" });
+
+    setRuntime({ connectionMode: "managed", apiBaseUrl: "http://127.0.0.1:9120", currentProfile: "default" });
+    expect(readLastUsedModel()).toEqual({ model: "k2.6", provider: "builtin" });
+  });
+
+  it("ignores legacy global selections", () => {
+    writeUiValue("hermes:last-used-model", {
+      ts: Date.now(),
+      selection: { model: "legacy-k2.6" },
+    });
+    expect(readLastUsedModel()).toBeNull();
+  });
+
   it("ignores selections without a model", () => {
     rememberLastUsedModel({ model: "" });
     expect(readLastUsedModel()).toBeNull();
@@ -38,20 +79,20 @@ describe("last-used-model", () => {
   it("expires entries older than 30 days", () => {
     rememberLastUsedModel({ model: "claude-sonnet-4-6" });
     const raw = readUiValue<{ selection: { model: string }; ts: number }>(
-      "hermes:last-used-model",
+      scopedKey(),
       { selection: { model: "" }, ts: 0 },
     );
     raw.ts = Date.now() - 31 * 24 * 60 * 60 * 1000;
-    writeUiValue("hermes:last-used-model", raw);
+    writeUiValue(scopedKey(), raw);
     expect(readLastUsedModel()).toBeNull();
   });
 
   it("survives malformed payloads", () => {
-    writeUiValue("hermes:last-used-model", "not an object");
+    writeUiValue(scopedKey(), "not an object");
     expect(readLastUsedModel()).toBeNull();
-    writeUiValue("hermes:last-used-model", { ts: Date.now() });
+    writeUiValue(scopedKey(), { ts: Date.now() });
     expect(readLastUsedModel()).toBeNull();
-    writeUiValue("hermes:last-used-model", { ts: Date.now(), selection: { model: 42 } });
+    writeUiValue(scopedKey(), { ts: Date.now(), selection: { model: 42 } });
     expect(readLastUsedModel()).toBeNull();
   });
 

--- a/web/src/lib/last-used-model.ts
+++ b/web/src/lib/last-used-model.ts
@@ -2,7 +2,8 @@ import { useEffect, useState } from "react";
 import { readUiValue, removeUiValue, subscribeUiStore, writeUiValue } from "@/lib/ui-store";
 import type { ComposerModelSelection } from "@/components/chat/composer-types";
 
-const STORAGE_KEY = "hermes:last-used-model";
+const STORAGE_KEY_PREFIX = "hermes:last-used-model";
+const LEGACY_STORAGE_KEY = STORAGE_KEY_PREFIX;
 const MAX_AGE_MS = 30 * 24 * 60 * 60 * 1000;
 
 const subscribers = new Set<() => void>();
@@ -26,14 +27,38 @@ function isValidSelection(value: unknown): value is ComposerModelSelection {
   return true;
 }
 
+function safeScopePart(value: string | undefined | null, fallback: string): string {
+  const normalized = (value ?? "").trim();
+  return encodeURIComponent(normalized || fallback);
+}
+
+export function modelSelectionScopeKey(): string {
+  const runtime = typeof window !== "undefined" ? window.__HERMES_RUNTIME__ : undefined;
+  const mode = runtime?.connectionMode ?? "managed";
+  const baseUrl = runtime?.apiBaseUrl || runtime?.dashboardApiBaseUrl || "relative";
+  const profile = runtime?.currentProfile || "default";
+  return [mode, baseUrl, profile].map((part) => safeScopePart(part, "default")).join(":");
+}
+
+function scopedStorageKey(): string {
+  return `${STORAGE_KEY_PREFIX}:${modelSelectionScopeKey()}`;
+}
+
+function readEntry(key: string): ComposerModelSelection | null {
+  const parsed = readUiValue<StoredEntry | null>(key, null);
+  if (!parsed || typeof parsed !== "object") return null;
+  if (typeof parsed.ts !== "number") return null;
+  if (Date.now() - parsed.ts > MAX_AGE_MS) return null;
+  if (!isValidSelection(parsed.selection)) return null;
+  return parsed.selection;
+}
+
 export function readLastUsedModel(): ComposerModelSelection | null {
   try {
-    const parsed = readUiValue<StoredEntry | null>(STORAGE_KEY, null);
-    if (!parsed || typeof parsed !== "object") return null;
-    if (typeof parsed.ts !== "number") return null;
-    if (Date.now() - parsed.ts > MAX_AGE_MS) return null;
-    if (!isValidSelection(parsed.selection)) return null;
-    return parsed.selection;
+    // Deliberately do not read the legacy global key. It was shared across the
+    // old local/remote split and could make a managed K2.6 selection override a
+    // newly attached CLI backend whose /api/model/info says gpt-5.5.
+    return readEntry(scopedStorageKey());
   } catch {
     return null;
   }
@@ -43,14 +68,17 @@ export function rememberLastUsedModel(selection: ComposerModelSelection) {
   if (!isValidSelection(selection)) return;
   try {
     const entry: StoredEntry = { selection, ts: Date.now() };
-    writeUiValue(STORAGE_KEY, entry);
+    writeUiValue(scopedStorageKey(), entry);
+    // Remove the obsolete global entry opportunistically so future readers in
+    // older renderer windows do not keep resurrecting a cross-backend model.
+    removeUiValue(LEGACY_STORAGE_KEY);
     notifyLastUsedModelChanged();
   } catch {}
 }
 
 export function forgetLastUsedModel() {
   try {
-    removeUiValue(STORAGE_KEY);
+    removeUiValue(scopedStorageKey());
     notifyLastUsedModelChanged();
   } catch {}
 }

--- a/web/src/lib/model-options-cache.test.ts
+++ b/web/src/lib/model-options-cache.test.ts
@@ -1,13 +1,27 @@
-import { describe, expect, it } from "vitest";
+import { beforeEach, describe, expect, it } from "vitest";
 import {
   getCachedModelOptions,
   invalidateModelOptionsCache,
   MODEL_OPTIONS_CACHE_TTL_MS,
 } from "./model-options-cache";
 
+function setRuntime(input: Partial<NonNullable<Window["__HERMES_RUNTIME__"]>> = {}) {
+  (globalThis as any).window = (globalThis as any).window ?? {};
+  window.__HERMES_RUNTIME__ = {
+    connectionMode: "managed",
+    apiBaseUrl: "http://127.0.0.1:9120",
+    currentProfile: "default",
+    ...input,
+  };
+}
+
 describe("model options cache", () => {
-  it("deduplicates concurrent loads and returns fresh cached values", async () => {
+  beforeEach(() => {
     invalidateModelOptionsCache();
+    setRuntime();
+  });
+
+  it("deduplicates concurrent loads and returns fresh cached values", async () => {
     let calls = 0;
     let now = 1000;
     const loader = async () => {
@@ -29,7 +43,6 @@ describe("model options cache", () => {
   });
 
   it("invalidates session-scoped entries independently", async () => {
-    invalidateModelOptionsCache();
     let calls = 0;
     const loader = async () => {
       calls += 1;
@@ -46,5 +59,27 @@ describe("model options cache", () => {
     const stillCached = await getCachedModelOptions("s2", loader);
     expect(refreshed.providers[0]?.slug).toBe("p3");
     expect(stillCached).toBe(second);
+  });
+
+  it("isolates entries by connection mode and backend URL", async () => {
+    let calls = 0;
+    const loader = async () => {
+      calls += 1;
+      return { providers: [{ slug: `backend-${calls}` }] };
+    };
+
+    const managed = await getCachedModelOptions(undefined, loader);
+    setRuntime({
+      connectionMode: "local",
+      apiBaseUrl: "http://127.0.0.1:9119",
+      dashboardApiBaseUrl: "http://127.0.0.1:9119",
+    });
+    const local = await getCachedModelOptions(undefined, loader);
+    setRuntime({ connectionMode: "managed", apiBaseUrl: "http://127.0.0.1:9120" });
+    const managedAgain = await getCachedModelOptions(undefined, loader);
+
+    expect(managed.providers[0]?.slug).toBe("backend-1");
+    expect(local.providers[0]?.slug).toBe("backend-2");
+    expect(managedAgain).toBe(managed);
   });
 });

--- a/web/src/lib/model-options-cache.ts
+++ b/web/src/lib/model-options-cache.ts
@@ -10,9 +10,23 @@ interface ModelOptionsCacheEntry {
 
 const cache = new Map<string, ModelOptionsCacheEntry>();
 
+function safeScopePart(value: string | undefined | null, fallback: string): string {
+  const normalized = (value ?? "").trim();
+  return encodeURIComponent(normalized || fallback);
+}
+
+function backendScopeKey(): string {
+  const runtime = typeof window !== "undefined" ? window.__HERMES_RUNTIME__ : undefined;
+  const mode = runtime?.connectionMode ?? "managed";
+  const baseUrl = runtime?.apiBaseUrl || runtime?.dashboardApiBaseUrl || "relative";
+  const profile = runtime?.currentProfile || "default";
+  return [mode, baseUrl, profile].map((part) => safeScopePart(part, "default")).join(":");
+}
+
 function cacheKey(sessionId?: string): string {
   const normalized = sessionId?.trim();
-  return normalized ? `session:${normalized}` : "global";
+  const sessionScope = normalized ? `session:${normalized}` : "global";
+  return `${backendScopeKey()}:${sessionScope}`;
 }
 
 export function invalidateModelOptionsCache(sessionId?: string): void {

--- a/web/src/lib/runtime.ts
+++ b/web/src/lib/runtime.ts
@@ -287,7 +287,7 @@ declare global {
       gatewayUrl?: string;
       sessionToken?: string;
       currentProfile?: string;
-      /** "remote" when the desktop is attached to a remote Hermes Agent as a shell. */
+      /** "managed" for desktop-owned runtime, "local"/"remote" for attached backends. */
       connectionMode?: ConnectionMode;
     };
     hermesDesktop?: {
@@ -390,9 +390,28 @@ export const runtime = {
     return window.__HERMES_RUNTIME__?.sessionToken ?? window.__HERMES_SESSION_TOKEN__;
   },
 
+  getConnectionMode(): ConnectionMode {
+    return window.__HERMES_RUNTIME__?.connectionMode ?? "managed";
+  },
+
+  /** True when the desktop owns and can restart the bundled Hermes runtime. */
+  isManaged(): boolean {
+    return this.getConnectionMode() === "managed";
+  },
+
+  /** True when the desktop is attached to a loopback Hermes Agent CLI dashboard. */
+  isLocalConnection(): boolean {
+    return this.getConnectionMode() === "local";
+  },
+
   /** True when the desktop is attached to a remote Hermes Agent (shell mode). */
   isRemote(): boolean {
-    return window.__HERMES_RUNTIME__?.connectionMode === "remote";
+    return this.getConnectionMode() === "remote";
+  },
+
+  /** True for either attached backend where process/profile lifecycle is external. */
+  isAttached(): boolean {
+    return this.getConnectionMode() !== "managed";
   },
 
   getApiUrl(path: string): string {

--- a/web/src/lib/tauri-bridge.ts
+++ b/web/src/lib/tauri-bridge.ts
@@ -767,7 +767,7 @@ export async function installTauriBridge(): Promise<void> {
     gatewayUrl: string;
     sessionToken?: string;
     currentProfile: string;
-    connectionMode?: "local" | "remote";
+    connectionMode?: "managed" | "local" | "remote";
   }>("get_runtime_config");
 
   // Dev mode: WebView loads from Vite dev server (http://localhost:9545).
@@ -805,13 +805,12 @@ export async function installTauriBridge(): Promise<void> {
     config = await invokeCommand("get_runtime_config");
   }
 
-  // Remote mode must keep the real URLs even in Vite dev: the Vite proxy
-  // targets the LOCAL dashboard port, so relative URLs would route remote
-  // traffic to a backend that isn't connected. With apiBaseUrl set, transport
-  // goes through the Rust proxy and the gateway socket through the Rust relay,
-  // exactly like production.
-  const isRemote = config.connectionMode === "remote";
-  const hideUrlsForViteProxy = isDevMode && !isRemote;
+  // Attached local/remote mode must keep the real URLs even in Vite dev: the
+  // Vite proxy targets the managed dashboard port (9120), so relative URLs
+  // would route traffic to the wrong backend. Managed dev still hides URLs and
+  // uses the proxy as before.
+  const connectionMode = config.connectionMode ?? "managed";
+  const hideUrlsForViteProxy = isDevMode && connectionMode === "managed";
 
   window.__HERMES_RUNTIME__ = {
     platform: "tauri" as const,
@@ -820,7 +819,7 @@ export async function installTauriBridge(): Promise<void> {
     gatewayUrl: hideUrlsForViteProxy ? undefined : config.gatewayUrl,
     sessionToken: config.sessionToken,
     currentProfile: config.currentProfile,
-    connectionMode: config.connectionMode ?? "local",
+    connectionMode,
   };
 
   (window as any).hermesDesktop = tauriBridge;

--- a/web/src/routes/cron.module.css
+++ b/web/src/routes/cron.module.css
@@ -170,11 +170,10 @@
 
 .jobRowTop {
   display: flex;
-  align-items: center;
+  align-items: flex-start;
   gap: 8px;
 }
 
-.jobTitle,
 .runTitle {
   min-width: 0;
   overflow: hidden;
@@ -184,8 +183,15 @@
 
 .jobTitle {
   flex: 1;
-  font-size: 13px;
+  min-width: 0;
+  display: -webkit-box;
+  overflow: hidden;
+  -webkit-box-orient: vertical;
+  -webkit-line-clamp: 2;
+  font-size: 12px;
   font-weight: 700;
+  line-height: 1.35;
+  overflow-wrap: anywhere;
 }
 
 .jobMeta {
@@ -203,6 +209,10 @@
   border-radius: var(--h-r-pill);
   flex: 0 0 auto;
   background: var(--h-text-4);
+}
+
+.dot {
+  margin-top: 4px;
 }
 
 .dot[data-tone="ok"],
@@ -265,10 +275,17 @@
 
 .cardHeader {
   display: flex;
-  align-items: flex-start;
+  flex-direction: column;
+  gap: 12px;
+  margin-bottom: 18px;
+}
+
+.cardHeaderTop {
+  min-width: 0;
+  display: flex;
+  align-items: center;
   justify-content: space-between;
   gap: 18px;
-  margin-bottom: 18px;
 }
 
 .titleBlock {
@@ -276,7 +293,8 @@
 }
 
 .breadcrumb {
-  margin-bottom: 14px;
+  min-width: 0;
+  margin-bottom: 0;
   color: var(--h-text-3);
   font-size: 12px;
 }
@@ -288,6 +306,17 @@
   line-height: 1.15;
   letter-spacing: -0.04em;
   font-weight: 650;
+}
+
+.titleBlock h1 {
+  font-size: clamp(20px, 2vw, 24px);
+  line-height: 1.24;
+  letter-spacing: -0.025em;
+  overflow-wrap: anywhere;
+}
+
+.card .titleBlock p {
+  max-width: none;
 }
 
 .card p {
@@ -641,7 +670,12 @@
   }
 
   .cardHeader {
+    gap: 12px;
+  }
+
+  .cardHeaderTop {
     flex-direction: column;
+    align-items: flex-start;
   }
 
   .detailActions {

--- a/web/src/routes/cron.tsx
+++ b/web/src/routes/cron.tsx
@@ -610,18 +610,20 @@ function JobDetail({ job, busy, onPauseResume, onTrigger, onDelete }: JobDetailP
   return (
     <section className={s.card}>
       <div className={s.cardHeader}>
-        <div className={s.titleBlock}>
+        <div className={s.cardHeaderTop}>
           <div className={s.breadcrumb}>自动化功能 / {cronJobProfile(job)}</div>
+          <div className={s.detailActions}>
+            <span className={s.statusBadge} data-tone={statusTone(job)}>{statusLabel(job)}</span>
+            <button type="button" className={s.secondaryButton} onClick={onPauseResume} disabled={busy}>
+              {paused ? <Play size={14} /> : <Pause size={14} />}{paused ? "恢复" : "暂停"}
+            </button>
+            <button type="button" className={s.primaryButton} onClick={onTrigger} disabled={busy}><Zap size={14} /> 立即运行</button>
+            <button type="button" className={s.dangerButton} onClick={onDelete} disabled={busy}><Trash2 size={14} /> 删除</button>
+          </div>
+        </div>
+        <div className={s.titleBlock}>
           <h1>{titleOf(job)}</h1>
           <p>{promptPreview(job).slice(0, 180)}</p>
-        </div>
-        <div className={s.detailActions}>
-          <span className={s.statusBadge} data-tone={statusTone(job)}>{statusLabel(job)}</span>
-          <button type="button" className={s.secondaryButton} onClick={onPauseResume} disabled={busy}>
-            {paused ? <Play size={14} /> : <Pause size={14} />}{paused ? "恢复" : "暂停"}
-          </button>
-          <button type="button" className={s.primaryButton} onClick={onTrigger} disabled={busy}><Zap size={14} /> 立即运行</button>
-          <button type="button" className={s.dangerButton} onClick={onDelete} disabled={busy}><Trash2 size={14} /> 删除</button>
         </div>
       </div>
 

--- a/web/src/routes/detail.tsx
+++ b/web/src/routes/detail.tsx
@@ -4,6 +4,7 @@ import { useNavigate, useParams, useSearchParams } from "react-router-dom";
 import { Bot, Check, Copy, PanelRight } from "lucide-react";
 import {
   activeSessionIdAtom,
+  assistantDisplayNameAtom,
   conversationFontSizeAtom,
   conversationFontSizeVars,
   conversationWidthMaxWidth,
@@ -93,6 +94,7 @@ export function DetailRoute() {
   const [activeSessionId, setActiveId] = useAtom(activeSessionIdAtom);
   const [conversationWidthMode, setConversationWidthMode] = useAtom(conversationWidthModeAtom);
   const conversationFontSizeMode = useAtomValue(conversationFontSizeAtom);
+  const assistantDisplayName = useAtomValue(assistantDisplayNameAtom);
   const [rightRailVisible, setRightRailVisible] = useAtom(rightRailVisibleAtom);
   const [searchParams] = useSearchParams();
   const taskId = activeSessionId ?? urlTaskId;
@@ -553,7 +555,7 @@ export function DetailRoute() {
   const stall = useStallWatchdog(runtime);
 
   const composerLoadingPlaceholder = runtimeIsBusy && runtime.turnStartedAt
-    ? `Hermes 思考中 · ${formatElapsedTimer(composerTick)}`
+    ? `${assistantDisplayName} 思考中 · ${formatElapsedTimer(composerTick)}`
     : undefined;
 
   const timelineStatus =

--- a/web/src/routes/settings-connection-section.tsx
+++ b/web/src/routes/settings-connection-section.tsx
@@ -1,13 +1,6 @@
-// Settings → 连接: choose between the local managed runtime and a remote
-// Hermes Agent (shell mode). Token-auth-only port of the official desktop's
-// gateway-settings UI (Hermes-CN-Core apps/desktop/src/app/settings/
-// gateway-settings.tsx), matching its product shape: side-by-side mode cards,
-// a debounced reachability probe under the URL field, a session-token entry
-// that never round-trips the saved secret, a prominent env-override warning,
-// and a Test / Save-for-next-restart / Save-and-reconnect button row.
-//
-// The official UI additionally offers OAuth sign-in and per-profile scopes;
-// this v1 is token-only and global (see the connection.rs scope decision).
+// Settings → 连接: choose between the desktop-managed runtime, a loopback
+// Hermes Agent CLI dashboard, and a remote Hermes Agent. 本地连接自动从
+// dashboard HTML 读取 session token；远程连接继续使用手动 session token。
 import { useEffect, useRef, useState } from "react";
 import {
   AlertTriangle,
@@ -34,6 +27,13 @@ interface SettingsSectionProps {
 type ProbeStatus = "idle" | "probing" | "reachable" | "unreachable" | "authRequired";
 
 const PROBE_DEBOUNCE_MS = 500;
+const DEFAULT_LOCAL_URL = "http://127.0.0.1:9119";
+
+function modeLabel(mode: ConnectionMode | undefined): string {
+  if (mode === "remote") return "远程连接";
+  if (mode === "local") return "本地连接";
+  return "本机内核";
+}
 
 function ModeCard({
   active,
@@ -92,7 +92,8 @@ export function ConnectionSection({ showHeading = true }: SettingsSectionProps) 
 
   const [config, setConfig] = useState<ConnectionConfigView | null>(null);
   const [loadError, setLoadError] = useState("");
-  const [mode, setMode] = useState<ConnectionMode>("local");
+  const [mode, setMode] = useState<ConnectionMode>("managed");
+  const [localUrl, setLocalUrl] = useState(DEFAULT_LOCAL_URL);
   const [remoteUrl, setRemoteUrl] = useState("");
   // The saved token never round-trips; this holds only what the user types.
   const [tokenInput, setTokenInput] = useState("");
@@ -110,6 +111,7 @@ export function ConnectionSection({ showHeading = true }: SettingsSectionProps) 
       .then((view) => {
         setConfig(view);
         setMode(view.mode);
+        setLocalUrl(view.localUrl || DEFAULT_LOCAL_URL);
         setRemoteUrl(view.remoteUrl);
       })
       .catch((error) => {
@@ -120,13 +122,14 @@ export function ConnectionSection({ showHeading = true }: SettingsSectionProps) 
   const envOverride = config?.envOverride ?? false;
   const busy = saving || applying;
   const disabled = !supported || envOverride || busy;
-  const trimmedUrl = remoteUrl.trim();
-  const effectiveMode = config?.effectiveMode ?? "local";
+  const trimmedLocalUrl = localUrl.trim() || DEFAULT_LOCAL_URL;
+  const trimmedRemoteUrl = remoteUrl.trim();
+  const effectiveMode = config?.effectiveMode ?? "managed";
 
-  // Debounced as-you-type reachability probe, sequence-guarded so a slow
-  // response for an old URL can't overwrite the status of the current one.
+  // Debounced as-you-type reachability probe for remote URLs, sequence-guarded
+  // so a slow response for an old URL can't overwrite the current status.
   useEffect(() => {
-    if (mode !== "remote" || envOverride || !/^https?:\/\//i.test(trimmedUrl)) {
+    if (mode !== "remote" || envOverride || !/^https?:\/\//i.test(trimmedRemoteUrl)) {
       setProbeStatus("idle");
       return;
     }
@@ -134,7 +137,7 @@ export function ConnectionSection({ showHeading = true }: SettingsSectionProps) 
     setProbeStatus("probing");
     const timer = window.setTimeout(() => {
       desktop
-        ?.probeConnectionConfig?.(trimmedUrl)
+        ?.probeConnectionConfig?.(trimmedRemoteUrl)
         .then((result) => {
           if (seq !== probeSeq.current) return;
           if (!result.reachable) setProbeStatus("unreachable");
@@ -148,20 +151,22 @@ export function ConnectionSection({ showHeading = true }: SettingsSectionProps) 
     }, PROBE_DEBOUNCE_MS);
     return () => window.clearTimeout(timer);
     // eslint-disable-next-line react-hooks/exhaustive-deps
-  }, [mode, trimmedUrl, envOverride]);
+  }, [mode, trimmedRemoteUrl, envOverride]);
 
-  // Enough to submit a remote connection: a URL plus either a freshly typed
-  // token or a previously saved one (mirrors the official canUseRemote gate).
-  const remoteReady = mode === "local" || Boolean(trimmedUrl && (tokenInput.trim() || config?.remoteTokenSet));
+  const remoteReady = Boolean(trimmedRemoteUrl && (tokenInput.trim() || config?.remoteTokenSet));
+  const localReady = Boolean(trimmedLocalUrl);
+  const canSubmit = mode === "managed" || (mode === "local" ? localReady : remoteReady);
 
   const handleTest = async () => {
-    if (!desktop?.testConnectionConfig) return;
+    if (!desktop?.testConnectionConfig || mode === "managed") return;
     setMessage(null);
     setTesting(true);
     try {
       const result = await desktop.testConnectionConfig({
-        remoteUrl: trimmedUrl || undefined,
-        remoteToken: tokenInput || undefined,
+        mode,
+        localUrl: mode === "local" ? trimmedLocalUrl : undefined,
+        remoteUrl: mode === "remote" ? trimmedRemoteUrl : undefined,
+        remoteToken: mode === "remote" ? tokenInput || undefined : undefined,
       });
       setMessage(testResultSummary(result));
     } catch (error) {
@@ -172,8 +177,11 @@ export function ConnectionSection({ showHeading = true }: SettingsSectionProps) 
   };
 
   const submit = async (apply: boolean) => {
-    if (mode === "remote" && !remoteReady) {
-      setMessage({ tone: "error", text: "请先填写远程地址和 session token" });
+    if (!canSubmit) {
+      setMessage({
+        tone: "error",
+        text: mode === "remote" ? "请先填写远程地址和 session token" : "请先填写本地连接地址",
+      });
       return;
     }
     setMessage(null);
@@ -182,15 +190,13 @@ export function ConnectionSection({ showHeading = true }: SettingsSectionProps) 
     try {
       const payload = {
         mode,
-        remoteUrl: mode === "remote" ? trimmedUrl : undefined,
-        remoteToken: tokenInput || undefined,
+        localUrl: mode === "local" ? trimmedLocalUrl : undefined,
+        remoteUrl: mode === "remote" ? trimmedRemoteUrl : undefined,
+        remoteToken: mode === "remote" ? tokenInput || undefined : undefined,
       };
       if (apply) {
         const result = await desktop!.applyConnectionConfig!(payload);
         if (result.ok) {
-          // The connection mode feeds transport routing, socket-path selection
-          // and every query cache — a clean reload rebuilds it all from
-          // get_runtime_config, exactly like a fresh boot.
           setMessage({ tone: "ok", text: "已切换，正在重新加载界面…" });
           window.setTimeout(() => window.location.reload(), 600);
           return;
@@ -226,19 +232,11 @@ export function ConnectionSection({ showHeading = true }: SettingsSectionProps) 
     ? "正在读取网关连接状态"
     : envOverride
       ? "网关连接由环境变量覆盖"
-      : effectiveMode === "remote"
-        ? "已连接远程 Hermes Agent"
-        : "本机 managed runtime 正在使用";
+      : `已连接${modeLabel(effectiveMode)}`;
   const connectionDescription = envOverride
     ? `当前会话由环境变量强制连接到远程端（${config?.remoteUrl ?? "远程地址"}），需取消环境变量后才能在此修改。`
-    : "桌面端默认在本机启动自己的 Hermes 内核。当你想把它当作「壳」连接另一台机器上已运行的 Hermes Agent 时，选择远程模式。当前版本仅支持 session token 认证。";
-  const connectionBadge = !connectionLoaded
-    ? "读取中"
-    : envOverride
-      ? "环境变量"
-      : effectiveMode === "remote"
-        ? "远程"
-        : "本机";
+    : "桌面端现在支持三种连接：本机内核由桌面端管理 9120；本地连接自动接入本机 CLI dashboard 9119；远程连接继续使用 session token。";
+  const connectionBadge = !connectionLoaded ? "读取中" : envOverride ? "环境变量" : modeLabel(effectiveMode);
 
   return (
     <div>
@@ -246,7 +244,7 @@ export function ConnectionSection({ showHeading = true }: SettingsSectionProps) 
 
       <SettingsHero
         ok={connectionLoaded}
-        icon={effectiveMode === "remote" || envOverride ? <Globe2 size={24} /> : <HardDrive size={24} />}
+        icon={effectiveMode === "remote" || envOverride ? <Globe2 size={24} /> : effectiveMode === "local" ? <Cable size={24} /> : <HardDrive size={24} />}
         eyebrow="Hermes Agent 网关连接"
         title={connectionTitle}
         description={connectionDescription}
@@ -270,11 +268,20 @@ export function ConnectionSection({ showHeading = true }: SettingsSectionProps) 
 
       <div className={s.connModeGrid}>
         <ModeCard
-          active={mode === "local"}
-          current={effectiveMode === "local"}
+          active={mode === "managed"}
+          current={effectiveMode === "managed"}
           icon={HardDrive}
           title="本机内核"
-          description="在本机启动私有 Hermes 后端，默认且可离线运行。"
+          description="桌面端启动并管理私有 Hermes runtime，默认端口 9120，适合离线和独立使用。"
+          disabled={disabled}
+          onSelect={() => setMode("managed")}
+        />
+        <ModeCard
+          active={mode === "local"}
+          current={effectiveMode === "local"}
+          icon={Cable}
+          title="本地连接"
+          description="连接本机已运行的 Hermes Agent CLI dashboard，默认 http://127.0.0.1:9119。"
           disabled={disabled}
           onSelect={() => setMode("local")}
         />
@@ -282,12 +289,35 @@ export function ConnectionSection({ showHeading = true }: SettingsSectionProps) 
           active={mode === "remote"}
           current={effectiveMode === "remote"}
           icon={Globe2}
-          title="远程 Hermes Agent"
+          title="远程连接"
           description="把桌面端作为界面壳连接另一台机器上的 Hermes 后端，使用 session token 认证。"
           disabled={disabled}
           onSelect={() => setMode("remote")}
         />
       </div>
+
+      {mode === "local" && (
+        <div className={s.row}>
+          <div className={s.rowLeft}>
+            <div className={s.rowLabel}>本地 Dashboard 地址</div>
+            <div className={s.rowSub}>
+              仅允许 localhost / 127.0.0.1 / ::1。连接时会自动从本机 dashboard 页面读取 session token，不需要手动粘贴。
+              若 9119 端口提示未连接，请先在命令行中输入 <code>hermes dashboard</code> 启动 dashboard。
+            </div>
+          </div>
+          <div className={s.rowRight}>
+            <Input
+              mono
+              style={{ minWidth: 280 }}
+              value={localUrl}
+              placeholder={DEFAULT_LOCAL_URL}
+              disabled={disabled}
+              onChange={(e) => setLocalUrl(e.target.value)}
+              spellCheck={false}
+            />
+          </div>
+        </div>
+      )}
 
       {mode === "remote" && (
         <>
@@ -300,13 +330,7 @@ export function ConnectionSection({ showHeading = true }: SettingsSectionProps) 
               {probeStatus !== "idle" && (
                 <div
                   className={s.connProbe}
-                  data-tone={
-                    probeStatus === "reachable"
-                      ? "ok"
-                      : probeStatus === "probing"
-                        ? undefined
-                        : "error"
-                  }
+                  data-tone={probeStatus === "reachable" ? "ok" : probeStatus === "probing" ? undefined : "error"}
                   aria-live="polite"
                 >
                   {probeStatus === "probing" && <Loader2 size={12} className={s.connSpin} />}
@@ -315,7 +339,7 @@ export function ConnectionSection({ showHeading = true }: SettingsSectionProps) 
                   {probeStatus === "probing" && "正在探测网关认证方式…"}
                   {probeStatus === "reachable" && "网关可达"}
                   {probeStatus === "unreachable" && "暂时无法连接该网关，检查地址与网络后会自动重试"}
-                  {probeStatus === "authRequired" && "该网关需要 OAuth 登录，当前版本仅支持 session token"}
+                  {probeStatus === "authRequired" && "该网关需要 OAuth 登录，本轮远程连接仍仅支持 session token"}
                 </div>
               )}
             </div>
@@ -336,8 +360,7 @@ export function ConnectionSection({ showHeading = true }: SettingsSectionProps) 
             <div className={s.rowLeft}>
               <div className={s.rowLabel}>Session Token</div>
               <div className={s.rowSub}>
-                远程端用于 REST 与 WebSocket 鉴权的会话令牌（启动远程 dashboard 时由
-                HERMES_DASHBOARD_SESSION_TOKEN 指定）。仅保存在本机，留空保持不变。
+                远程端用于 REST 与 WebSocket 鉴权的会话令牌。仅保存在本机，留空保持不变。
               </div>
             </div>
             <div className={s.rowRight}>
@@ -357,13 +380,13 @@ export function ConnectionSection({ showHeading = true }: SettingsSectionProps) 
       )}
 
       <div className={s.connFooter}>
-        {mode === "remote" && (
+        {mode !== "managed" && (
           <Button
             type="button"
             className={s.connFooterSpacer}
             variant="outline"
             onClick={() => void handleTest()}
-            disabled={disabled || testing || !trimmedUrl}
+            disabled={disabled || testing || (mode === "local" ? !trimmedLocalUrl : !trimmedRemoteUrl)}
             aria-busy={testing}
           >
             {testing ? <Loader2 size={13} className={s.connSpin} /> : <Cable size={13} />}
@@ -374,7 +397,7 @@ export function ConnectionSection({ showHeading = true }: SettingsSectionProps) 
           type="button"
           variant="outline"
           onClick={() => void submit(false)}
-          disabled={disabled || (mode === "remote" && !remoteReady)}
+          disabled={disabled || !canSubmit}
           aria-busy={saving}
         >
           仅保存（下次启动生效）
@@ -384,11 +407,11 @@ export function ConnectionSection({ showHeading = true }: SettingsSectionProps) 
           variant="solid"
           tone="accent"
           onClick={() => void submit(true)}
-          disabled={disabled || (mode === "remote" && !remoteReady)}
+          disabled={disabled || !canSubmit}
           aria-busy={applying}
         >
           {applying && <Loader2 size={13} className={s.connSpin} />}
-          {mode === "remote" ? "保存并连接远程" : "保存并切回本机"}
+          {mode === "remote" ? "保存并连接远程" : mode === "local" ? "保存并连接本地" : "保存并切回本机内核"}
         </Button>
       </div>
 

--- a/web/src/routes/settings-models-section.tsx
+++ b/web/src/routes/settings-models-section.tsx
@@ -40,6 +40,7 @@ import {
   type ProviderPreset,
 } from "@/lib/provider-catalog";
 import { useProviderCatalog } from "@/hooks/use-provider-catalog";
+import { useOAuthProviders } from "@/hooks/use-oauth-providers";
 import { ModelCombobox } from "@/components/settings/model-combobox";
 import { translateEnvCategory, translateEnvVar } from "@/lib/env-translations";
 import { rememberLastUsedModel } from "@/lib/last-used-model";
@@ -667,6 +668,7 @@ export function ModelsSection() {
     refetch: refetchConfig,
   } = useConfig();
   const { data: modelInfo } = useModelInfo();
+  const { data: oauthProviders, isLoading: oauthProvidersLoading } = useOAuthProviders();
   const saveConfig = useSaveConfig();
   const setEnv = useSetEnv();
   const deleteEnv = useDeleteEnv();
@@ -898,6 +900,11 @@ export function ModelsSection() {
     () => allProviders.filter((provider) =>
       providerHasSavedCredentials(config, provider.id, resolvedEnvVars, provider)).length,
     [allProviders, config, resolvedEnvVars],
+  );
+  const currentProviderOAuthLoggedIn = useMemo(
+    () => oauthProviders?.some((provider) =>
+      provider.id === currentProviderId && provider.status.logged_in) ?? false,
+    [currentProviderId, oauthProviders],
   );
   const providerEnvEntries = useMemo(
     () => Object.entries(resolvedEnvVars)
@@ -1487,7 +1494,10 @@ export function ModelsSection() {
   }
 
   const envLoadWarning = envIsError ? (envError instanceof Error ? envError.message : "环境变量加载失败") : "";
-  const needsInitialModelSetup = !modelInfo?.model?.trim() || !modelInfo?.provider?.trim() || configuredCount === 0;
+  const needsInitialModelSetup =
+    !modelInfo?.model?.trim() ||
+    !modelInfo?.provider?.trim() ||
+    (!currentProviderOAuthLoggedIn && configuredCount === 0 && !oauthProvidersLoading);
   const customProviderIsLocal = customProviderMode === "local";
   const customProviderTitle = customProviderIsLocal ? "添加本地部署服务商" : "添加自定义服务商";
   const customProviderHint = customProviderIsLocal

--- a/web/src/routes/settings-oauth-section.tsx
+++ b/web/src/routes/settings-oauth-section.tsx
@@ -67,13 +67,14 @@ function flowLabel(flow: string | undefined): string {
   switch (flow) {
     case "pkce": return "浏览器授权";
     case "device_code": return "设备码登录";
+    case "loopback": return "浏览器回调";
     case "external": return "外部管理";
     default: return "";
   }
 }
 
 export function OAuthProvidersSection() {
-  const { data: providers, isLoading, refetch } = useOAuthProviders();
+  const { data: providers, isLoading, isError, error, refetch } = useOAuthProviders();
   const disconnect = useDisconnectOAuth();
   const [loginProvider, setLoginProvider] = useState<OAuthProvider | null>(null);
 
@@ -92,6 +93,19 @@ export function OAuthProvidersSection() {
   );
 
   if (isLoading) return <div className={s.oauthBlock}><span className={settings.desc}>加载 OAuth 状态…</span></div>;
+  if (isError) {
+    return (
+      <div className={s.oauthBlock}>
+        <div className={s.oauthHeader}>
+          <div>
+            <div className={s.oauthTitle}>OAuth 登录</div>
+            <div className={s.oauthDesc}>OAuth 状态加载失败：{error instanceof Error ? error.message : String(error)}</div>
+          </div>
+          <Button variant="outline" onClick={() => void refetch()}>重试</Button>
+        </div>
+      </div>
+    );
+  }
   if (!providers || providers.length === 0) return null;
 
   return (
@@ -108,7 +122,9 @@ export function OAuthProvidersSection() {
 
       {providers.map((provider) => {
         const status = badgeStatus(provider);
-        const canLogin = !provider.status.logged_in && (provider.flow === "pkce" || provider.flow === "device_code");
+        const canLogin = !provider.status.logged_in && (
+          provider.flow === "pkce" || provider.flow === "device_code" || provider.flow === "loopback"
+        );
         const canDisconnect = provider.status.logged_in && provider.flow !== "external";
         const expiry = formatExpiry(provider.status.expires_at);
 
@@ -189,13 +205,20 @@ interface StartResultDeviceCode {
   poll_interval: number;
 }
 
+interface StartResultLoopback {
+  flow: "loopback";
+  session_id: string;
+  auth_url: string;
+  expires_in: number;
+}
+
 function OAuthLoginModal({ provider, onClose }: { provider: OAuthProvider; onClose: () => void }) {
   const startLogin = useStartOAuthLogin();
   const submitCode = useSubmitOAuthCode();
   const cancelSession = useCancelOAuthSession();
 
   const [phase, setPhase] = useState<LoginPhase>("starting");
-  const [startResult, setStartResult] = useState<StartResultPkce | StartResultDeviceCode | null>(null);
+  const [startResult, setStartResult] = useState<StartResultPkce | StartResultDeviceCode | StartResultLoopback | null>(null);
   const [code, setCode] = useState("");
   const [errorMsg, setErrorMsg] = useState("");
   const [countdown, setCountdown] = useState(0);
@@ -203,19 +226,22 @@ function OAuthLoginModal({ provider, onClose }: { provider: OAuthProvider; onClo
 
   const polling = usePollOAuthSession(
     provider.id,
-    startResult?.flow === "device_code" ? startResult.session_id : null,
+    startResult?.flow === "device_code" || startResult?.flow === "loopback" ? startResult.session_id : null,
     phase === "polling",
   );
 
   useEffect(() => {
     startLogin.mutateAsync(provider.id).then((result) => {
-      setStartResult(result as StartResultPkce | StartResultDeviceCode);
+      setStartResult(result as StartResultPkce | StartResultDeviceCode | StartResultLoopback);
       sessionIdRef.current = result.session_id;
       setCountdown(result.expires_in);
 
       if (result.flow === "pkce") {
         void openExternalUrl(result.auth_url);
         setPhase("awaiting_user");
+      } else if (result.flow === "loopback") {
+        void openExternalUrl(result.auth_url);
+        setPhase("polling");
       } else {
         void openExternalUrl(result.verification_url);
         setPhase("polling");
@@ -362,6 +388,24 @@ function OAuthLoginModal({ provider, onClose }: { provider: OAuthProvider; onClo
               </button>
             </div>
             <div className={s.statusMessage} data-type="pending">等待授权中…</div>
+            {countdown > 0 && <div className={s.countdown}>剩余时间: {formatCountdown(countdown)}</div>}
+          </>
+        )}
+
+        {phase === "polling" && startResult?.flow === "loopback" && (
+          <>
+            <p style={{ fontSize: 13, color: "var(--h-text)", margin: "0 0 8px" }}>
+              浏览器已打开授权页；授权完成后会自动回到本机回调地址，无需复制验证码。
+            </p>
+            <div className={s.modalActions}>
+              <button
+                className={s.linkBtn}
+                onClick={() => void openExternalUrl(startResult.auth_url)}
+              >
+                重新打开授权页
+              </button>
+            </div>
+            <div className={s.statusMessage} data-type="pending">等待浏览器回调中…</div>
             {countdown > 0 && <div className={s.countdown}>剩余时间: {formatCountdown(countdown)}</div>}
           </>
         )}

--- a/web/src/routes/settings.module.css
+++ b/web/src/routes/settings.module.css
@@ -3131,3 +3131,97 @@
   gap: 8px;
   margin-top: 2px;
 }
+
+.assistantProfileControl,
+.assistantAvatarControl {
+  display: inline-flex;
+  align-items: center;
+  justify-content: flex-end;
+  gap: 8px;
+  min-width: 0;
+}
+
+.assistantProfileControl {
+  width: min(320px, 38vw);
+}
+
+.assistantNameInput {
+  box-sizing: border-box;
+  width: 100%;
+  min-width: 0;
+  padding: 7px 10px;
+  border: 1px solid var(--h-line);
+  border-radius: 8px;
+  background: var(--h-bg-input);
+  color: var(--h-text);
+  font-family: var(--h-font-cn);
+  font-size: 12px;
+  outline: none;
+}
+
+.assistantNameInput:focus {
+  border-color: color-mix(in srgb, var(--h-accent) 56%, var(--h-line));
+  box-shadow: 0 0 0 2px color-mix(in srgb, var(--h-accent) 14%, transparent);
+}
+
+.iconPlainButton {
+  width: 28px;
+  height: 28px;
+  flex: 0 0 auto;
+  display: inline-flex;
+  align-items: center;
+  justify-content: center;
+  border: 1px solid var(--h-line);
+  border-radius: 8px;
+  background: var(--h-bg-pane);
+  color: var(--h-text-3);
+  cursor: pointer;
+}
+
+.iconPlainButton:hover {
+  color: var(--h-text);
+  background: var(--h-bg-soft);
+}
+
+.hiddenFileInput {
+  display: none;
+}
+
+.assistantAvatarPreview,
+.assistantAvatarPlaceholder {
+  width: 34px;
+  height: 34px;
+  flex: 0 0 auto;
+  border-radius: 50%;
+  border: 1px solid var(--h-line);
+  background: var(--h-bg-chip);
+}
+
+.assistantAvatarPreview {
+  display: block;
+  object-fit: cover;
+}
+
+.assistantAvatarPlaceholder {
+  display: inline-flex;
+  align-items: center;
+  justify-content: center;
+  color: var(--h-text-3);
+}
+
+.assistantProfileError,
+.assistantProfileStorageHint {
+  margin: 8px 0 0;
+  padding-left: 0;
+  font-size: 11px;
+  line-height: 1.6;
+  font-family: var(--h-font-cn);
+}
+
+.assistantProfileError {
+  color: var(--h-err);
+}
+
+.assistantProfileStorageHint {
+  color: var(--h-text-3);
+}

--- a/web/src/routes/settings.tsx
+++ b/web/src/routes/settings.tsx
@@ -6,6 +6,7 @@ import {
   AlertTriangle,
   Brush,
   Bug,
+  Cable,
   CheckCircle2,
   Copy,
   ExternalLink as ExternalLinkIcon,
@@ -1090,6 +1091,9 @@ export function KernelSection({ showHeading = true }: SettingsSectionProps) {
   const kernelRuntimeTag = kernelRuntimeTagLabel(info?.current);
   const rendererRuntime = typeof window !== "undefined" ? window.__HERMES_RUNTIME__ : undefined;
   const isRemote = rendererRuntime?.connectionMode === "remote";
+  const isLocalConnection = rendererRuntime?.connectionMode === "local";
+  const isAttachedConnection = rendererRuntime?.connectionMode === "remote" || rendererRuntime?.connectionMode === "local";
+  const attachedConnectionLabel = isRemote ? "远程 Hermes Agent" : "本地 Hermes Agent CLI";
   const hermesHomePath = status?.hermes_home;
   const runtimeRootPath = info?.runtimeRoot;
   const runtimeVersionPath = info?.current?.path;
@@ -1142,13 +1146,13 @@ export function KernelSection({ showHeading = true }: SettingsSectionProps) {
     <div>
       {showHeading && <h2 className={s.heading}>内核</h2>}
       <SettingsHero
-        ok={isRemote || isolationOk}
-        icon={isRemote ? <Globe2 size={24} /> : isolationOk ? <ShieldCheck size={24} /> : <Bug size={24} />}
+        ok={isAttachedConnection || isolationOk}
+        icon={isRemote ? <Globe2 size={24} /> : isLocalConnection ? <Cable size={24} /> : isolationOk ? <ShieldCheck size={24} /> : <Bug size={24} />}
         eyebrow="Hermes Agent 中文社区桌面版内核"
-        title={isRemote ? "已连接远程 Hermes Agent" : isolationOk ? (process?.ownsProcess ? "独立 runtime 内核正在运行" : "已连接到 managed runtime dashboard") : "正在读取内核隔离状态"}
+        title={isAttachedConnection ? `已连接${attachedConnectionLabel}` : isolationOk ? (process?.ownsProcess ? "独立 runtime 内核正在运行" : "已连接到 managed runtime dashboard") : "正在读取内核隔离状态"}
         description={
-          isRemote
-              ? `桌面端当前作为界面壳运行，所有会话与配置由远程端（${rendererRuntime?.dashboardApiBaseUrl ?? "远程地址"}）提供。本机 runtime 未在使用，可在 设置 → 连接 切回本机内核。`
+          isAttachedConnection
+              ? `桌面端当前作为界面壳运行，所有会话与配置由${isRemote ? "远程端" : "本机 CLI dashboard"}（${rendererRuntime?.dashboardApiBaseUrl ?? rendererRuntime?.apiBaseUrl ?? "目标地址"}）提供。本机 managed runtime 未在使用，可在 设置 → 连接 切回本机内核。`
               : isolationOk && process?.ownsProcess
               ? "当前 Dashboard 由桌面端托管的 managed runtime 子进程提供，内核、gateway runtime 与锁文件都收束在桌面 runtime 目录下。"
               : isolationOk
@@ -1156,12 +1160,12 @@ export function KernelSection({ showHeading = true }: SettingsSectionProps) {
               : "此处用于确认桌面端是否真的使用独立 hermes-agent-cn runtime，而不是复用全局 PATH 或外部 dashboard。"
         }
         badge={(
-          <span className={s.statusBadge} data-on={isRemote || isolationOk}>
-            {isRemote ? "远程" : info ? runtimeModeLabel(info.mode) : "读取中"}
+          <span className={s.statusBadge} data-on={isAttachedConnection || isolationOk}>
+            {isRemote ? "远程" : isLocalConnection ? "本地" : info ? runtimeModeLabel(info.mode) : "读取中"}
           </span>
         )}
       >
-        {!isRemote && kernelRuntimeTag && (
+        {!isAttachedConnection && kernelRuntimeTag && (
           <code className={s.aboutRuntimeTag} title="当前安装的 runtime 发行版本（对应 Hermes-CN-Core release tag）">
             {kernelRuntimeTag}
           </code>
@@ -1199,8 +1203,8 @@ export function KernelSection({ showHeading = true }: SettingsSectionProps) {
           variant="solid"
           tone="accent"
           onClick={() => void gatewayRestart.restart()}
-          disabled={gatewayRestart.locked || isRemote}
-          title={isRemote ? "远程模式下由远程端管理 Gateway" : gatewayRestartTitle(gatewayRestart.phase, gatewayRestart.message)}
+          disabled={gatewayRestart.locked || isAttachedConnection}
+          title={isAttachedConnection ? "当前连接模式下由目标后端管理 Gateway" : gatewayRestartTitle(gatewayRestart.phase, gatewayRestart.message)}
           aria-busy={gatewayRestart.busy}
         >
           <RotateCcw size={13} />
@@ -1293,8 +1297,8 @@ export function KernelSection({ showHeading = true }: SettingsSectionProps) {
                   variant="outline"
                   type="button"
                   onClick={handleCheckRuntime}
-                  disabled={!info?.updatesConfigured || checking || isRemote}
-                  title={isRemote ? "远程模式下本机 runtime 未在使用" : undefined}
+                  disabled={!info?.updatesConfigured || checking || isAttachedConnection}
+                  title={isAttachedConnection ? "当前连接模式下本机 runtime 未在使用" : undefined}
                 >
                   <RefreshCw size={13} />
                   {checking ? "检查中" : "检查更新"}
@@ -1304,8 +1308,8 @@ export function KernelSection({ showHeading = true }: SettingsSectionProps) {
                   tone="accent"
                   type="button"
                   onClick={handleInstallRuntime}
-                  disabled={!canInstall || installing || isRemote}
-                  title={isRemote ? "远程模式下本机 runtime 未在使用" : undefined}
+                  disabled={!canInstall || installing || isAttachedConnection}
+                  title={isAttachedConnection ? "当前连接模式下本机 runtime 未在使用" : undefined}
                 >
                   {installing ? "安装中…" : "安装更新"}
                 </Button>
@@ -1313,8 +1317,8 @@ export function KernelSection({ showHeading = true }: SettingsSectionProps) {
                   variant="outline"
                   type="button"
                   onClick={handleRollbackRuntime}
-                  disabled={!info?.current?.previousRuntimeVersion || rollingBack || isRemote}
-                  title={isRemote ? "远程模式下本机 runtime 未在使用" : undefined}
+                  disabled={!info?.current?.previousRuntimeVersion || rollingBack || isAttachedConnection}
+                  title={isAttachedConnection ? "当前连接模式下本机 runtime 未在使用" : undefined}
                 >
                   {rollingBack ? "回滚中…" : "回滚 Runtime"}
                 </Button>

--- a/web/src/routes/settings.tsx
+++ b/web/src/routes/settings.tsx
@@ -15,6 +15,7 @@ import {
   GitFork,
   Globe2,
   Heart,
+  Image as ImageIcon,
   Info,
   MessageCircle,
   RefreshCw,
@@ -23,6 +24,8 @@ import {
   Server,
   ShieldCheck,
   Terminal,
+  Upload,
+  X,
 } from "lucide-react";
 import { Alert, Button, Dialog, Field, Input, Select, useTheme, type ThemeConfig } from "@hermes/shared-ui";
 import { useConfig, useConfigSchema, useSaveConfig } from "@/hooks/use-config";
@@ -41,6 +44,9 @@ import {
 } from "@/hooks/use-runtime-update";
 import {
   CONVERSATION_FONT_SIZE_OPTIONS,
+  DEFAULT_ASSISTANT_DISPLAY_NAME,
+  assistantAvatarDataUrlAtom,
+  assistantDisplayNameAtom,
   composerSubmitShortcutAtom,
   conversationFontSizeAtom,
   notifyOnApprovalAtom,
@@ -50,6 +56,7 @@ import {
   notifySystemAtom,
   profileSwitchingAtom,
   showReasoningAtom,
+  normalizeAssistantDisplayName,
   type ConversationFontSizeMode,
 } from "@/stores/ui";
 import { playChime, shouldPlayFallbackSound } from "@/lib/notifications";
@@ -82,6 +89,45 @@ interface SettingsSectionProps {
 export function GeneralSection({ showHeading = true }: SettingsSectionProps) {
   const [showReasoning, setShowReasoning] = useAtom(showReasoningAtom);
   const [composerSubmitShortcut, setComposerSubmitShortcut] = useAtom(composerSubmitShortcutAtom);
+  const [assistantDisplayName, setAssistantDisplayName] = useAtom(assistantDisplayNameAtom);
+  const [assistantAvatarDataUrl, setAssistantAvatarDataUrl] = useAtom(assistantAvatarDataUrlAtom);
+  const avatarInputRef = useRef<HTMLInputElement | null>(null);
+  const [assistantProfileError, setAssistantProfileError] = useState("");
+
+  const handleAssistantNameChange = (value: string) => {
+    setAssistantProfileError("");
+    setAssistantDisplayName(value);
+  };
+
+  const handleAvatarFile = async (file: File | undefined) => {
+    if (!file) return;
+    setAssistantProfileError("");
+    if (!file.type.startsWith("image/")) {
+      setAssistantProfileError("请选择 PNG、JPG、WebP、GIF 或 SVG 图片。");
+      return;
+    }
+    if (file.size > 2 * 1024 * 1024) {
+      setAssistantProfileError("头像图片不能超过 2 MB。");
+      return;
+    }
+    try {
+      const dataUrl = await new Promise<string>((resolve, reject) => {
+        const reader = new FileReader();
+        reader.onload = () => resolve(String(reader.result ?? ""));
+        reader.onerror = () => reject(reader.error ?? new Error("读取头像失败"));
+        reader.readAsDataURL(file);
+      });
+      if (!dataUrl.startsWith("data:image/")) {
+        setAssistantProfileError("头像文件格式不受支持。");
+        return;
+      }
+      setAssistantAvatarDataUrl(dataUrl);
+    } catch (error) {
+      setAssistantProfileError(error instanceof Error ? error.message : "读取头像失败");
+    } finally {
+      if (avatarInputRef.current) avatarInputRef.current.value = "";
+    }
+  };
 
   return (
     <div>
@@ -92,6 +138,54 @@ export function GeneralSection({ showHeading = true }: SettingsSectionProps) {
       <Row label="发送快捷键" sub="控制对话输入框的提交方式；未触发发送的 Enter 会保留为换行。" right={
         <RadioGroup value={composerSubmitShortcut} options={[{ value: "enter", label: "Enter 发送" }, { value: "ctrl-enter", label: "Ctrl+Enter 发送" }]} onChange={(v) => setComposerSubmitShortcut(v as ComposerSubmitShortcut)} />
       } />
+      <Row label="Hermes 名称" sub="修改后会影响对话中助手消息上方显示的名称；留空会恢复 Hermes。" right={
+        <div className={s.assistantProfileControl}>
+          <input
+            className={s.assistantNameInput}
+            value={assistantDisplayName === DEFAULT_ASSISTANT_DISPLAY_NAME ? "" : assistantDisplayName}
+            placeholder={DEFAULT_ASSISTANT_DISPLAY_NAME}
+            maxLength={40}
+            onChange={(event) => handleAssistantNameChange(event.target.value)}
+            onBlur={(event) => setAssistantDisplayName(normalizeAssistantDisplayName(event.target.value))}
+          />
+          {assistantDisplayName !== DEFAULT_ASSISTANT_DISPLAY_NAME ? (
+            <button
+              type="button"
+              className={s.iconPlainButton}
+              onClick={() => handleAssistantNameChange("")}
+              title="恢复默认名称"
+            >
+              <X size={13} />
+            </button>
+          ) : null}
+        </div>
+      } />
+      <Row label="Hermes 头像" sub="上传后会显示在 Hermes 的对话消息旁；不设置时保持原有纯文本样式。" right={
+        <div className={s.assistantAvatarControl}>
+          <input
+            ref={avatarInputRef}
+            className={s.hiddenFileInput}
+            type="file"
+            accept="image/png,image/jpeg,image/webp,image/gif,image/svg+xml"
+            onChange={(event) => void handleAvatarFile(event.target.files?.[0])}
+          />
+          {assistantAvatarDataUrl ? (
+            <img className={s.assistantAvatarPreview} src={assistantAvatarDataUrl} alt="Hermes 头像预览" />
+          ) : (
+            <span className={s.assistantAvatarPlaceholder}><ImageIcon size={16} /></span>
+          )}
+          <button type="button" className={s.btn} onClick={() => avatarInputRef.current?.click()}>
+            <Upload size={13} /> 上传
+          </button>
+          {assistantAvatarDataUrl ? (
+            <button type="button" className={s.btn} onClick={() => { setAssistantProfileError(""); setAssistantAvatarDataUrl(""); }}>
+              移除
+            </button>
+          ) : null}
+        </div>
+      } />
+      {assistantProfileError ? <p className={s.assistantProfileError}>{assistantProfileError}</p> : null}
+      <p className={s.assistantProfileStorageHint}>名称和头像只影响桌面端显示，不会改写模型提示词；清空名称和移除头像后会恢复之前的对话样式。</p>
       <ApprovalModeSection />
     </div>
   );

--- a/web/src/stores/ui.test.ts
+++ b/web/src/stores/ui.test.ts
@@ -276,3 +276,40 @@ describe("runtimeUpdatingAtom", () => {
     expect(store.get(runtimeUpdatingAtom)).toEqual({ active: true, mode: "rollback" });
   });
 });
+
+describe("assistant display profile atoms (persisted)", () => {
+  it("defaults to Hermes and restores a saved custom name", async () => {
+    const { assistantDisplayNameAtom } = await loadUi();
+    const store = createStore();
+    expect(store.get(assistantDisplayNameAtom)).toBe("Hermes");
+
+    const restored = await loadUi({ "hermes.assistant-display-name": "Claudia" });
+    const restoredStore = createStore();
+    expect(restoredStore.get(restored.assistantDisplayNameAtom)).toBe("Claudia");
+  });
+
+  it("trims, limits and persists custom assistant names", async () => {
+    const { assistantDisplayNameAtom, uiStore } = await loadUi();
+    const store = createStore();
+    store.set(assistantDisplayNameAtom, "  Claudia   Agent  ");
+    expect(store.get(assistantDisplayNameAtom)).toBe("Claudia Agent");
+    expect(uiStore.readUiValue("hermes.assistant-display-name", "")).toBe("Claudia Agent");
+
+    store.set(assistantDisplayNameAtom, "");
+    expect(store.get(assistantDisplayNameAtom)).toBe("Hermes");
+    expect(uiStore.readUiValue("hermes.assistant-display-name", "fallback")).toBe("");
+  });
+
+  it("accepts image data URLs and rejects non-image avatar values", async () => {
+    const { assistantAvatarDataUrlAtom, uiStore } = await loadUi();
+    const store = createStore();
+    const avatar = "data:image/png;base64,AAAA";
+    store.set(assistantAvatarDataUrlAtom, avatar);
+    expect(store.get(assistantAvatarDataUrlAtom)).toBe(avatar);
+    expect(uiStore.readUiValue("hermes.assistant-avatar-data-url", "")).toBe(avatar);
+
+    store.set(assistantAvatarDataUrlAtom, "https://example.test/avatar.png");
+    expect(store.get(assistantAvatarDataUrlAtom)).toBe("");
+    expect(uiStore.readUiValue("hermes.assistant-avatar-data-url", "fallback")).toBe("");
+  });
+});

--- a/web/src/stores/ui.ts
+++ b/web/src/stores/ui.ts
@@ -23,6 +23,11 @@ export const CONVERSATION_FONT_SIZE_OPTIONS = [
 
 export type ConversationFontSizeMode = typeof CONVERSATION_FONT_SIZE_OPTIONS[number]["value"];
 
+export const DEFAULT_ASSISTANT_DISPLAY_NAME = "Hermes";
+export const ASSISTANT_DISPLAY_NAME_KEY = "hermes.assistant-display-name";
+export const ASSISTANT_AVATAR_KEY = "hermes.assistant-avatar-data-url";
+const MAX_ASSISTANT_DISPLAY_NAME_LENGTH = 40;
+
 const DEFAULT_CONVERSATION_WIDTH_MODE: ConversationWidthMode = "medium";
 const CONVERSATION_WIDTH_KEY = "hermes.conversation-width";
 const CONVERSATION_WIDTH_VALUES = CONVERSATION_WIDTH_OPTIONS.map((option) => option.value);
@@ -50,6 +55,18 @@ export function conversationFontSizeVars(mode: ConversationFontSizeMode): { font
   const option = CONVERSATION_FONT_SIZE_OPTIONS.find((item) => item.value === mode)
     ?? CONVERSATION_FONT_SIZE_OPTIONS[1];
   return { fontSize: option.fontSize, lineHeight: option.lineHeight };
+}
+
+export function normalizeAssistantDisplayName(value: unknown): string {
+  const trimmed = typeof value === "string" ? value.replace(/\s+/g, " ").trim() : "";
+  if (!trimmed) return DEFAULT_ASSISTANT_DISPLAY_NAME;
+  return Array.from(trimmed).slice(0, MAX_ASSISTANT_DISPLAY_NAME_LENGTH).join("");
+}
+
+export function normalizeAssistantAvatarDataUrl(value: unknown): string {
+  const text = typeof value === "string" ? value.trim() : "";
+  if (!text) return "";
+  return /^data:image\/(?:png|jpe?g|gif|webp|svg\+xml);base64,/i.test(text) ? text : "";
 }
 
 const conversationWidthModeBaseAtom = atom<ConversationWidthMode>(
@@ -92,6 +109,34 @@ export const activeProfileAtom = atom(
   (_get, set, next: string) => {
     set(activeProfileBaseAtom, next);
     writeUiValue("hermes.active-profile", next);
+  },
+);
+
+const assistantDisplayNameBaseAtom = atom<string>(
+  normalizeAssistantDisplayName(readUiValue(ASSISTANT_DISPLAY_NAME_KEY, DEFAULT_ASSISTANT_DISPLAY_NAME)),
+);
+export const assistantDisplayNameAtom = atom(
+  (get) => get(assistantDisplayNameBaseAtom),
+  (_get, set, next: string) => {
+    const value = normalizeAssistantDisplayName(next);
+    set(assistantDisplayNameBaseAtom, value);
+    if (value === DEFAULT_ASSISTANT_DISPLAY_NAME) {
+      writeUiValue(ASSISTANT_DISPLAY_NAME_KEY, "");
+    } else {
+      writeUiValue(ASSISTANT_DISPLAY_NAME_KEY, value);
+    }
+  },
+);
+
+const assistantAvatarDataUrlBaseAtom = atom<string>(
+  normalizeAssistantAvatarDataUrl(readUiValue(ASSISTANT_AVATAR_KEY, "")),
+);
+export const assistantAvatarDataUrlAtom = atom(
+  (get) => get(assistantAvatarDataUrlBaseAtom),
+  (_get, set, next: string) => {
+    const value = normalizeAssistantAvatarDataUrl(next);
+    set(assistantAvatarDataUrlBaseAtom, value);
+    writeUiValue(ASSISTANT_AVATAR_KEY, value);
   },
 );
 


### PR DESCRIPTION
## 变更说明

这次把桌面端连接模型从原来的本机/远程拆成「本机内核」「本地连接」「远程连接」三态。本地连接默认接入 `http://127.0.0.1:9119`，并自动从本机 dashboard HTML 读取 session token，避免用户手动粘贴。

同时修复本地连接 9119 时 Memory、OAuth 状态、健康检查、默认模型和最近模型缓存仍串到内置 9120 内核的问题，并优化了定时任务页面的标题布局、详情区空间利用、加载性能和右上角 Profile 图标基线。

本次还在「常规」页增加 Hermes 名称与头像设置。用户设置名称后，对话中的助手显示名会同步变化；上传头像后，助手消息会显示自定义头像；未设置头像时仍保持原来的样式。

另外修复了会话中后台进程通知的渲染问题：后台进程通知会作为系统提示展示，自动去除 ANSI 控制字符，并避免已被中断的 live assistant 残影与后续正式回答重复合并显示；系统通知图标与文字基线也已校正。

## 用户影响

本机已经运行 Hermes Agent CLI dashboard 时，桌面端可以直接选择「本地连接」，模型页会正确识别 Codex OAuth，健康检查会显示当前 9119 后端和模型凭证状态，新建对话默认模型会跟随当前后端主模型。

定时任务页面的长标题会在 1 到 2 行内展示，详情区不再留下大块空白，进入页面时不再被不必要的状态请求拖慢。

用户可以在常规设置里自定义 Hermes 的显示名称和头像，并在对话中看到对应效果；后台进程通知会更清晰地显示为系统提示。

## 验证

- `pnpm typecheck`
- `pnpm test:unit`
- `git diff --check`
- `cargo test --lib`

<!-- gk-ai-analysis-start:75f6f26fa3ab6f8f3c70a8c44d0a2b5c7c3afd31 -->
<!-- gk-ai-analysis-data:eyJzdW1tYXJ5IjoiU3BsaXRzIGNvbm5lY3Rpb24gY29uZmlnIGludG8gbWFuYWdlZCwgbG9jYWwsIGFuZCByZW1vdGUgbW9kZXMsIGFkZGluZyBzdXBwb3J0IGZvciBhIGxvY2FsIENMSSBkYXNoYm9hcmQgYW5kIGFzc2lzdGFudCBwZXJzb25hbGl6YXRpb24uIiwia2V5SW5zaWdodHMiOlt7InRpdGxlIjoiQ29ubmVjdGlvbk1vZGUgZW51bSBleHBhbmRlZCIsImRlc2NyaXB0aW9uIjoiQ29ubmVjdGlvbk1vZGUgbm93IGRpZmZlcmVudGlhdGVzIGJldHdlZW4gTWFuYWdlZCwgTG9jYWwsIGFuZCBSZW1vdGUsIHJlcGxhY2luZyB0aGUgYmluYXJ5IGxvY2FsL3JlbW90ZSBkaXN0aW5jdGlvbi4iLCJzZXZlcml0eSI6Im1lZGl1bSIsImZpbGVQYXRoIjoic3JjL2Nvbm5lY3Rpb24ucnMiLCJsaW5lU3RhcnQiOjM4fSx7InRpdGxlIjoiTG9jYWwgZGFzaGJvYXJkIGF0dGFjaG1lbnQgcHJvYmluZyIsImRlc2NyaXB0aW9uIjoiQWRkZWQgZGVkaWNhdGVkIHByb2JlIGFuZCBIRVJNRVNfSE9NRSBmZXRjaCBtZWNoYW5pc21zIGZvciBhdHRhY2hlZCBsb2NhbCBkYXNoYm9hcmRzIHRoYXQgbWlnaHQgaGF2ZSBsb25nZXIgcmVzcG9uc2UgdGltZXMuIiwic2V2ZXJpdHkiOiJtZWRpdW0iLCJmaWxlUGF0aCI6InNyYy9wcm9jZXNzL2Rhc2hib2FyZC5ycyIsImxpbmVTdGFydCI6NDc1fSx7InRpdGxlIjoiQXNzaXN0YW50IHBlcnNvbmFsaXphdGlvbiBzZXR0aW5ncyBhZGRlZCIsImRlc2NyaXB0aW9uIjoiQWRkZWQgc2V0dGluZ3Mgc2VjdGlvbiB0byBjdXN0b21pemUgdGhlIGFzc2lzdGFudCdzIGRpc3BsYXkgbmFtZSBhbmQgYXZhdGFyLCByZXN0cmljdGluZyBhdmF0YXJzIHRvIDJNQiBpbWFnZXMuIiwic2V2ZXJpdHkiOiJsb3ciLCJmaWxlUGF0aCI6IndlYi9zcmMvcm91dGVzL3NldHRpbmdzLnRzeCIsImxpbmVTdGFydCI6OTJ9XSwiaXNzdWVzIjpbXSwic3VnZ2VzdGlvbnMiOltdLCJzZWN1cml0eSI6W119 -->
<!-- gk-ai-analysis-end:75f6f26fa3ab6f8f3c70a8c44d0a2b5c7c3afd31 -->

<!-- gitkraken-review-badge-begin -->
---
<a href="https://gitkraken.dev/review/github/Eynzof/Hermes-CN-Desktop/pull/284?source=pr_review_chip">
  <picture>
    <source media="(prefers-color-scheme: dark)" srcset="https://gitkraken.dev/images/figures/gitkraken-review-badge-dark.svg">
    <img src="https://gitkraken.dev/images/figures/gitkraken-review-badge-light.svg" alt="Open with GitKraken">
  </picture>
</a>
<!-- gitkraken-review-badge-end -->