### PR TITLE
perf: instant model save/set — drop 450ms loading floor (Core P-027 companion)

### DIFF
--- a/web/src/routes/settings-models-section.tsx
+++ b/web/src/routes/settings-models-section.tsx
@@ -83,7 +83,12 @@ const PROVIDER_GROUPS: { prefix: string; name: string; priority: number }[] = [
   { prefix: "COMPSHARE_", name: "优云智算 (Compshare)", priority: 14 },
 ];
 
-const PROVIDER_ACTION_LOADING_MIN_MS = 450;
+// Minimum on-screen time for the save / set-current spinner. Purely
+// anti-flicker — keep it small. It used to be 450ms to mask a slow backend,
+// but the model save/switch round-trip is fast now (Core P-027 took the
+// blocking models.dev fetch off the critical path), so the old floor just
+// added dead wait to every action.
+const PROVIDER_ACTION_LOADING_MIN_MS = 150;
 const PROVIDER_SWITCH_LOADING_MIN_MS = 280;
 const PROVIDER_ORDER_SAVE_DEBOUNCE_MS = 320;
 const EMPTY_ENV_VARS: Record<string, EnvVarInfo> = {};


### PR DESCRIPTION
## What

The /models page's **保存** and **设为当前模型** buttons held their loading spinner for a minimum of **450ms** (`PROVIDER_ACTION_LOADING_MIN_MS`). That floor existed to mask a slow backend.

With the companion Core change — **Eynzof/Hermes-CN-Core#60** (P-027) — the blocking `models.dev` fetch is off the model save/switch critical path, so the round-trip is fast now. The 450ms floor was just dead wait on every action. Reduce it to **150ms**: enough to avoid spinner flicker, without the perceived sluggishness.

## Why

Pure UX latency cleanup. The real "十几秒" stall was the backend network call (fixed in Core#60); this removes the remaining client-side floor so the action feels instant once the backend returns.

## Validation

- `pnpm -r typecheck` ✓ (protocol / shared-ui / web)
- web `test:unit` ✓ (789 tests, 92 files)
- `cargo check` ✓
- No unit test references the floor constant or the save/set handlers.

## Note

The backend fix is the load-bearing one; merge order doesn't matter (this change is independent and safe on its own).

🤖 Generated with [Claude Code](https://claude.com/claude-code)
