### PR TITLE
ci(e2e): run the e2e job on Node 22 (global WebSocket)

### DIFF
--- a/.github/workflows/web-e2e.yml
+++ b/.github/workflows/web-e2e.yml
@@ -39,7 +39,9 @@ jobs:
 
       - uses: actions/setup-node@v4
         with:
-          node-version: 20
+          # 22, not 20: the protocol smoke uses the global WebSocket, which only
+          # exists from Node 21+ (Node 20 -> "WebSocket is not defined").
+          node-version: 22
           cache: pnpm
           cache-dependency-path: Hermes-CN-Desktop/pnpm-lock.yaml
 


### PR DESCRIPTION
Follow-up to #315. The `e2e` job failed with `WebSocket is not defined` because it pinned Node 20; `harness/protocol-smoke.mjs` uses the global `WebSocket`, which only exists from Node 21+. Bump to Node 22.

This is the only CI-environment issue surfaced by #315's first run; the heavy setup steps (Core checkout + pip install, Playwright install) passed. Watching the `e2e` check on this PR to confirm it now goes green end-to-end.

🤖 Generated with [Claude Code](https://claude.com/claude-code)