### PR TITLE
feat: inject bundled node runtime + prebuilt TUI into spawned processes

### DIFF
--- a/src/commands/terminal.rs
+++ b/src/commands/terminal.rs
@@ -501,13 +501,31 @@ fn build_terminal_env(
     let effective = crate::path_resolver::effective_path_os()
         .to_string_lossy()
         .to_string();
-    vars.insert("PATH".to_string(), effective.clone());
+    // Prepend the bundled node bin dir (P-032) so `hermes --tui`, `npx`, and
+    // node-based MCP/lint tools resolve node/npm/npx in the in-app + external
+    // terminal without a host Node install. HERMES_NODE/HERMES_TUI_DIR make
+    // the TUI launcher deterministic and source-checkout-free.
+    let mut path = effective;
+    if let Some(node_bin) = runtime::current_node_bin_dir() {
+        let node_bin = node_bin.to_string_lossy().into_owned();
+        path = prepend_path(&node_bin, &path);
+    }
+    if let Some(node) = runtime::current_node_binary() {
+        vars.insert(
+            "HERMES_NODE".to_string(),
+            node.to_string_lossy().into_owned(),
+        );
+    }
+    if let Some(tui_dir) = runtime::current_tui_dir() {
+        vars.insert(
+            "HERMES_TUI_DIR".to_string(),
+            tui_dir.to_string_lossy().into_owned(),
+        );
+    }
+    vars.insert("PATH".to_string(), path.clone());
 
     if let Some(summary) = runtime_summary {
-        vars.insert(
-            "PATH".to_string(),
-            prepend_path(&summary.shim_dir, &effective),
-        );
+        vars.insert("PATH".to_string(), prepend_path(&summary.shim_dir, &path));
         vars.insert(
             "HERMES_MANAGED_RUNTIME".to_string(),
             summary.executable_path.clone(),

--- a/src/process/dashboard.rs
+++ b/src/process/dashboard.rs
@@ -878,7 +878,11 @@ fn spawn_dashboard(options: &EnsureDashboardOptions) -> Result<SpawnedDashboard,
     // the whole runtime tree: dashboard → gateway → MCP stdio servers only
     // see node/npx/rg through it (#190 #196 #197). env_file treats PATH as a
     // reserved key, so this explicit set is the single source of child PATH.
-    let effective_path = crate::path_resolver::effective_path_os();
+    // Prepend the bundled node bin dir (P-032) so /chat's Ink TUI and
+    // node-based MCP servers work without a host Node install.
+    let effective_path = crate::process::runtime::prepend_bundled_node_to_path(
+        crate::path_resolver::effective_path_os(),
+    );
     cmd.env("PATH", &effective_path);
     let session_token = session_token_for_spawn();
     let gateway_runtime_dir = crate::process::runtime::gateway_runtime_dir();
@@ -921,6 +925,19 @@ fn spawn_dashboard(options: &EnsureDashboardOptions) -> Result<SpawnedDashboard,
         cmd.env("HERMES_BUNDLED_PLUGINS", &plugins_dir);
     } else {
         log::warn!("Bundled plugins are missing from the managed runtime");
+    }
+    // Bundled Node runtime + prebuilt Ink TUI (P-032): HERMES_NODE makes node
+    // resolution deterministic for the /chat PTY launcher; HERMES_TUI_DIR
+    // points it at the prebuilt bundle so it never needs a ui-tui/ checkout.
+    if let Some(node) = crate::process::runtime::current_node_binary() {
+        cmd.env("HERMES_NODE", &node);
+    } else {
+        log::warn!("Bundled node is missing from the managed runtime; /chat will be unavailable");
+    }
+    if let Some(tui_dir) = crate::process::runtime::current_tui_dir() {
+        cmd.env("HERMES_TUI_DIR", &tui_dir);
+    } else {
+        log::warn!("Bundled TUI is missing from the managed runtime; /chat will be unavailable");
     }
     cmd.env("HERMES_GATEWAY_LOCK_DIR", &gateway_lock_dir)
         .env("HERMES_GATEWAY_RUNTIME_DIR", &gateway_runtime_dir)

--- a/src/process/gateway.rs
+++ b/src/process/gateway.rs
@@ -329,7 +329,17 @@ fn apply_managed_gateway_env(
         .env("HERMES_GATEWAY_DETACHED", "1")
         .env("HERMES_NONINTERACTIVE", "1")
         .env("PYTHONUNBUFFERED", "1")
-        .env("PATH", crate::path_resolver::effective_path_os());
+        // Prepend the bundled node bin dir (P-032) so gateway-spawned
+        // node-based MCP stdio servers resolve node/npx without a host install.
+        .env(
+            "PATH",
+            crate::process::runtime::prepend_bundled_node_to_path(
+                crate::path_resolver::effective_path_os(),
+            ),
+        );
+    if let Some(node) = crate::process::runtime::current_node_binary() {
+        cmd.env("HERMES_NODE", node);
+    }
 }
 
 fn spawn_gateway_stop_helper(

--- a/src/process/runtime.rs
+++ b/src/process/runtime.rs
@@ -883,6 +883,85 @@ pub fn current_bundled_plugins_dir() -> Option<PathBuf> {
     }
 }
 
+// --- Bundled Node.js runtime + prebuilt Ink TUI (P-032) -------------------
+// release-runtime.yml stages a full Node LTS dist and the prebuilt TUI into
+// the runtime payload. Layout (relative to the installed runtime root, i.e.
+// the install record `path`):
+//   POSIX:   node/bin/{node,npm,npx} + node/lib/node_modules/npm
+//   Windows: node/{node.exe,npm.cmd,npx.cmd} + node/node_modules/npm
+//   TUI:     tui/dist/entry.js
+fn runtime_node_bin_dir(runtime_dir: &Path) -> PathBuf {
+    let node = runtime_dir.join("node");
+    if cfg!(target_os = "windows") {
+        node
+    } else {
+        node.join("bin")
+    }
+}
+
+fn runtime_node_binary(runtime_dir: &Path) -> PathBuf {
+    let bin = runtime_node_bin_dir(runtime_dir);
+    if cfg!(target_os = "windows") {
+        bin.join("node.exe")
+    } else {
+        bin.join("node")
+    }
+}
+
+fn runtime_tui_dir(runtime_dir: &Path) -> PathBuf {
+    runtime_dir.join("tui")
+}
+
+fn node_bin_dir_if_present(runtime_dir: &Path) -> Option<PathBuf> {
+    runtime_node_binary(runtime_dir)
+        .is_file()
+        .then(|| runtime_node_bin_dir(runtime_dir))
+}
+
+fn node_binary_if_present(runtime_dir: &Path) -> Option<PathBuf> {
+    let node = runtime_node_binary(runtime_dir);
+    node.is_file().then_some(node)
+}
+
+fn tui_dir_if_present(runtime_dir: &Path) -> Option<PathBuf> {
+    let tui = runtime_tui_dir(runtime_dir);
+    tui.join("dist").join("entry.js").is_file().then_some(tui)
+}
+
+/// Directory holding the bundled `node`/`npm`/`npx`, when the current managed
+/// runtime ships one. Prepend to a spawned child's PATH so `shutil.which`
+/// (TUI launch, node-based MCP servers, playwright, `npx tsc`) resolves them
+/// without a host Node install. See FORK_NOTES P-032.
+pub fn current_node_bin_dir() -> Option<PathBuf> {
+    node_bin_dir_if_present(Path::new(&read_current_record()?.path))
+}
+
+/// Absolute path to the bundled `node` executable, for the `HERMES_NODE` env
+/// var the frozen runtime prefers when launching the Ink TUI (P-032).
+pub fn current_node_binary() -> Option<PathBuf> {
+    node_binary_if_present(Path::new(&read_current_record()?.path))
+}
+
+/// Directory holding the prebuilt Ink TUI bundle (`tui/dist/entry.js`), for
+/// `HERMES_TUI_DIR` so the frozen runtime launches /chat without a ui-tui/
+/// source checkout (P-032).
+pub fn current_tui_dir() -> Option<PathBuf> {
+    tui_dir_if_present(Path::new(&read_current_record()?.path))
+}
+
+/// Prepend the bundled node `bin/` dir (when present) to `base`, so a spawned
+/// child resolves the runtime's `node`/`npm`/`npx` via PATH — for the Ink TUI,
+/// node-based MCP stdio servers, playwright, and `npx tsc`. Returns `base`
+/// unchanged when no bundled node is installed. See FORK_NOTES P-032.
+pub fn prepend_bundled_node_to_path(base: std::ffi::OsString) -> std::ffi::OsString {
+    let Some(node_bin) = current_node_bin_dir() else {
+        return base;
+    };
+    let mut dirs = vec![node_bin];
+    dirs.extend(std::env::split_paths(&base));
+    std::env::join_paths(dirs).unwrap_or(base)
+}
+
 fn sync_dashboard_web_dist_from_resource(
     resource_dir: Option<&Path>,
     runtime_dir: &Path,
@@ -2337,6 +2416,40 @@ mod tests {
         assert!(now.ends_with('Z'), "missing Z suffix: {now}");
         assert_eq!(&now[4..5], "-");
         assert_eq!(&now[10..11], "T");
+    }
+
+    #[test]
+    fn node_helpers_gate_on_bundled_binary() {
+        let dir = TempDir::new().unwrap();
+        let root = dir.path();
+        // Nothing staged → no node.
+        assert!(node_bin_dir_if_present(root).is_none());
+        assert!(node_binary_if_present(root).is_none());
+
+        // Stage the node binary at the platform-correct path (helper decides
+        // node/bin/node on POSIX, node/node.exe on Windows).
+        let node = runtime_node_binary(root);
+        std::fs::create_dir_all(node.parent().unwrap()).unwrap();
+        std::fs::write(&node, b"x").unwrap();
+
+        assert_eq!(node_binary_if_present(root), Some(node));
+        assert_eq!(
+            node_bin_dir_if_present(root),
+            Some(runtime_node_bin_dir(root))
+        );
+    }
+
+    #[test]
+    fn tui_dir_present_only_with_entry_js() {
+        let dir = TempDir::new().unwrap();
+        let root = dir.path();
+        let dist = root.join("tui").join("dist");
+        std::fs::create_dir_all(&dist).unwrap();
+        // Directory exists but entry.js missing → not usable.
+        assert!(tui_dir_if_present(root).is_none());
+
+        std::fs::write(dist.join("entry.js"), b"//tui").unwrap();
+        assert_eq!(tui_dir_if_present(root), Some(root.join("tui")));
     }
 
     #[test]


### PR DESCRIPTION
## Problem
Packaged macOS build: `/chat` showed **`Chat unavailable: 1`** and the in-app / external terminal was monochrome. Root cause is in the managed runtime (no bundled node / TUI) — fixed in Eynzof/Hermes-CN-Core#68 (P-032). This PR is the desktop half: resolve the newly-bundled node + TUI and feed them to every spawned child.

## Change
- **`process/runtime.rs`**: `current_node_bin_dir()` / `current_node_binary()` / `current_tui_dir()` (resolve `<runtime_root>/node` + `tui/dist/entry.js`, POSIX vs Windows layout) and a `prepend_bundled_node_to_path()` helper. With unit tests.
- **`process/dashboard.rs`**, **`process/gateway.rs`**, **`commands/terminal.rs`**: prepend the bundled `node/bin` dir to the child PATH and set `HERMES_NODE` / `HERMES_TUI_DIR`.

Result: `/chat`'s Ink TUI launches, the in-app + external terminal run the colorful `hermes --tui`, and node-based MCP servers / playwright / `npx tsc` work without a host Node install.

## Validation
- `cargo check` ✓, `cargo test --lib` (337 passed, incl. new runtime + terminal-env tests) ✓, `cargo fmt --check` ✓, `cargo clippy --all-features -- -D warnings` ✓.
- No TypeScript changed.

## Depends on
Core PR #68 (must ship a new `runtime-v*` with node+TUI baked in). This PR is a no-op until the desktop points at such a runtime.

🤖 Generated with [Claude Code](https://claude.com/claude-code)