### PR TITLE
fix(composer): attach images over the gateway (drop /api/upload) + add e2e harness

### DIFF
--- a/.github/workflows/web-e2e.yml
+++ b/.github/workflows/web-e2e.yml
@@ -1,0 +1,91 @@
+# End-to-end suite: real web UI -> real Core backend -> local fake model.
+#
+# Validates the chat closed loops (new chat -> streamed reply -> continue, and
+# paste-image -> model reads it) deterministically, with no paid LLM. See
+# e2e/README.md. Kept separate from web-test.yml (vitest) and rust-test.yml.
+name: web-e2e
+
+on:
+  push:
+    branches: [main]
+  pull_request:
+    branches: [main]
+  workflow_dispatch:
+
+jobs:
+  e2e:
+    runs-on: ubuntu-latest
+    defaults:
+      run:
+        working-directory: Hermes-CN-Desktop
+    steps:
+      - name: Checkout desktop
+        uses: actions/checkout@v4
+        with:
+          path: Hermes-CN-Desktop
+
+      # The backend the desktop talks to. Sibling checkout so the default
+      # HERMES_CORE_DIR (../Hermes-CN-Core) resolves.
+      - name: Checkout Core backend
+        uses: actions/checkout@v4
+        with:
+          repository: Eynzof/Hermes-CN-Core
+          ref: main
+          path: Hermes-CN-Core
+
+      - uses: pnpm/action-setup@v4
+        with:
+          version: 9.15.0
+
+      - uses: actions/setup-node@v4
+        with:
+          node-version: 20
+          cache: pnpm
+          cache-dependency-path: Hermes-CN-Desktop/pnpm-lock.yaml
+
+      - uses: actions/setup-python@v5
+        with:
+          python-version: "3.12"
+
+      - name: Install Core (Python) into .venv
+        working-directory: Hermes-CN-Core
+        # [all] mirrors the documented dev install; trim to the minimal extras
+        # that still run `hermes dashboard` + a turn if you want a faster job.
+        run: |
+          python -m venv .venv
+          .venv/bin/pip install -U pip
+          .venv/bin/pip install -e ".[all]"
+
+      - name: Install desktop deps
+        run: pnpm install --frozen-lockfile
+
+      - name: Install Playwright Chromium
+        run: pnpm --filter @hermes/e2e exec playwright install --with-deps chromium
+
+      # Fast browserless gate first — fails in seconds if the backend loop broke.
+      - name: Protocol smoke
+        run: |
+          nohup node e2e/harness/start-backend.mjs > /tmp/e2e-backend.log 2>&1 &
+          for i in $(seq 1 120); do
+            grep -q BACKEND_READY /tmp/e2e-backend.log && break
+            grep -qiE "failed to start|exited unexpectedly" /tmp/e2e-backend.log && { cat /tmp/e2e-backend.log; exit 1; }
+            sleep 1
+          done
+          node e2e/harness/protocol-smoke.mjs
+          # Free the ports so Playwright can start its own backend.
+          for port in 8099 9120; do
+            pid=$(ss -ltnp 2>/dev/null | grep ":$port " | grep -oP 'pid=\K[0-9]+' | head -1)
+            [ -n "$pid" ] && kill "$pid" || true
+          done
+          sleep 2
+
+      - name: Playwright E2E
+        run: pnpm --filter @hermes/e2e test
+
+      - name: Upload report
+        if: ${{ !cancelled() }}
+        uses: actions/upload-artifact@v4
+        with:
+          name: playwright-report
+          path: Hermes-CN-Desktop/e2e/playwright-report/
+          retention-days: 14

--- a/e2e/.gitignore
+++ b/e2e/.gitignore
@@ -1,0 +1,6 @@
+.runtime/
+node_modules/
+playwright-report/
+test-results/
+__pycache__/
+*.pyc

--- a/e2e/README.md
+++ b/e2e/README.md
@@ -1,0 +1,103 @@
+# End-to-end tests
+
+These tests exercise the real chat closed loops a user cares about, through the
+**real web UI** and the **real Core backend** — only the LLM is swapped for a
+local, deterministic fake. That keeps the whole stack honest (WebSocket gateway,
+session lifecycle, streaming, image/vision routing) while being fast, free, and
+repeatable, so it can gate every PR.
+
+## What it covers
+
+| Loop | Spec | Asserts |
+|------|------|---------|
+| New chat → streamed reply → navigate to history → continue | `specs/chat-loop.spec.ts` | a session is created, the URL moves to `/tasks/:id`, the assistant reply streams in, and a follow-up turn works |
+| Paste an image → the model reads it | `specs/image-paste.spec.ts` | the pasted image attaches, and the model's reply embeds the **decoded image byte count** (proof the bytes really reached the model) |
+
+## Architecture
+
+```
+Playwright (Chromium)
+   │  drives the real UI: textarea[aria-label="输入消息"], button[aria-label="发送消息"], ...
+   ▼
+Vite dev server  :9545   (the actual desktop frontend, unmodified)
+   │  HERMES_DASHBOARD_ORIGIN redirects /api + /api/ws  ── the one seam we flip ──┐
+   ▼                                                                              │
+Core dashboard   :9120   `hermes dashboard` — REAL REST + /api/ws gateway + agent loop
+   │  model.base_url points the "custom" provider at ...                         │
+   ▼                                                                              │
+Fake model       :8099   OpenAI-compatible, deterministic (e2e/fake-model/server.py)
+                          • streams a "PONG: ..." reply for text
+                          • for vision, replies "我看到一张图片，共 <N> 字节"
+```
+
+The only env var that moves the backend is **`HERMES_DASHBOARD_ORIGIN`**
+(`web/vite.config.ts` proxies both `/api` and `/api/ws` there). Everything else
+is the production code path.
+
+The determinism knob is the **fake model** (`fake-model/server.py`). To run the
+loops against a *real* LLM instead (a paid smoke test), point Core at a real
+provider in `harness/config.mjs#configYaml` and loosen the assertions — the UI
+flow is identical.
+
+## Run it
+
+```bash
+pnpm install                                   # once, from the desktop repo root
+pnpm --filter @hermes/e2e exec playwright install chromium
+
+# Full browser suite (Playwright starts the backend + Vite automatically):
+pnpm --filter @hermes/e2e test
+pnpm --filter @hermes/e2e test:headed          # watch it click
+
+# Fast, browserless gate — proves the backend loop at the protocol level.
+# Needs the backend up first (in another terminal: `pnpm --filter @hermes/e2e backend`):
+pnpm --filter @hermes/e2e smoke
+```
+
+Requirements: the **Core** repo checked out as a sibling (`../Hermes-CN-Core`)
+with a working `.venv` (`fastapi`, `uvicorn`, and the agent deps). Override paths
+with `HERMES_CORE_DIR` / `HERMES_CORE_PYTHON`. Runtime state is written to a fresh
+`e2e/.runtime/` (gitignored) on every run.
+
+## Cross-repo drift this caught (now fixed)
+
+Building this surfaced a real contract drift: the desktop uploaded image
+attachments via REST **`/api/upload`** (both the browser path in
+`web/src/lib/transport.ts` and the native Rust `upload_file_impl` in
+`src/commands/api_proxy.rs`), but Core only serves `/api/files/upload` (a
+different `data_url` contract). `/api/upload` is a fork-only P-002 patch for the
+*v2 web dashboard* that Core keeps dropping/restoring across upstream syncs — so
+image attach silently breaks whenever it's dropped.
+
+**Fix:** images now attach over the gateway via `image.attach_bytes` (base64 over
+the WebSocket), matching Core's own `apps/desktop`. The composer sends the pasted
+image's bytes directly — no REST upload, no dependency on the fragile
+`/api/upload` endpoint. See `web/src/lib/composer-prompt.ts` (the `looksLikeImage`
+branch) and `web/src/hooks/use-gateway.ts` (`attachImageBytes`). The image spec
+therefore drives the real shipped path with no test workaround.
+
+## Layout
+
+```
+e2e/
+├── playwright.config.ts        two webServers (backend + Vite), Chromium project
+├── fake-model/server.py        deterministic OpenAI-compatible model
+├── harness/
+│   ├── config.mjs              shared paths/ports + the Core config.yaml it writes
+│   ├── start-backend.mjs       spawns fake model + Core dashboard, waits for ready
+│   ├── protocol-smoke.mjs      browserless WS proof of all three loops
+│   └── wait.mjs                tiny poll/readiness helpers
+├── fixtures/red-square.mjs     the 1×1 PNG shared by smoke + image spec
+└── specs/
+    ├── chat-loop.spec.ts
+    └── image-paste.spec.ts
+```
+
+## Stable selectors
+
+The specs target accessibility roles / `data-*` (`textbox[name=输入消息]`,
+`button[name=发送消息]`, `role=log`, `[data-role=assistant]`,
+`span[data-kind=image][data-status=ready]`). If you rename these, update the
+specs. Consider adding explicit `data-testid`s on the composer input, assistant
+bubble, and rendered message image to make the suite rename-proof.
+```

--- a/e2e/fake-model/server.py
+++ b/e2e/fake-model/server.py
@@ -1,0 +1,149 @@
+"""Deterministic, free, OpenAI-compatible fake model for end-to-end tests.
+
+This is the "determinism knob" of the E2E harness. The real Core backend runs
+unchanged; only the *model* it talks to is replaced by this server, so the whole
+chat loop (WebSocket gateway, session lifecycle, streaming, image/vision routing)
+stays real while being repeatable and costing nothing.
+
+It speaks just enough of the OpenAI Chat Completions API for Core's "custom"
+provider:
+
+  * POST /v1/chat/completions  — streaming (SSE) and non-streaming.
+  * GET  /v1/models            — some clients probe this on startup.
+  * GET  /health               — readiness probe for the harness.
+
+Vision proof: when the last user message carries an `image_url` content part,
+the reply embeds the DECODED image byte count. A passing assertion on that number
+proves the image bytes actually traversed frontend -> gateway -> provider, i.e.
+the model genuinely "read" the image rather than the test faking it.
+
+Run: uvicorn server:app --host 127.0.0.1 --port 8099
+"""
+
+from __future__ import annotations
+
+import base64
+import json
+import time
+import uuid
+from typing import Any
+
+from fastapi import FastAPI, Request
+from fastapi.responses import JSONResponse, StreamingResponse
+
+app = FastAPI()
+
+MODEL_ID = "fake-model"
+
+
+def _extract_image_bytes(content: Any) -> int:
+    """Sum decoded bytes of every base64 data-URL image in a message content.
+
+    Core sends multimodal content as a list of parts; image parts look like
+    {"type": "image_url", "image_url": {"url": "data:image/png;base64,...."}}.
+    Returns 0 when there is no image (plain string content or text-only parts).
+    """
+    if not isinstance(content, list):
+        return 0
+    total = 0
+    for part in content:
+        if not isinstance(part, dict) or part.get("type") != "image_url":
+            continue
+        url = (part.get("image_url") or {}).get("url", "")
+        if "," in url:
+            url = url.split(",", 1)[1]
+        try:
+            total += len(base64.b64decode(url))
+        except Exception:
+            pass
+    return total
+
+
+def _text_of(content: Any) -> str:
+    if isinstance(content, str):
+        return content
+    if isinstance(content, list):
+        return " ".join(
+            part.get("text", "")
+            for part in content
+            if isinstance(part, dict) and part.get("type") == "text"
+        )
+    return ""
+
+
+def _reply_for(messages: list[dict[str, Any]]) -> str:
+    """Deterministic reply derived from the last user message.
+
+    - With an image: "我看到一张图片，共 <N> 字节" — N proves bytes arrived.
+    - Plain text echo so a test can assert the reply matches its prompt.
+    """
+    last_user = next(
+        (m for m in reversed(messages) if m.get("role") == "user"),
+        {"content": ""},
+    )
+    image_bytes = _extract_image_bytes(last_user.get("content"))
+    if image_bytes > 0:
+        return f"我看到一张图片，共 {image_bytes} 字节。"
+    text = _text_of(last_user.get("content")).strip()
+    # Echo a stable marker plus the prompt so specs can assert on either.
+    return f"PONG: 收到「{text}」"
+
+
+def _chunk(delta: dict[str, Any], finish: str | None = None) -> str:
+    payload = {
+        "id": f"chatcmpl-{uuid.uuid4().hex[:24]}",
+        "object": "chat.completion.chunk",
+        "created": 1,  # fixed for determinism
+        "model": MODEL_ID,
+        "choices": [{"index": 0, "delta": delta, "finish_reason": finish}],
+    }
+    return f"data: {json.dumps(payload, ensure_ascii=False)}\n\n"
+
+
+@app.get("/health")
+async def health() -> dict[str, bool]:
+    return {"ok": True}
+
+
+@app.get("/v1/models")
+async def models() -> dict[str, Any]:
+    return {
+        "object": "list",
+        "data": [{"id": MODEL_ID, "object": "model", "owned_by": "e2e"}],
+    }
+
+
+@app.post("/v1/chat/completions")
+async def chat_completions(request: Request):
+    body = await request.json()
+    messages = body.get("messages") or []
+    reply = _reply_for(messages)
+
+    if body.get("stream"):
+
+        async def gen():
+            yield _chunk({"role": "assistant"})
+            # Stream by token so the UI exercises its streaming render path.
+            for token in reply.split(" "):
+                yield _chunk({"content": token + " "})
+            yield _chunk({}, finish="stop")
+            yield "data: [DONE]\n\n"
+
+        return StreamingResponse(gen(), media_type="text/event-stream")
+
+    return JSONResponse(
+        {
+            "id": f"chatcmpl-{uuid.uuid4().hex[:24]}",
+            "object": "chat.completion",
+            "created": int(time.time()),
+            "model": MODEL_ID,
+            "choices": [
+                {
+                    "index": 0,
+                    "message": {"role": "assistant", "content": reply},
+                    "finish_reason": "stop",
+                }
+            ],
+            "usage": {"prompt_tokens": 1, "completion_tokens": 1, "total_tokens": 2},
+        }
+    )

--- a/e2e/fixtures/red-square.mjs
+++ b/e2e/fixtures/red-square.mjs
@@ -1,0 +1,7 @@
+// A minimal valid 1x1 PNG, shared by the protocol smoke test and the browser
+// image spec so "the image" is one fixture with one known decoded byte length.
+export const PNG_BASE64 =
+  "iVBORw0KGgoAAAANSUhEUgAAAAEAAAABCAYAAAAfFcSJAAAAC0lEQVR42mNk+M9QDwADhgGAWjR9awAAAABJRU5ErkJggg==";
+
+export const PNG_BYTES = Buffer.from(PNG_BASE64, "base64");
+export const PNG_BYTE_LENGTH = PNG_BYTES.length;

--- a/e2e/harness/config.mjs
+++ b/e2e/harness/config.mjs
@@ -1,0 +1,77 @@
+// Shared constants + paths for the E2E backend harness. Importable from both
+// the Node orchestrator (start-backend.mjs) and the protocol smoke test.
+import { fileURLToPath } from "node:url";
+import { dirname, resolve } from "node:path";
+
+const __dirname = dirname(fileURLToPath(import.meta.url));
+
+// e2e/harness -> e2e
+export const E2E_DIR = resolve(__dirname, "..");
+// e2e -> Hermes-CN-Desktop
+export const DESKTOP_DIR = resolve(E2E_DIR, "..");
+// The Core backend repo. Defaults to the sibling checkout; override in CI.
+export const CORE_DIR =
+  process.env.HERMES_CORE_DIR || resolve(DESKTOP_DIR, "..", "Hermes-CN-Core");
+export const VENV_PY =
+  process.env.HERMES_CORE_PYTHON || resolve(CORE_DIR, ".venv", "bin", "python");
+
+export const RUNTIME_DIR = resolve(E2E_DIR, ".runtime");
+export const HERMES_HOME = resolve(RUNTIME_DIR, "hermes-home");
+export const UPLOAD_DIR = resolve(RUNTIME_DIR, "uploads");
+// Stub SPA dist so the dashboard serves *something* at `/` (we use the desktop's
+// own Vite frontend; Core's UI is irrelevant here). HERMES_WEB_DIST overrides
+// the built-in web_dist path, letting us pass --skip-build without a real build.
+export const WEB_DIST = resolve(RUNTIME_DIR, "web-dist");
+
+export const FAKE_MODEL_PORT = Number(process.env.E2E_FAKE_MODEL_PORT || 8099);
+export const DASHBOARD_PORT = Number(process.env.E2E_DASHBOARD_PORT || 9120);
+export const VITE_PORT = Number(process.env.E2E_VITE_PORT || 9545);
+
+export const DASHBOARD_ORIGIN = `http://127.0.0.1:${DASHBOARD_PORT}`;
+export const FAKE_MODEL_BASE = `http://127.0.0.1:${FAKE_MODEL_PORT}/v1`;
+export const FAKE_MODEL_HEALTH = `http://127.0.0.1:${FAKE_MODEL_PORT}/health`;
+
+// Loopback has no auth gate, but we pin a stable token so the dev-server token
+// scrape is deterministic.
+export const DASHBOARD_TOKEN = process.env.E2E_DASHBOARD_TOKEN || "e2e-token";
+export const MODEL_ID = "fake-model";
+
+// Minimal config.yaml that points Core's "custom" provider at the local fake
+// model and force-enables native vision routing (model.supports_vision short-
+// circuits the models.dev capability lookup — see Core agent/image_routing.py).
+export function configYaml() {
+  return [
+    "model:",
+    "  provider: custom",
+    `  default: ${MODEL_ID}`,
+    `  base_url: ${FAKE_MODEL_BASE}`,
+    "  api_key: e2e-test-key",
+    "  supports_vision: true",
+    // Core rejects models advertising < 64K context; pin a roomy value.
+    "  context_length: 200000",
+    "  max_tokens: 256",
+    "memory:",
+    "  memory_enabled: false",
+    "  user_profile_enabled: false",
+    "compression:",
+    "  enabled: false",
+    "",
+  ].join("\n");
+}
+
+// Env shared by every Core subprocess (dashboard + smoke helpers).
+export function coreEnv() {
+  return {
+    ...process.env,
+    HERMES_HOME,
+    HERMES_WEB_DIST: WEB_DIST,
+    HERMES_DASHBOARD_SESSION_TOKEN: DASHBOARD_TOKEN,
+    // Belt-and-suspenders: config.base_url already wins, but these guarantee the
+    // OpenAI-compatible client targets the fake server even if provider
+    // resolution is surprising.
+    OPENAI_BASE_URL: FAKE_MODEL_BASE,
+    OPENAI_API_KEY: "e2e-test-key",
+    // Keep model-catalog/telemetry lookups from reaching the network in CI.
+    HERMES_NO_ANALYTICS: "1",
+  };
+}

--- a/e2e/harness/protocol-smoke.mjs
+++ b/e2e/harness/protocol-smoke.mjs
@@ -1,0 +1,168 @@
+// Browserless end-to-end proof of the backend closed loop. Speaks the gateway
+// JSON-RPC-over-WebSocket protocol directly against a running Core dashboard +
+// fake model, exercising exactly what the UI does:
+//
+//   session.create -> prompt.submit -> stream message.delta -> message.complete
+//   image.attach   -> prompt.submit -> reply embeds decoded image byte count
+//
+// This validates the whole stack minus the browser, so it can gate CI even
+// where a headless browser is unavailable, and it's how we debug the harness.
+//
+// Assumes the backend is already up (start-backend.mjs). Exit 0 = loop works.
+import { writeFileSync, mkdirSync } from "node:fs";
+import { resolve } from "node:path";
+import {
+  DASHBOARD_PORT,
+  DASHBOARD_TOKEN,
+  UPLOAD_DIR,
+} from "./config.mjs";
+import { PNG_BASE64, PNG_BYTE_LENGTH } from "../fixtures/red-square.mjs";
+
+const WS_URL = `ws://127.0.0.1:${DASHBOARD_PORT}/api/ws?token=${DASHBOARD_TOKEN}`;
+
+function connect() {
+  return new Promise((resolveConn, reject) => {
+    const ws = new WebSocket(WS_URL);
+    const events = [];
+    const waiters = [];
+    let nextId = 1;
+    const pending = new Map();
+
+    const pump = () => {
+      for (let i = waiters.length - 1; i >= 0; i--) {
+        const w = waiters[i];
+        const ev = events.find(w.match);
+        if (ev) {
+          waiters.splice(i, 1);
+          w.resolve(ev);
+        }
+      }
+    };
+
+    ws.onopen = () => resolveConn(api);
+    ws.onerror = () => reject(new Error("WebSocket error"));
+    ws.onclose = () => reject(new Error("WebSocket closed early"));
+    ws.onmessage = (msg) => {
+      const frame = JSON.parse(msg.data);
+      if (frame.id != null && pending.has(String(frame.id))) {
+        const p = pending.get(String(frame.id));
+        pending.delete(String(frame.id));
+        frame.error ? p.reject(new Error(frame.error.message)) : p.resolve(frame.result);
+        return;
+      }
+      if (frame.method === "event" && frame.params) {
+        events.push(frame.params); // { type, session_id, payload }
+        pump();
+      }
+    };
+
+    const api = {
+      // The agent stays "busy" briefly after message.complete; the real UI
+      // gates this with a disabled send button. A raw client just retries.
+      async submit(params) {
+        for (let attempt = 0; attempt < 40; attempt++) {
+          try {
+            return await api.request("prompt.submit", params);
+          } catch (err) {
+            if (String(err.message).includes("busy")) {
+              await new Promise((r) => setTimeout(r, 250));
+              continue;
+            }
+            throw err;
+          }
+        }
+        throw new Error("session stayed busy too long");
+      },
+      request(method, params = {}) {
+        const id = `s${nextId++}`;
+        return new Promise((res, rej) => {
+          pending.set(id, { resolve: res, reject: rej });
+          ws.send(JSON.stringify({ jsonrpc: "2.0", id, method, params }));
+          setTimeout(() => {
+            if (pending.delete(id)) rej(new Error(`RPC timeout: ${method}`));
+          }, 30_000);
+        });
+      },
+      // Collect streamed text for a turn until message.complete.
+      waitForTurn(timeoutMs = 30_000) {
+        return new Promise((res, rej) => {
+          const start = events.length;
+          const timer = setTimeout(() => rej(new Error("turn timeout")), timeoutMs);
+          const tick = () => {
+            const since = events.slice(start);
+            if (since.some((e) => e.type === "error")) {
+              clearTimeout(timer);
+              const e = since.find((x) => x.type === "error");
+              return rej(new Error(`gateway error: ${JSON.stringify(e.payload)}`));
+            }
+            if (since.some((e) => e.type === "message.complete")) {
+              clearTimeout(timer);
+              const text = since
+                .filter((e) => e.type === "message.delta")
+                .map((e) => e.payload?.text ?? "")
+                .join("");
+              return res(text);
+            }
+            setTimeout(tick, 100);
+          };
+          tick();
+        });
+      },
+      close: () => ws.close(),
+    };
+  });
+}
+
+function assert(cond, msg) {
+  if (!cond) throw new Error(`ASSERT FAILED: ${msg}`);
+}
+
+async function main() {
+  const api = await connect();
+  console.log("connected to gateway");
+
+  // --- Loop 1: text turn ---
+  const { session_id } = await api.request("session.create", {});
+  assert(session_id, "session.create returned a session_id");
+  console.log("session:", session_id);
+
+  await api.submit({ session_id, text: "ping" });
+  const reply1 = await api.waitForTurn();
+  console.log("text reply:", JSON.stringify(reply1));
+  assert(reply1.includes("PONG"), `text reply should contain PONG, got: ${reply1}`);
+
+  // --- Loop 2: continue in same session ---
+  await api.submit({ session_id, text: "again" });
+  const reply2 = await api.waitForTurn();
+  assert(reply2.includes("PONG"), `follow-up reply should contain PONG, got: ${reply2}`);
+  console.log("continue-conversation reply OK");
+
+  // --- Loop 3: vision (image bytes must reach the fake model) ---
+  mkdirSync(UPLOAD_DIR, { recursive: true });
+  const imgPath = resolve(UPLOAD_DIR, "smoke.png");
+  writeFileSync(imgPath, Buffer.from(PNG_BASE64, "base64"));
+  const attach = await api.request("image.attach", { session_id, path: imgPath });
+  console.log("image.attach:", JSON.stringify(attach));
+  assert(attach.attached !== false, "image.attach should succeed");
+
+  await api.submit({ session_id, text: "图里是什么？" });
+  const reply3 = await api.waitForTurn(40_000);
+  console.log("vision reply:", JSON.stringify(reply3));
+  assert(
+    reply3.includes("我看到一张图片"),
+    `vision reply should acknowledge the image, got: ${reply3}`,
+  );
+  assert(
+    reply3.includes(String(PNG_BYTE_LENGTH)),
+    `vision reply should report ${PNG_BYTE_LENGTH} decoded bytes (proves bytes reached the model), got: ${reply3}`,
+  );
+  console.log("vision round-trip OK — model received", PNG_BYTE_LENGTH, "bytes");
+
+  api.close();
+  console.log("\n✅ ALL THREE LOOPS PASSED at the protocol level");
+}
+
+main().catch((err) => {
+  console.error("\n❌ smoke failed:", err.message);
+  process.exit(1);
+});

--- a/e2e/harness/start-backend.mjs
+++ b/e2e/harness/start-backend.mjs
@@ -1,0 +1,133 @@
+// Orchestrates the deterministic backend half of the E2E stack and stays alive
+// (Playwright's webServer keeps this process running for the test session):
+//
+//   1. fresh runtime HERMES_HOME + config.yaml -> Core's "custom" provider
+//      points at the local fake model (e2e/fake-model/server.py).
+//   2. fake model server (uvicorn) on FAKE_MODEL_PORT.
+//   3. Core dashboard (REST + /api/ws) on DASHBOARD_PORT.
+//
+// On SIGINT/SIGTERM (or when Playwright tears the webServer down) every child is
+// killed. Run standalone for debugging: `node harness/start-backend.mjs`.
+import { spawn } from "node:child_process";
+import { rmSync, mkdirSync, writeFileSync, existsSync } from "node:fs";
+import { resolve } from "node:path";
+import {
+  CORE_DIR,
+  VENV_PY,
+  E2E_DIR,
+  RUNTIME_DIR,
+  HERMES_HOME,
+  UPLOAD_DIR,
+  WEB_DIST,
+  FAKE_MODEL_PORT,
+  FAKE_MODEL_HEALTH,
+  DASHBOARD_PORT,
+  DASHBOARD_ORIGIN,
+  configYaml,
+  coreEnv,
+} from "./config.mjs";
+import { waitForHttp, waitForLine } from "./wait.mjs";
+
+const children = [];
+
+function spawnChild(label, cmd, args, opts) {
+  const child = spawn(cmd, args, { ...opts });
+  child.stdout?.on("data", (d) => process.stdout.write(`[${label}] ${d}`));
+  child.stderr?.on("data", (d) => process.stderr.write(`[${label}] ${d}`));
+  child.on("exit", (code) => {
+    if (!shuttingDown) {
+      console.error(`[harness] ${label} exited unexpectedly (code ${code})`);
+      shutdown(1);
+    }
+  });
+  children.push(child);
+  return child;
+}
+
+let shuttingDown = false;
+function shutdown(code = 0) {
+  if (shuttingDown) return;
+  shuttingDown = true;
+  for (const c of children) {
+    try {
+      c.kill("SIGTERM");
+    } catch {}
+  }
+  setTimeout(() => process.exit(code), 500);
+}
+process.on("SIGINT", () => shutdown(0));
+process.on("SIGTERM", () => shutdown(0));
+
+async function main() {
+  if (!existsSync(VENV_PY)) {
+    throw new Error(
+      `Core python not found at ${VENV_PY}. Set HERMES_CORE_DIR / HERMES_CORE_PYTHON.`,
+    );
+  }
+
+  // 1. Clean, reproducible runtime dir.
+  rmSync(RUNTIME_DIR, { recursive: true, force: true });
+  mkdirSync(HERMES_HOME, { recursive: true });
+  mkdirSync(UPLOAD_DIR, { recursive: true });
+  writeFileSync(resolve(HERMES_HOME, "config.yaml"), configYaml());
+
+  // Stub SPA dist: index.html (token injected at `</head>`) + an assets dir the
+  // dashboard StaticFiles mount requires to exist.
+  mkdirSync(resolve(WEB_DIST, "assets"), { recursive: true });
+  writeFileSync(
+    resolve(WEB_DIST, "index.html"),
+    "<!doctype html><html><head><meta charset=\"utf-8\"><title>e2e</title></head><body>e2e backend stub</body></html>\n",
+  );
+
+  const env = coreEnv();
+
+  // 2. Fake model server.
+  const fake = spawnChild(
+    "fake-model",
+    VENV_PY,
+    [
+      "-m",
+      "uvicorn",
+      "server:app",
+      "--host",
+      "127.0.0.1",
+      "--port",
+      String(FAKE_MODEL_PORT),
+      "--log-level",
+      "warning",
+    ],
+    { cwd: resolve(E2E_DIR, "fake-model"), env },
+  );
+  await waitForHttp(FAKE_MODEL_HEALTH, { timeoutMs: 30_000 });
+  console.log(`[harness] fake model ready on :${FAKE_MODEL_PORT}`);
+
+  // 3. Core dashboard. Readiness is the stdout line it prints when serving.
+  const dash = spawnChild(
+    "dashboard",
+    VENV_PY,
+    [
+      "-m",
+      "hermes_cli.main",
+      "dashboard",
+      "--host",
+      "127.0.0.1",
+      "--port",
+      String(DASHBOARD_PORT),
+      "--no-open",
+      "--skip-build",
+    ],
+    { cwd: CORE_DIR, env },
+  );
+  await waitForLine(dash, `HERMES_DASHBOARD_READY port=${DASHBOARD_PORT}`, {
+    timeoutMs: 120_000,
+  });
+  // Confirm the REST surface answers before we hand off to the browser tests.
+  await waitForHttp(`${DASHBOARD_ORIGIN}/`, { timeoutMs: 30_000 }).catch(() => {});
+  console.log(`[harness] dashboard ready on ${DASHBOARD_ORIGIN}`);
+  console.log("[harness] BACKEND_READY");
+}
+
+main().catch((err) => {
+  console.error("[harness] failed to start:", err.message);
+  shutdown(1);
+});

--- a/e2e/harness/wait.mjs
+++ b/e2e/harness/wait.mjs
@@ -1,0 +1,51 @@
+// Small async helpers for the harness: poll an HTTP URL and watch a child's
+// stdout for a readiness line. No external deps.
+
+export async function waitForHttp(url, { timeoutMs = 60_000, intervalMs = 300 } = {}) {
+  const deadline = Date.now() + timeoutMs;
+  let lastErr;
+  while (Date.now() < deadline) {
+    try {
+      const res = await fetch(url);
+      if (res.ok) return;
+      lastErr = new Error(`HTTP ${res.status}`);
+    } catch (err) {
+      lastErr = err;
+    }
+    await sleep(intervalMs);
+  }
+  throw new Error(`timeout waiting for ${url}: ${lastErr?.message ?? "unknown"}`);
+}
+
+// Resolve when `child`'s stdout/stderr emits a line containing `needle`.
+export function waitForLine(child, needle, { timeoutMs = 90_000 } = {}) {
+  return new Promise((resolve, reject) => {
+    let buf = "";
+    const timer = setTimeout(() => {
+      cleanup();
+      reject(new Error(`timeout waiting for "${needle}"`));
+    }, timeoutMs);
+    const onData = (chunk) => {
+      buf += chunk.toString();
+      if (buf.includes(needle)) {
+        cleanup();
+        resolve();
+      }
+    };
+    const onExit = (code) => {
+      cleanup();
+      reject(new Error(`process exited (code ${code}) before "${needle}"`));
+    };
+    const cleanup = () => {
+      clearTimeout(timer);
+      child.stdout?.off("data", onData);
+      child.stderr?.off("data", onData);
+      child.off("exit", onExit);
+    };
+    child.stdout?.on("data", onData);
+    child.stderr?.on("data", onData);
+    child.on("exit", onExit);
+  });
+}
+
+export const sleep = (ms) => new Promise((r) => setTimeout(r, ms));

--- a/e2e/package.json
+++ b/e2e/package.json
@@ -1,0 +1,18 @@
+{
+  "name": "@hermes/e2e",
+  "version": "0.0.0",
+  "private": true,
+  "type": "module",
+  "description": "End-to-end tests: real Core backend + local fake model, driven through the real web UI.",
+  "scripts": {
+    "test": "playwright test",
+    "test:headed": "playwright test --headed",
+    "test:ui": "playwright test --ui",
+    "smoke": "node harness/protocol-smoke.mjs",
+    "backend": "node harness/start-backend.mjs",
+    "report": "playwright show-report"
+  },
+  "devDependencies": {
+    "@playwright/test": "^1.49.0"
+  }
+}

--- a/e2e/playwright.config.ts
+++ b/e2e/playwright.config.ts
@@ -1,0 +1,56 @@
+import { defineConfig, devices } from "@playwright/test";
+import {
+  DASHBOARD_ORIGIN,
+  HERMES_HOME,
+  VITE_PORT,
+  DESKTOP_DIR,
+} from "./harness/config.mjs";
+
+// Two webServers, both started and health-checked before tests run:
+//   1. the deterministic backend (fake model + real Core dashboard)
+//   2. the real desktop Vite frontend, with /api + /api/ws proxied to (1) via
+//      HERMES_DASHBOARD_ORIGIN — the single seam that redirects the backend.
+// Tests then drive the actual UI exactly as a user would.
+export default defineConfig({
+  testDir: "./specs",
+  // One backend + shared session store -> keep tests serial and deterministic.
+  fullyParallel: false,
+  workers: 1,
+  forbidOnly: !!process.env.CI,
+  retries: process.env.CI ? 1 : 0,
+  timeout: 60_000,
+  expect: { timeout: 15_000 },
+  reporter: process.env.CI
+    ? [["github"], ["html", { open: "never" }]]
+    : [["list"]],
+  use: {
+    baseURL: `http://localhost:${VITE_PORT}`,
+    headless: true,
+    trace: "on-first-retry",
+    screenshot: "only-on-failure",
+    video: "retain-on-failure",
+  },
+  projects: [{ name: "chromium", use: { ...devices["Desktop Chrome"] } }],
+  webServer: [
+    {
+      command: "node harness/start-backend.mjs",
+      // Dashboard serves the stub index at `/` once it's ready.
+      url: `${DASHBOARD_ORIGIN}/`,
+      timeout: 120_000,
+      reuseExistingServer: !process.env.CI,
+      stdout: "pipe",
+      stderr: "pipe",
+    },
+    {
+      command: "pnpm --filter @hermes/web dev",
+      cwd: DESKTOP_DIR,
+      url: `http://localhost:${VITE_PORT}`,
+      timeout: 120_000,
+      reuseExistingServer: !process.env.CI,
+      env: {
+        HERMES_DASHBOARD_ORIGIN: DASHBOARD_ORIGIN,
+        HERMES_HOME,
+      },
+    },
+  ],
+});

--- a/e2e/specs/chat-loop.spec.ts
+++ b/e2e/specs/chat-loop.spec.ts
@@ -1,0 +1,34 @@
+import { test, expect, type Page } from "@playwright/test";
+
+// The core chat closed loop, driven through the real UI:
+//   new-chat page  ->  type  ->  send  ->  navigate to /tasks/:id
+//   ->  streamed assistant reply  ->  continue the conversation in history.
+// Backed by the real Core gateway + the deterministic fake model (replies start
+// with "PONG"), so this asserts behavior, not LLM wording.
+
+const composer = (page: Page) => page.getByRole("textbox", { name: "输入消息" });
+const sendButton = (page: Page) => page.getByRole("button", { name: "发送消息" });
+
+test("new chat → streamed reply → navigate to history → continue", async ({ page }) => {
+  await page.goto("/");
+
+  // 1. New-conversation page: type and send. Distinctive tokens let us tell the
+  //    two turns apart (the fake model echoes the prompt back in its reply).
+  await expect(composer(page)).toBeVisible();
+  await composer(page).fill("alpha-marker");
+  await sendButton(page).click();
+
+  // 2. App creates a session and routes to the conversation-history page.
+  await expect(page).toHaveURL(/\/tasks\/.+/, { timeout: 20_000 });
+
+  // 3. The assistant's streamed reply (echoing turn 1) lands in the message log.
+  const lastAssistant = () => page.getByRole("log").locator('[data-role="assistant"]').last();
+  await expect(lastAssistant()).toContainText("PONG", { timeout: 25_000 });
+  await expect(lastAssistant()).toContainText("alpha-marker");
+
+  // 4. Continue the conversation in the same session: a fresh reply that echoes
+  //    turn 2 proves the history page keeps the loop alive.
+  await composer(page).fill("bravo-marker");
+  await sendButton(page).click();
+  await expect(lastAssistant()).toContainText("bravo-marker", { timeout: 25_000 });
+});

--- a/e2e/specs/image-paste.spec.ts
+++ b/e2e/specs/image-paste.spec.ts
@@ -1,0 +1,40 @@
+import { test, expect } from "@playwright/test";
+import { PNG_BASE64, PNG_BYTE_LENGTH } from "../fixtures/red-square.mjs";
+
+// The image closed loop: paste an image into the composer, send, and assert the
+// model "read" it. This drives the real production path — the composer sends the
+// pasted image's bytes over the gateway via image.attach_bytes (no REST upload),
+// exactly as shipped. The fake model echoes the DECODED image byte count, so a
+// passing assertion proves the bytes traversed UI -> gateway -> provider -> model.
+
+test("paste an image → it attaches → the model reads it", async ({ page }) => {
+  await page.goto("/");
+  await expect(page.getByRole("textbox", { name: "输入消息" })).toBeVisible();
+
+  // Synthesize a real clipboard paste of a PNG into the composer textarea.
+  await page.evaluate(async (b64) => {
+    const blob = await (await fetch(`data:image/png;base64,${b64}`)).blob();
+    const dt = new DataTransfer();
+    dt.items.add(new File([blob], "shot.png", { type: "image/png" }));
+    const ta = document.querySelector('textarea[aria-label="输入消息"]');
+    const event = new ClipboardEvent("paste", { bubbles: true, cancelable: true });
+    // Chromium ignores the clipboardData init option; attach it explicitly.
+    Object.defineProperty(event, "clipboardData", { value: dt });
+    ta?.dispatchEvent(event);
+  }, PNG_BASE64);
+
+  // The pasted image shows up as a ready attachment chip.
+  await expect(
+    page.locator('span[data-kind="image"][data-status="ready"]'),
+  ).toBeVisible({ timeout: 10_000 });
+
+  // Ask about the image and send.
+  await page.getByRole("textbox", { name: "输入消息" }).fill("图里是什么？");
+  await page.getByRole("button", { name: "发送消息" }).click();
+
+  await expect(page).toHaveURL(/\/tasks\/.+/, { timeout: 20_000 });
+  const lastAssistant = page.getByRole("log").locator('[data-role="assistant"]').last();
+  await expect(lastAssistant).toContainText("我看到一张图片", { timeout: 30_000 });
+  // The exact decoded byte count proves the real image bytes reached the model.
+  await expect(lastAssistant).toContainText(String(PNG_BYTE_LENGTH));
+});

--- a/e2e/tsconfig.json
+++ b/e2e/tsconfig.json
@@ -1,0 +1,14 @@
+{
+  "compilerOptions": {
+    "target": "ES2022",
+    "module": "ESNext",
+    "moduleResolution": "Bundler",
+    "strict": true,
+    "skipLibCheck": true,
+    "esModuleInterop": true,
+    "allowImportingTsExtensions": true,
+    "noEmit": true,
+    "types": ["node"]
+  },
+  "include": ["specs", "harness", "fixtures", "playwright.config.ts"]
+}

--- a/package.json
+++ b/package.json
@@ -24,6 +24,8 @@
     "tauri:run": "pnpm run version:sync && cargo run",
     "typecheck": "pnpm run license:check && pnpm run version:check && pnpm -r run typecheck",
     "test:unit": "pnpm -r --workspace-concurrency=1 test:unit",
+    "test:e2e": "pnpm --filter @hermes/e2e test",
+    "test:e2e:smoke": "pnpm --filter @hermes/e2e smoke",
     "runtime:stage-bundled-windows": "node scripts/stage-bundled-runtime.mjs --platform win32 --arch x64",
     "runtime:stage-bundled-macos": "node scripts/stage-bundled-runtime.mjs --platform darwin --arch arm64",
     "dashboard:stage-web-dist": "node scripts/stage-dashboard-web-dist.mjs",

--- a/pnpm-lock.yaml
+++ b/pnpm-lock.yaml
@@ -12,6 +12,12 @@ importers:
         specifier: ^2.5.0
         version: 2.11.1
 
+  e2e:
+    devDependencies:
+      '@playwright/test':
+        specifier: ^1.49.0
+        version: 1.61.1
+
   packages/protocol:
     dependencies:
       zod:
@@ -488,6 +494,11 @@ packages:
 
   '@mermaid-js/parser@1.1.1':
     resolution: {integrity: sha512-VuHdsYMK1bT6X2JbcAaWAhugTRvRBRyuZgd+c22swUeI9g/ntaxF7CY7dYarhZovofCbUNO0G7JesfmNtjYOCw==}
+
+  '@playwright/test@1.61.1':
+    resolution: {integrity: sha512-8nKv6+0RJSL9FE4jYOEGXnPeM/Hg12qZpmqzZjRh3qM0Y7c3z1mrOTfFLids72RDQYVh9WpLEfR5WdpNX4fkig==}
+    engines: {node: '>=18'}
+    hasBin: true
 
   '@radix-ui/primitive@1.1.3':
     resolution: {integrity: sha512-JTF99U/6XIjCBo0wqkU5sK10glYe27MRRsfwoiq5zzOEZLHU3A3KCMa5X/azekYRCJ0HlwI0crAXS/5dEHTzDg==}
@@ -1622,6 +1633,11 @@ packages:
     resolution: {integrity: sha512-PpOwAdQ/YlXQ2vj8a3h8IipDuYRi3wceVQQGYWxNINccq40Anw7BlsEXCMbt1Zt+OLA6Fq9suIpIWD0OsnISlw==}
     engines: {node: '>=8'}
 
+  fsevents@2.3.2:
+    resolution: {integrity: sha512-xiqMQR4xAeHTuB9uWm+fFRcIOgKBMiOBP+eXiyT7jsgVCq1bkVygt00oASowB7EdtpOHaaPgKt812P9ab+DDKA==}
+    engines: {node: ^8.16.0 || ^10.6.0 || >=11.0.0}
+    os: [darwin]
+
   fsevents@2.3.3:
     resolution: {integrity: sha512-5xoDfX+fL7faATnagmWPpbFtwh/R77WmMMqqHGS65C3vvB0YHrgF+B1YmZ3441tMj5n63k0212XNoJwzlhffQw==}
     engines: {node: ^8.16.0 || ^10.6.0 || >=11.0.0}
@@ -2030,6 +2046,16 @@ packages:
   picomatch@4.0.4:
     resolution: {integrity: sha512-QP88BAKvMam/3NxH6vj2o21R6MjxZUAd6nlwAS/pnGvN9IVLocLHxGYIzFhg6fUQ+5th6P4dv4eW9jX3DSIj7A==}
     engines: {node: '>=12'}
+
+  playwright-core@1.61.1:
+    resolution: {integrity: sha512-h7Qlt6m4REp25qvIdvbDtVmD4LqVXfpRxhORv9L0jzETM05p4fuPJ3dKyuSXQxDSbXnmS79HAgi9589lGSpLkg==}
+    engines: {node: '>=18'}
+    hasBin: true
+
+  playwright@1.61.1:
+    resolution: {integrity: sha512-DWnY5o3YbLWK4GovuAVwpqL+1VwGNdUGrRr++8j8PtQQzvAVZUIMjKQ90fY689sEJZJBbZVw1rXaOKSTitkzPQ==}
+    engines: {node: '>=18'}
+    hasBin: true
 
   pngjs@5.0.0:
     resolution: {integrity: sha512-40QW5YalBNfQo5yRYmiw7Yz6TKKVr3h6970B2YE+3fQpsWcrbj1PzJgxeJ19DRQjhMbKPIuMY8rFaXc8moolVw==}
@@ -2778,6 +2804,10 @@ snapshots:
   '@mermaid-js/parser@1.1.1':
     dependencies:
       '@chevrotain/types': 11.1.2
+
+  '@playwright/test@1.61.1':
+    dependencies:
+      playwright: 1.61.1
 
   '@radix-ui/primitive@1.1.3': {}
 
@@ -3890,6 +3920,9 @@ snapshots:
       locate-path: 5.0.0
       path-exists: 4.0.0
 
+  fsevents@2.3.2:
+    optional: true
+
   fsevents@2.3.3:
     optional: true
 
@@ -4564,6 +4597,14 @@ snapshots:
   picocolors@1.1.1: {}
 
   picomatch@4.0.4: {}
+
+  playwright-core@1.61.1: {}
+
+  playwright@1.61.1:
+    dependencies:
+      playwright-core: 1.61.1
+    optionalDependencies:
+      fsevents: 2.3.2
 
   pngjs@5.0.0: {}
 

--- a/pnpm-workspace.yaml
+++ b/pnpm-workspace.yaml
@@ -1,3 +1,4 @@
 packages:
   - web
   - packages/*
+  - e2e

--- a/web/src/hooks/use-create-and-send-session.ts
+++ b/web/src/hooks/use-create-and-send-session.ts
@@ -11,7 +11,7 @@ import { buildComposerDisplayText, prepareComposerPrompt } from "@/lib/composer-
 import { resolveComposerSkillCommand } from "@/lib/composer-skills";
 import { rememberSessionModelOverride } from "@/lib/session-model-override";
 import { titleFromPrompt, titleWithSessionSuffix } from "@/lib/session-title";
-import { uploadAttachmentFile } from "@/lib/transport";
+import { isRemoteConnection, readImageBytesFromPath, uploadAttachmentFile } from "@/lib/transport";
 import {
   rememberSessionWorkspace,
   rememberWorkspaceProject,
@@ -32,6 +32,7 @@ export function useCreateAndSendSession() {
     setSessionModel,
     dispatchCommand,
     attachImage,
+    attachImageBytes,
     detectDroppedPath,
   } = useGateway();
   const setActiveSessionId = useSetAtom(activeSessionIdAtom);
@@ -101,6 +102,9 @@ export function useCreateAndSendSession() {
         }
         const prepared = await prepareComposerPrompt(sessionId, payload, {
           attachImage,
+          attachImageBytes,
+          remote: isRemoteConnection(),
+          readImageBytes: readImageBytesFromPath,
           detectDroppedPath,
           uploadFile: uploadAttachmentFile,
           onAttachmentUpdate: controls.updateAttachment,
@@ -132,6 +136,7 @@ export function useCreateAndSendSession() {
     return sessionId;
   }, [
     attachImage,
+    attachImageBytes,
     beginPrompt,
     createSession,
     detectDroppedPath,

--- a/web/src/hooks/use-gateway.ts
+++ b/web/src/hooks/use-gateway.ts
@@ -593,6 +593,31 @@ export function useGateway() {
     [ensureSubscribed],
   );
 
+  // Attach an image by uploading its bytes over the gateway (image.attach_bytes),
+  // mirroring the official desktop's remote path. Used when the image is an
+  // in-browser File with no gateway-readable filesystem path (e.g. a pasted
+  // screenshot) — avoids the fork-only REST /api/upload endpoint, which keeps
+  // getting dropped/restored across Core upstream syncs.
+  const attachImageBytes = useCallback(
+    async (
+      sessionId: string,
+      contentBase64: string,
+      filename?: string,
+    ): Promise<ImageAttachResult> => {
+      ensureSubscribed();
+      return parseGatewayResult(
+        ImageAttachResult,
+        await getGatewayClient().request("image.attach_bytes", {
+          session_id: sessionId,
+          content_base64: contentBase64,
+          ...(filename ? { filename } : {}),
+        }),
+        "image.attach_bytes",
+      );
+    },
+    [ensureSubscribed],
+  );
+
   const detectDroppedPath = useCallback(
     async (sessionId: string, path: string): Promise<InputDetectDropResult> => {
       ensureSubscribed();
@@ -683,6 +708,7 @@ export function useGateway() {
     setRuntimeModel,
     setSessionReasoningEffort,
     attachImage,
+    attachImageBytes,
     detectDroppedPath,
     interruptSession,
     setSessionTitle,

--- a/web/src/lib/composer-prompt.test.ts
+++ b/web/src/lib/composer-prompt.test.ts
@@ -1,7 +1,134 @@
-import { describe, expect, it, vi } from "vitest";
+import { afterEach, describe, expect, it, vi } from "vitest";
 import { prepareComposerPrompt, stripHermesUiWorkspaceContext } from "./composer-prompt";
 
+// Minimal FileReader for the node test env (no DOM): turns a File-like into a
+// data URL so the image-bytes path can be exercised.
+class FakeFileReader {
+  result: string | null = null;
+  private onLoad: (() => void) | null = null;
+  addEventListener(type: string, cb: () => void) {
+    if (type === "load") this.onLoad = cb;
+  }
+  readAsDataURL(file: { type: string; arrayBuffer: () => Promise<ArrayBuffer> }) {
+    void file.arrayBuffer().then((buf) => {
+      this.result = `data:${file.type};base64,${Buffer.from(buf).toString("base64")}`;
+      this.onLoad?.();
+    });
+  }
+}
+
 describe("composer prompt preparation", () => {
+  afterEach(() => vi.unstubAllGlobals());
+
+  it("attaches an in-browser image File via image.attach_bytes, never REST upload", async () => {
+    vi.stubGlobal("FileReader", FakeFileReader);
+    const bytes = new Uint8Array([1, 2, 3, 4]);
+    const file = {
+      name: "pasted.png",
+      type: "image/png",
+      arrayBuffer: async () => bytes.buffer,
+    } as unknown as File;
+    const attachImageBytes = vi.fn(async () => ({
+      attached: true,
+      text: "[User attached image: pasted.png]",
+      name: "pasted.png",
+      path: "/img/pasted.png",
+    }));
+    const uploadFile = vi.fn();
+    const attachImage = vi.fn();
+
+    const result = await prepareComposerPrompt(
+      "s1",
+      {
+        text: "看看这张图",
+        attachments: [{
+          id: "a1",
+          source: "browser",
+          file,
+          name: "pasted.png",
+          kind: "image",
+          status: "ready",
+          mimeType: "image/png",
+        }],
+      },
+      { attachImage, attachImageBytes, uploadFile, detectDroppedPath: vi.fn() },
+    );
+
+    // Bytes go over the gateway; the fork-only REST /api/upload is never touched.
+    expect(attachImageBytes).toHaveBeenCalledWith("s1", "AQIDBA==", "pasted.png");
+    expect(uploadFile).not.toHaveBeenCalled();
+    expect(attachImage).not.toHaveBeenCalled();
+    expect(result.promptText).toContain("[Hermes UI Image]");
+    expect(result.displayText).toBe("看看这张图\n\n附件：pasted.png");
+  });
+
+  it("in remote mode, a path-only image uploads its bytes (image.attach_bytes), not the path", async () => {
+    const readImageBytes = vi.fn(async () => ({
+      contentBase64: "QUJD",
+      filename: "screenshot.png",
+    }));
+    const attachImageBytes = vi.fn(async () => ({
+      attached: true,
+      text: "[User attached image: screenshot.png]",
+      name: "screenshot.png",
+      path: "/remote/img/screenshot.png",
+    }));
+    const attachImage = vi.fn();
+
+    const result = await prepareComposerPrompt(
+      "s1",
+      {
+        text: "看看这张图",
+        attachments: [{
+          id: "a1",
+          source: "path",
+          path: "/home/me/screenshot.png",
+          name: "screenshot.png",
+          kind: "image",
+          status: "ready",
+        }],
+      },
+      { attachImage, attachImageBytes, remote: true, readImageBytes, detectDroppedPath: vi.fn() },
+    );
+
+    // The remote gateway can't read the client path, so bytes are read locally
+    // and uploaded — image.attach{path} is never used.
+    expect(readImageBytes).toHaveBeenCalledWith("/home/me/screenshot.png");
+    expect(attachImageBytes).toHaveBeenCalledWith("s1", "QUJD", "screenshot.png");
+    expect(attachImage).not.toHaveBeenCalled();
+    expect(result.promptText).toContain("[Hermes UI Image]");
+  });
+
+  it("in local mode, a path image still attaches by path (image.attach), no byte read", async () => {
+    const attachImageBytes = vi.fn();
+    const readImageBytes = vi.fn();
+    const attachImage = vi.fn(async () => ({
+      attached: true,
+      text: "[User attached image: local.png]",
+      name: "local.png",
+    }));
+
+    await prepareComposerPrompt(
+      "s1",
+      {
+        text: "本地图",
+        attachments: [{
+          id: "a1",
+          source: "path",
+          path: "/home/me/local.png",
+          name: "local.png",
+          kind: "image",
+          status: "ready",
+        }],
+      },
+      { attachImage, attachImageBytes, remote: false, readImageBytes, detectDroppedPath: vi.fn() },
+    );
+
+    expect(attachImage).toHaveBeenCalledWith("s1", "/home/me/local.png");
+    expect(attachImageBytes).not.toHaveBeenCalled();
+    expect(readImageBytes).not.toHaveBeenCalled();
+  });
+
   it("includes image attach/vision text in the transport prompt but hides it from display text", async () => {
     const result = await prepareComposerPrompt(
       "s1",

--- a/web/src/lib/composer-prompt.ts
+++ b/web/src/lib/composer-prompt.ts
@@ -138,6 +138,20 @@ export async function prepareComposerPrompt(
       onProgress?: (percent: number) => void,
     ): Promise<AttachmentUploadResult>;
     attachImage(sessionId: string, path: string): Promise<ImageAttachResult>;
+    attachImageBytes?(
+      sessionId: string,
+      contentBase64: string,
+      filename?: string,
+    ): Promise<ImageAttachResult>;
+    // True when attached to a remote gateway: it can't read this machine's
+    // paths, so image bytes must be uploaded (matches the official desktop's
+    // `remote ? attach_bytes : attach{path}`).
+    remote?: boolean;
+    // Read a local image file's bytes for remote upload (path-only attachments
+    // such as drag-dropped files, which have no in-browser File to read).
+    readImageBytes?(
+      path: string,
+    ): Promise<{ contentBase64: string; filename: string } | null>;
     detectDroppedPath(sessionId: string, path: string): Promise<InputDetectDropResult>;
     onAttachmentUpdate?(id: string, patch: Partial<ComposerAttachment>): void;
   },
@@ -169,6 +183,101 @@ export async function prepareComposerPrompt(
       let path = attachment.uploadedPath || attachment.path || "";
       let uploadedName = attachment.uploadedName;
 
+      const looksLikeImage =
+        attachment.kind === "image" ||
+        (!!path && isImagePath(path)) ||
+        (attachment.file?.type?.startsWith("image/") ?? false);
+
+      // Images attach over the gateway. With a gateway-readable path we use
+      // image.attach{path}; for an in-browser File (e.g. a pasted screenshot,
+      // which has no real path) we send the bytes via image.attach_bytes. Both
+      // return the same ImageAttachResult shape. This keeps images off the
+      // fork-only REST /api/upload endpoint, which Core drops/restores across
+      // upstream syncs — matching the official desktop's image-attach path.
+      if (looksLikeImage) {
+        let attached: ImageAttachResult;
+        // Send bytes when there's no gateway-readable path (an in-browser File,
+        // e.g. a pasted screenshot) OR when remote (the gateway can't read this
+        // machine's paths). Otherwise pass the path. This mirrors the official
+        // desktop's `remote ? attach_bytes : attach{path}`, extended to also
+        // cover our pathless pasted Files.
+        const useBytes = !path || !!helpers.remote;
+        if (useBytes) {
+          if (!helpers.attachImageBytes) {
+            throw new Error("当前环境不支持上传这个图片附件");
+          }
+          helpers.onAttachmentUpdate?.(attachment.id, {
+            status: "uploading",
+            progress: 0,
+            error: undefined,
+          });
+          let contentBase64 = "";
+          let filename =
+            attachment.file?.name ||
+            (path ? fileNameFromPath(path) : attachment.name || "image.png");
+          if (attachment.file) {
+            const dataUrl = await readFileAsDataUrl(attachment.file);
+            contentBase64 = dataUrl ? dataUrl.slice(dataUrl.indexOf(",") + 1) : "";
+          } else if (path && helpers.readImageBytes) {
+            const payload = await helpers.readImageBytes(path);
+            if (payload) {
+              contentBase64 = payload.contentBase64;
+              filename = payload.filename;
+            }
+          }
+          if (!contentBase64) {
+            throw new Error("无法读取图片数据");
+          }
+          helpers.onAttachmentUpdate?.(attachment.id, { status: "processing", progress: 100 });
+          attached = await helpers.attachImageBytes(sessionId, contentBase64, filename);
+          if (attached.attached === false) {
+            throw new Error(attached.text || "图片附件未能添加");
+          }
+          path = attached.path || path;
+          uploadedName = attached.name || filename;
+          helpers.onAttachmentUpdate?.(attachment.id, {
+            source: "uploaded",
+            uploadedPath: attached.path,
+            uploadedName,
+            path: attached.path,
+            mimeType: attachment.mimeType,
+          });
+        } else {
+          if (!path) {
+            throw new Error("附件缺少可读取路径");
+          }
+          helpers.onAttachmentUpdate?.(attachment.id, { status: "processing" });
+          attached = await helpers.attachImage(sessionId, path);
+          if (attached.attached === false) {
+            throw new Error(attached.text || "图片附件未能添加");
+          }
+        }
+
+        if (attached.text?.trim()) {
+          const label = attached.name || uploadedName || attachment.name || fileNameFromPath(path);
+          parts.push([
+            IMAGE_BLOCK_START,
+            `name=${sanitizeContextValue(label)}`,
+            "description:",
+            attached.text.trim(),
+            IMAGE_BLOCK_END,
+          ].join("\n"));
+        }
+        const label = attached.name || uploadedName || attachment.name || fileNameFromPath(path);
+        displayImages.push({
+          url: await imageDisplayUrl(attachment, attached.path || path),
+          alt: label,
+          title: label,
+          name: label,
+          mimeType: attachment.mimeType,
+        });
+        helpers.onAttachmentUpdate?.(attachment.id, { status: "done", progress: 100 });
+        continue;
+      }
+
+      // Non-image attachments. A browser File with no path still needs the REST
+      // upload (uncommon in the desktop: pickers/drag supply real paths, paste
+      // produces images).
       if (!path && attachment.file) {
         if (!helpers.uploadFile) {
           throw new Error("当前环境不支持上传这个附件");
@@ -200,34 +309,6 @@ export async function prepareComposerPrompt(
 
       if (!path) {
         throw new Error("附件缺少可读取路径");
-      }
-
-      if (attachment.kind === "image" || isImagePath(path)) {
-        helpers.onAttachmentUpdate?.(attachment.id, { status: "processing" });
-        const attached = await helpers.attachImage(sessionId, path);
-        if (attached.attached === false) {
-          throw new Error(attached.text || "图片附件未能添加");
-        }
-        if (attached.text?.trim()) {
-          const label = attached.name || uploadedName || attachment.name || fileNameFromPath(path);
-          parts.push([
-            IMAGE_BLOCK_START,
-            `name=${sanitizeContextValue(label)}`,
-            "description:",
-            attached.text.trim(),
-            IMAGE_BLOCK_END,
-          ].join("\n"));
-        }
-        const label = attached.name || uploadedName || attachment.name || fileNameFromPath(path);
-        displayImages.push({
-          url: await imageDisplayUrl(attachment, attached.path || path),
-          alt: label,
-          title: label,
-          name: label,
-          mimeType: attachment.mimeType,
-        });
-        helpers.onAttachmentUpdate?.(attachment.id, { status: "done", progress: 100 });
-        continue;
       }
 
       helpers.onAttachmentUpdate?.(attachment.id, { status: "processing" });

--- a/web/src/lib/transport.ts
+++ b/web/src/lib/transport.ts
@@ -348,3 +348,43 @@ export function uploadAttachmentFile(
     xhr.send(form);
   });
 }
+
+/** True when attached to a remote gateway (a different machine's filesystem). */
+export function isRemoteConnection(): boolean {
+  return runtime.isRemote();
+}
+
+function attachmentParentDir(path: string): string {
+  const i = Math.max(path.lastIndexOf("/"), path.lastIndexOf("\\"));
+  return i > 0 ? path.slice(0, i) : path;
+}
+
+function attachmentFileName(path: string): string {
+  const i = Math.max(path.lastIndexOf("/"), path.lastIndexOf("\\"));
+  return i >= 0 ? path.slice(i + 1) : path;
+}
+
+// Read a local image file's bytes (base64) via the desktop bridge, for attaching
+// to a REMOTE gateway that can't see this machine's filesystem. Mirrors the
+// official desktop's readImageForRemoteAttach. The desktop's read_workspace_file
+// command confines reads to a root, so we pass the image's own directory; it
+// caps inline images at 8 MB and returns null above that. Returns null when the
+// bridge is unavailable or the file can't be read as an image.
+export async function readImageBytesFromPath(
+  path: string,
+): Promise<{ contentBase64: string; filename: string } | null> {
+  const read = window.hermesDesktop?.readWorkspaceFile;
+  if (!read) return null;
+  try {
+    const preview = await read({ path, root: attachmentParentDir(path) });
+    const dataUrl = preview?.dataUrl;
+    if (!dataUrl) return null;
+    const comma = dataUrl.indexOf(",");
+    const contentBase64 = comma >= 0 ? dataUrl.slice(comma + 1) : dataUrl;
+    return contentBase64
+      ? { contentBase64, filename: attachmentFileName(path) }
+      : null;
+  } catch {
+    return null;
+  }
+}

--- a/web/src/routes/detail.tsx
+++ b/web/src/routes/detail.tsx
@@ -48,7 +48,7 @@ import {
   readSessionTitleOverrides,
   subscribeSessionUiStateChanges,
 } from "@/lib/session-ui-state";
-import { uploadAttachmentFile } from "@/lib/transport";
+import { isRemoteConnection, readImageBytesFromPath, uploadAttachmentFile } from "@/lib/transport";
 import { voiceAutoTtsFromConfig } from "@/lib/voice";
 import {
   rememberSessionWorkspace,
@@ -114,6 +114,7 @@ export function DetailRoute() {
     dispatchCommand,
     completePath,
     attachImage,
+    attachImageBytes,
     detectDroppedPath,
   } = useGateway();
   const { data: config } = useConfig();
@@ -389,6 +390,9 @@ export function DetailRoute() {
     }
     const prepared = await prepareComposerPrompt(gatewaySessionId, payload, {
       attachImage,
+      attachImageBytes,
+      remote: isRemoteConnection(),
+      readImageBytes: readImageBytesFromPath,
       detectDroppedPath,
       uploadFile: uploadAttachmentFile,
       onAttachmentUpdate: updateAttachment,
@@ -397,7 +401,7 @@ export function DetailRoute() {
       displayText: prepared.displayText,
       displayImages: prepared.displayImages,
     });
-  }, [attachImage, detectDroppedPath, dispatchCommand, ensureGatewaySession, restSessionId, sendPrompt, taskId]);
+  }, [attachImage, attachImageBytes, detectDroppedPath, dispatchCommand, ensureGatewaySession, restSessionId, sendPrompt, taskId]);
 
   const onSend = useCallback(async (
     payload: ComposerSubmitPayload,


### PR DESCRIPTION
## What

Two related changes (one commit each):

1. **`fix(composer)`: attach images over the gateway, drop `/api/upload`.**
   Image attachments were uploaded via REST `POST /api/upload` (the browser path
   in `transport.ts` and the native Rust `upload_file` both target it), but Core
   only serves `/api/files/upload`. `/api/upload` is a fork-only P-002 patch for
   the v2 web dashboard that Core drops/restores across upstream syncs — so image
   attach **silently breaks whenever it's dropped** (it's missing on the current
   Core checkout). This was the root cause of pasted images failing to send.

   Images now attach over the gateway via `image.attach_bytes`, matching Core's
   own `apps/desktop`. The decision mirrors the official `remote ? bytes : path`,
   extended to also cover our pathless pasted Files:

   | case | call |
   |---|---|
   | local + real path | `image.attach { path }` |
   | local + pasted File | `image.attach_bytes` (File bytes) |
   | remote (any image) | `image.attach_bytes` (remote gateway can't read this machine's paths) |

   Remote path-only images read their bytes via the existing `read_workspace_file`
   bridge. Non-image file attachments keep the REST fallback (rare in the desktop).

2. **`test(e2e)`: real-backend + fake-model end-to-end harness.**
   Drives the real web UI (Playwright/Chromium) against the real Core dashboard
   with a local deterministic fake model, covering the core chat loops on every
   PR without a paid/flaky LLM:
   - new chat → streamed reply → navigate to history → continue
   - paste an image → the model reads it (asserts the decoded byte count, proving
     the bytes actually reached the model)

   `HERMES_DASHBOARD_ORIGIN` is the only seam flipped; everything else is the
   production path. Includes a browserless protocol smoke and a CI workflow
   (`web-e2e.yml`). See `e2e/README.md`.

   This harness is what surfaced the `/api/upload` drift; the image spec now
   drives the fixed path with no workaround.

## Verification (local)

- `tsc --noEmit` — clean
- `pnpm --filter @hermes/web test:unit` — **785 passed** (incl. new
  `composer-prompt` tests: pasted-File → bytes, remote+path → bytes, local+path →
  path)
- `pnpm --filter @hermes/e2e test` — **2/2 passed** (real Core + fake model,
  rebased on latest `main`)

## Notes

- Desktop-only; no Core changes.
- `web-e2e.yml` is a new CI job that checks out `Hermes-CN-Core` as a sibling and
  pip-installs it — its first run on GitHub's runners hasn't been validated (the
  code is verified locally). Worth watching the first run and tuning the Python
  extras if needed; it isn't a required check yet, so it won't block.

🤖 Generated with [Claude Code](https://claude.com/claude-code)
