### PR TITLE
fix: re-pin chat timeline to bottom on composer/viewport resize

### DIFF
--- a/web/src/components/chat/message-timeline.tsx
+++ b/web/src/components/chat/message-timeline.tsx
@@ -1180,6 +1180,11 @@ export function MessageTimeline({
       frame = window.requestAnimationFrame(anchorToBottom);
     });
     observer.observe(messagesElement);
+    // composer 增高（多行输入 / 技能面板 / 附件托盘 / 上下文告警 / 队列面板等）会让滚动视口
+    // 从底部变矮，但 .messages 内容高度不变、上面这个 observer 不会触发，导致最新内容被挤到
+    // 视口下沿之外（看起来"藏在输入框后面"）。一并观察滚动容器自身：视口高度变化时也走
+    // anchorToBottom 重新贴底——其守卫（userDetached / nearBottom）保证不会把已上滑的用户拽回。
+    observer.observe(container);
     return () => {
       window.cancelAnimationFrame(frame);
       observer.disconnect();


### PR DESCRIPTION
## 问题

贴底跟随时，输入框区域（composer）增高——多行输入、技能面板、附件托盘、上下文告警、队列面板等——会让滚动视口 `.scroll` 从底部变矮。`message-timeline.tsx` 里的 ResizeObserver 只观察消息内容 `.messages`，而它的高度并没变，所以不会触发重新贴底；最新内容被挤到视口下沿之外，表现为"最新内容被输入框挡住、不自动滚上去"。

> 用户反馈"缩放窗口有时能修好"——正是因为窗口 resize 让文字重排、`.messages` 高度变化，才碰巧触发了那个 observer。这反过来印证了根因：缺少"视口/输入框高度变化时的重新贴底"。

附带澄清：网上流传的一份归因（Electron 壳、`VirtualizedThread` 虚拟滚动"三方打架"、若干 GitHub issue 编号）经核对与本仓库**不符**——本项目是 Tauri + React，聊天区**没有任何虚拟滚动**，相关组件/issue 并不存在。

## 改动

在已有的 `observer.observe(messagesElement)` 之外，再 `observer.observe(container)`（滚动容器自身）。视口高度变化时也走现成的、带 rAF 防抖的 `anchorToBottom()` 重新贴底。共 +5 行，单文件。

## 为什么安全

- `anchorToBottom` 的守卫（`userDetachedFromBottomRef` / `nearBottomRef`）保证**只对"正在跟随"的用户重新贴底，绝不把已主动上滑的用户拽回底部**。
- 只改 `scrollTop`、不改变容器尺寸 → **不产生 ResizeObserver 反馈环**。
- 上滑脱离、流式自动贴底等既有行为不受影响。

## 验证

- `pnpm typecheck` ✅
- `pnpm test:unit` ✅（web 789、protocol 42 全绿）
- 手动（`pnpm tauri:dev`）：滚到底后输入多行长文本 / 打开技能面板 / 触发上下文告警，最新内容都应保持在输入框上方可见；上滑后 composer 增高不应被拽回。
- 未新增针对 ResizeObserver 的单测：jsdom 无布局几何（`scrollHeight`/`clientHeight` 恒为 0），该行为依赖真实布局、最适合手动验证；其"防拽回"逻辑已被现有 `resolveBottomFollowState` / `shouldDetachOnScroll` 纯函数单测覆盖。

🤖 Generated with [Claude Code](https://claude.com/claude-code)
