### PR TITLE
fix: retry runtime smoke-check spawn on ETXTBSY to de-flake CI

### DIFF
--- a/src/process/runtime.rs
+++ b/src/process/runtime.rs
@@ -42,6 +42,13 @@ const RUNTIME_ARTIFACT_HTTP_TIMEOUT: Duration = Duration::from_secs(15 * 60);
 // first run. Keep the smoke check long enough for the cold path and let normal
 // launches stay fast via the runtime's own cache.
 const SMOKE_TIMEOUT: Duration = Duration::from_secs(60);
+// Spawning a just-written/just-extracted executable can transiently fail with
+// ETXTBSY ("Text file busy"): a concurrent fork in another thread may have
+// inherited a write fd to the file, so exec sees it as still open for writing.
+// A few short retries let that inherited fd close (the racing child execs or
+// exits). This hardens both the real post-install path and the smoke-check test
+// under cargo's multi-threaded runner.
+const SMOKE_SPAWN_RETRIES: u32 = 5;
 static RUNTIME_HTTP_CLIENT: LazyLock<reqwest::Client> = LazyLock::new(|| {
     reqwest::Client::builder()
         .connect_timeout(RUNTIME_HTTP_CONNECT_TIMEOUT)
@@ -1201,27 +1208,52 @@ async fn smoke_check_runtime(executable_path: &Path) -> Result<(), String> {
         .map(|metadata| metadata.len().to_string())
         .unwrap_or_else(|e| format!("<unavailable: {}>", e));
 
-    let child = Command::new(executable_path)
-        .current_dir(workdir)
-        .args(["dashboard", "--help"])
-        .env("HERMES_DISABLE_LAZY_INSTALLS", "1")
-        .env("HERMES_DASHBOARD_PREWARM_AGENT", "0")
-        .stdout(Stdio::null())
-        .stderr(Stdio::null())
-        .spawn()
-        .map_err(|e| {
-            format!(
-                "Smoke check spawn failed for {} (exists={}, file_size={}, cwd={}, workdir={}): {}",
-                executable_display,
-                executable_path.is_file(),
-                size,
-                cwd_display,
-                workdir_display,
-                e
-            )
-        })?;
+    let mut attempt = 0;
+    let child = loop {
+        match Command::new(executable_path)
+            .current_dir(workdir)
+            .args(["dashboard", "--help"])
+            .env("HERMES_DISABLE_LAZY_INSTALLS", "1")
+            .env("HERMES_DASHBOARD_PREWARM_AGENT", "0")
+            .stdout(Stdio::null())
+            .stderr(Stdio::null())
+            .spawn()
+        {
+            Ok(child) => break child,
+            Err(e) if is_text_file_busy(&e) && attempt < SMOKE_SPAWN_RETRIES => {
+                attempt += 1;
+                tokio::time::sleep(Duration::from_millis(50 * u64::from(attempt))).await;
+            }
+            Err(e) => {
+                return Err(format!(
+                    "Smoke check spawn failed for {} (exists={}, file_size={}, cwd={}, workdir={}): {}",
+                    executable_display,
+                    executable_path.is_file(),
+                    size,
+                    cwd_display,
+                    workdir_display,
+                    e
+                ));
+            }
+        }
+    };
 
     wait_for_smoke_child(child, SMOKE_TIMEOUT).await
+}
+
+/// True when the spawn error is ETXTBSY ("Text file busy"), which can briefly
+/// occur right after writing/extracting an executable. Unix-only; the kind has
+/// no Windows equivalent here.
+fn is_text_file_busy(e: &std::io::Error) -> bool {
+    #[cfg(unix)]
+    {
+        e.raw_os_error() == Some(libc::ETXTBSY)
+    }
+    #[cfg(not(unix))]
+    {
+        let _ = e;
+        false
+    }
 }
 
 fn install_record_from_manifest(


### PR DESCRIPTION
## 问题

`rust-test` 上偶发红勾，失败的总是 `process::runtime::tests::smoke_check_runs_from_executable_directory`：

```
Smoke check spawn failed for .../hermes-agent-cn-runtime-linux-x64 ... : Text file busy (os error 26)
```

`Text file busy = ETXTBSY` 是一个**与被测代码无关的偶发 race**：`cargo test` 默认多线程并行，该测试把脚本写到临时目录后立刻 exec，而**另一个并行测试线程恰好在这一瞬间 fork**，子进程继承了刚写出文件的写 fd，于是 exec 时内核认为文件「正被写」。`main` 上长期是绿的，只是偶尔撞上（例如 #292 的 run）。

## 修复

把 `smoke_check_runtime` 的 spawn 包进**有界重试循环**：仅当错误是 `ETXTBSY` 时短退避重试（最多 5 次，50ms→250ms），其它错误立即按原诊断信息返回。等待继承的写 fd 在那个 racing 子进程 exec/退出后关闭即可成功。

这同时**硬化了真实的「解压后立刻 exec runtime」路径**——生产安装流程也是写出 runtime 二进制后马上 exec，理论上同样可能撞 ETXTBSY。

## 改动

- `src/process/runtime.rs`
  - 新增 `SMOKE_SPAWN_RETRIES` 常量 + `is_text_file_busy()`（`#[cfg(unix)]` 用 `libc::ETXTBSY` 精确匹配，非 unix 恒 false）
  - `smoke_check_runtime` 的 spawn 改为有界 ETXTBSY 重试循环
  - 现有测试 `smoke_check_runs_from_executable_directory` 不改，加了重试后即稳定

## 验证

- `cargo fmt --all -- --check` — clean
- `cargo clippy --all-targets -- -D warnings` — clean
- `cargo test --all-features --no-fail-fast` — 全绿
- 加压：连跑 `smoke_check_runs_from_executable_directory` 多轮不再复现 ETXTBSY

🤖 Generated with [Claude Code](https://claude.com/claude-code)
