### PR TITLE
[codex] 添加官方看板入口

### DIFF
--- a/web/src/app.tsx
+++ b/web/src/app.tsx
@@ -15,6 +15,7 @@ import { DetailRoute } from "@/routes/detail";
 import { HistoryRoute } from "@/routes/history";
 import { ProjectsRoute } from "@/routes/projects";
 import { ProjectDetailRoute } from "@/routes/project-detail";
+import { KanbanRoute } from "@/routes/kanban";
 import { SkillsRoute } from "@/routes/skills";
 import { ModelsRoute } from "@/routes/models";
 import { VoiceRoute } from "@/routes/voice";
@@ -66,6 +67,7 @@ export function App() {
           <Route path="/history" element={withBoundary(<HistoryRoute />)} />
           <Route path="/projects" element={withBoundary(<ProjectsRoute />)} />
           <Route path="/projects/:workspacePath" element={withBoundary(<ProjectDetailRoute />)} />
+          <Route path="/kanban" element={withBoundary(<KanbanRoute />)} />
           <Route path="/skills" element={withBoundary(<SkillsRoute />)} />
           <Route path="/models" element={withBoundary(<ModelsRoute />)} />
           <Route path="/voice" element={withBoundary(<VoiceRoute />)} />

--- a/web/src/components/app-shell/use-active-top-tab.test.ts
+++ b/web/src/components/app-shell/use-active-top-tab.test.ts
@@ -17,6 +17,10 @@ describe("TOP_TABS", () => {
     expect(tabFor("/im/weixin")).toBe("gateway");
   });
 
+  it("keeps kanban under the 01 workbench tab", () => {
+    expect(tabFor("/kanban")).toBe("workbench");
+  });
+
   it("keeps canonical advanced pages under the 04 advanced tab", () => {
     expect(tabFor("/common")).toBe("advanced");
     expect(tabFor("/notifications")).toBe("advanced");

--- a/web/src/components/app-shell/use-active-top-tab.ts
+++ b/web/src/components/app-shell/use-active-top-tab.ts
@@ -39,7 +39,8 @@ export const TOP_TABS: readonly TopTabDef[] = [
       path.startsWith("/new") ||
       path.startsWith("/tasks/") ||
       path.startsWith("/history") ||
-      path.startsWith("/projects"),
+      path.startsWith("/projects") ||
+      path.startsWith("/kanban"),
   },
   {
     id: "skills",

--- a/web/src/components/app-shell/workbench-sidebar.tsx
+++ b/web/src/components/app-shell/workbench-sidebar.tsx
@@ -74,6 +74,18 @@ function sectionLabel(index: number, label: string): string {
   return `§${index.toString().padStart(2, "0")} · ${label}`;
 }
 
+function KanbanQuickIcon() {
+  return (
+    <svg width="16" height="16" viewBox="0 0 16 16" fill="none" aria-hidden="true">
+      <rect x="2.2" y="2.4" width="11.6" height="11.2" rx="1.8" stroke="currentColor" strokeWidth="1.3" />
+      <path d="M6 4.8v6.4M10 4.8v6.4" stroke="currentColor" strokeWidth="1.1" strokeLinecap="round" />
+      <rect x="3.8" y="4.5" width="2.2" height="3" rx="0.6" fill="currentColor" opacity="0.8" />
+      <rect x="6.9" y="4.5" width="2.2" height="4.8" rx="0.6" fill="currentColor" opacity="0.58" />
+      <rect x="10" y="4.5" width="2.2" height="2.6" rx="0.6" fill="currentColor" opacity="0.72" />
+    </svg>
+  );
+}
+
 interface SessionRowProps {
   session: SessionSummary;
   state: "live" | "ok" | "err" | "idle";
@@ -337,6 +349,18 @@ export function WorkbenchSidebar() {
           </span>
           <span className={s.entryLabel}>工作空间</span>
           <span className={s.entryCommand}>/workspace</span>
+        </button>
+        <button
+          type="button"
+          className={s.quickNavButton}
+          data-active={location.pathname.startsWith("/kanban") ? "true" : undefined}
+          onClick={() => navigate("/kanban")}
+        >
+          <span className={s.entryIcon}>
+            <KanbanQuickIcon />
+          </span>
+          <span className={s.entryLabel}>看板</span>
+          <span className={s.entryCommand}>/kanban</span>
         </button>
       </div>
 

--- a/web/src/lib/command-palette.test.ts
+++ b/web/src/lib/command-palette.test.ts
@@ -3,6 +3,7 @@ import type { FsEntry, SessionSummary, SkillInfo } from "@hermes/protocol";
 import {
   buildCommandPaletteItems,
   buildFileItems,
+  COMMAND_PALETTE_COMMANDS,
   filterCommandPaletteGroups,
   shouldLoadCommandPaletteFiles,
 } from "./command-palette";
@@ -40,6 +41,14 @@ describe("command palette item building and filtering", () => {
   it("matches fixed commands by Chinese and English keywords", () => {
     expect(groupLabels("健康")).toContain("健康检查");
     expect(groupLabels("provider")).toContain("模型配置");
+  });
+
+  it("includes a Kanban command that navigates to the desktop guide route", () => {
+    const command = COMMAND_PALETTE_COMMANDS.find((item) => item.id === "command-kanban");
+    expect(command?.label).toBe("看板 Kanban");
+    expect(command?.action).toEqual({ type: "navigate", to: "/kanban" });
+    expect(groupLabels("kanban")).toContain("看板 Kanban");
+    expect(groupLabels("看板")).toContain("看板 Kanban");
   });
 
   it("matches sessions by title, preview and id", () => {

--- a/web/src/lib/command-palette.ts
+++ b/web/src/lib/command-palette.ts
@@ -112,6 +112,17 @@ export const COMMAND_PALETTE_COMMANDS: readonly CommandPaletteItem[] = [
     priority: 2,
   },
   {
+    id: "command-kanban",
+    group: "commands",
+    label: "看板 Kanban",
+    subtitle: "/kanban · 打开官方 Dashboard 看板",
+    keywords: ["kanban", "board", "dashboard", "official", "看板", "任务板"],
+    icon: "project",
+    action: { type: "navigate", to: "/kanban" },
+    defaultVisible: true,
+    priority: 3,
+  },
+  {
     id: "command-skills",
     group: "commands",
     label: "Skills 管理",
@@ -120,7 +131,7 @@ export const COMMAND_PALETTE_COMMANDS: readonly CommandPaletteItem[] = [
     icon: "skill",
     action: { type: "navigate", to: "/skills" },
     defaultVisible: true,
-    priority: 3,
+    priority: 4,
   },
   {
     id: "command-models",
@@ -131,7 +142,7 @@ export const COMMAND_PALETTE_COMMANDS: readonly CommandPaletteItem[] = [
     icon: "models",
     action: { type: "navigate", to: "/models" },
     defaultVisible: true,
-    priority: 4,
+    priority: 5,
   },
   {
     id: "command-mcp",
@@ -142,7 +153,7 @@ export const COMMAND_PALETTE_COMMANDS: readonly CommandPaletteItem[] = [
     icon: "mcp",
     action: { type: "navigate", to: "/mcp" },
     defaultVisible: true,
-    priority: 5,
+    priority: 6,
   },
   {
     id: "command-profiles",
@@ -153,7 +164,7 @@ export const COMMAND_PALETTE_COMMANDS: readonly CommandPaletteItem[] = [
     icon: "profiles",
     action: { type: "navigate", to: "/profiles" },
     defaultVisible: true,
-    priority: 6,
+    priority: 7,
   },
   {
     id: "command-cron",
@@ -164,7 +175,7 @@ export const COMMAND_PALETTE_COMMANDS: readonly CommandPaletteItem[] = [
     icon: "cron",
     action: { type: "navigate", to: "/cron" },
     defaultVisible: true,
-    priority: 7,
+    priority: 8,
   },
   {
     id: "command-health",
@@ -175,7 +186,7 @@ export const COMMAND_PALETTE_COMMANDS: readonly CommandPaletteItem[] = [
     icon: "health",
     action: { type: "navigate", to: "/health" },
     defaultVisible: true,
-    priority: 8,
+    priority: 9,
   },
   {
     id: "command-analytics",
@@ -185,7 +196,7 @@ export const COMMAND_PALETTE_COMMANDS: readonly CommandPaletteItem[] = [
     keywords: ["analytics", "usage", "tokens", "cost", "statistics", "统计", "用量"],
     icon: "analytics",
     action: { type: "navigate", to: "/analytics" },
-    priority: 9,
+    priority: 10,
   },
   {
     id: "command-logs",
@@ -195,7 +206,7 @@ export const COMMAND_PALETTE_COMMANDS: readonly CommandPaletteItem[] = [
     keywords: ["logs", "log", "debug", "journal", "日志"],
     icon: "file",
     action: { type: "navigate", to: "/logs" },
-    priority: 10,
+    priority: 11,
   },
   {
     id: "command-debug",
@@ -205,7 +216,7 @@ export const COMMAND_PALETTE_COMMANDS: readonly CommandPaletteItem[] = [
     keywords: ["debug", "diagnostics", "bundle", "troubleshoot", "调试", "排障"],
     icon: "debug",
     action: { type: "navigate", to: "/debug" },
-    priority: 11,
+    priority: 12,
   },
   {
     id: "command-settings",
@@ -215,7 +226,7 @@ export const COMMAND_PALETTE_COMMANDS: readonly CommandPaletteItem[] = [
     keywords: ["settings", "config", "preferences", "common", "设置", "配置"],
     icon: "settings",
     action: { type: "navigate", to: "/common" },
-    priority: 12,
+    priority: 13,
   },
   {
     id: "command-backup",
@@ -225,7 +236,7 @@ export const COMMAND_PALETTE_COMMANDS: readonly CommandPaletteItem[] = [
     keywords: ["backup", "restore", "export", "import", "备份", "恢复"],
     icon: "backup",
     action: { type: "navigate", to: "/backup" },
-    priority: 13,
+    priority: 14,
   },
   {
     id: "command-memory",
@@ -235,7 +246,7 @@ export const COMMAND_PALETTE_COMMANDS: readonly CommandPaletteItem[] = [
     keywords: ["memory", "profile", "remember", "记忆", "用户画像"],
     icon: "memory",
     action: { type: "navigate", to: "/memory" },
-    priority: 14,
+    priority: 15,
   },
   {
     id: "command-soul",
@@ -245,7 +256,7 @@ export const COMMAND_PALETTE_COMMANDS: readonly CommandPaletteItem[] = [
     keywords: ["soul", "prompt", "persona", "system prompt", "灵魂", "人格"],
     icon: "soul",
     action: { type: "navigate", to: "/soul" },
-    priority: 15,
+    priority: 16,
   },
   {
     id: "command-console",
@@ -255,7 +266,7 @@ export const COMMAND_PALETTE_COMMANDS: readonly CommandPaletteItem[] = [
     keywords: ["console", "terminal", "command", "shell", "终端", "命令行"],
     icon: "console",
     action: { type: "navigate", to: "/console" },
-    priority: 16,
+    priority: 17,
   },
 ];
 

--- a/web/src/lib/dashboard-url.test.ts
+++ b/web/src/lib/dashboard-url.test.ts
@@ -1,5 +1,5 @@
 import { describe, expect, it } from "vitest";
-import { dashboardPortFromUrl, dashboardUrlFromInputs } from "./dashboard-url";
+import { dashboardPageUrlFromInputs, dashboardPortFromUrl, dashboardUrlFromInputs } from "./dashboard-url";
 
 describe("dashboardUrlFromInputs", () => {
   it("opens the dashboard origin from gateway health URLs", () => {
@@ -27,5 +27,25 @@ describe("dashboardPortFromUrl", () => {
     expect(dashboardPortFromUrl("http://localhost:9120/")).toBe("9120");
     expect(dashboardPortFromUrl("http://localhost/")).toBe("80");
     expect(dashboardPortFromUrl("bad")).toBe("9120");
+  });
+});
+
+describe("dashboardPageUrlFromInputs", () => {
+  it("builds official dashboard page URLs from the normalized dashboard origin", () => {
+    expect(
+      dashboardPageUrlFromInputs(
+        { healthUrl: "http://127.0.0.1:9120/api/gateway/health" },
+        "/kanban",
+      ),
+    ).toBe("http://localhost:9120/kanban");
+  });
+
+  it("accepts page paths without a leading slash", () => {
+    expect(
+      dashboardPageUrlFromInputs(
+        { runtimeConfig: { dashboardApiBaseUrl: "http://127.0.0.1:9567" } },
+        "kanban",
+      ),
+    ).toBe("http://localhost:9567/kanban");
   });
 });

--- a/web/src/lib/dashboard-url.ts
+++ b/web/src/lib/dashboard-url.ts
@@ -52,6 +52,13 @@ export function dashboardUrlFromInputs(inputs: DashboardUrlInputs): string {
   return `http://localhost:${DEFAULT_DESKTOP_DASHBOARD_PORT}/`;
 }
 
+export function dashboardPageUrlFromInputs(inputs: DashboardUrlInputs, pagePath: string): string {
+  const base = dashboardUrlFromInputs(inputs);
+  const path = pagePath.trim();
+  const normalizedPath = path.startsWith("/") ? path : `/${path}`;
+  return new URL(normalizedPath || "/", base).toString();
+}
+
 export function dashboardPortFromUrl(raw: string | null | undefined): string {
   const url = parseHttpUrl(raw);
   if (!url) return DEFAULT_DESKTOP_DASHBOARD_PORT;

--- a/web/src/routes/kanban.module.css
+++ b/web/src/routes/kanban.module.css
@@ -1,0 +1,230 @@
+.layout {
+  display: grid;
+  gap: 16px;
+  max-width: 1040px;
+}
+
+.topActions {
+  display: inline-flex;
+  align-items: center;
+  gap: 8px;
+}
+
+.primaryButton,
+.secondaryButton {
+  border-radius: 10px;
+  display: inline-flex;
+  align-items: center;
+  justify-content: center;
+  gap: 7px;
+  font-size: 12px;
+  font-weight: 650;
+  white-space: nowrap;
+  cursor: pointer;
+}
+
+.primaryButton {
+  min-height: 34px;
+  padding: 0 12px;
+  border: 1px solid var(--h-accent);
+  background: var(--h-accent);
+  color: var(--h-accent-contrast, #fff);
+  font-family: var(--h-font-cn);
+}
+
+.primaryButton:hover:not(:disabled) {
+  background: color-mix(in srgb, var(--h-accent) 84%, var(--h-text));
+  border-color: color-mix(in srgb, var(--h-accent) 84%, var(--h-text));
+}
+
+.secondaryButton {
+  min-height: 34px;
+  padding: 0 11px;
+}
+
+.primaryButton:disabled,
+.secondaryButton:disabled {
+  cursor: not-allowed;
+  opacity: 0.58;
+}
+
+.hero,
+.card {
+  border: 1px solid var(--h-line);
+  border-radius: 18px;
+  background: var(--h-bg-surface);
+  box-shadow: var(--h-shadow-soft);
+}
+
+.hero {
+  position: relative;
+  display: grid;
+  grid-template-columns: auto minmax(0, 1fr) auto;
+  gap: 18px;
+  align-items: start;
+  padding: 22px;
+  overflow: hidden;
+}
+
+.hero::before {
+  content: "";
+  position: absolute;
+  inset: 0;
+  background:
+    radial-gradient(circle at 12% 0%, color-mix(in srgb, var(--h-accent) 14%, transparent), transparent 32%),
+    linear-gradient(135deg, color-mix(in srgb, var(--h-bg-pane) 92%, transparent), transparent);
+  pointer-events: none;
+}
+
+.heroMark,
+.heroCopy,
+.statusBadge {
+  position: relative;
+  z-index: 1;
+}
+
+.heroMark {
+  width: 54px;
+  height: 54px;
+  border: 1px solid color-mix(in srgb, var(--h-accent) 34%, var(--h-line));
+  border-radius: 16px;
+  display: grid;
+  place-items: center;
+  background: color-mix(in srgb, var(--h-accent) 10%, var(--h-bg-pane));
+  color: var(--h-accent);
+}
+
+.eyebrow,
+.cardEyebrow {
+  color: var(--h-accent);
+  font-family: var(--h-font-mono);
+  font-size: 10px;
+  letter-spacing: 0.14em;
+  text-transform: uppercase;
+}
+
+.heroCopy h2,
+.cardHeader h3 {
+  margin: 0;
+  color: var(--h-text);
+}
+
+.heroCopy h2 {
+  margin-top: 7px;
+  font-size: 22px;
+  letter-spacing: -0.03em;
+}
+
+.heroCopy p {
+  margin: 10px 0 0;
+  max-width: 720px;
+  color: var(--h-text-2);
+  font-size: 13px;
+  line-height: 1.7;
+}
+
+.heroCopy code {
+  color: var(--h-text);
+  font-family: var(--h-font-mono);
+}
+
+.statusBadge {
+  border: 1px solid var(--h-line-soft);
+  border-radius: 999px;
+  padding: 5px 9px;
+  background: var(--h-bg-pane);
+  color: var(--h-text-2);
+  font-size: 11px;
+  white-space: nowrap;
+}
+
+.statusBadge[data-tone="ready"] {
+  border-color: rgba(127, 192, 131, 0.42);
+  color: #7fc083;
+}
+
+.statusBadge[data-tone="warn"] {
+  border-color: rgba(215, 168, 77, 0.42);
+  color: #d7a84d;
+}
+
+.card {
+  padding: 18px;
+}
+
+.cardHeader {
+  display: flex;
+  align-items: center;
+  justify-content: space-between;
+  gap: 14px;
+  margin-bottom: 14px;
+}
+
+.cardHeader h3 {
+  margin-top: 6px;
+  font-size: 15px;
+}
+
+.urlGrid {
+  display: grid;
+  grid-template-columns: repeat(2, minmax(0, 1fr));
+  gap: 10px;
+}
+
+.urlField {
+  min-width: 0;
+  border: 1px solid var(--h-line-soft);
+  border-radius: 13px;
+  background: var(--h-bg-pane);
+  padding: 11px 12px;
+}
+
+.urlField span {
+  display: block;
+  margin-bottom: 6px;
+  color: var(--h-text-3);
+  font-size: 11px;
+}
+
+.urlField strong {
+  display: block;
+  overflow: hidden;
+  color: var(--h-text);
+  font-family: var(--h-font-mono);
+  font-size: 12px;
+  font-weight: 600;
+  text-overflow: ellipsis;
+  white-space: nowrap;
+}
+
+.helpText {
+  margin: 14px 0 0;
+  color: var(--h-text-2);
+  font-size: 12.5px;
+  line-height: 1.65;
+}
+
+.errorBox {
+  margin-top: 12px;
+  border: 1px solid rgba(215, 111, 84, 0.34);
+  border-radius: 12px;
+  background: rgba(215, 111, 84, 0.1);
+  color: #e18b74;
+  padding: 10px 12px;
+  font-size: 12px;
+}
+
+@media (max-width: 840px) {
+  .hero {
+    grid-template-columns: auto minmax(0, 1fr);
+  }
+
+  .statusBadge {
+    grid-column: 1 / -1;
+    justify-self: start;
+  }
+
+  .urlGrid {
+    grid-template-columns: minmax(0, 1fr);
+  }
+}

--- a/web/src/routes/kanban.tsx
+++ b/web/src/routes/kanban.tsx
@@ -1,0 +1,114 @@
+import { useState } from "react";
+import { Copy, ExternalLink } from "lucide-react";
+import { CopyButton } from "@/components/ui/copy-button";
+import { useStatus } from "@/hooks/use-status";
+import { dashboardPageUrlFromInputs, dashboardUrlFromInputs } from "@/lib/dashboard-url";
+import { openExternalUrl } from "@/lib/external-links";
+import { SectionShell } from "./section-shell";
+import s from "./kanban.module.css";
+
+function KanbanMark() {
+  return (
+    <svg width="28" height="28" viewBox="0 0 28 28" fill="none" aria-hidden="true">
+      <rect x="4" y="5" width="20" height="18" rx="3" stroke="currentColor" strokeWidth="1.8" />
+      <path d="M10 9.5v10M18 9.5v10" stroke="currentColor" strokeWidth="1.5" strokeLinecap="round" />
+      <rect x="6.8" y="8.5" width="4.2" height="5.2" rx="1" fill="currentColor" opacity="0.82" />
+      <rect x="12.3" y="8.5" width="4.2" height="8.4" rx="1" fill="currentColor" opacity="0.58" />
+      <rect x="17.8" y="8.5" width="4.2" height="4.1" rx="1" fill="currentColor" opacity="0.72" />
+    </svg>
+  );
+}
+
+export function KanbanRoute() {
+  const { data: status, isError } = useStatus();
+  const [opening, setOpening] = useState(false);
+  const [openError, setOpenError] = useState<string | null>(null);
+  const dashboardInputs = {
+    healthUrl: status?.gateway_health_url,
+    runtimeConfig: typeof window === "undefined" ? null : window.__HERMES_RUNTIME__,
+    envOrigin: import.meta.env.VITE_HERMES_DASHBOARD_ORIGIN,
+  };
+  const dashboardUrl = dashboardUrlFromInputs(dashboardInputs);
+  const kanbanUrl = dashboardPageUrlFromInputs(dashboardInputs, "/kanban");
+  const statusTone = status ? "ready" : isError ? "warn" : "checking";
+  const statusLabel = status ? "Dashboard 已连接" : isError ? "尚未确认 Dashboard 在线" : "正在确认 Dashboard 状态";
+
+  const openKanban = async () => {
+    if (opening) return;
+    setOpening(true);
+    setOpenError(null);
+    try {
+      const opened = await openExternalUrl(kanbanUrl);
+      if (!opened) {
+        setOpenError("没有可用的外部浏览器打开方式，请复制地址后手动打开。");
+      }
+    } finally {
+      setOpening(false);
+    }
+  };
+
+  return (
+    <SectionShell
+      title="看板"
+      sub="官方 Dashboard /kanban"
+      right={
+        <div className={s.topActions}>
+          <CopyButton variant="outline" size="md" className={s.secondaryButton} text={kanbanUrl}>
+            <Copy size={14} />
+            复制地址
+          </CopyButton>
+          <button type="button" className={s.primaryButton} onClick={() => void openKanban()} disabled={opening}>
+            <ExternalLink size={14} />
+            {opening ? "正在打开…" : "打开官方看板"}
+          </button>
+        </div>
+      }
+    >
+      <div className={s.layout}>
+        <section className={s.hero}>
+          <div className={s.heroMark}>
+            <KanbanMark />
+          </div>
+          <div className={s.heroCopy}>
+            <div className={s.eyebrow}>OFFICIAL DASHBOARD</div>
+            <h2>桌面端只提供入口，看板功能继续使用内核自带 Dashboard。</h2>
+            <p>
+              Kanban 的任务列、分解、调度和运行状态都由 Hermes Agent 内核的官方 Dashboard 维护。
+              这里不会复刻一个桌面端看板，只会把你带到当前运行时对应的 <code>/kanban</code> 页面。
+            </p>
+          </div>
+          <span className={s.statusBadge} data-tone={statusTone}>
+            {statusLabel}
+          </span>
+        </section>
+
+        <section className={s.card}>
+          <div className={s.cardHeader}>
+            <div>
+              <div className={s.cardEyebrow}>目标地址</div>
+              <h3>官方 Dashboard 看板</h3>
+            </div>
+            <button type="button" className={s.primaryButton} onClick={() => void openKanban()} disabled={opening}>
+              <ExternalLink size={14} />
+              {opening ? "正在打开…" : "在浏览器打开"}
+            </button>
+          </div>
+          <div className={s.urlGrid}>
+            <div className={s.urlField}>
+              <span>Dashboard</span>
+              <strong title={dashboardUrl}>{dashboardUrl}</strong>
+            </div>
+            <div className={s.urlField}>
+              <span>Kanban</span>
+              <strong title={kanbanUrl}>{kanbanUrl}</strong>
+            </div>
+          </div>
+          <p className={s.helpText}>
+            如果按钮没有反应，可以复制 Kanban 地址到浏览器打开。Dashboard 未就绪时，请先确认底部状态栏里的网关端口或到健康检查页查看内核运行状态。
+          </p>
+          {openError ? <div className={s.errorBox} role="alert">{openError}</div> : null}
+        </section>
+      </div>
+    </SectionShell>
+  );
+}


### PR DESCRIPTION
## 变更内容

- 新增桌面端 `/kanban` 引导页，说明看板功能由官方 Dashboard 提供。
- 在工作台侧栏和命令面板增加看板入口，入口先进入桌面端引导页，再打开当前内核 Dashboard 的 `/kanban`。
- 增加 Dashboard 页面 URL 拼接 helper，并补充导航、URL、命令面板相关单测。

## 影响

桌面端不实现独立看板，也不修改 Core runtime 或 Rust command；用户默认通过系统浏览器打开官方 Dashboard 看板。

## 验证

- `pnpm typecheck`
- `pnpm test:unit`
- `cargo check`
