### PR TITLE
feat: add GLM-5.2 quick-pick and refresh CN provider models

### DIFF
--- a/web/src/lib/provider-catalog.ts
+++ b/web/src/lib/provider-catalog.ts
@@ -220,7 +220,7 @@ export function parseContextWindowInput(raw: string | undefined): number {
   return Math.floor(parsed);
 }
 
-export const BUILTIN_PROVIDER_CATALOG_VERSION = "2026.06.07.1";
+export const BUILTIN_PROVIDER_CATALOG_VERSION = "2026.06.28.1";
 
 export const BUILTIN_PROVIDER_CATALOG: ProviderCatalog = {
   version: BUILTIN_PROVIDER_CATALOG_VERSION,
@@ -269,6 +269,8 @@ export const BUILTIN_PROVIDER_CATALOG: ProviderCatalog = {
       defaultModel: "qwen3-coder-plus",
       models: [
         { id: "qwen3-coder-plus", supportsTools: true, supportsReasoning: true },
+        { id: "qwen3.7-max", supportsTools: true, supportsReasoning: true },
+        { id: "qwen3.7-plus", supportsTools: true, supportsVision: true, supportsReasoning: true },
         { id: "qwen3-max", supportsTools: true, supportsReasoning: true },
         { id: "qwen-plus", supportsTools: true },
         { id: "qwen-max", supportsTools: true },
@@ -324,6 +326,7 @@ export const BUILTIN_PROVIDER_CATALOG: ProviderCatalog = {
       docsUrl: "https://docs.bigmodel.cn/",
       defaultModel: "glm-5.1",
       models: [
+        { id: "glm-5.2", supportsTools: true, supportsReasoning: true },
         { id: "glm-5.1", supportsTools: true, supportsReasoning: true },
         { id: "glm-4.6", supportsTools: true, supportsReasoning: true },
         { id: "glm-4.5", supportsTools: true },
@@ -342,6 +345,7 @@ export const BUILTIN_PROVIDER_CATALOG: ProviderCatalog = {
       docsUrl: "https://docs.bigmodel.cn/cn/api/introduction",
       defaultModel: "glm-5.1",
       models: [
+        { id: "glm-5.2", supportsTools: true, supportsReasoning: true },
         { id: "glm-5.1", supportsTools: true, supportsReasoning: true },
         { id: "glm-4.7", supportsTools: true, supportsReasoning: true },
         { id: "glm-4.6", supportsTools: true, supportsReasoning: true },
@@ -360,6 +364,7 @@ export const BUILTIN_PROVIDER_CATALOG: ProviderCatalog = {
       docsUrl: "https://platform.moonshot.cn/docs",
       defaultModel: "kimi-k2.6",
       models: [
+        { id: "kimi-k2.7-code", supportsTools: true, supportsReasoning: true },
         { id: "kimi-k2.6", supportsTools: true },
         { id: "kimi-k2-0905-preview", supportsTools: true },
         { id: "kimi-latest", supportsTools: true },
@@ -520,6 +525,7 @@ export const BUILTIN_PROVIDER_CATALOG: ProviderCatalog = {
       docsUrl: "https://platform.xiaomimimo.com/docs/en-US/api/chat/openai-api",
       defaultModel: "mimo-v2.5-pro",
       models: [
+        { id: "mimo-v2.5-pro-ultraspeed", supportsTools: true, supportsReasoning: true },
         { id: "mimo-v2.5-pro", supportsTools: true, supportsVision: true, supportsReasoning: true },
         { id: "mimo-v2.5", supportsTools: true, supportsVision: true, supportsReasoning: true },
         { id: "mimo-v2-flash", supportsTools: true },
@@ -538,6 +544,8 @@ export const BUILTIN_PROVIDER_CATALOG: ProviderCatalog = {
       defaultModel: "Qwen/Qwen3-Coder-480B-A35B-Instruct",
       models: [
         { id: "Qwen/Qwen3-Coder-480B-A35B-Instruct", supportsTools: true },
+        { id: "zai-org/GLM-5.2", supportsTools: true, supportsReasoning: true },
+        { id: "deepseek-ai/DeepSeek-V4-Pro", supportsTools: true, supportsReasoning: true },
         { id: "deepseek-ai/DeepSeek-V3.2", supportsTools: true },
         { id: "deepseek-ai/DeepSeek-R1", supportsReasoning: true },
       ],


### PR DESCRIPTION
## 背景
对照 [models.dev](https://models.dev/) 刷新桌面端模型「快选」清单（`web/src/lib/provider-catalog.ts`），加入智谱最新旗舰 **GLM-5.2**，并把其他已策展 provider 补到最新。

## 改动
仅 `web/src/lib/provider-catalog.ts`；bump `BUILTIN_PROVIDER_CATALOG_VERSION` → `2026.06.28.1`。

**GLM 两个 provider（默认保持 `glm-5.1`，`glm-5.2` 置顶加入快选）** — GLM-5.2：2026-06-13、1M 上下文、tools+reasoning
- `zai`（智谱·按量付费）：glm-5.2, glm-5.1(默认), glm-4.6, glm-4.5, glm-4.5v
- `zai-coding-cn`（智谱·Coding Plan）：glm-5.2, glm-5.1(默认), glm-4.7, glm-4.6

**其他 provider 补新模型（默认均不变）**
| Provider | 新增 | 依据 |
|---|---|---|
| `kimi-for-coding`（Moonshot CN） | `kimi-k2.7-code` | 2026-06-12，编码特化 |
| `xiaomi`（小米 MiMo） | `mimo-v2.5-pro-ultraspeed` | 2026-06-08 |
| `siliconflow`（硅基流动） | `zai-org/GLM-5.2`、`deepseek-ai/DeepSeek-V4-Pro` | 2026-06/04 |
| `alibaba`（阿里百炼） | `qwen3.7-max`、`qwen3.7-plus` | 2026-05/06 |

能力 flag 取自 models.dev。`deepseek`/`minimax-cn`/`stepfun` 已最新，未动；`tencent`/`baidu`/火山/优云智算在 models.dev 无对应源，未动。

## 验证
- `pnpm typecheck` ✅
- `pnpm test:unit` ✅（protocol 58/58、web 800/800）
- 纯数据改动未碰 Rust，无需 cargo check

🤖 Generated with [Claude Code](https://claude.com/claude-code)