### PR TITLE
feat(mcp): 接入官方 MCP 管理面板（增删改/启停/测试/目录）

### DIFF
--- a/packages/protocol/src/hermes-api.ts
+++ b/packages/protocol/src/hermes-api.ts
@@ -521,6 +521,106 @@ export const McpServersResponse = z.object({
 });
 export type McpServersResponse = z.infer<typeof McpServersResponse>;
 
+// ── MCP 服务管理（/api/mcp/* — 官方上游接口）──────────────────────────
+// 官方 Dashboard 自带的完整管理面（增删改 / 启停 / 测试连接 / 目录浏览 /
+// 一键安装），桌面版直接复用，不再走只读的 fork 端点 /api/mcp-servers。
+// 这些 schema 对齐 hermes_cli/web_server.py 里的响应形状。
+
+// GET /api/mcp/servers 的单条。transport: "http" | "stdio" | "unknown"。
+// env 的值已被后端脱敏（仅用于展示键名/计数，不含真实密钥）。
+export const McpServer = z.object({
+  name: z.string(),
+  transport: z.string(),
+  url: z.string().nullable().optional(),
+  command: z.string().nullable().optional(),
+  args: z.array(z.string()).optional().default([]),
+  env: z.record(z.string()).optional().default({}),
+  auth: z.string().nullable().optional(),
+  enabled: z.boolean(),
+  // 启用的工具名列表；null = 全部启用。
+  tools: z.array(z.string()).nullable().optional(),
+});
+export type McpServer = z.infer<typeof McpServer>;
+
+export const McpServersFullResponse = z.object({
+  servers: z.array(McpServer),
+});
+export type McpServersFullResponse = z.infer<typeof McpServersFullResponse>;
+
+// POST /api/mcp/servers/{name}/test — 连接→列工具→断开。
+export const McpToolInfo = z.object({
+  name: z.string(),
+  description: z.string().nullable().optional().transform((v) => v ?? ""),
+});
+export type McpToolInfo = z.infer<typeof McpToolInfo>;
+
+export const McpTestResult = z.object({
+  ok: z.boolean(),
+  error: z.string().nullable().optional(),
+  tools: z.array(McpToolInfo).optional().default([]),
+});
+export type McpTestResult = z.infer<typeof McpTestResult>;
+
+// PUT /api/mcp/servers/{name}/enabled
+export const McpEnabledResponse = z.object({
+  ok: z.boolean(),
+  name: z.string().optional(),
+  enabled: z.boolean().optional(),
+});
+export type McpEnabledResponse = z.infer<typeof McpEnabledResponse>;
+
+// GET /api/mcp/catalog — Nous 官方审核过的 MCP 目录（optional-mcps/ manifest）。
+export const McpCatalogRequiredEnv = z.object({
+  name: z.string(),
+  prompt: z.string().optional().default(""),
+  required: z.boolean().optional().default(false),
+});
+export type McpCatalogRequiredEnv = z.infer<typeof McpCatalogRequiredEnv>;
+
+export const McpCatalogEntry = z.object({
+  name: z.string(),
+  description: z.string().optional().default(""),
+  source: z.string().optional().default(""),
+  transport: z.string(),
+  auth_type: z.string().optional().default("none"),
+  required_env: z.array(McpCatalogRequiredEnv).optional().default([]),
+  command: z.string().nullable().optional(),
+  args: z.array(z.string()).optional().default([]),
+  url: z.string().nullable().optional(),
+  // git bootstrap（仅 clone+build 类条目有）。
+  install_url: z.string().nullable().optional(),
+  install_ref: z.string().nullable().optional(),
+  bootstrap: z.array(z.string()).optional().default([]),
+  default_enabled: z.array(z.string()).nullable().optional(),
+  post_install: z.string().optional().default(""),
+  needs_install: z.boolean().optional().default(false),
+  installed: z.boolean().optional().default(false),
+  enabled: z.boolean().optional().default(false),
+});
+export type McpCatalogEntry = z.infer<typeof McpCatalogEntry>;
+
+export const McpCatalogDiagnostic = z.object({
+  name: z.string(),
+  kind: z.string(),
+  message: z.string(),
+});
+export type McpCatalogDiagnostic = z.infer<typeof McpCatalogDiagnostic>;
+
+export const McpCatalogResponse = z.object({
+  entries: z.array(McpCatalogEntry),
+  diagnostics: z.array(McpCatalogDiagnostic).optional().default([]),
+});
+export type McpCatalogResponse = z.infer<typeof McpCatalogResponse>;
+
+// POST /api/mcp/catalog/install。background=true 表示 git clone/build 在后台进行。
+export const McpCatalogInstallResponse = z.object({
+  ok: z.boolean(),
+  name: z.string().optional(),
+  background: z.boolean().optional().default(false),
+  action: z.string().nullable().optional(),
+});
+export type McpCatalogInstallResponse = z.infer<typeof McpCatalogInstallResponse>;
+
 // ── Analytics (/api/analytics/usage) ──────────────────────────────────
 
 export const AnalyticsTotals = z.object({
@@ -836,13 +936,17 @@ export const ProfileSoulResponse = z.object({
 });
 export type ProfileSoulResponse = z.infer<typeof ProfileSoulResponse>;
 
-// 创建档案时可一并写入的 MCP server（profile builder）。url（HTTP）或
-// command+args（stdio）二选一。env/auth 不在向导里暴露。
+// 创建 MCP server 的请求体（POST /api/mcp/servers，也复用于 profile builder 的
+// ProfileCreateRequest.mcp_servers）。url（HTTP/SSE）或 command+args（stdio）二选一。
+// env（stdio 的 KEY=VALUE，含 API key 等）、auth（"oauth" 等）由 MCP 管理页填写；
+// 早期 profile 向导不发这两个字段，故均为 optional、向后兼容。
 export const McpServerCreate = z.object({
   name: z.string(),
   url: z.string().optional(),
   command: z.string().optional(),
   args: z.array(z.string()).optional(),
+  env: z.record(z.string()).optional(),
+  auth: z.string().optional(),
 });
 export type McpServerCreate = z.infer<typeof McpServerCreate>;
 

--- a/packages/protocol/src/mcp-api.test.ts
+++ b/packages/protocol/src/mcp-api.test.ts
@@ -1,0 +1,177 @@
+import { describe, expect, it } from "vitest";
+import {
+  McpCatalogInstallResponse,
+  McpCatalogResponse,
+  McpEnabledResponse,
+  McpServer,
+  McpServerCreate,
+  McpServersFullResponse,
+  McpTestResult,
+} from "./hermes-api";
+
+// 这些 payload 对齐 Hermes-CN-Core/hermes_cli/web_server.py 里 /api/mcp/* 各
+// handler 的真实输出（_mcp_server_summary / test / catalog / install），用于
+// 锁定桌面版与官方上游接口之间的契约。
+
+describe("McpServersFullResponse (GET /api/mcp/servers)", () => {
+  it("parses http + stdio servers as returned by _mcp_server_summary", () => {
+    const payload = {
+      servers: [
+        {
+          name: "remote-api",
+          transport: "http",
+          url: "https://example.com/mcp",
+          command: null,
+          args: [],
+          env: {},
+          auth: "oauth",
+          enabled: true,
+          tools: null,
+        },
+        {
+          name: "smoke-fs",
+          transport: "stdio",
+          url: null,
+          command: "npx",
+          args: ["-y", "@modelcontextprotocol/server-filesystem", "/tmp"],
+          // 后端会脱敏 env 值，这里仍是字符串。
+          env: { SAMPLE_KEY: "sk-***redacted***" },
+          auth: null,
+          enabled: false,
+          tools: ["read_file", "write_file"],
+        },
+      ],
+    };
+    const parsed = McpServersFullResponse.parse(payload);
+    expect(parsed.servers).toHaveLength(2);
+    expect(parsed.servers[0].transport).toBe("http");
+    expect(parsed.servers[1].args).toContain("/tmp");
+    expect(parsed.servers[1].enabled).toBe(false);
+  });
+
+  it("single McpServer matches the POST /api/mcp/servers response", () => {
+    const added = McpServer.parse({
+      name: "added",
+      transport: "stdio",
+      command: "uvx",
+      args: ["some-server"],
+      env: {},
+      enabled: true,
+      tools: null,
+    });
+    expect(added.command).toBe("uvx");
+  });
+});
+
+describe("McpTestResult (POST /api/mcp/servers/{name}/test)", () => {
+  it("parses a successful probe (no error key)", () => {
+    const ok = McpTestResult.parse({
+      ok: true,
+      tools: [
+        { name: "read_file", description: "Read a file" },
+        { name: "noop", description: null },
+      ],
+    });
+    expect(ok.ok).toBe(true);
+    expect(ok.tools).toHaveLength(2);
+    // null description 归一为空串。
+    expect(ok.tools[1].description).toBe("");
+  });
+
+  it("parses a failed probe", () => {
+    const fail = McpTestResult.parse({ ok: false, error: "connection refused", tools: [] });
+    expect(fail.ok).toBe(false);
+    expect(fail.error).toBe("connection refused");
+  });
+});
+
+describe("McpEnabledResponse (PUT /api/mcp/servers/{name}/enabled)", () => {
+  it("parses the toggle response", () => {
+    expect(McpEnabledResponse.parse({ ok: true, name: "smoke-fs", enabled: true }).enabled).toBe(true);
+  });
+});
+
+describe("McpCatalogResponse (GET /api/mcp/catalog)", () => {
+  it("parses http-oauth and stdio-git entries plus diagnostics", () => {
+    const payload = {
+      entries: [
+        {
+          name: "linear",
+          description: "Linear issue tracker",
+          source: "https://linear.app",
+          transport: "http",
+          auth_type: "oauth",
+          required_env: [],
+          command: null,
+          args: [],
+          url: "https://mcp.linear.app/mcp",
+          install_url: null,
+          install_ref: null,
+          bootstrap: [],
+          default_enabled: null,
+          post_install: "",
+          needs_install: false,
+          installed: false,
+          enabled: false,
+        },
+        {
+          name: "n8n",
+          description: "n8n workflow automation",
+          source: "github.com/n8n",
+          transport: "stdio",
+          auth_type: "api_key",
+          required_env: [{ name: "N8N_API_KEY", prompt: "n8n API key", required: true }],
+          command: "node",
+          args: ["dist/index.js"],
+          url: null,
+          install_url: "https://github.com/example/n8n-mcp",
+          install_ref: "v1.2.3",
+          bootstrap: ["npm install", "npm run build"],
+          default_enabled: ["list_workflows"],
+          post_install: "Set up your n8n instance first.",
+          needs_install: true,
+          installed: true,
+          enabled: true,
+        },
+      ],
+      diagnostics: [{ name: "n8n", kind: "warning", message: "requires Node 20+" }],
+    };
+    const parsed = McpCatalogResponse.parse(payload);
+    expect(parsed.entries).toHaveLength(2);
+    expect(parsed.entries[1].required_env[0].name).toBe("N8N_API_KEY");
+    expect(parsed.entries[1].bootstrap).toHaveLength(2);
+    expect(parsed.diagnostics[0].message).toContain("Node 20");
+  });
+
+  it("defaults diagnostics to [] when omitted", () => {
+    expect(McpCatalogResponse.parse({ entries: [] }).diagnostics).toEqual([]);
+  });
+});
+
+describe("McpCatalogInstallResponse (POST /api/mcp/catalog/install)", () => {
+  it("parses sync and background installs", () => {
+    expect(McpCatalogInstallResponse.parse({ ok: true, name: "linear", background: false }).background).toBe(false);
+    const bg = McpCatalogInstallResponse.parse({
+      ok: true,
+      name: "n8n",
+      background: true,
+      action: "mcp-install",
+    });
+    expect(bg.action).toBe("mcp-install");
+  });
+});
+
+describe("McpServerCreate (request body)", () => {
+  it("accepts stdio with env + auth and http url", () => {
+    expect(() =>
+      McpServerCreate.parse({
+        name: "fs",
+        command: "npx",
+        args: ["-y", "server"],
+        env: { API_KEY: "secret" },
+        auth: "oauth",
+      }),
+    ).not.toThrow();
+    expect(() => McpServerCreate.parse({ name: "remote", url: "https://x/mcp" })).not.toThrow();
+  });
+});

--- a/web/src/components/mcp/index.ts
+++ b/web/src/components/mcp/index.ts
@@ -1,0 +1,5 @@
+export { McpAddDialog } from "./mcp-add-dialog";
+export { McpInstallDialog } from "./mcp-install-dialog";
+export { McpDeleteDialog } from "./mcp-delete-dialog";
+export { McpServerCard } from "./mcp-server-card";
+export { McpCatalogCard } from "./mcp-catalog-card";

--- a/web/src/components/mcp/mcp-add-dialog.tsx
+++ b/web/src/components/mcp/mcp-add-dialog.tsx
@@ -1,0 +1,160 @@
+import { useState } from "react";
+import { Button, Field, Input, Select, Textarea } from "@hermes/shared-ui";
+import type { McpServerCreate } from "@hermes/protocol";
+import { useAddMcpServer } from "@/hooks/use-mcp";
+import { McpDialogShell } from "./mcp-dialog-shell";
+import { errText, parseArgs, parseEnv } from "./parse";
+import s from "./mcp.module.css";
+
+type Transport = "http" | "stdio";
+
+export function McpAddDialog({
+  existingNames,
+  onClose,
+  onSaved,
+}: {
+  existingNames: string[];
+  onClose: () => void;
+  onSaved: () => void;
+}) {
+  const add = useAddMcpServer();
+  const [name, setName] = useState("");
+  const [transport, setTransport] = useState<Transport>("http");
+  const [url, setUrl] = useState("");
+  const [command, setCommand] = useState("");
+  const [args, setArgs] = useState("");
+  const [env, setEnv] = useState("");
+  const [error, setError] = useState<string | null>(null);
+
+  const submit = () => {
+    setError(null);
+    const trimmed = name.trim();
+    if (!trimmed) {
+      setError("请填写服务名称");
+      return;
+    }
+    if (existingNames.includes(trimmed)) {
+      setError("已存在同名服务");
+      return;
+    }
+    if (transport === "http" && !url.trim()) {
+      setError("HTTP/SSE 服务需要填写 URL");
+      return;
+    }
+    if (transport === "stdio" && !command.trim()) {
+      setError("stdio 服务需要填写命令");
+      return;
+    }
+
+    const body: McpServerCreate = { name: trimmed };
+    if (transport === "http") {
+      body.url = url.trim();
+    } else {
+      body.command = command.trim();
+      const argList = parseArgs(args);
+      if (argList.length) body.args = argList;
+    }
+    const envMap = parseEnv(env);
+    if (Object.keys(envMap).length) body.env = envMap;
+
+    add.mutate(body, {
+      onSuccess: () => {
+        onSaved();
+        onClose();
+      },
+      onError: (err) => setError(errText(err)),
+    });
+  };
+
+  return (
+    <McpDialogShell
+      open
+      title="添加 MCP 服务"
+      busy={add.isPending}
+      onClose={onClose}
+      footer={
+        <>
+          <Button variant="outline" onClick={onClose} disabled={add.isPending}>
+            取消
+          </Button>
+          <Button
+            variant="solid"
+            tone="accent"
+            onClick={submit}
+            loading={add.isPending}
+            disabled={name.trim().length === 0}
+          >
+            添加
+          </Button>
+        </>
+      }
+    >
+      <Field label="名称" required hint="字母 / 数字 / - / _，用于在工具名中标识该服务。">
+        <Input
+          value={name}
+          onChange={(e) => setName(e.target.value)}
+          placeholder="例如 filesystem"
+          mono
+          autoFocus
+          disabled={add.isPending}
+        />
+      </Field>
+
+      <Field label="传输方式">
+        <Select
+          value={transport}
+          onChange={(e) => setTransport(e.target.value as Transport)}
+          disabled={add.isPending}
+        >
+          <option value="http">HTTP / SSE（远程服务）</option>
+          <option value="stdio">stdio（本地命令）</option>
+        </Select>
+      </Field>
+
+      {transport === "http" ? (
+        <Field label="URL" required>
+          <Input
+            value={url}
+            onChange={(e) => setUrl(e.target.value)}
+            placeholder="https://example.com/mcp"
+            mono
+            disabled={add.isPending}
+          />
+        </Field>
+      ) : (
+        <>
+          <Field label="命令" required>
+            <Input
+              value={command}
+              onChange={(e) => setCommand(e.target.value)}
+              placeholder="npx"
+              mono
+              disabled={add.isPending}
+            />
+          </Field>
+          <Field label="参数（可选）" hint="按空格或逗号分隔。">
+            <Input
+              value={args}
+              onChange={(e) => setArgs(e.target.value)}
+              placeholder="-y @modelcontextprotocol/server-filesystem /tmp"
+              mono
+              disabled={add.isPending}
+            />
+          </Field>
+        </>
+      )}
+
+      <Field label="环境变量（可选）" hint="每行一个 KEY=VALUE，写入服务配置（如 API key）。">
+        <Textarea
+          className={s.envArea}
+          value={env}
+          onChange={(e) => setEnv(e.target.value)}
+          placeholder={"API_KEY=secret\nDEBUG=1"}
+          disabled={add.isPending}
+        />
+      </Field>
+
+      {error && <div className={s.formError}>{error}</div>}
+    </McpDialogShell>
+  );
+}

--- a/web/src/components/mcp/mcp-catalog-card.tsx
+++ b/web/src/components/mcp/mcp-catalog-card.tsx
@@ -1,0 +1,136 @@
+import type { ReactNode } from "react";
+import { Badge, Button } from "@hermes/shared-ui";
+import type { McpCatalogEntry } from "@hermes/protocol";
+import { openExternalUrl } from "@/lib/external-links";
+import { isHttpUrl, transportTone } from "./parse";
+import s from "./mcp.module.css";
+
+function ExternalLink({ href, children }: { href: string; children: ReactNode }) {
+  return (
+    <a
+      href={href}
+      className={s.link}
+      onClick={(e) => {
+        e.preventDefault();
+        void openExternalUrl(href);
+      }}
+    >
+      {children}
+    </a>
+  );
+}
+
+export function McpCatalogCard({
+  entry,
+  diagnostics,
+  installing,
+  onInstall,
+}: {
+  entry: McpCatalogEntry;
+  diagnostics: string[];
+  installing: boolean;
+  onInstall: () => void;
+}) {
+  return (
+    <div className={s.card}>
+      <div className={s.cardMain}>
+        <div className={s.cardHead}>
+          <span className={s.cardName}>{entry.name}</span>
+          <Badge tone={transportTone(entry.transport)} variant="soft" size="sm">
+            {entry.transport}
+          </Badge>
+          <Badge tone="neutral" variant="outline" size="sm">
+            认证：{entry.auth_type}
+          </Badge>
+          {entry.source &&
+            (isHttpUrl(entry.source) ? (
+              <ExternalLink href={entry.source}>来源 ↗</ExternalLink>
+            ) : (
+              <Badge tone="neutral" variant="outline" size="sm">
+                {entry.source}
+              </Badge>
+            ))}
+          {entry.installed && (
+            <Badge tone="success" variant="soft" size="sm">
+              已安装
+            </Badge>
+          )}
+          {entry.installed && !entry.enabled && (
+            <Badge tone="neutral" variant="outline" size="sm">
+              已禁用
+            </Badge>
+          )}
+        </div>
+
+        {entry.description && <p className={s.cardDesc}>{entry.description}</p>}
+
+        {entry.transport === "http" && entry.url && (
+          <p className={s.detail}>
+            <span className={s.detailLabel}>端点：</span>
+            <code>{entry.url}</code>
+          </p>
+        )}
+        {entry.transport === "stdio" && entry.command && (
+          <p className={s.detail}>
+            <span className={s.detailLabel}>运行：</span>
+            <code>{[entry.command, ...entry.args].join(" ")}</code>
+          </p>
+        )}
+
+        {entry.install_url && (
+          <p className={s.detail}>
+            <span className={s.detailLabel}>安装自：</span>{" "}
+            {isHttpUrl(entry.install_url) ? (
+              <ExternalLink href={entry.install_url}>{entry.install_url}</ExternalLink>
+            ) : (
+              <code>{entry.install_url}</code>
+            )}
+            {entry.install_ref && <span> @ {entry.install_ref}</span>}
+          </p>
+        )}
+
+        {entry.bootstrap.length > 0 && (
+          <details className={s.details}>
+            <summary>初始化命令（{entry.bootstrap.length}）</summary>
+            <div className={s.detailsList}>
+              {entry.bootstrap.map((cmd, i) => (
+                <code key={`${entry.name}-bs-${i}`}>{cmd}</code>
+              ))}
+            </div>
+          </details>
+        )}
+
+        {entry.post_install && (
+          <details className={s.details}>
+            <summary>安装说明</summary>
+            <p className={s.postInstall}>{entry.post_install.trim()}</p>
+          </details>
+        )}
+
+        {diagnostics.map((msg, i) => (
+          <p key={`${entry.name}-diag-${i}`} className={s.diag}>
+            {msg}
+          </p>
+        ))}
+      </div>
+
+      <div className={s.cardActions}>
+        {entry.installed ? (
+          <Badge tone="success" variant="soft" size="sm">
+            已安装
+          </Badge>
+        ) : (
+          <Button
+            variant="solid"
+            tone="accent"
+            size="sm"
+            loading={installing}
+            onClick={onInstall}
+          >
+            {installing ? "安装中…" : "安装"}
+          </Button>
+        )}
+      </div>
+    </div>
+  );
+}

--- a/web/src/components/mcp/mcp-delete-dialog.tsx
+++ b/web/src/components/mcp/mcp-delete-dialog.tsx
@@ -1,0 +1,54 @@
+import { useState } from "react";
+import { Button } from "@hermes/shared-ui";
+import { useRemoveMcpServer } from "@/hooks/use-mcp";
+import { McpDialogShell } from "./mcp-dialog-shell";
+import { errText } from "./parse";
+import s from "./mcp.module.css";
+
+export function McpDeleteDialog({
+  name,
+  onClose,
+  onDeleted,
+}: {
+  name: string;
+  onClose: () => void;
+  onDeleted: () => void;
+}) {
+  const remove = useRemoveMcpServer();
+  const [error, setError] = useState<string | null>(null);
+
+  const confirm = () => {
+    setError(null);
+    remove.mutate(name, {
+      onSuccess: () => {
+        onDeleted();
+        onClose();
+      },
+      onError: (err) => setError(errText(err)),
+    });
+  };
+
+  return (
+    <McpDialogShell
+      open
+      title="删除 MCP 服务"
+      busy={remove.isPending}
+      onClose={onClose}
+      footer={
+        <>
+          <Button variant="outline" onClick={onClose} disabled={remove.isPending}>
+            取消
+          </Button>
+          <Button variant="solid" tone="danger" onClick={confirm} loading={remove.isPending}>
+            确认删除
+          </Button>
+        </>
+      }
+    >
+      <p className={s.intro}>
+        将从配置中移除服务 <code>{name}</code>。其工具会在重载后从对话中消失，可随时重新添加。
+      </p>
+      {error && <div className={s.formError}>{error}</div>}
+    </McpDialogShell>
+  );
+}

--- a/web/src/components/mcp/mcp-dialog-shell.tsx
+++ b/web/src/components/mcp/mcp-dialog-shell.tsx
@@ -1,0 +1,66 @@
+import type { ReactNode } from "react";
+import { Dialog } from "@hermes/shared-ui";
+import { X } from "lucide-react";
+import s from "./mcp.module.css";
+
+export interface McpDialogShellProps {
+  open: boolean;
+  title: ReactNode;
+  /** 进行中：禁止 Esc / 点遮罩关闭，避免请求途中丢状态。 */
+  busy?: boolean;
+  onClose: () => void;
+  footer?: ReactNode;
+  children: ReactNode;
+}
+
+/**
+ * MCP 各对话框（添加服务 / 安装目录项 / 删除确认）共用的弹窗外壳。
+ * 复用 shared-ui 的 Radix Dialog（自带居中面板/遮罩/动效），与档案弹窗一致。
+ */
+export function McpDialogShell({
+  open,
+  title,
+  busy = false,
+  onClose,
+  footer,
+  children,
+}: McpDialogShellProps) {
+  return (
+    <Dialog.Root
+      open={open}
+      onOpenChange={(next) => {
+        if (!next && !busy) onClose();
+      }}
+    >
+      <Dialog.Portal>
+        <Dialog.Overlay />
+        <Dialog.Content
+          className={s.dialog}
+          onEscapeKeyDown={(event) => {
+            if (busy) event.preventDefault();
+          }}
+          onInteractOutside={(event) => {
+            if (busy) event.preventDefault();
+          }}
+        >
+          <div className={s.dialogHead}>
+            <Dialog.Title asChild>
+              <h2 className={s.dialogTitle}>{title}</h2>
+            </Dialog.Title>
+            <button
+              type="button"
+              className={s.dialogClose}
+              onClick={onClose}
+              disabled={busy}
+              aria-label="关闭"
+            >
+              <X size={15} />
+            </button>
+          </div>
+          <div className={s.dialogBody}>{children}</div>
+          {footer ? <div className={s.dialogFoot}>{footer}</div> : null}
+        </Dialog.Content>
+      </Dialog.Portal>
+    </Dialog.Root>
+  );
+}

--- a/web/src/components/mcp/mcp-install-dialog.tsx
+++ b/web/src/components/mcp/mcp-install-dialog.tsx
@@ -1,0 +1,99 @@
+import { useState } from "react";
+import { Button, Field, Input } from "@hermes/shared-ui";
+import type { McpCatalogEntry } from "@hermes/protocol";
+import { useInstallCatalogEntry } from "@/hooks/use-mcp";
+import { McpDialogShell } from "./mcp-dialog-shell";
+import { errText } from "./parse";
+import s from "./mcp.module.css";
+
+// 目录项声明了 required_env 时弹出，收集这些值后再安装。
+export function McpInstallDialog({
+  entry,
+  onClose,
+  onInstalled,
+}: {
+  entry: McpCatalogEntry;
+  onClose: () => void;
+  onInstalled: (background: boolean) => void;
+}) {
+  const install = useInstallCatalogEntry();
+  const [values, setValues] = useState<Record<string, string>>(() => {
+    const init: Record<string, string> = {};
+    entry.required_env.forEach((item) => {
+      init[item.name] = "";
+    });
+    return init;
+  });
+  const [error, setError] = useState<string | null>(null);
+
+  const submit = () => {
+    setError(null);
+    const missing = entry.required_env.find(
+      (item) => item.required && !(values[item.name] ?? "").trim(),
+    );
+    if (missing) {
+      setError(`请填写「${missing.prompt || missing.name}」`);
+      return;
+    }
+    const envMap: Record<string, string> = {};
+    Object.entries(values).forEach(([k, v]) => {
+      if (v.trim()) envMap[k] = v.trim();
+    });
+
+    install.mutate(
+      { name: entry.name, env: envMap, enable: true },
+      {
+        onSuccess: (res) => {
+          onInstalled(Boolean(res.background));
+          onClose();
+        },
+        onError: (err) => setError(errText(err)),
+      },
+    );
+  };
+
+  return (
+    <McpDialogShell
+      open
+      title={`安装 ${entry.name}`}
+      busy={install.isPending}
+      onClose={onClose}
+      footer={
+        <>
+          <Button variant="outline" onClick={onClose} disabled={install.isPending}>
+            取消
+          </Button>
+          <Button
+            variant="solid"
+            tone="accent"
+            onClick={submit}
+            loading={install.isPending}
+          >
+            安装
+          </Button>
+        </>
+      }
+    >
+      <p className={s.intro}>该服务需要先配置以下值才能使用。</p>
+      {entry.required_env.map((item) => (
+        <Field
+          key={item.name}
+          label={item.prompt || item.name}
+          required={item.required}
+        >
+          <Input
+            type="password"
+            value={values[item.name] ?? ""}
+            onChange={(e) =>
+              setValues((prev) => ({ ...prev, [item.name]: e.target.value }))
+            }
+            placeholder={item.name}
+            mono
+            disabled={install.isPending}
+          />
+        </Field>
+      ))}
+      {error && <div className={s.formError}>{error}</div>}
+    </McpDialogShell>
+  );
+}

--- a/web/src/components/mcp/mcp-server-card.tsx
+++ b/web/src/components/mcp/mcp-server-card.tsx
@@ -1,0 +1,109 @@
+import { Badge, Button } from "@hermes/shared-ui";
+import { Power, Trash2, Zap } from "lucide-react";
+import type { McpServer, McpTestResult } from "@hermes/protocol";
+import { transportTone } from "./parse";
+import s from "./mcp.module.css";
+
+export function McpServerCard({
+  server,
+  result,
+  testing,
+  toggling,
+  onTest,
+  onToggle,
+  onDelete,
+}: {
+  server: McpServer;
+  result?: McpTestResult;
+  testing: boolean;
+  toggling: boolean;
+  onTest: () => void;
+  onToggle: () => void;
+  onDelete: () => void;
+}) {
+  const envCount = Object.keys(server.env ?? {}).length;
+  const target =
+    server.transport === "http"
+      ? server.url ?? "—"
+      : [server.command, ...(server.args ?? [])].filter(Boolean).join(" ") || "—";
+
+  return (
+    <div className={`${s.card} ${!server.enabled ? s.cardDisabled : ""}`}>
+      <div className={s.cardMain}>
+        <div className={s.cardHead}>
+          <span className={s.cardName}>{server.name}</span>
+          <Badge tone={transportTone(server.transport)} variant="soft" size="sm">
+            {server.transport}
+          </Badge>
+          {server.auth && (
+            <Badge tone="info" variant="outline" size="sm">
+              {server.auth}
+            </Badge>
+          )}
+          {!server.enabled && (
+            <Badge tone="neutral" variant="outline" size="sm">
+              已禁用
+            </Badge>
+          )}
+        </div>
+
+        <div className={s.cardMetaRow}>
+          <span className={s.cardMono}>{target}</span>
+          {envCount > 0 && <span>{envCount} 个环境变量</span>}
+        </div>
+
+        {result && (
+          result.ok ? (
+            <p className={s.testOk}>
+              {result.tools.length === 0
+                ? "连接成功 · 未发现工具"
+                : `工具（${result.tools.length}）：`}
+              {result.tools.length > 0 && (
+                <span className={s.toolNames}>
+                  {result.tools.map((t) => t.name).join("、")}
+                </span>
+              )}
+            </p>
+          ) : (
+            <p className={s.testErr}>{result.error ?? "连接失败"}</p>
+          )
+        )}
+      </div>
+
+      <div className={s.cardActions}>
+        <Button
+          variant="ghost"
+          size="sm"
+          tone={server.enabled ? "success" : "neutral"}
+          loading={toggling}
+          leadingIcon={toggling ? undefined : <Power size={14} />}
+          onClick={onToggle}
+        >
+          {server.enabled ? "禁用" : "启用"}
+        </Button>
+        <Button
+          iconOnly
+          variant="ghost"
+          size="sm"
+          aria-label="测试连接"
+          title="测试连接"
+          loading={testing}
+          onClick={onTest}
+        >
+          {testing ? null : <Zap size={15} />}
+        </Button>
+        <Button
+          iconOnly
+          variant="ghost"
+          tone="danger"
+          size="sm"
+          aria-label="删除"
+          title="删除"
+          onClick={onDelete}
+        >
+          <Trash2 size={15} />
+        </Button>
+      </div>
+    </div>
+  );
+}

--- a/web/src/components/mcp/mcp.module.css
+++ b/web/src/components/mcp/mcp.module.css
@@ -1,0 +1,227 @@
+/* ── 弹窗外壳（基于 shared-ui Dialog.Content，自带居中面板/边框/阴影）── */
+.dialog {
+  width: 520px;
+  max-width: calc(100vw - 32px);
+}
+
+.dialogHead {
+  display: flex;
+  align-items: center;
+  justify-content: space-between;
+  gap: 12px;
+  padding: 16px 18px 12px;
+  border-bottom: 1px solid var(--h-line-soft);
+}
+
+.dialogTitle {
+  margin: 0;
+  font-size: 14px;
+  font-weight: 600;
+  color: var(--h-text);
+}
+
+.dialogClose {
+  display: inline-flex;
+  align-items: center;
+  justify-content: center;
+  width: 28px;
+  height: 28px;
+  border-radius: 6px;
+  border: 1px solid transparent;
+  background: transparent;
+  color: var(--h-text-3);
+  cursor: pointer;
+  flex-shrink: 0;
+}
+
+.dialogClose:hover:not(:disabled) {
+  background: var(--h-bg-soft);
+  color: var(--h-text);
+}
+
+.dialogClose:disabled {
+  opacity: 0.5;
+  cursor: default;
+}
+
+.dialogBody {
+  display: flex;
+  flex-direction: column;
+  gap: 14px;
+  padding: 16px 18px;
+  overflow-y: auto;
+}
+
+.dialogFoot {
+  display: flex;
+  justify-content: flex-end;
+  gap: 8px;
+  padding: 12px 18px 16px;
+  border-top: 1px solid var(--h-line-soft);
+}
+
+.formError {
+  font-size: 12px;
+  color: var(--h-err);
+  line-height: 1.5;
+}
+
+.intro {
+  margin: 0;
+  font-size: 12px;
+  color: var(--h-text-3);
+  line-height: 1.6;
+}
+
+.envArea {
+  min-height: 84px;
+  font-family: var(--h-font-mono);
+  font-size: 12px;
+}
+
+/* ── 服务 / 目录卡片 ── */
+.card {
+  display: flex;
+  align-items: flex-start;
+  gap: 12px;
+  padding: 14px;
+  border: 1px solid var(--h-line-soft);
+  border-radius: 10px;
+  background: var(--h-bg-pane);
+}
+
+.cardDisabled {
+  opacity: 0.6;
+}
+
+.cardMain {
+  flex: 1;
+  min-width: 0;
+  display: flex;
+  flex-direction: column;
+  gap: 6px;
+}
+
+.cardHead {
+  display: flex;
+  align-items: center;
+  gap: 8px;
+  flex-wrap: wrap;
+}
+
+.cardName {
+  font-family: var(--h-font-mono);
+  font-size: 13px;
+  font-weight: 600;
+  color: var(--h-text);
+  word-break: break-all;
+}
+
+.cardMetaRow {
+  display: flex;
+  align-items: center;
+  gap: 12px;
+  flex-wrap: wrap;
+  font-size: 11.5px;
+  color: var(--h-text-3);
+}
+
+.cardMono {
+  font-family: var(--h-font-mono);
+  font-size: 12px;
+  color: var(--h-text-3);
+  word-break: break-all;
+}
+
+.cardDesc {
+  font-size: 12px;
+  color: var(--h-text-2);
+  line-height: 1.5;
+}
+
+.cardActions {
+  display: flex;
+  align-items: center;
+  gap: 4px;
+  flex-shrink: 0;
+}
+
+.testOk {
+  font-size: 11.5px;
+  color: var(--h-ok, #22c55e);
+  line-height: 1.5;
+}
+
+.testErr {
+  font-size: 11.5px;
+  color: var(--h-err);
+  line-height: 1.5;
+  word-break: break-word;
+}
+
+.toolNames {
+  font-family: var(--h-font-mono);
+}
+
+.detail {
+  font-size: 11.5px;
+  color: var(--h-text-3);
+  line-height: 1.5;
+  word-break: break-all;
+}
+
+.detailLabel {
+  color: var(--h-text-2);
+  font-weight: 500;
+}
+
+.detail code {
+  font-family: var(--h-font-mono);
+  font-size: 11px;
+}
+
+.details {
+  font-size: 11.5px;
+  color: var(--h-text-3);
+}
+
+.details summary {
+  cursor: pointer;
+  user-select: none;
+}
+
+.detailsList {
+  margin: 4px 0 0;
+  padding-left: 16px;
+  display: flex;
+  flex-direction: column;
+  gap: 2px;
+}
+
+.detailsList code {
+  font-family: var(--h-font-mono);
+  font-size: 11px;
+  word-break: break-all;
+}
+
+.postInstall {
+  margin: 4px 0 0;
+  white-space: pre-wrap;
+  line-height: 1.5;
+}
+
+.diag {
+  font-size: 11.5px;
+  color: var(--h-warn, #f59e0b);
+  line-height: 1.5;
+}
+
+.link {
+  color: var(--h-accent);
+  text-decoration: underline;
+  text-underline-offset: 2px;
+}
+
+.link:hover {
+  opacity: 0.85;
+}

--- a/web/src/components/mcp/parse.ts
+++ b/web/src/components/mcp/parse.ts
@@ -1,0 +1,41 @@
+// stdio 服务的 args / env 解析，行为对齐官方 McpPage：
+// args 按空白或逗号切分；env 每行一个 KEY=VALUE（取第一个 = 之前为 key）。
+
+export function parseArgs(raw: string): string[] {
+  return raw
+    .split(/[\s,]+/)
+    .map((s) => s.trim())
+    .filter(Boolean);
+}
+
+export function parseEnv(raw: string): Record<string, string> {
+  const env: Record<string, string> = {};
+  raw
+    .split("\n")
+    .map((line) => line.trim())
+    .filter(Boolean)
+    .forEach((line) => {
+      const idx = line.indexOf("=");
+      if (idx === -1) return;
+      const key = line.slice(0, idx).trim();
+      const value = line.slice(idx + 1).trim();
+      if (key) env[key] = value;
+    });
+  return env;
+}
+
+export function isHttpUrl(value: string): boolean {
+  return /^https?:\/\//i.test(value.trim());
+}
+
+export function errText(err: unknown): string {
+  return err instanceof Error ? err.message : "操作失败";
+}
+
+import type { BadgeTone } from "@hermes/shared-ui";
+
+export function transportTone(transport: string): BadgeTone {
+  if (transport === "http") return "success";
+  if (transport === "stdio") return "warning";
+  return "neutral";
+}

--- a/web/src/hooks/use-mcp.ts
+++ b/web/src/hooks/use-mcp.ts
@@ -1,0 +1,126 @@
+import { getDefaultStore } from "jotai";
+import { useMutation, useQuery, useQueryClient } from "@tanstack/react-query";
+import { deleteJSON, fetchJSON, postJSON, putJSON } from "@/lib/transport";
+import { getGatewayClient } from "@/lib/gateway-client";
+import { useActiveProfileName } from "@/hooks/use-profiles";
+import { gwSessionIdAtom } from "@/stores/chat";
+import {
+  McpCatalogInstallResponse,
+  McpCatalogResponse,
+  McpEnabledResponse,
+  McpServer,
+  McpServerCreate,
+  McpServersFullResponse,
+  McpTestResult,
+  MutationOkResponse,
+} from "@hermes/protocol";
+
+// 桌面版的 MCP 管理直接打官方上游接口 /api/mcp/*（增删改 / 启停 / 测试 / 目录），
+// 与只读的 fork 端点 /api/mcp-servers（health 面板用）相互独立。
+
+const SERVERS_KEY = "mcp-servers-full";
+const CATALOG_KEY = "mcp-catalog";
+
+const mcpPath = (name: string, suffix = "") =>
+  `/api/mcp/servers/${encodeURIComponent(name)}${suffix}`;
+
+// GET /api/mcp/servers — 完整服务列表（env 已脱敏）。queryKey 含 profile，
+// 与 use-mcp-servers / use-profiles 的 profile-aware 失效保持一致。
+export function useMcpServersFull() {
+  const profile = useActiveProfileName();
+  return useQuery<McpServer[]>({
+    queryKey: [SERVERS_KEY, profile],
+    queryFn: async ({ signal }) => {
+      const r = await fetchJSON("/api/mcp/servers", { signal }, McpServersFullResponse);
+      return r.servers;
+    },
+    staleTime: 30_000,
+  });
+}
+
+// GET /api/mcp/catalog — Nous 官方目录 + 诊断。
+export function useMcpCatalog() {
+  const profile = useActiveProfileName();
+  return useQuery<McpCatalogResponse>({
+    queryKey: [CATALOG_KEY, profile],
+    queryFn: ({ signal }) => fetchJSON("/api/mcp/catalog", { signal }, McpCatalogResponse),
+    staleTime: 60_000,
+  });
+}
+
+export function useAddMcpServer() {
+  const qc = useQueryClient();
+  return useMutation<McpServer, Error, McpServerCreate>({
+    mutationFn: (body) => postJSON("/api/mcp/servers", body, McpServer),
+    onSuccess: () => qc.invalidateQueries({ queryKey: [SERVERS_KEY] }),
+  });
+}
+
+export function useRemoveMcpServer() {
+  const qc = useQueryClient();
+  return useMutation<MutationOkResponse, Error, string>({
+    mutationFn: (name) => deleteJSON(mcpPath(name), undefined, MutationOkResponse),
+    onSuccess: () => qc.invalidateQueries({ queryKey: [SERVERS_KEY] }),
+  });
+}
+
+export interface SetMcpEnabledInput {
+  name: string;
+  enabled: boolean;
+}
+
+export function useSetMcpEnabled() {
+  const qc = useQueryClient();
+  return useMutation<McpEnabledResponse, Error, SetMcpEnabledInput>({
+    mutationFn: ({ name, enabled }) =>
+      putJSON(mcpPath(name, "/enabled"), { enabled }, McpEnabledResponse),
+    onSuccess: () => qc.invalidateQueries({ queryKey: [SERVERS_KEY] }),
+  });
+}
+
+// 测试连接：后端连服务、列工具、断开。OAuth 服务会在这里触发浏览器授权。
+// 不进 query 缓存——结果由调用方按服务名自行存。
+export function useTestMcpServer() {
+  return useMutation<McpTestResult, Error, string>({
+    mutationFn: (name) => postJSON(mcpPath(name, "/test"), {}, McpTestResult),
+  });
+}
+
+export interface InstallCatalogInput {
+  name: string;
+  env?: Record<string, string>;
+  enable?: boolean;
+}
+
+export function useInstallCatalogEntry() {
+  const qc = useQueryClient();
+  return useMutation<McpCatalogInstallResponse, Error, InstallCatalogInput>({
+    mutationFn: ({ name, env, enable = true }) =>
+      postJSON(
+        "/api/mcp/catalog/install",
+        { name, env: env ?? {}, enable },
+        McpCatalogInstallResponse,
+      ),
+    onSuccess: () => {
+      qc.invalidateQueries({ queryKey: [SERVERS_KEY] });
+      qc.invalidateQueries({ queryKey: [CATALOG_KEY] });
+    },
+  });
+}
+
+export interface ReloadMcpResult {
+  status: string;
+  message?: string;
+}
+
+// 触发官方 reload.mcp（WS JSON-RPC，无 REST 版）。增删改 / 启停后调用即可让改动
+// 即时生效：handler 内部全局 shutdown_mcp_servers() + discover_mcp_tools()，再刷新
+// 当前会话的工具快照。settings 页通常没有活跃会话，session_id 传空字符串即触发
+// 全局重连，下次会话自然用上新配置。confirm:true 跳过会话级确认门。
+export async function reloadMcp(): Promise<ReloadMcpResult> {
+  const sessionId = getDefaultStore().get(gwSessionIdAtom) ?? "";
+  return getGatewayClient().request<ReloadMcpResult>("reload.mcp", {
+    session_id: sessionId,
+    confirm: true,
+  });
+}

--- a/web/src/hooks/use-profiles.ts
+++ b/web/src/hooks/use-profiles.ts
@@ -158,6 +158,8 @@ export const PROFILE_AWARE_QUERY_KEYS = [
   "env",
   "skills",
   "mcp-servers",
+  "mcp-servers-full",
+  "mcp-catalog",
   "status",
   "sessions",
   "session",

--- a/web/src/routes/mcp.module.css
+++ b/web/src/routes/mcp.module.css
@@ -6,70 +6,106 @@
   max-width: 720px;
 }
 
-.list {
-  display: flex;
-  flex-direction: column;
-  gap: 8px;
-}
-
-.row {
+/* 操作反馈横幅 */
+.notice {
   display: flex;
   align-items: center;
   gap: 12px;
-  padding: 12px 14px;
-  border: 1px solid var(--h-line-soft);
+  padding: 10px 14px;
   border-radius: 10px;
-  background: var(--h-bg-pane);
+  font-size: 12px;
+  line-height: 1.5;
+  margin-bottom: 16px;
+  max-width: 720px;
+  border: 1px solid var(--h-line);
+  background: var(--h-bg-soft);
+  color: var(--h-text-2);
 }
 
-.rowMeta {
-  display: flex;
-  align-items: center;
-  gap: 12px;
+.notice[data-tone="ok"] {
+  border-color: color-mix(in srgb, var(--h-ok, #22c55e) 35%, transparent);
+  background: color-mix(in srgb, var(--h-ok, #22c55e) 8%, transparent);
+}
+
+.notice[data-tone="warn"] {
+  border-color: color-mix(in srgb, var(--h-warn, #f59e0b) 40%, transparent);
+  background: color-mix(in srgb, var(--h-warn, #f59e0b) 7%, transparent);
+}
+
+.notice[data-tone="err"] {
+  border-color: color-mix(in srgb, var(--h-err) 35%, transparent);
+  background: color-mix(in srgb, var(--h-err) 6%, transparent);
+}
+
+.notice span {
   flex: 1;
   min-width: 0;
 }
 
-.rowName {
-  font-family: var(--h-font-mono);
-  font-size: 12.5px;
-  color: var(--h-text);
-  font-weight: 500;
-}
-
-.rowState {
+.noticeDismiss {
+  flex-shrink: 0;
   font-size: 11px;
-  padding: 2px 8px;
-  border-radius: 12px;
-  font-weight: 500;
+  padding: 4px 10px;
+  border-radius: 6px;
+  border: 1px solid var(--h-line);
+  background: transparent;
+  color: var(--h-text-2);
+  cursor: pointer;
 }
 
-.rowState[data-tone="ok"] {
-  color: var(--h-ok, #22c55e);
-  background: color-mix(in srgb, var(--h-ok, #22c55e) 14%, transparent);
-}
-
-.rowState[data-tone="off"] {
-  color: var(--h-text-3);
+.noticeDismiss:hover {
   background: var(--h-bg-soft);
 }
 
+/* 分区标题 */
+.sectionHead {
+  display: flex;
+  align-items: center;
+  gap: 8px;
+  margin: 24px 0 6px;
+  color: var(--h-text-2);
+}
+
+.sectionHead:first-of-type {
+  margin-top: 8px;
+}
+
+.sectionTitle {
+  font-size: 12.5px;
+  font-weight: 600;
+  color: var(--h-text);
+}
+
+.sectionCount {
+  font-size: 11px;
+  padding: 1px 7px;
+  border-radius: 10px;
+  background: var(--h-bg-soft);
+  color: var(--h-text-3);
+}
+
+.sectionDesc {
+  margin: 0 0 12px;
+  font-size: 11.5px;
+  color: var(--h-text-3);
+  line-height: 1.6;
+}
+
+.list {
+  display: flex;
+  flex-direction: column;
+  gap: 8px;
+  margin-bottom: 8px;
+}
+
 .emptyState {
-  padding: 28px;
+  padding: 24px;
   text-align: center;
   color: var(--h-text-3);
   font-size: 12.5px;
   border: 1px dashed var(--h-line);
   border-radius: 10px;
   line-height: 1.7;
-}
-
-.emptyState code {
-  font-family: var(--h-font-mono);
-  font-size: 11.5px;
-  background: var(--h-bg-soft);
-  padding: 1px 4px;
-  border-radius: 3px;
 }
 
 .errorState {
@@ -91,19 +127,4 @@
 .errorState p {
   margin: 0;
   color: var(--h-text-2);
-}
-
-.footnote {
-  margin-top: 24px;
-  font-size: 11.5px;
-  color: var(--h-text-3);
-  line-height: 1.7;
-}
-
-.footnote code {
-  font-family: var(--h-font-mono);
-  font-size: 11px;
-  background: var(--h-bg-soft);
-  padding: 1px 4px;
-  border-radius: 3px;
 }

--- a/web/src/routes/mcp.tsx
+++ b/web/src/routes/mcp.tsx
@@ -1,61 +1,278 @@
-import { useMcpServers } from "@/hooks/use-mcp-servers";
+import { useCallback, useState } from "react";
+import { Button } from "@hermes/shared-ui";
+import { Package, Plus, RefreshCw, Server } from "lucide-react";
+import type { McpCatalogEntry, McpServer, McpTestResult } from "@hermes/protocol";
+import {
+  reloadMcp,
+  useInstallCatalogEntry,
+  useMcpCatalog,
+  useMcpServersFull,
+  useSetMcpEnabled,
+  useTestMcpServer,
+} from "@/hooks/use-mcp";
+import {
+  McpAddDialog,
+  McpCatalogCard,
+  McpDeleteDialog,
+  McpInstallDialog,
+  McpServerCard,
+} from "@/components/mcp";
+import { errText } from "@/components/mcp/parse";
 import { SectionShell } from "./section-shell";
 import s from "./mcp.module.css";
 
-export function McpRoute() {
-  const { data, isLoading, isError, error } = useMcpServers();
+type Editor =
+  | { kind: "add" }
+  | { kind: "install"; entry: McpCatalogEntry }
+  | { kind: "delete"; name: string };
 
-  const summary = data?.summary;
+type Notice = { tone: "ok" | "warn" | "err"; text: string };
+
+export function McpRoute() {
+  const serversQuery = useMcpServersFull();
+  const catalogQuery = useMcpCatalog();
+  const setEnabled = useSetMcpEnabled();
+  const testMut = useTestMcpServer();
+  const installMut = useInstallCatalogEntry();
+
+  const [editor, setEditor] = useState<Editor | null>(null);
+  const [notice, setNotice] = useState<Notice | null>(null);
+  const [testResults, setTestResults] = useState<Record<string, McpTestResult>>({});
+  const [testingName, setTestingName] = useState<string | null>(null);
+  const [togglingName, setTogglingName] = useState<string | null>(null);
+  const [installingName, setInstallingName] = useState<string | null>(null);
+  const [reloading, setReloading] = useState(false);
+
+  const servers = serversQuery.data ?? [];
+  const isError = serversQuery.isError;
+  const isLoading = serversQuery.isLoading;
+  const enabledCount = servers.filter((srv) => srv.enabled).length;
+
   const sub = isError
     ? "未接入"
-    : summary
-      ? `${summary.enabled} / ${summary.total} 启用`
+    : serversQuery.data
+      ? `${enabledCount} / ${servers.length} 启用`
       : isLoading
         ? "加载中…"
         : "—";
 
+  // 增删改后调用官方 reload.mcp 让改动即时生效；失败不阻断操作，仅降级提示。
+  const runReload = useCallback(async (okText: string) => {
+    setReloading(true);
+    try {
+      const r = await reloadMcp();
+      // 正常返回 { status: "reloaded" }；若服务端开了确认门则返回
+      // confirm_required（理论上 confirm:true 已跳过）。其余已解析的返回都按成功处理。
+      if (r?.status === "confirm_required") {
+        setNotice({
+          tone: "warn",
+          text: "配置已保存。即时重载需要确认，重启 dashboard 或下次会话后生效。",
+        });
+      } else {
+        setNotice({ tone: "ok", text: okText });
+      }
+    } catch {
+      setNotice({
+        tone: "warn",
+        text: "配置已保存，但即时重载未成功；重启 dashboard 或下次会话后生效。",
+      });
+    } finally {
+      setReloading(false);
+    }
+  }, []);
+
+  const handleToggle = (server: McpServer) => {
+    const next = !server.enabled;
+    setTogglingName(server.name);
+    setEnabled.mutate(
+      { name: server.name, enabled: next },
+      {
+        onSuccess: () => runReload(`已${next ? "启用" : "禁用"} ${server.name}`),
+        onError: (err) => setNotice({ tone: "err", text: errText(err) }),
+        onSettled: () => setTogglingName(null),
+      },
+    );
+  };
+
+  const handleTest = (server: McpServer) => {
+    setTestingName(server.name);
+    testMut.mutate(server.name, {
+      onSuccess: (res) => {
+        setTestResults((prev) => ({ ...prev, [server.name]: res }));
+        if (!res.ok) setNotice({ tone: "err", text: `${server.name}：${res.error ?? "连接失败"}` });
+      },
+      onError: (err) => setNotice({ tone: "err", text: errText(err) }),
+      onSettled: () => setTestingName(null),
+    });
+  };
+
+  const handleInstallClick = (entry: McpCatalogEntry) => {
+    if (entry.required_env.length > 0) {
+      setEditor({ kind: "install", entry });
+      return;
+    }
+    setInstallingName(entry.name);
+    installMut.mutate(
+      { name: entry.name, enable: true },
+      {
+        onSuccess: (res) =>
+          res.background
+            ? setNotice({ tone: "ok", text: `${entry.name} 正在后台安装…` })
+            : runReload(`已安装 ${entry.name}`),
+        onError: (err) => setNotice({ tone: "err", text: errText(err) }),
+        onSettled: () => setInstallingName(null),
+      },
+    );
+  };
+
+  const catalog = catalogQuery.data?.entries ?? [];
+  const diagnosticsByName: Record<string, string[]> = {};
+  (catalogQuery.data?.diagnostics ?? []).forEach((d) => {
+    (diagnosticsByName[d.name] ??= []).push(d.message);
+  });
+
   return (
-    <SectionShell title="MCP 服务" sub={sub}>
+    <SectionShell
+      title="MCP 服务"
+      sub={sub}
+      right={
+        !isError ? (
+          <span style={{ display: "inline-flex", gap: 8 }}>
+            <Button
+              variant="outline"
+              size="sm"
+              leadingIcon={<RefreshCw size={14} />}
+              loading={reloading}
+              onClick={() => runReload("已重新载入 MCP")}
+            >
+              重新载入
+            </Button>
+            <Button
+              variant="solid"
+              tone="accent"
+              size="sm"
+              leadingIcon={<Plus size={14} />}
+              onClick={() => setEditor({ kind: "add" })}
+            >
+              添加服务
+            </Button>
+          </span>
+        ) : undefined
+      }
+    >
       <p className={s.desc}>
-        Model Context Protocol 服务由 Hermes 网关托管。这里展示 dashboard 当前感知到的服务实例与启用状态。
+        Model Context Protocol 服务由 Hermes 网关托管。在这里添加、启停、测试服务，或从官方目录一键安装；改动通过官方 reload 即时生效，无需手改配置或重启。
       </p>
+
+      {notice && (
+        <div className={s.notice} data-tone={notice.tone}>
+          <span>{notice.text}</span>
+          <button type="button" className={s.noticeDismiss} onClick={() => setNotice(null)}>
+            知道了
+          </button>
+        </div>
+      )}
+
+      {/* ── 我的 MCP 服务 ── */}
+      <div className={s.sectionHead}>
+        <Server size={15} />
+        <span className={s.sectionTitle}>我的 MCP 服务</span>
+        {!isError && serversQuery.data && (
+          <span className={s.sectionCount}>{servers.length}</span>
+        )}
+      </div>
 
       {isError ? (
         <div className={s.errorState}>
-          <strong>无法读取 MCP 状态。</strong>
+          <strong>无法读取 MCP 服务。</strong>
           <p>
-            {error instanceof Error ? error.message : "未知错误"}。常见原因是 dashboard 启动早于 gateway，重启 dashboard 即可。
+            {serversQuery.error instanceof Error ? serversQuery.error.message : "未知错误"}
+            。常见原因是 dashboard 启动早于 gateway，重启 dashboard 即可。
           </p>
         </div>
-      ) : isLoading || !data ? (
+      ) : isLoading ? (
         <div className={s.emptyState}>加载中…</div>
-      ) : data.servers.length === 0 ? (
+      ) : servers.length === 0 ? (
         <div className={s.emptyState}>
-          没有任何 MCP 服务。可以在 <code>~/.hermes/config.yaml</code> 的 <code>mcp_servers</code>
-          字段添加，或者通过{" "}
-          <code>hermes config set mcp_servers.&lt;name&gt;.command "..."</code> 添加。
+          还没有任何 MCP 服务。点右上角「添加服务」，或从下方目录一键安装。
         </div>
       ) : (
         <div className={s.list}>
-          {data.servers.map((srv) => (
-            <div key={srv.name} className={s.row}>
-              <div className={s.rowMeta}>
-                <span className={s.rowName}>{srv.name}</span>
-                <span
-                  className={s.rowState}
-                  data-tone={srv.enabled ? "ok" : "off"}
-                >
-                  {srv.enabled ? "已启用" : "已禁用"}
-                </span>
-              </div>
-            </div>
+          {servers.map((server) => (
+            <McpServerCard
+              key={server.name}
+              server={server}
+              result={testResults[server.name]}
+              testing={testingName === server.name}
+              toggling={togglingName === server.name}
+              onTest={() => handleTest(server)}
+              onToggle={() => handleToggle(server)}
+              onDelete={() => setEditor({ kind: "delete", name: server.name })}
+            />
           ))}
         </div>
       )}
 
-      <p className={s.footnote}>
-        启用/禁用 MCP 服务暂未在 UI 内提供 —— 修改 <code>~/.hermes/config.yaml</code> 后重启 dashboard 生效。
-      </p>
+      {/* ── 服务目录 ── */}
+      <div className={s.sectionHead}>
+        <Package size={15} />
+        <span className={s.sectionTitle}>服务目录</span>
+        {catalogQuery.data && <span className={s.sectionCount}>{catalog.length}</span>}
+      </div>
+      <p className={s.sectionDesc}>浏览官方审核过的 MCP 服务，一键安装。</p>
+
+      {catalogQuery.isError ? (
+        <div className={s.emptyState}>目录暂不可用。</div>
+      ) : catalogQuery.isLoading ? (
+        <div className={s.emptyState}>加载中…</div>
+      ) : catalog.length === 0 ? (
+        <div className={s.emptyState}>目录暂无可用条目。</div>
+      ) : (
+        <div className={s.list}>
+          {catalog.map((entry) => (
+            <McpCatalogCard
+              key={entry.name}
+              entry={entry}
+              diagnostics={diagnosticsByName[entry.name] ?? []}
+              installing={installingName === entry.name}
+              onInstall={() => handleInstallClick(entry)}
+            />
+          ))}
+        </div>
+      )}
+
+      {editor?.kind === "add" && (
+        <McpAddDialog
+          existingNames={servers.map((srv) => srv.name)}
+          onClose={() => setEditor(null)}
+          onSaved={() => runReload("已添加服务并重新载入")}
+        />
+      )}
+      {editor?.kind === "install" && (
+        <McpInstallDialog
+          entry={editor.entry}
+          onClose={() => setEditor(null)}
+          onInstalled={(background) =>
+            background
+              ? setNotice({ tone: "ok", text: `${editor.entry.name} 正在后台安装…` })
+              : runReload(`已安装 ${editor.entry.name}`)
+          }
+        />
+      )}
+      {editor?.kind === "delete" && (
+        <McpDeleteDialog
+          name={editor.name}
+          onClose={() => setEditor(null)}
+          onDeleted={() => {
+            setTestResults((prev) => {
+              const next = { ...prev };
+              delete next[editor.name];
+              return next;
+            });
+            void runReload(`已删除 ${editor.name}`);
+          }}
+        />
+      )}
     </SectionShell>
   );
 }


### PR DESCRIPTION
## 背景

中文桌面版的 MCP 功能此前只有一个**只读**状态页（`web/src/routes/mcp.tsx`，仅显示 name + enabled），要改服务还得手动编辑 `~/.hermes/config.yaml` 并重启 dashboard。

调研后发现:**官方 MCP 引擎本来就在桌面版里跑着**——桌面外壳启动的 `hermes dashboard`(Core)已内置官方完整的 MCP 客户端**和**一整套上游管理接口 `/api/mcp/*`(增删改 / 启停 / 测试连接 / 目录浏览 / 一键安装),桌面版只是从没接上。

本 PR 把桌面前端接到这套**官方上游接口**,并把官方 Dashboard 的 `McpPage` 完整交互按桌面版设计系统(shared-ui + Zod 协议 + TanStack Query + CSS Modules)重做、文案本地化。**不是** Python→Rust 移植,**不是**重新实现 MCP 客户端。

## 改动

- **协议** `packages/protocol/src/hermes-api.ts`:补齐 `/api/mcp/*` 的 Zod schema(服务/测试/目录/安装),并给 `McpServerCreate` 增加 `env`/`auth`。
- **数据** `web/src/hooks/use-mcp.ts`(新):服务/目录查询 + 增删改/启停/测试/安装 mutation;增删改后复用官方 `reload.mcp`(WS JSON-RPC)**即时生效**,无需重启。
- **界面**:重写 `/mcp` 为完整管理页 + `web/src/components/mcp/*`(添加/安装/删除弹窗、服务卡、目录卡)。
- **测试** `packages/protocol/src/mcp-api.test.ts`(新):按 `web_server.py` 各 handler 真实输出锁定响应形状。

> **Core 零改动、零新增 fork 补丁**——`/api/mcp/*` 与 `reload.mcp` 均为上游能力。

## 验证

- `pnpm -r typecheck` ✅(protocol / shared-ui / web)
- 单元测试 ✅:protocol 51(含 9 个新 MCP 契约测试)、web 789
- 健康面板 / 侧栏 / 命令面板的 `/mcp` 入口不受影响(只读端点 `/api/mcp-servers` 保留)

### 待人工点穿(需真实桌面环境)
进 `/mcp` → 添加 stdio `npx -y @modelcontextprotocol/server-filesystem /tmp` → 测试连接 → 启停 → 开会话确认工具可用(验证 `reload.mcp` 即时生效)→ 目录安装/删除。

🤖 Generated with [Claude Code](https://claude.com/claude-code)