### PR TITLE
perf: faster first token + smoother streaming + snappier Models page

### DIFF
--- a/web/src/components/panel/panel-composer.tsx
+++ b/web/src/components/panel/panel-composer.tsx
@@ -33,6 +33,9 @@ export function PanelComposer() {
     connect,
     getModelOptions,
     completePath,
+    createSession,
+    closeSession,
+    adoptCreatedSession,
   } = useGateway();
   const createAndSendSession = useCreateAndSendSession();
   const { data: config } = useConfig();
@@ -50,6 +53,10 @@ export function PanelComposer() {
   const [prefill, setPrefill] = useAtom(composerPrefillAtom);
   const composerSubmitShortcut = useAtomValue(composerSubmitShortcutAtom);
   const wrapperRef = useRef<HTMLDivElement>(null);
+  // Pre-warmed draft session (created by the effect below). Holds the backend
+  // session id + the cwd it was built for, so send only reuses it while the
+  // requested workspace still matches.
+  const draftRef = useRef<{ id: string; cwd: string } | null>(null);
   const initialWorkspacePath = normalizeWorkspacePath(searchParams.get("workspace"));
   const submitShortcutHint = composerSubmitShortcutHint(composerSubmitShortcut);
   const enabledSkills = useMemo(
@@ -71,9 +78,38 @@ export function PanelComposer() {
     setPrefill(null);
   }, [prefill, setPrefill]);
 
+  // Pre-warm: create a draft session as soon as the new-task composer mounts so
+  // the backend starts building the agent (tool/model/MCP discovery) while the
+  // user is still typing. The first prompt then only waits on the model, not a
+  // cold agent build — which is the bulk of the desktop-vs-CLI first-token gap.
+  // `activate: false` keeps it off-screen; send adopts it. An unused draft is
+  // closed on unmount / workspace change so it never holds an active-session
+  // slot. Any failure (e.g. the server's session-slot limit) just leaves
+  // draftRef null and send falls back to a normal cold create.
   useEffect(() => {
-    void connect().catch(() => {});
-  }, [connect]);
+    const cwd = initialWorkspacePath || "";
+    let cancelled = false;
+    void (async () => {
+      try {
+        await connect();
+        if (cancelled) return;
+        const id = await createSession({ cwd: cwd || undefined, activate: false });
+        if (cancelled) {
+          void closeSession(id).catch(() => {});
+          return;
+        }
+        draftRef.current = { id, cwd };
+      } catch {
+        draftRef.current = null;
+      }
+    })();
+    return () => {
+      cancelled = true;
+      const draft = draftRef.current;
+      draftRef.current = null;
+      if (draft) void closeSession(draft.id).catch(() => {});
+    };
+  }, [connect, createSession, closeSession, initialWorkspacePath]);
 
   const contextSelection = useMemo(() => {
     const model = selectedModel?.model ?? modelInfo?.model;
@@ -130,7 +166,28 @@ export function PanelComposer() {
     if (sending) return;
     setSending(true);
     try {
-      await createAndSendSession(payload, controls);
+      const draft = draftRef.current;
+      const requestedCwd = payload.workspacePath?.trim() || "";
+      let options: { createSession: () => Promise<string> } | undefined;
+      if (draft && draft.cwd === requestedCwd) {
+        // Reuse the pre-warmed draft — its agent has been building for this exact
+        // cwd. Claim it (null the ref so unmount cleanup won't close it) and
+        // adopt it as the live session, mirroring a normal create.
+        draftRef.current = null;
+        const draftId = draft.id;
+        options = {
+          createSession: async () => {
+            adoptCreatedSession(draftId);
+            return draftId;
+          },
+        };
+      } else if (draft) {
+        // Workspace changed since pre-warm → the warm agent has the wrong cwd.
+        // Release it and let createAndSendSession make a fresh (cold) session.
+        draftRef.current = null;
+        void closeSession(draft.id).catch(() => {});
+      }
+      await createAndSendSession(payload, controls, options);
     } catch (err) {
       console.error("Failed to create session:", err);
       throw err;
@@ -140,6 +197,8 @@ export function PanelComposer() {
   }, [
     sending,
     createAndSendSession,
+    adoptCreatedSession,
+    closeSession,
   ]);
 
   return (

--- a/web/src/hooks/use-config.ts
+++ b/web/src/hooks/use-config.ts
@@ -19,6 +19,10 @@ export function useConfig() {
   return useQuery<Record<string, any>>({
     queryKey: ["config", profile],
     queryFn: ({ signal }) => fetchJSON("/api/config", { signal }, ConfigResponse),
+    // Config changes only via saves (which invalidate this query), so avoid the
+    // focus-refetch storm that re-hits the Models page's backing endpoints.
+    staleTime: 60_000,
+    refetchOnWindowFocus: false,
   });
 }
 
@@ -36,6 +40,10 @@ export function useModelInfo() {
   return useQuery<ModelInfo>({
     queryKey: ["model-info", profile],
     queryFn: ({ signal }) => fetchJSON("/api/model/info", { signal }, ModelInfo),
+    // Model metadata changes via config saves (which invalidate this) or an
+    // explicit model switch; no need to refetch on every window focus.
+    staleTime: 60_000,
+    refetchOnWindowFocus: false,
   });
 }
 

--- a/web/src/hooks/use-gateway.ts
+++ b/web/src/hooks/use-gateway.ts
@@ -50,6 +50,7 @@ import {
 } from "@/stores/chat";
 import { sessionTipRedirectAtom } from "@/stores/ui";
 import { recordTipRedirect } from "@/lib/session-tip-redirect";
+import { createDeltaCoalescer } from "@/lib/gateway-delta-coalescer";
 
 type GatewayState = ReturnType<typeof getGatewayClient>["state"];
 
@@ -64,6 +65,7 @@ interface GatewaySubscriptionBridge {
   unsubscribeState: () => void;
   unsubscribeAny: () => void;
   unsubscribeDisconnect: () => void;
+  flushPendingDeltas: () => void;
 }
 
 let gatewayBridge: GatewaySubscriptionBridge | null = null;
@@ -131,9 +133,18 @@ function ensureGatewayBridge(): GatewaySubscriptionBridge {
     unsubscribeState: () => {},
     unsubscribeAny: () => {},
     unsubscribeDisconnect: () => {},
+    flushPendingDeltas: () => {},
   };
   const client = getGatewayClient();
   client.enableAutoReconnect();
+
+  // Coalesce streaming message.delta into one apply per animation frame (see
+  // lib/gateway-delta-coalescer). apply() resolves the primary subscriber lazily
+  // so a buffered flush always lands on the current chat-store binding.
+  const coalescer = createDeltaCoalescer((event) =>
+    primarySubscriber(bridge)?.applyGatewayEvent(event),
+  );
+  bridge.flushPendingDeltas = coalescer.flush;
 
   // Re-issue session.resume only after a disconnect, never on the very first
   // connect (there is no in-flight state to re-pin yet). `gateway.disconnected`
@@ -152,12 +163,14 @@ function ensureGatewayBridge(): GatewaySubscriptionBridge {
     }
   });
   bridge.unsubscribeAny = client.onAny((event) => {
-    primarySubscriber(bridge)?.applyGatewayEvent(event);
+    coalescer.dispatch(event);
   });
   bridge.unsubscribeDisconnect = client.on("gateway.disconnected", () => {
-    // A disconnect that the transport could not silently recover. Keep the
-    // in-flight turn alive (don't freeze it as an error) and arm a one-shot
+    // A disconnect that the transport could not silently recover. Flush any
+    // buffered deltas first so the in-flight turn's last tokens aren't stranded,
+    // keep the turn alive (don't freeze it as an error), and arm a one-shot
     // session.resume for when the connection comes back.
+    coalescer.flush();
     needsResumeOnReopen = true;
     getDefaultStore().set(markStreamsReconnectingAtom);
   });
@@ -181,6 +194,7 @@ function subscribeGateway(
       bridge.subscribers.splice(index, 1);
     }
     if (bridge.subscribers.length === 0 && gatewayBridge === bridge) {
+      bridge.flushPendingDeltas();
       bridge.unsubscribeState();
       bridge.unsubscribeAny();
       bridge.unsubscribeDisconnect();
@@ -256,6 +270,17 @@ export function useGateway() {
     await getGatewayClient().connect();
   }, [ensureSubscribed]);
 
+  // Pin an already-created gateway session as the live one: target for
+  // reconnect-resume (getActiveSessionId reads gwSessionIdAtom), reset its chat
+  // runtime, and remember it as the persistent key. Shared by createSession's
+  // default activation path and the composer's draft-prewarm reuse, so a
+  // pre-created draft is adopted with the exact same state as a fresh create.
+  const adoptCreatedSession = useCallback((sessionId: string) => {
+    setGwSessionId(sessionId);
+    resetChatSession(sessionId);
+    void rememberPersistentSessionKey(sessionId);
+  }, [resetChatSession, setGwSessionId]);
+
   const createSession = useCallback(async (options?: CreateSessionOptions): Promise<string> => {
     ensureSubscribed();
     const result = parseGatewayResult(
@@ -266,12 +291,10 @@ export function useGateway() {
       "session.create",
     );
     if (options?.activate !== false) {
-      setGwSessionId(result.session_id);
-      resetChatSession(result.session_id);
-      void rememberPersistentSessionKey(result.session_id);
+      adoptCreatedSession(result.session_id);
     }
     return result.session_id;
-  }, [ensureSubscribed, resetChatSession, setGwSessionId]);
+  }, [adoptCreatedSession, ensureSubscribed]);
 
   const closeSession = useCallback(async (sessionId: string) => {
     if (!sessionId) return;
@@ -692,6 +715,7 @@ export function useGateway() {
     streamStatus,
     connect,
     createSession,
+    adoptCreatedSession,
     closeSession,
     beginPrompt,
     failPrompt,

--- a/web/src/hooks/use-oauth-providers.ts
+++ b/web/src/hooks/use-oauth-providers.ts
@@ -17,7 +17,12 @@ export function useOAuthProviders() {
       return res.providers;
     },
     retry: 1,
-    staleTime: 30_000,
+    // Enumerating provider login state is the Models page's slowest call (it
+    // probes every provider's auth store server-side). Don't re-run it every
+    // time the window regains focus, and keep it fresh longer; connect/disconnect
+    // mutations already invalidate this query explicitly.
+    staleTime: 60_000,
+    refetchOnWindowFocus: false,
   });
 }
 

--- a/web/src/lib/gateway-delta-coalescer.test.ts
+++ b/web/src/lib/gateway-delta-coalescer.test.ts
@@ -1,0 +1,123 @@
+import { describe, expect, it, vi } from "vitest";
+import type { GatewayEvent } from "@hermes/protocol";
+import { createDeltaCoalescer } from "./gateway-delta-coalescer";
+
+function delta(sessionId: string, text: string): GatewayEvent {
+  return { type: "message.delta", session_id: sessionId, payload: { text } } as GatewayEvent;
+}
+
+/** A manual frame scheduler so tests fire the rAF flush deterministically. */
+function makeFrame() {
+  let cb: (() => void) | null = null;
+  let handle = 0;
+  return {
+    requestFrame: (fn: () => void) => {
+      cb = fn;
+      return ++handle;
+    },
+    cancelFrame: () => {
+      cb = null;
+    },
+    run: () => {
+      const fn = cb;
+      cb = null;
+      fn?.();
+    },
+    pending: () => cb !== null,
+  };
+}
+
+function setup() {
+  const applied: GatewayEvent[] = [];
+  const frame = makeFrame();
+  const coalescer = createDeltaCoalescer((e) => applied.push(e), {
+    requestFrame: frame.requestFrame,
+    cancelFrame: frame.cancelFrame,
+  });
+  return { applied, frame, coalescer };
+}
+
+describe("createDeltaCoalescer", () => {
+  it("merges consecutive pure-text deltas into one apply per frame", () => {
+    const { applied, frame, coalescer } = setup();
+
+    coalescer.dispatch(delta("s1", "Hello "));
+    coalescer.dispatch(delta("s1", "world"));
+    expect(applied).toEqual([]); // nothing applied until the frame fires
+
+    frame.run();
+    expect(applied).toHaveLength(1);
+    expect(applied[0].type).toBe("message.delta");
+    expect(applied[0].session_id).toBe("s1");
+    expect((applied[0].payload as Record<string, unknown>).text).toBe("Hello world");
+  });
+
+  it("flushes buffered deltas before a non-delta event, preserving order", () => {
+    const { applied, coalescer } = setup();
+
+    coalescer.dispatch(delta("s1", "Hi"));
+    coalescer.dispatch({ type: "message.complete", session_id: "s1", payload: {} } as GatewayEvent);
+
+    expect(applied.map((e) => e.type)).toEqual(["message.delta", "message.complete"]);
+    expect((applied[0].payload as Record<string, unknown>).text).toBe("Hi");
+  });
+
+  it("does not merge image-bearing deltas; flushes prior text then applies as-is", () => {
+    const { applied, coalescer } = setup();
+
+    coalescer.dispatch(delta("s1", "before "));
+    coalescer.dispatch({
+      type: "message.delta",
+      session_id: "s1",
+      payload: { text: "img", images: ["data:image/png;base64,AAAA"] },
+    } as GatewayEvent);
+
+    expect(applied).toHaveLength(2);
+    expect((applied[0].payload as Record<string, unknown>).text).toBe("before ");
+    expect((applied[1].payload as Record<string, unknown>).images).toEqual([
+      "data:image/png;base64,AAAA",
+    ]);
+  });
+
+  it("flush() applies pending deltas immediately and cancels the frame", () => {
+    const { applied, frame, coalescer } = setup();
+
+    coalescer.dispatch(delta("s1", "abc"));
+    expect(applied).toEqual([]);
+    expect(frame.pending()).toBe(true);
+
+    coalescer.flush();
+    expect(applied).toHaveLength(1);
+    expect((applied[0].payload as Record<string, unknown>).text).toBe("abc");
+    expect(frame.pending()).toBe(false);
+  });
+
+  it("buffers deltas per session independently", () => {
+    const { applied, frame, coalescer } = setup();
+
+    coalescer.dispatch(delta("s1", "a"));
+    coalescer.dispatch(delta("s2", "x"));
+    coalescer.dispatch(delta("s1", "b"));
+    frame.run();
+
+    expect(applied).toHaveLength(2);
+    const bySession = Object.fromEntries(
+      applied.map((e) => [e.session_id, (e.payload as Record<string, unknown>).text]),
+    );
+    expect(bySession).toEqual({ s1: "ab", s2: "x" });
+  });
+
+  it("applies immediately when no frame scheduler is available", () => {
+    vi.stubGlobal("requestAnimationFrame", undefined);
+    try {
+      const applied: GatewayEvent[] = [];
+      const coalescer = createDeltaCoalescer((e) => applied.push(e));
+      coalescer.dispatch(delta("s1", "z"));
+      // No scheduler → no buffering; the delta is applied synchronously.
+      expect(applied).toHaveLength(1);
+      expect((applied[0].payload as Record<string, unknown>).text).toBe("z");
+    } finally {
+      vi.unstubAllGlobals();
+    }
+  });
+});

--- a/web/src/lib/gateway-delta-coalescer.ts
+++ b/web/src/lib/gateway-delta-coalescer.ts
@@ -1,0 +1,109 @@
+import type { GatewayEvent } from "@hermes/protocol";
+
+/**
+ * Coalesce streaming `message.delta` events into one apply per animation frame.
+ *
+ * Each gateway `message.delta` triggers a Jotai write and a full re-parse of the
+ * growing assistant markdown (`<Streamdown>` + KaTeX/mermaid/rehype). At token
+ * speed that re-renders dozens of times a second, which is what makes long
+ * answers feel choppy in the desktop app compared to the CLI (which just
+ * line-buffers prints). Buffering the pure-text deltas that arrive within a
+ * single frame and applying their concatenation once collapses N re-renders per
+ * frame down to one, with no change to the reducer.
+ *
+ * Ordering guarantees:
+ *  - Only plain-text deltas (a string `payload.text`, no image fields) are
+ *    buffered. Any other event — including a delta that also carries images —
+ *    first flushes the buffered text, then applies as-is, so nothing is
+ *    reordered or dropped.
+ *  - `message.complete` / `message.start` / `error` are non-delta events, so the
+ *    final tokens of a turn are always flushed before the turn closes.
+ */
+type ApplyFn = (event: GatewayEvent) => void;
+
+interface CoalescerOptions {
+  /** Frame scheduler; injectable for tests / non-browser environments. */
+  requestFrame?: (cb: () => void) => number;
+  cancelFrame?: (handle: number) => void;
+}
+
+export interface DeltaCoalescer {
+  dispatch: (event: GatewayEvent) => void;
+  /** Apply any buffered deltas immediately (call on disconnect / teardown). */
+  flush: () => void;
+}
+
+function isCoalescablePureTextDelta(event: GatewayEvent): boolean {
+  if (event.type !== "message.delta" || !event.session_id) return false;
+  const payload =
+    event.payload && typeof event.payload === "object"
+      ? (event.payload as Record<string, unknown>)
+      : null;
+  if (!payload || typeof payload.text !== "string") return false;
+  // A delta that also carries an image must keep its exact position relative to
+  // surrounding text — never merge those.
+  if ("images" in payload || "image" in payload || "image_url" in payload) {
+    return false;
+  }
+  return true;
+}
+
+export function createDeltaCoalescer(
+  apply: ApplyFn,
+  options: CoalescerOptions = {},
+): DeltaCoalescer {
+  const requestFrame =
+    options.requestFrame ??
+    (typeof requestAnimationFrame === "function"
+      ? (cb: () => void) => requestAnimationFrame(cb)
+      : null);
+  const cancelFrame =
+    options.cancelFrame ??
+    (typeof cancelAnimationFrame === "function"
+      ? (handle: number) => cancelAnimationFrame(handle)
+      : undefined);
+
+  // session_id -> running text concat + the latest delta event used as a shape
+  // template (its own `text` is overwritten with the concatenation on flush).
+  const pending = new Map<string, { text: string; template: GatewayEvent }>();
+  let frameHandle: number | null = null;
+
+  function flush(): void {
+    if (frameHandle !== null) {
+      cancelFrame?.(frameHandle);
+      frameHandle = null;
+    }
+    if (pending.size === 0) return;
+    const buffered = Array.from(pending.values());
+    pending.clear();
+    for (const { text, template } of buffered) {
+      const basePayload =
+        template.payload && typeof template.payload === "object"
+          ? (template.payload as Record<string, unknown>)
+          : {};
+      apply({ ...template, payload: { ...basePayload, text } } as GatewayEvent);
+    }
+  }
+
+  function dispatch(event: GatewayEvent): void {
+    // Without a frame scheduler (SSR / tests) never buffer — apply immediately.
+    if (requestFrame && isCoalescablePureTextDelta(event)) {
+      const sessionId = event.session_id as string;
+      const chunk = (event.payload as Record<string, unknown>).text as string;
+      const prev = pending.get(sessionId);
+      pending.set(sessionId, { text: (prev?.text ?? "") + chunk, template: event });
+      if (frameHandle === null) {
+        frameHandle = requestFrame(() => {
+          frameHandle = null;
+          flush();
+        });
+      }
+      return;
+    }
+    // Any non-buffered event: preserve ordering by applying buffered text first.
+    flush();
+    apply(event);
+  }
+
+  return { dispatch, flush };
+}


### PR DESCRIPTION
## Why

Users reported chatting in the desktop app responds **much slower than the CLI**, and that the **模型页 (Models page)** opens very slowly. The transport is already true token-level streaming — the slowness was elsewhere.

## What

**Chat — first token (`perf(chat)`)**: Core builds the AIAgent lazily on the first prompt (tool/model/MCP discovery), and the composer created the session only at *send*, so create + submit raced and the first prompt waited on the cold build. The new-task composer now pre-creates a **draft session on mount** (`activate:false`) so the backend builds the agent while the user types, and **adopts it on send** when the workspace cwd still matches (else falls back to a normal cold create). Unused drafts are closed on unmount so they never hold an active-session slot. Activation is factored into `adoptCreatedSession` so the draft is pinned exactly like a fresh create (reconnect-resume targets it).

**Chat — streaming smoothness (`perf(chat)`)**: every `message.delta` drove a Jotai write + a full re-parse of the growing markdown (Streamdown + KaTeX/mermaid), dozens of times a second. New `lib/gateway-delta-coalescer.ts` coalesces consecutive pure-text deltas per session into **one apply per animation frame**. Ordering is preserved — any non-delta event, image-bearing delta, disconnect, or teardown flushes the buffer first, so a turn's tail is never lost.

**Models page (`perf(models)`)**: the global React Query default (`staleTime 30s` + `refetchOnWindowFocus`) re-hit `/api/providers/oauth`, `/api/model/info`, `/api/config` on every window focus. Those three queries now use a longer `staleTime` + `refetchOnWindowFocus:false` (per-query, not the global default). Connect/disconnect and config saves already invalidate them. Pairs with Core **P-025** (server-side oauth status cache).

## Test
- `pnpm typecheck` — green (license / version / protocol / shared-ui / web)
- `pnpm --filter @hermes/web test:unit` — 795 passing (incl. 6 new `gateway-delta-coalescer` tests)
- `pnpm --filter @hermes/web build` — local run OOM-killed in the sandbox (environmental, module graph resolved before kill); CI validates the production build.
- Not run headless: live `pnpm tauri:dev` GUI smoke (first-token / streaming feel) — recommend a manual pass.

🤖 Generated with [Claude Code](https://claude.com/claude-code)
