### PR TITLE
[codex] 修复桌面端界面提示问题

### DIFF
--- a/packages/protocol/src/hermes-api.test.ts
+++ b/packages/protocol/src/hermes-api.test.ts
@@ -341,9 +341,10 @@ describe("OAuth schemas", () => {
       id: "xai-oauth",
       name: "xAI Grok OAuth",
       flow: "loopback",
-      status: { logged_in: false },
+      status: { logged_in: false, source: null },
     });
     expect(provider.flow).toBe("loopback");
+    expect(provider.status.source).toBeNull();
 
     const start = OAuthStartResponse.parse({
       session_id: "sid",

--- a/packages/protocol/src/hermes-api.ts
+++ b/packages/protocol/src/hermes-api.ts
@@ -665,7 +665,7 @@ export type LogsResponse = z.infer<typeof LogsResponse>;
 
 export const OAuthProviderStatus = z.object({
   logged_in: z.boolean(),
-  source: z.string().optional(),
+  source: z.string().nullable().optional(),
   source_label: z.string().nullable().optional(),
   token_preview: z.string().nullable().optional(),
   expires_at: z.union([z.string(), z.number()]).nullable().optional(),

--- a/web/src/components/app-shell/app-top-bar.module.css
+++ b/web/src/components/app-shell/app-top-bar.module.css
@@ -134,7 +134,7 @@
   color: var(--h-text-2);
   border-radius: 3px;
   letter-spacing: 0.01em;
-  font-family: var(--h-font-mono);
+  font-family: var(--h-font-cn);
   text-transform: lowercase;
   cursor: pointer;
   display: inline-flex;
@@ -170,6 +170,7 @@
 }
 
 .navNum {
+  font-family: var(--h-font-mono);
   font-size: 9px;
   color: var(--h-text-3);
   margin-right: 6px;

--- a/web/src/components/chat/message-timeline.test.tsx
+++ b/web/src/components/chat/message-timeline.test.tsx
@@ -259,6 +259,30 @@ describe("MessageTimeline", () => {
 
     expect(html).not.toContain("对话轮次定位");
   });
+  it("falls back to session usage stats for the latest completed assistant message", () => {
+    const messages: ChatMessage[] = [
+      { id: "user-1", role: "user", createdAt: 1, text: "问题" },
+      { id: "assistant-1", role: "assistant", createdAt: 2, status: "complete", text: "回答" },
+    ];
+
+    const html = ReactDOMServer.renderToStaticMarkup(
+      <MessageTimeline
+        messages={messages}
+        sessionUsage={{
+          model: "deepseek-v4-flash",
+          input: 900,
+          output: 300,
+          total: 1200,
+          cache_read: 100,
+          calls: 1,
+        } as any}
+      />,
+    );
+
+    expect(html).toContain("1.2k");
+    expect(html).toContain('title="详细统计"');
+  });
+
   it("renders read-aloud controls only for completed assistant messages", () => {
     const messages: ChatMessage[] = [
       { id: "user-1", role: "user", createdAt: 1, text: "问题" },

--- a/web/src/components/chat/message-timeline.tsx
+++ b/web/src/components/chat/message-timeline.tsx
@@ -534,6 +534,45 @@ function finishReasonRisk(reason: string | undefined): "warn" | "err" | undefine
   return undefined;
 }
 
+function sessionUsageFallbackStats(
+  message: ChatMessage,
+  sessionUsage: SessionUsageResult | null | undefined,
+): AssistantMessageStats | undefined {
+  if (message.role !== "assistant" || message.status === "streaming" || message.status === "error") return undefined;
+  if (!sessionUsage) return undefined;
+
+  const stats: AssistantMessageStats = {};
+  const tokensInput = sessionUsage.input ?? sessionUsage.prompt;
+  const tokensOutput = sessionUsage.output ?? sessionUsage.completion;
+  const tokensTotal = sessionUsage.total ?? (
+    typeof tokensInput === "number" || typeof tokensOutput === "number"
+      ? (tokensInput ?? 0) + (tokensOutput ?? 0)
+      : undefined
+  );
+
+  if (typeof tokensInput === "number") stats.tokensInput = tokensInput;
+  if (typeof tokensOutput === "number") stats.tokensOutput = tokensOutput;
+  if (typeof tokensTotal === "number") stats.tokensTotal = tokensTotal;
+  if (typeof sessionUsage.cache_read === "number") stats.cacheRead = sessionUsage.cache_read;
+  if (typeof sessionUsage.cache_write === "number") stats.cacheWrite = sessionUsage.cache_write;
+  if (typeof sessionUsage.calls === "number") stats.apiCalls = sessionUsage.calls;
+  if (typeof sessionUsage.model === "string" && sessionUsage.model) stats.model = sessionUsage.model;
+
+  const costStatus = typeof sessionUsage.cost_status === "string"
+    ? sessionUsage.cost_status.toLowerCase()
+    : undefined;
+  if (
+    typeof sessionUsage.cost_usd === "number" &&
+    Number.isFinite(sessionUsage.cost_usd) &&
+    costStatus !== "stale_pricing" &&
+    costStatus !== "unknown"
+  ) {
+    stats.costUsd = sessionUsage.cost_usd;
+  }
+
+  return Object.keys(stats).length > 0 ? stats : undefined;
+}
+
 function MessageStatsFooter({ stats }: { stats: AssistantMessageStats }) {
   const [open, setOpen] = useState(false);
   const wrapRef = useRef<HTMLSpanElement>(null);
@@ -649,6 +688,7 @@ function MessageBubble({ message, turnStartedAt, sessionUsage, progressModel, sp
   const speechStatus = speech?.state.messageId === message.id ? speech.state.status : "idle";
   const speechBusy = speechStatus === "preparing" || speechStatus === "speaking";
   const hasBlocks = !isUser && Boolean(message.blocks?.length);
+  const messageStats = message.stats ?? sessionUsageFallbackStats(message, sessionUsage);
 
   if (isToolOnly) {
     return (
@@ -761,7 +801,7 @@ function MessageBubble({ message, turnStartedAt, sessionUsage, progressModel, sp
               <span className={s.messageSpeechError}>{speech.error.message}</span>
             ) : null}
           </span>
-          {message.stats ? <MessageStatsFooter stats={message.stats} /> : null}
+          {messageStats ? <MessageStatsFooter stats={messageStats} /> : null}
         </div>
       </div>
     </div>

--- a/web/src/lib/tauri-bridge.ts
+++ b/web/src/lib/tauri-bridge.ts
@@ -487,10 +487,10 @@ const tauriBridge = {
   },
 };
 
-// Overlay shown while the Rust side downloads the managed runtime on
-// first launch. Pre-React, plain DOM — we can't mount React yet
-// because the bridge isn't ready (no apiBaseUrl => API calls would
-// throw). Phase strings match the `runtime-status` event emitted by
+// Overlay shown while the Rust side prepares the managed runtime and
+// dashboard before React can mount. Pre-React, plain DOM — we can't mount
+// React yet because the bridge isn't ready (no apiBaseUrl => API calls
+// would throw). Phase strings match the `runtime-status` event emitted by
 // src/main.rs::emit_runtime_status.
 function showBootstrapOverlay(initialMessage: string): {
   update(phase: string, message: string): void;
@@ -631,7 +631,7 @@ function showBootstrapOverlay(initialMessage: string): {
     "font-family:'JetBrains Mono',ui-monospace,monospace;font-size:11px;" +
       "color:rgba(255,255,255,0.45);letter-spacing:0.06em;text-transform:uppercase;",
   );
-  sub.textContent = "Hermes Agent 中文社区桌面版 · 首次启动";
+  sub.textContent = "Hermes Agent 中文社区桌面版 · 启动中";
   panel.appendChild(sub);
 
   root.appendChild(panel);
@@ -673,7 +673,7 @@ function showBootstrapOverlay(initialMessage: string): {
         errorText.textContent = lastErrorMessage;
         detail.style.display = "block";
         copyButton.disabled = false;
-        sub.textContent = "首次启动失败";
+        sub.textContent = "启动失败";
       } else if (msg) {
         message.textContent = msg;
       }

--- a/web/src/routes/settings-connection-section.tsx
+++ b/web/src/routes/settings-connection-section.tsx
@@ -25,9 +25,12 @@ interface SettingsSectionProps {
 }
 
 type ProbeStatus = "idle" | "probing" | "reachable" | "unreachable" | "authRequired";
+type ConnectionMessage = { tone: "ok" | "error"; text: string; hint?: string };
 
 const PROBE_DEBOUNCE_MS = 500;
 const DEFAULT_LOCAL_URL = "http://127.0.0.1:9119";
+const LOCAL_DASHBOARD_RECOVERY_HINT =
+  "如果您确定本机已经安装了 Hermes，请尝试使用 hermes dashboard 启动网关后，确认 http://127.0.0.1:9119/ 可以在浏览器中访问，再试一次。";
 
 function modeLabel(mode: ConnectionMode | undefined): string {
   if (mode === "remote") return "远程连接";
@@ -73,7 +76,7 @@ function ModeCard({
   );
 }
 
-function testResultSummary(result: TestConnectionResult): { tone: "ok" | "error"; text: string } {
+function testResultSummary(result: TestConnectionResult): ConnectionMessage {
   if (result.ok) {
     const version = result.version ? ` · Hermes ${result.version}` : "";
     return { tone: "ok", text: `连接正常：HTTP 与 WebSocket 均可用（${result.baseUrl}${version}）` };
@@ -84,6 +87,11 @@ function testResultSummary(result: TestConnectionResult): { tone: "ok" | "error"
     `WebSocket ${result.wsOk ? "✓" : "✗"}`,
   ];
   return { tone: "error", text: `${detail}　[${parts.join("，")}]` };
+}
+
+function withLocalDashboardHint(message: ConnectionMessage, mode: ConnectionMode): ConnectionMessage {
+  if (mode !== "local" || message.tone !== "error") return message;
+  return { ...message, hint: LOCAL_DASHBOARD_RECOVERY_HINT };
 }
 
 export function ConnectionSection({ showHeading = true }: SettingsSectionProps) {
@@ -102,7 +110,7 @@ export function ConnectionSection({ showHeading = true }: SettingsSectionProps) 
   const [testing, setTesting] = useState(false);
   const [saving, setSaving] = useState(false);
   const [applying, setApplying] = useState(false);
-  const [message, setMessage] = useState<{ tone: "ok" | "error"; text: string } | null>(null);
+  const [message, setMessage] = useState<ConnectionMessage | null>(null);
 
   useEffect(() => {
     if (!desktop?.getConnectionConfig) return;
@@ -168,9 +176,9 @@ export function ConnectionSection({ showHeading = true }: SettingsSectionProps) 
         remoteUrl: mode === "remote" ? trimmedRemoteUrl : undefined,
         remoteToken: mode === "remote" ? tokenInput || undefined : undefined,
       });
-      setMessage(testResultSummary(result));
+      setMessage(withLocalDashboardHint(testResultSummary(result), mode));
     } catch (error) {
-      setMessage({ tone: "error", text: error instanceof Error ? error.message : String(error) });
+      setMessage(withLocalDashboardHint({ tone: "error", text: error instanceof Error ? error.message : String(error) }, mode));
     } finally {
       setTesting(false);
     }
@@ -201,7 +209,7 @@ export function ConnectionSection({ showHeading = true }: SettingsSectionProps) 
           window.setTimeout(() => window.location.reload(), 600);
           return;
         }
-        setMessage({ tone: "error", text: result.error ?? "切换失败" });
+        setMessage(withLocalDashboardHint({ tone: "error", text: result.error ?? "切换失败" }, mode));
       } else {
         const view = await desktop!.saveConnectionConfig!(payload);
         setConfig(view);
@@ -209,7 +217,7 @@ export function ConnectionSection({ showHeading = true }: SettingsSectionProps) 
         setMessage({ tone: "ok", text: "已保存，下次启动桌面端时生效" });
       }
     } catch (error) {
-      setMessage({ tone: "error", text: error instanceof Error ? error.message : String(error) });
+      setMessage(withLocalDashboardHint({ tone: "error", text: error instanceof Error ? error.message : String(error) }, mode));
     } finally {
       setBusy(false);
     }
@@ -302,7 +310,7 @@ export function ConnectionSection({ showHeading = true }: SettingsSectionProps) 
             <div className={s.rowLabel}>本地 Dashboard 地址</div>
             <div className={s.rowSub}>
               仅允许 localhost / 127.0.0.1 / ::1。连接时会自动从本机 dashboard 页面读取 session token，不需要手动粘贴。
-              若 9119 端口提示未连接，请先在命令行中输入 <code>hermes dashboard</code> 启动 dashboard。
+              如果您确定本机已经安装了 Hermes，请尝试使用 <code>hermes dashboard</code> 启动网关后，确认 <code>http://127.0.0.1:9119/</code> 可以在浏览器中访问，再试一次。
             </div>
           </div>
           <div className={s.rowRight}>
@@ -417,7 +425,8 @@ export function ConnectionSection({ showHeading = true }: SettingsSectionProps) 
 
       {message && (
         <Alert className={s.connResult} tone={message.tone} size="sm">
-          {message.text}
+          <div>{message.text}</div>
+          {message.hint && <div className={s.connResultHint}>{message.hint}</div>}
         </Alert>
       )}
     </div>

--- a/web/src/routes/settings-oauth-section.module.css
+++ b/web/src/routes/settings-oauth-section.module.css
@@ -78,7 +78,7 @@
 }
 
 .modal {
-  background: var(--h-bg);
+  background: var(--h-bg-pane);
   border: 1px solid var(--h-line);
   border-radius: 12px;
   box-shadow: 0 8px 32px rgba(0, 0, 0, 0.18);

--- a/web/src/routes/settings.module.css
+++ b/web/src/routes/settings.module.css
@@ -3033,6 +3033,11 @@
   color: var(--h-err);
 }
 
+.connResultHint {
+  margin-top: 4px;
+  color: var(--h-text-2);
+}
+
 /* ── Danger zone (high-risk operations, e.g. YOLO mode) ──────────────── */
 .dangerZone {
   margin-top: 28px;


### PR DESCRIPTION
## 变更内容

修复 OAuth 登录弹窗面板背景透明的问题，将弹窗背景从未定义的 `--h-bg` 调整为已有的 `--h-bg-pane`。

在连接设置页补充本地 Hermes Agent CLI 不可达时的排障提示：如果用户已确认本机安装了 Hermes，可以先用 `hermes dashboard` 启动网关，并确认 `http://127.0.0.1:9119/` 能在浏览器中访问后再重试。

修正启动页底部状态文案，避免普通启动过程也显示“首次启动”；启动失败时也统一显示为“启动失败”。

兼容 Windows 测试中发现的 OAuth provider 状态响应：`status.source` 可能为 `null`，协议 schema 现在允许该值，避免整个 OAuth 登录区块加载失败。

修复 Windows 顶部主导航中文菜单使用等宽字体栈时回退到衬线体的问题。菜单文字改用中文 UI 非衬线字体栈，编号仍保留等宽字体。

补全回复底部统计兜底：当最新已完成助手回复本身没有逐回合 stats 时，使用当前 `session.usage` 补出模型、输入/输出/总 tokens、缓存和 API 调用等统计，避免 Windows 上只显示复制/朗读按钮。

## 原因与影响

此前 OAuth 登录弹窗的 `.modal` 使用的 CSS 变量未定义，浏览器会丢弃该背景声明，导致弹窗区域透出底层配置页面。修复后弹窗拥有稳定的实体面板背景，设备码、按钮和状态信息的可读性恢复正常。

本地连接失败时，原错误只说明 `/api/status` 无响应，用户不容易知道下一步应先启动 CLI dashboard。本次提示会在本地连接错误反馈中展示具体命令和验证地址，降低排障成本。

启动页是运行时和 dashboard 准备期间的通用遮罩，不只用于首次启动。将固定“首次启动”文案改为通用“启动中”，避免每次启动都给用户造成误导。

Windows 调试包显示运行时 `0.16.0-cn.9` 的 `/api/providers/oauth` 会对未配置的 provider 返回 `status.source: null`。前端原本只允许字符串或缺省，Zod 校验失败后会阻断整块 OAuth UI。本次改为按真实后端响应兼容 `null`，并补了回归测试。

顶部导航此前整体使用 `--h-font-mono`，Windows 上中文 glyph 会落到宋体类回退字体。现在导航文字使用 `--h-font-cn`，只有 `01/02/03/04` 编号继续使用 `--h-font-mono`。

消息 footer 原本只读取消息自身 metadata 或本地 turn_stats；如果 Windows 运行时没有把逐回合 stats 命中到最终消息，footer 就会整体消失。本次增加只针对最新完成回复的 `session.usage` 兜底，不覆盖已有逐回合 stats。

## 验证

- `pnpm --filter @hermes/web test:unit -- message-timeline.test.tsx`
- `pnpm --filter @hermes/protocol test:unit`
- `pnpm typecheck`
- `pnpm test:unit`
- `cargo check`
