### PR TITLE
fix: tolerate null/absent fields in session search + status responses

### DIFF
--- a/packages/protocol/src/hermes-api.test.ts
+++ b/packages/protocol/src/hermes-api.test.ts
@@ -12,10 +12,12 @@ import {
   FsListResponse,
   ProfileCreateResponse,
   ProfileSummary,
+  SearchResponse,
   SessionsResponse,
   SkillsHubSearchResponse,
   SessionCompressResult,
   SessionSummary,
+  StatusResponse,
 } from "./hermes-api";
 
 
@@ -489,5 +491,67 @@ describe("FsListResponse schema", () => {
     });
     expect(parsed.entries[0].is_dir).toBe(true);
     expect(parsed.parent).toBe("/");
+  });
+});
+
+describe("SearchResponse schema", () => {
+  it("tolerates null role/model/source/started from the session-id-match branch", () => {
+    const parsed = SearchResponse.parse({
+      results: [
+        {
+          session_id: "s1",
+          snippet: "Session ID: s1",
+          role: null,
+          source: null,
+          model: null,
+          session_started: null,
+        },
+      ],
+    });
+    // Null wire values normalize to undefined (Zod v3 `.optional()` would throw on null).
+    expect(parsed.results[0].role).toBeUndefined();
+    expect(parsed.results[0].model).toBeUndefined();
+    expect(parsed.results[0].source).toBeUndefined();
+    expect(parsed.results[0].session_started).toBeUndefined();
+    expect(parsed.results[0].session_id).toBe("s1");
+  });
+
+  it("still accepts populated fields", () => {
+    const parsed = SearchResponse.parse({
+      results: [{ session_id: "s2", snippet: "hi", role: "user", model: "gpt", session_started: 123 }],
+    });
+    expect(parsed.results[0].model).toBe("gpt");
+    expect(parsed.results[0].session_started).toBe(123);
+  });
+});
+
+describe("StatusResponse schema", () => {
+  it("parses an auth-gated /api/status that omits gateway_pid/gateway_health_url", () => {
+    const parsed = StatusResponse.parse({
+      version: "0.5.4",
+      release_date: "2026-06-28",
+      gateway_running: false,
+      gateway_exit_reason: null,
+      gateway_updated_at: null,
+      active_sessions: 0,
+    });
+    expect(parsed.gateway_pid).toBeUndefined();
+    expect(parsed.gateway_health_url).toBeUndefined();
+    expect(parsed.gateway_running).toBe(false);
+  });
+
+  it("parses a loopback /api/status that includes them", () => {
+    const parsed = StatusResponse.parse({
+      version: "0.5.4",
+      release_date: "2026-06-28",
+      gateway_running: true,
+      gateway_pid: 4321,
+      gateway_health_url: "http://127.0.0.1:9120/health",
+      gateway_exit_reason: null,
+      gateway_updated_at: null,
+      active_sessions: 2,
+    });
+    expect(parsed.gateway_pid).toBe(4321);
+    expect(parsed.gateway_health_url).toContain("9120");
   });
 });

--- a/packages/protocol/src/hermes-api.ts
+++ b/packages/protocol/src/hermes-api.ts
@@ -2,6 +2,13 @@ import { z } from "zod";
 
 const NullableStringAsEmpty = z.string().nullable().optional().transform((value) => value ?? "");
 
+// Wire value may be null (SQL NULL) or absent; normalize both to `undefined` so
+// consumers keep the simple `string | undefined` / `number | undefined` shape.
+// Zod v3's bare `.optional()` rejects an explicit JSON `null`, which is exactly
+// how routes serialize unset columns — hence these tolerant helpers.
+const NullishString = z.string().nullish().transform((value) => value ?? undefined);
+const NullishNumber = z.number().nullish().transform((value) => value ?? undefined);
+
 function stringifyMessageContent(value: unknown): string | null {
   if (typeof value === "string") return value;
   if (value == null) return null;
@@ -31,8 +38,11 @@ export const StatusResponse = z.object({
   config_version: z.number().optional(),
   latest_config_version: z.number().optional(),
   gateway_running: z.boolean(),
-  gateway_pid: z.number().nullable(),
-  gateway_health_url: z.string().nullable(),
+  // `/api/status` is in PUBLIC_API_PATHS and omits these on an auth-gated bind,
+  // emitting them only on a loopback/insecure bind — so they're optional too,
+  // not merely nullable, otherwise a gated dashboard's 200 fails to parse.
+  gateway_pid: z.number().nullable().optional(),
+  gateway_health_url: z.string().nullable().optional(),
   gateway_state: NullableStringAsEmpty,
   gateway_platforms: z.record(z.string(), PlatformStatus).optional(),
   gateway_exit_reason: z.string().nullable(),
@@ -371,11 +381,13 @@ export type MessagesResponse = z.infer<typeof MessagesResponse>;
 
 export const SearchResult = z.object({
   session_id: z.string(),
-  snippet: z.string().optional(),
-  role: z.string().optional(),
-  source: z.string().optional(),
-  model: z.string().optional(),
-  session_started: z.number().optional(),
+  // The session-id-match branch hardcodes `role: null` and passes nullable
+  // `model`/`source`/`started_at` straight from SQL — all must tolerate null.
+  snippet: NullishString,
+  role: NullishString,
+  source: NullishString,
+  model: NullishString,
+  session_started: NullishNumber,
 });
 export type SearchResult = z.infer<typeof SearchResult>;
 


### PR DESCRIPTION
## Context

Follow-up to the `/api/fs/list` contract-drift incident (#330). I audited every other Desktop-consumed `/api/*` route's Zod schema against the actual Core output. Most are defensive (`.passthrough()` / `.optional()`), but **two** had the same failure class as #330 — a Zod field stricter than what the route emits, so a 200 throws in `z.parse` and breaks the feature.

## Fixes

### DRIFT 2 — session search (active bug)
`/api/sessions/search`'s session-id-match branch hardcodes `"role": None` and passes nullable `model`/`source`/`started_at` straight from SQL (`web_server.py:3434-3437`). Zod v3's bare `.optional()` **rejects an explicit `null`**, so any search that hits that branch — or a content match on a session with a null `model` — threw, and search showed an error instead of results. `SearchResult` fields are now null-tolerant (`null` → `undefined`, inferred type unchanged → zero consumer ripple).

### DRIFT 1 — `/api/status` (latent hardening)
`/api/status` is in `PUBLIC_API_PATHS` and omits `gateway_pid`/`gateway_health_url` on an auth-gated bind, emitting them only on a loopback/insecure bind (`web_server.py:2110-2117`). They were `.nullable()` (required-present), so a gated dashboard's 200 would fail to parse. Now `.nullable().optional()`. Latent for the loopback managed runtime that ships, but correct to harden. Consumers already use `?.`/`?? "—"`/truthy, so no ripple.

### Not a bug — archive (false positive)
The audit also flagged `POST /api/sessions/{id}/archive` as a 404 (Core only has `PATCH /api/sessions/{id}`). It's a **false positive**: the desktop's Rust proxy intercepts that route locally via `session_archive::handle_archive_request` (`src/commands/api_proxy.rs:434`) and serves archive state from `ui_store`. No change needed.

## Verification

- `pnpm typecheck` ✅ (zero ripple) · `pnpm test:unit` ✅ (protocol 58 incl. 4 new, web 800).
- Same tolerant-parser direction as #330; durable across future upstream syncs; no Core change.

🤖 Generated with [Claude Code](https://claude.com/claude-code)