### PR TITLE
fix: tolerate upstream /api/fs/list shape so file browser lists dirs

### DIFF
--- a/packages/protocol/src/hermes-api.test.ts
+++ b/packages/protocol/src/hermes-api.test.ts
@@ -9,6 +9,7 @@ import {
   CronRunDetail,
   CronRunsResponse,
   ElevenLabsVoicesResponse,
+  FsListResponse,
   ProfileCreateResponse,
   ProfileSummary,
   SessionsResponse,
@@ -454,5 +455,39 @@ describe("OAuth schemas", () => {
       expires_in: 900,
     });
     expect(start.flow).toBe("loopback");
+  });
+});
+
+describe("FsListResponse schema", () => {
+  it("parses the upstream /api/fs/list shape (isDirectory, no path/parent/home)", () => {
+    const parsed = FsListResponse.parse({
+      entries: [
+        { name: "src", path: "/proj/src", isDirectory: true },
+        { name: "README.md", path: "/proj/README.md", isDirectory: false },
+      ],
+    });
+    // Normalized to the canonical `is_dir` regardless of wire field name.
+    expect(parsed.entries[0].is_dir).toBe(true);
+    expect(parsed.entries[1].is_dir).toBe(false);
+    expect(parsed.path).toBeUndefined();
+    expect(parsed.parent).toBeUndefined();
+    expect(parsed.home).toBeUndefined();
+  });
+
+  it("surfaces upstream's HTTP-200 soft error", () => {
+    const parsed = FsListResponse.parse({ entries: [], error: "EACCES" });
+    expect(parsed.error).toBe("EACCES");
+    expect(parsed.entries).toEqual([]);
+  });
+
+  it("still parses the legacy fork shape (is_dir + path/parent/home)", () => {
+    const parsed = FsListResponse.parse({
+      path: "/proj",
+      parent: "/",
+      home: "/home/u",
+      entries: [{ name: "src", path: "/proj/src", is_dir: true }],
+    });
+    expect(parsed.entries[0].is_dir).toBe(true);
+    expect(parsed.parent).toBe("/");
   });
 });

--- a/packages/protocol/src/hermes-api.ts
+++ b/packages/protocol/src/hermes-api.ts
@@ -1203,17 +1203,29 @@ export const AttachmentUploadResult = z.object({
 }).passthrough();
 export type AttachmentUploadResult = z.infer<typeof AttachmentUploadResult>;
 
+// `/api/fs/list` entry. Upstream's handler returns `isDirectory`; the fork's
+// original P-004 handler returned `is_dir`. Accept either off the wire and
+// normalize to a single canonical `is_dir` so every consumer (and the inferred
+// type) stays stable regardless of which Core shape answers.
 export const FsEntry = z.object({
   name: z.string(),
   path: z.string(),
-  is_dir: z.boolean(),
-});
+  is_dir: z.boolean().optional(),
+  isDirectory: z.boolean().optional(),
+}).transform((e) => ({
+  name: e.name,
+  path: e.path,
+  is_dir: e.is_dir ?? e.isDirectory ?? false,
+}));
 export type FsEntry = z.infer<typeof FsEntry>;
 
+// `path` / `parent` / `home` are fork-only extras (gone after an upstream sync),
+// so they're optional; `error` is upstream's HTTP-200 soft error (EACCES/ENOENT/…).
 export const FsListResponse = z.object({
-  path: z.string(),
-  parent: z.string().nullable(),
-  home: z.string(),
+  path: z.string().optional(),
+  parent: z.string().nullable().optional(),
+  home: z.string().optional(),
+  error: z.string().optional(),
   entries: z.array(FsEntry).default([]),
 }).passthrough();
 export type FsListResponse = z.infer<typeof FsListResponse>;

--- a/web/src/components/chat/preview-rail/file-preview-tab.tsx
+++ b/web/src/components/chat/preview-rail/file-preview-tab.tsx
@@ -10,7 +10,13 @@ import {
 import { ChevronUp, File as FileIcon, Folder, RefreshCw } from "lucide-react";
 import { useFsList } from "@/hooks/use-fs-list";
 import type { FilePreview } from "@/lib/runtime";
-import { buildBreadcrumbs, formatBytes, isMarkdownPath } from "@/lib/preview-rail";
+import {
+  buildBreadcrumbs,
+  formatBytes,
+  fsListErrorText,
+  isMarkdownPath,
+  parentDir,
+} from "@/lib/preview-rail";
 import { MarkdownText } from "@/components/chat/markdown-renderer";
 import s from "./preview-rail.module.css";
 
@@ -50,7 +56,9 @@ export function FilePreviewTab({ workspaceRoot, filePath, onSelectFile }: FilePr
       return a.name.localeCompare(b.name);
     });
   }, [list.data?.entries]);
-  const canGoUp = Boolean(dir && workspaceRoot && dir !== workspaceRoot && list.data?.parent);
+  // Derive the parent client-side: `/api/fs/list` no longer returns `parent`.
+  const parent = useMemo(() => parentDir(dir), [dir]);
+  const canGoUp = Boolean(dir && workspaceRoot && dir !== workspaceRoot && parent);
   const crumbs = useMemo(() => buildBreadcrumbs(dir), [dir]);
 
   // Draggable split between the directory browser (top) and the content (below).
@@ -188,7 +196,7 @@ export function FilePreviewTab({ workspaceRoot, filePath, onSelectFile }: FilePr
           <button
             type="button"
             className={s.fileEntry}
-            onClick={() => list.data?.parent && setDir(list.data.parent)}
+            onClick={() => parent && setDir(parent)}
           >
             <ChevronUp size={14} className={s.fileEntryIcon} aria-hidden />
             ..
@@ -212,8 +220,8 @@ export function FilePreviewTab({ workspaceRoot, filePath, onSelectFile }: FilePr
             {entry.name}
           </button>
         ))}
-        {list.isError ? (
-          <div className={s.crumb}>无法打开此目录（可能超出可访问范围）。</div>
+        {list.isError || list.data?.error ? (
+          <div className={s.crumb}>{fsListErrorText(list.data?.error)}</div>
         ) : !list.isLoading && entries.length === 0 ? (
           <div className={s.crumb}>空目录</div>
         ) : null}

--- a/web/src/components/composer/workspace-picker/workspace-picker-modal.tsx
+++ b/web/src/components/composer/workspace-picker/workspace-picker-modal.tsx
@@ -11,6 +11,7 @@ import { createPortal } from "react-dom";
 import { ArrowUp, Folder, X } from "lucide-react";
 import type { FsEntry } from "@hermes/protocol";
 import { useFsList } from "@/hooks/use-fs-list";
+import { parentDir } from "@/lib/preview-rail";
 import s from "./workspace-picker-modal.module.css";
 
 interface WorkspacePickerModalProps {
@@ -84,7 +85,8 @@ export function WorkspacePickerModal({
   );
 
   const resolvedPath = data?.path ?? currentPath;
-  const parentPath = data?.parent ?? null;
+  // `/api/fs/list` no longer returns `parent`; derive it from the resolved path.
+  const parentPath = parentDir(resolvedPath);
   const [lastKnownHome, setLastKnownHome] = useState("");
   const home = data?.home ?? lastKnownHome;
   const breadcrumb = useMemo(() => splitBreadcrumb(resolvedPath, home), [resolvedPath, home]);

--- a/web/src/lib/preview-rail.test.ts
+++ b/web/src/lib/preview-rail.test.ts
@@ -5,9 +5,11 @@ import {
   detectLanguage,
   fileExtension,
   formatBytes,
+  fsListErrorText,
   isMarkdownPath,
   isPreviewableUrl,
   normalizePreviewPanel,
+  parentDir,
   toFencedMarkdown,
 } from "./preview-rail";
 
@@ -118,5 +120,36 @@ describe("buildBreadcrumbs", () => {
       { label: "Users", path: "C:\\Users" },
       { label: "Enzo", path: "C:\\Users\\Enzo" },
     ]);
+  });
+});
+
+describe("parentDir", () => {
+  it("returns the parent of a POSIX directory", () => {
+    expect(parentDir("/a/b/c")).toBe("/a/b");
+    expect(parentDir("/a")).toBe("/");
+  });
+
+  it("returns null at the filesystem root or for blank input", () => {
+    expect(parentDir("/")).toBeNull();
+    expect(parentDir("")).toBeNull();
+  });
+
+  it("returns the parent of a Windows directory", () => {
+    expect(parentDir("C:\\Users\\x")).toBe("C:\\Users");
+    expect(parentDir("C:\\Users")).toBe("C:\\");
+    expect(parentDir("C:\\")).toBeNull();
+  });
+});
+
+describe("fsListErrorText", () => {
+  it("maps errno-style codes to messages", () => {
+    expect(fsListErrorText("ENOENT")).toContain("不存在");
+    expect(fsListErrorText("EACCES")).toContain("无权限");
+    expect(fsListErrorText("ENOTDIR")).toContain("不是一个目录");
+  });
+
+  it("falls back for unknown codes and transport failures", () => {
+    expect(fsListErrorText(undefined)).toContain("无法读取");
+    expect(fsListErrorText("weird")).toContain("无法读取");
   });
 });

--- a/web/src/lib/preview-rail.ts
+++ b/web/src/lib/preview-rail.ts
@@ -158,3 +158,32 @@ export function buildBreadcrumbs(dir: string): Breadcrumb[] {
   });
   return crumbs;
 }
+
+/**
+ * Parent of an absolute directory, or `null` at the filesystem root. Reuses
+ * {@link buildBreadcrumbs} so POSIX and Windows splitting stay in one place —
+ * the parent is simply the second-to-last breadcrumb. Used to drive the ".."
+ * control client-side now that `/api/fs/list` no longer returns `parent`.
+ */
+export function parentDir(dir: string): string | null {
+  const crumbs = buildBreadcrumbs(dir);
+  return crumbs.length >= 2 ? crumbs[crumbs.length - 2].path : null;
+}
+
+/**
+ * Human message for a `/api/fs/list` failure. `code` is the upstream HTTP-200
+ * soft-error string (errno-style); `undefined` covers transport/HTTP failures
+ * surfaced via TanStack Query's `isError`.
+ */
+export function fsListErrorText(code?: string | null): string {
+  switch (code) {
+    case "ENOENT":
+      return "目录不存在。";
+    case "EACCES":
+      return "无权限访问此目录。";
+    case "ENOTDIR":
+      return "这不是一个目录。";
+    default:
+      return "无法读取此目录，请稍后重试。";
+  }
+}


### PR DESCRIPTION
## Problem

Desktop users on **both Windows and macOS** report that the session preview rail's **文件** tab shows **"无法打开此目录（可能超出可访问范围）"** for *every* directory.

**Root cause: a Core↔Desktop response-shape contract drift.** An upstream sync into `Hermes-CN-Core` replaced the fork's `/api/fs/list` handler. The route (`hermes_cli/web_server.py` `fs_list` → `_fs_path`) now returns the **upstream** shape:

```json
{ "entries": [ { "name": "...", "path": "...", "isDirectory": true } ] }
```

and on permission/IO errors returns **HTTP 200** with `{ "entries": [], "error": "EACCES" }`. It no longer sends the fork's top-level `path`/`parent`/`home`, and entries use `isDirectory` instead of `is_dir`.

The Desktop's Zod parser `FsListResponse` still **required** the old fork shape, so `z.parse` threw inside `fetchJSON`, TanStack Query set `list.isError`, and the UI rendered the generic error for every directory. Because the failure is a Zod parse in the webview, it hit Win + Mac identically and every directory — hence the volume of reports. The same endpoint silently broke the **workspace picker** and **command-palette file search** too.

## Fix

Adapt the **Desktop frontend** to upstream's actual shape (durable across future upstream syncs; no Core change):

- `FsEntry` accepts `isDirectory | is_dir` and normalizes to a canonical `is_dir`, so every consumer and the inferred type stay stable.
- `FsListResponse` makes `path`/`parent`/`home` optional and surfaces upstream's HTTP-200 soft `error`.
- New `parentDir()` helper (reuses `buildBreadcrumbs`) derives the ".." parent client-side now that Core no longer sends `parent` — applied in the preview rail and the workspace picker up-nav.
- Error/empty messaging maps the soft-error codes (`ENOENT`/`EACCES`/`ENOTDIR`) to accurate text and drops the misleading "超出可访问范围" wording (no home restriction remains upstream).

We deliberately do **not** restore P-004's home-subtree restriction — it would re-break workspaces that legitimately live outside `$HOME`.

## Tests

- `packages/protocol/src/hermes-api.test.ts`: upstream payload normalizes to `is_dir`, soft `error` surfaces, legacy fork shape still parses.
- `web/src/lib/preview-rail.test.ts`: `parentDir` POSIX/root/Windows + `fsListErrorText` mapping.
- `pnpm typecheck` ✅ · `pnpm test:unit` ✅ (protocol 54, web 800). No Rust touched.

🤖 Generated with [Claude Code](https://claude.com/claude-code)