### PR TITLE
feat: 新增界面缩放设置并改善 Windows 文字可读性

### DIFF
--- a/packages/shared-ui/src/hooks/use-theme.ts
+++ b/packages/shared-ui/src/hooks/use-theme.ts
@@ -2,27 +2,53 @@ import { atom, useAtom } from "jotai";
 
 export type ThemeVariant = "light" | "light-modern" | "dark" | "dark-modern";
 export type DensityVariant = "comfortable" | "compact";
+/** Global interface scale steps. Maps to a single CSS `zoom` on the document
+ *  root so text, spacing and icons enlarge together — see {@link SCALE_FACTORS}. */
+export type ScaleVariant = "sm" | "md" | "lg" | "xl" | "2xl";
 
 export interface ThemeConfig {
   theme: ThemeVariant;
   density: DensityVariant;
+  scale: ScaleVariant;
 }
 
 export const DEFAULT_THEME_CONFIG: ThemeConfig = {
   theme: "light-modern",
   density: "comfortable",
+  scale: "md",
+};
+
+/** Interface-scale step → zoom factor.
+ *
+ *  The whole UI is enlarged with one `zoom` on the document root rather than a
+ *  root font-size, because nearly all font sizes are hard-coded px (the
+ *  `--h-font-size-*` tokens are unused), so a root font-size would not cascade.
+ *  `zoom` reflows the layout (unlike `transform: scale`) and is supported across
+ *  Chromium WebView2 / WKWebView / WebKitGTK. */
+export const SCALE_FACTORS: Record<ScaleVariant, number> = {
+  sm: 0.9,
+  md: 1,
+  lg: 1.1,
+  xl: 1.25,
+  "2xl": 1.5,
 };
 
 const THEME_VARIANTS = new Set<ThemeVariant>(["light", "light-modern", "dark", "dark-modern"]);
+const SCALE_VARIANTS = new Set<ScaleVariant>(["sm", "md", "lg", "xl", "2xl"]);
 
 function isThemeVariant(value: unknown): value is ThemeVariant {
   return typeof value === "string" && THEME_VARIANTS.has(value as ThemeVariant);
+}
+
+function isScaleVariant(value: unknown): value is ScaleVariant {
+  return typeof value === "string" && SCALE_VARIANTS.has(value as ScaleVariant);
 }
 
 export function normalizeThemeConfig(value: Partial<ThemeConfig> | null | undefined): ThemeConfig {
   return {
     theme: isThemeVariant(value?.theme) ? value.theme : DEFAULT_THEME_CONFIG.theme,
     density: value?.density === "compact" ? "compact" : DEFAULT_THEME_CONFIG.density,
+    scale: isScaleVariant(value?.scale) ? value.scale : DEFAULT_THEME_CONFIG.scale,
   };
 }
 
@@ -49,6 +75,15 @@ export function applyThemeToDOM(config: ThemeConfig) {
   const root = document.documentElement;
   root.setAttribute("data-theme", config.theme);
   root.setAttribute("data-density", config.density);
+  root.setAttribute("data-scale", config.scale);
+  // Single global scaling knob: enlarge the entire interface via `zoom` on the
+  // root element. Skip the property at 1× so default rendering is untouched.
+  const factor = SCALE_FACTORS[config.scale] ?? 1;
+  if (factor === 1) {
+    root.style.removeProperty("zoom");
+  } else {
+    root.style.setProperty("zoom", String(factor));
+  }
 }
 
 export function useTheme() {

--- a/packages/shared-ui/src/index.ts
+++ b/packages/shared-ui/src/index.ts
@@ -1,5 +1,6 @@
 export {
   DEFAULT_THEME_CONFIG,
+  SCALE_FACTORS,
   applyThemeToDOM,
   hydrateThemeAtom,
   normalizeThemeConfig,
@@ -7,7 +8,7 @@ export {
   themeWriteAtom,
   useTheme,
 } from "./hooks/use-theme";
-export type { DensityVariant, ThemeConfig, ThemeVariant } from "./hooks/use-theme";
+export type { DensityVariant, ScaleVariant, ThemeConfig, ThemeVariant } from "./hooks/use-theme";
 export { usePlatform, applyPlatformToDOM } from "./hooks/use-platform";
 export { cn, type ClassValue } from "./utils/cn";
 export * from "./components";

--- a/packages/shared-ui/src/tokens/colors.css
+++ b/packages/shared-ui/src/tokens/colors.css
@@ -48,7 +48,8 @@
   --h-text: var(--ink-300);
   --h-text-2: var(--ink-700);
   --h-text-3: var(--ink-800);
-  --h-text-4: #cac4b6;
+  /* Was #cac4b6 (~1.7:1 on the cream bg — effectively invisible). */
+  --h-text-4: var(--bone-500);
   --h-ok: #6b8e5a;
   --h-ok-soft: #e3ecdc;
   --h-warn: #c08828;
@@ -76,8 +77,10 @@
   --h-line-soft: #e5e5e5;
   --h-text: #1f1f1f;
   --h-text-2: #3f3f46;
-  --h-text-3: #6e6e6e;
-  --h-text-4: #a6a6a6;
+  /* Deepened for WCAG AA: #6e6e6e (~4.5:1, sub-AA on chips) → #595959 (~7:1);
+     #a6a6a6 (~2.4:1) → #757575 (~4.6:1). Secondary text is the workhorse here. */
+  --h-text-3: #595959;
+  --h-text-4: #757575;
   --h-ok: #16825d;
   --h-ok-soft: rgba(22, 130, 93, 0.1);
   --h-warn: #9d6b00;
@@ -142,7 +145,8 @@
   --h-text: #d4d4d4;
   --h-text-2: #c5c5c5;
   --h-text-3: #9d9d9d;
-  --h-text-4: #6f6f6f;
+  /* Was #6f6f6f (~3.3:1 on #1f1f1f) → #8a8a8a (~4.9:1) for AA on small text. */
+  --h-text-4: #8a8a8a;
   --h-ok: #89d185;
   --h-ok-soft: rgba(137, 209, 133, 0.1);
   --h-warn: #cca700;

--- a/packages/shared-ui/src/tokens/typography.css
+++ b/packages/shared-ui/src/tokens/typography.css
@@ -36,8 +36,13 @@
 }
 
 :root {
+  /* Stack order is deliberate: macOS keeps PingFang SC (CJK+Latin) and SF.
+     Windows has none of HarmonyOS/PingFang/SF, so Latin lands on Segoe UI and
+     CJK on "Microsoft YaHei UI" (sharper hinting and more weights than the bare
+     "Microsoft YaHei" the app fell back to before — no font is bundled). */
   --h-font-ui: "HarmonyOS Sans SC", "HarmonyOS Sans", "PingFang SC",
-    "Microsoft YaHei", -apple-system, BlinkMacSystemFont, sans-serif;
+    "Segoe UI", "Microsoft YaHei UI", "Microsoft YaHei",
+    -apple-system, BlinkMacSystemFont, "Helvetica Neue", Arial, sans-serif;
   --h-font-cn: var(--h-font-ui);
   --h-font-mono: "Cascadia Code", "Cascadia Mono", "JetBrains Mono", "SF Mono",
     Consolas, monospace;

--- a/web/src/lib/theme-defaults.test.ts
+++ b/web/src/lib/theme-defaults.test.ts
@@ -3,16 +3,21 @@ import { DEFAULT_THEME_CONFIG, normalizeThemeConfig } from "@hermes/shared-ui";
 
 describe("theme defaults", () => {
   it("defaults to modern light when no skin is stored", () => {
-    expect(DEFAULT_THEME_CONFIG).toEqual({ theme: "light-modern", density: "comfortable" });
+    expect(DEFAULT_THEME_CONFIG).toEqual({ theme: "light-modern", density: "comfortable", scale: "md" });
     expect(normalizeThemeConfig(undefined)).toEqual(DEFAULT_THEME_CONFIG);
   });
 
   it("keeps supported stored skins instead of overwriting user preference", () => {
-    expect(normalizeThemeConfig({ theme: "dark", density: "compact" })).toEqual({ theme: "dark", density: "compact" });
-    expect(normalizeThemeConfig({ theme: "dark-modern" })).toEqual({ theme: "dark-modern", density: "comfortable" });
+    expect(normalizeThemeConfig({ theme: "dark", density: "compact" })).toEqual({ theme: "dark", density: "compact", scale: "md" });
+    expect(normalizeThemeConfig({ theme: "dark-modern" })).toEqual({ theme: "dark-modern", density: "comfortable", scale: "md" });
   });
 
   it("falls back to modern light for unsupported stored skins", () => {
     expect(normalizeThemeConfig({ theme: "legacy" as never, density: "tiny" as never })).toEqual(DEFAULT_THEME_CONFIG);
+  });
+
+  it("keeps a supported interface scale and falls back for unknown values", () => {
+    expect(normalizeThemeConfig({ scale: "xl" }).scale).toBe("xl");
+    expect(normalizeThemeConfig({ scale: "huge" as never }).scale).toBe("md");
   });
 });

--- a/web/src/main.tsx
+++ b/web/src/main.tsx
@@ -1,9 +1,9 @@
 import { StrictMode } from "react";
 import { createRoot } from "react-dom/client";
 import { BrowserRouter, HashRouter } from "react-router-dom";
-import { Provider as JotaiProvider } from "jotai";
+import { Provider as JotaiProvider, createStore } from "jotai";
 import { QueryClientProvider } from "@tanstack/react-query";
-import { DEFAULT_THEME_CONFIG, applyPlatformToDOM, applyThemeToDOM, normalizeThemeConfig, type ThemeConfig } from "@hermes/shared-ui";
+import { DEFAULT_THEME_CONFIG, applyPlatformToDOM, applyThemeToDOM, normalizeThemeConfig, themeAtom, type ThemeConfig } from "@hermes/shared-ui";
 import { queryClient } from "./lib/query-client";
 import { applyHostOSToDOM, runtime } from "./lib/runtime";
 import { installDebugCapture } from "./lib/debug-install";
@@ -42,8 +42,12 @@ async function bootstrap() {
   installExternalLinkHandling();
   await initUiStore();
 
-  const initialTheme = readUiValue<Partial<ThemeConfig>>("hermes-theme", DEFAULT_THEME_CONFIG);
-  applyThemeToDOM(normalizeThemeConfig(initialTheme));
+  const initialTheme = normalizeThemeConfig(readUiValue<Partial<ThemeConfig>>("hermes-theme", DEFAULT_THEME_CONFIG));
+  applyThemeToDOM(initialTheme);
+  // Seed the shared jotai store so `useTheme()` (and the appearance controls)
+  // start from the persisted theme/density/scale instead of the defaults.
+  const jotaiStore = createStore();
+  jotaiStore.set(themeAtom, initialTheme);
 
   await fetchDevToken();
   installDebugCapture();
@@ -55,7 +59,7 @@ async function bootstrap() {
     <StrictMode>
       <ErrorBoundary>
         <QueryClientProvider client={queryClient}>
-          <JotaiProvider>
+          <JotaiProvider store={jotaiStore}>
             <Router>
               <App />
             </Router>

--- a/web/src/routes/settings.tsx
+++ b/web/src/routes/settings.tsx
@@ -296,6 +296,14 @@ export function NotificationSection({ showHeading = true }: SettingsSectionProps
   );
 }
 
+const UI_SCALE_OPTIONS: Array<{ value: ThemeConfig["scale"]; label: string }> = [
+  { value: "sm", label: "90%" },
+  { value: "md", label: "100%" },
+  { value: "lg", label: "110%" },
+  { value: "xl", label: "125%" },
+  { value: "2xl", label: "150%" },
+];
+
 export function ThemeSection({ showHeading = true }: SettingsSectionProps) {
   const { config, update } = useTheme();
   const [conversationFontSize, setConversationFontSize] = useAtom(conversationFontSizeAtom);
@@ -330,6 +338,13 @@ export function ThemeSection({ showHeading = true }: SettingsSectionProps) {
               value={config.theme}
               onChange={(theme) => update({ theme })}
             />
+          }
+        />
+        <AppearanceRow
+          label="界面缩放"
+          sub="整体放大或缩小界面（文字、间距、图标一起缩放），适配高分屏 / 4K 显示器。标准为 100%。"
+          right={
+            <RadioGroup value={config.scale} options={UI_SCALE_OPTIONS} onChange={(v) => update({ scale: v as ThemeConfig["scale"] })} />
           }
         />
         <AppearanceRow

--- a/web/src/styles/global.css
+++ b/web/src/styles/global.css
@@ -30,6 +30,7 @@ html {
 body {
   font-family: var(--h-font-ui);
   font-size: var(--h-fs);
+  font-weight: 400;
   line-height: var(--h-lh);
   background: var(--h-bg-app);
   color: var(--h-text);
@@ -41,6 +42,11 @@ body {
   /* Keep Chinese punctuation in its native full-width form. `proportional-width`
      makes `，。；：` render like narrow Latin punctuation in WebView fonts. */
   font-variant-east-asian: normal;
+}
+
+/* Grayscale antialiasing is a macOS preference; on Windows it disables ClearType
+   (subpixel) and makes small CJK text look thinner/softer, so scope it to mac. */
+body[data-hermes-host-os="macos"] {
   -webkit-font-smoothing: antialiased;
   -moz-osx-font-smoothing: grayscale;
 }


### PR DESCRIPTION
## 背景

社区反馈:桌面端在 **Windows / 4K** 下字太小、字偏细、次级灰字看不清。诊断发现是三层问题叠加,而非单纯字号:

1. **字号体系是"死的"** — `--h-font-size-*` 7 级 token 零消费,97.8%(~838 处)是硬编码 px,改 token 不级联,系统/浏览器缩放也救不回。
2. **Windows 字体回退到微软雅黑** — `@font-face` 只有 `local()`、未打包字体,鸿蒙/苹方在 Windows 都没有;正文又无显式字重 → 发虚。
3. **次级灰字对比度不达标** — 默认主题 `--h-text-4` 仅 ~2.4:1、`--h-text-3`(用 383 次)在 chip 底跌破 4.5:1;经典浅色 text-4 仅 ~1.7:1。
4. **4K 无应用级缩放兜底** — `tauri.conf`/Rust 完全无 zoom/DPI 处理。

## 改动

**① 新增「界面缩放」设置(整体等比缩放)**
- `ThemeConfig` 增加 `scale` 字段('sm'|'md'|'lg'|'xl'|'2xl' → 0.9/1/1.1/1.25/1.5),`applyThemeToDOM` 在 `<html>` 上设 **CSS `zoom`**。选 zoom 是因为字号全是硬编码 px、根字号不会级联;zoom 会重排(不像 transform: scale),三端 WebView 均支持。
- 设置页「界面外观」卡片新增一行单选(默认 100%,档位 90/100/110/125/150%)。
- 复用现有 `hermes-theme` 持久化键(ui_kv 通用 kv),**后端零改动**。
- `main.tsx` 启动时 seed jotai store,顺手修掉"设置控件不反映已存偏好"的旧隐患(首帧不再闪默认值)。

**② 易读性修复(token 层,全局生效)**
- 字体栈补 `Segoe UI`(拉丁)/`Microsoft YaHei UI`(中文),macOS 顺序不回归。
- 对比度上调:`text-3 #6e6e6e→#595959`(~7:1)、`text-4 #a6a6a6→#757575`(~4.6:1);经典浅色 text-4 1.7→3.7:1;现代深色 text-4 3.3→4.9:1。
- 正文显式 `font-weight:400`;`-webkit-font-smoothing:antialiased` 限定 macOS,Windows 保留 ClearType 让小字更清晰。

## 测试

- `pnpm typecheck` ✓
- `pnpm test:unit`(protocol 58 + web 801,93 个 web 测试文件)✓,含 `theme-defaults` 新增的 scale 用例
- `cargo check` ✓
- Playwright 实测 zoom 机制:固定元素 200px→250px/180px 精确缩放;`height:100%` 链不破、无溢出滚动条;fixed 浮层正确缩放定位。

## 后续(本 PR 未含)

- 可选:打包 HarmonyOS Sans SC 子集 webfont(品牌一致性,需核 OFL 授权 + 体积)。
- 建议在真实 Windows / 4K 机器上 `pnpm tauri:dev` 做一次冒烟(顶栏拖拽、弹层、各缩放档)。

🤖 Generated with [Claude Code](https://claude.com/claude-code)