### PR TITLE
fix: list provider models via gateway so LAN self-hosted providers refresh

### DIFF
--- a/packages/protocol/src/hermes-api.test.ts
+++ b/packages/protocol/src/hermes-api.test.ts
@@ -10,6 +10,7 @@ import {
   CronRunsResponse,
   ElevenLabsVoicesResponse,
   FsListResponse,
+  ProviderModelsListResult,
   ProfileCreateResponse,
   ProfileSummary,
   SearchResponse,
@@ -553,5 +554,42 @@ describe("StatusResponse schema", () => {
     });
     expect(parsed.gateway_pid).toBe(4321);
     expect(parsed.gateway_health_url).toContain("9120");
+  });
+});
+
+describe("ProviderModelsListResult schema", () => {
+  it("parses a successful provider.models result", () => {
+    const parsed = ProviderModelsListResult.parse({
+      ok: true,
+      models: ["qwen2.5-coder:7b", "llama3"],
+      model_count: 2,
+      status_code: 200,
+      error: null,
+      error_kind: null,
+    });
+    expect(parsed.ok).toBe(true);
+    expect(parsed.models).toEqual(["qwen2.5-coder:7b", "llama3"]);
+    expect(parsed.model_count).toBe(2);
+  });
+
+  it("defaults optional fields so a bare {ok} envelope still parses", () => {
+    const parsed = ProviderModelsListResult.parse({ ok: false });
+    expect(parsed.models).toEqual([]);
+    expect(parsed.model_count).toBe(0);
+    expect(parsed.status_code).toBeNull();
+    expect(parsed.error).toBeNull();
+    expect(parsed.error_kind).toBeNull();
+  });
+
+  it("carries an auth failure as data", () => {
+    const parsed = ProviderModelsListResult.parse({
+      ok: false,
+      models: [],
+      status_code: 401,
+      error: "API key rejected (HTTP 401)",
+      error_kind: "auth",
+    });
+    expect(parsed.ok).toBe(false);
+    expect(parsed.error_kind).toBe("auth");
   });
 });

--- a/packages/protocol/src/hermes-api.ts
+++ b/packages/protocol/src/hermes-api.ts
@@ -435,17 +435,6 @@ export const ModelInfo = z.object({
 });
 export type ModelInfo = z.infer<typeof ModelInfo>;
 
-export const ProviderModelsResponse = z.object({
-  object: z.string().optional(),
-  data: z.array(z.object({
-    id: z.string(),
-    object: z.string().optional(),
-    owned_by: z.string().optional(),
-    created: z.number().optional(),
-  })).default([]),
-});
-export type ProviderModelsResponse = z.infer<typeof ProviderModelsResponse>;
-
 // ── Environment Variables (/api/env) ──────────────────────────────────
 
 export const EnvVarInfo = z.object({
@@ -1188,6 +1177,20 @@ export const ProviderProbeResult = z.object({
   error_kind: z.enum(["auth", "timeout", "http", "network", "unknown"]).nullable(),
 }).passthrough();
 export type ProviderProbeResult = z.infer<typeof ProviderProbeResult>;
+
+// Result of the `provider.models` gateway RPC: the full model-id list for a
+// provider, fetched on the backend (no external-request SSRF guard there), so a
+// self-hosted provider on a LAN IP is reachable. Sibling to ProviderProbeResult
+// — that samples 5 for a connectivity check, this returns the complete list.
+export const ProviderModelsListResult = z.object({
+  ok: z.boolean(),
+  models: z.array(z.string()).default([]),
+  model_count: z.number().default(0),
+  status_code: z.number().nullable().default(null),
+  error: z.string().nullable().default(null),
+  error_kind: z.enum(["auth", "timeout", "http", "network", "unknown"]).nullable().default(null),
+}).passthrough();
+export type ProviderModelsListResult = z.infer<typeof ProviderModelsListResult>;
 
 export const ConfigSetResult = z.object({
   key: z.string().optional(),

--- a/web/src/hooks/use-gateway.ts
+++ b/web/src/hooks/use-gateway.ts
@@ -8,6 +8,7 @@ import {
   InputDetectDropResult,
   ModelOptionsResult,
   PromptSubmitParams,
+  ProviderModelsListResult,
   ProviderProbeResult,
   SessionCreateResult,
   SessionResumeResult,
@@ -523,6 +524,26 @@ export function useGateway() {
     [ensureSubscribed],
   );
 
+  // List a provider's full model set from the backend (which has no
+  // external-request SSRF guard), so a self-hosted provider on a LAN IP — and
+  // the web shell, which can't fetch it cross-origin — can refresh the picker.
+  const listProviderModels = useCallback(
+    async (params: {
+      provider: string;
+      api_key?: string;
+      base_url?: string;
+      timeout_ms?: number;
+    }): Promise<ProviderModelsListResult> => {
+      ensureSubscribed();
+      return parseGatewayResult(
+        ProviderModelsListResult,
+        await getGatewayClient().request("provider.models", params),
+        "provider.models",
+      );
+    },
+    [ensureSubscribed],
+  );
+
   const setSessionModel = useCallback(
     async (
       sessionId: string,
@@ -728,6 +749,7 @@ export function useGateway() {
     completePath,
     dispatchCommand,
     probeProvider,
+    listProviderModels,
     setSessionModel,
     setRuntimeModel,
     setSessionReasoningEffort,

--- a/web/src/hooks/use-provider-models.test.ts
+++ b/web/src/hooks/use-provider-models.test.ts
@@ -1,43 +1,54 @@
 import { describe, expect, it } from "vitest";
-import { ProviderModelsResponse } from "@hermes/protocol";
-import { buildModelsUrl } from "./use-provider-models";
+import { selectProviderModelIds } from "./use-provider-models";
 
-describe("buildModelsUrl", () => {
-  it("appends /models to the base URL", () => {
-    expect(buildModelsUrl("https://api.modelverse.cn/v1")).toBe(
-      "https://api.modelverse.cn/v1/models",
-    );
-  });
-
-  it("normalises trailing slashes", () => {
-    expect(buildModelsUrl("https://api.modelverse.cn/v1/")).toBe(
-      "https://api.modelverse.cn/v1/models",
-    );
-    expect(buildModelsUrl("https://api.modelverse.cn/v1///")).toBe(
-      "https://api.modelverse.cn/v1/models",
-    );
-  });
-});
-
-describe("ProviderModelsResponse parsing", () => {
-  it("parses canonical OpenAI shape", () => {
-    const result = ProviderModelsResponse.parse({
-      object: "list",
-      data: [
-        { id: "gpt-4", object: "model", owned_by: "openai", created: 1 },
-        { id: "gpt-3.5-turbo", object: "model", owned_by: "openai" },
-      ],
+describe("selectProviderModelIds", () => {
+  it("sorts and de-dupes the returned ids", () => {
+    const ids = selectProviderModelIds({
+      ok: true,
+      models: ["qwen2.5-coder:7b", "llama3", "qwen2.5-coder:7b"],
+      model_count: 3,
+      status_code: 200,
+      error: null,
+      error_kind: null,
     });
-    expect(result.data.map((m) => m.id)).toEqual(["gpt-4", "gpt-3.5-turbo"]);
+    expect(ids).toEqual(["llama3", "qwen2.5-coder:7b"]);
   });
 
-  it("tolerates missing optional fields", () => {
-    const result = ProviderModelsResponse.parse({ data: [{ id: "deepseek-v4-flash" }] });
-    expect(result.data[0]?.id).toBe("deepseek-v4-flash");
+  it("drops empty ids", () => {
+    const ids = selectProviderModelIds({
+      ok: true,
+      models: ["", "a", ""],
+      model_count: 3,
+      status_code: 200,
+      error: null,
+      error_kind: null,
+    });
+    expect(ids).toEqual(["a"]);
   });
 
-  it("defaults data to empty when omitted", () => {
-    const result = ProviderModelsResponse.parse({});
-    expect(result.data).toEqual([]);
+  it("throws the backend error when the probe failed", () => {
+    expect(() =>
+      selectProviderModelIds({
+        ok: false,
+        models: [],
+        model_count: 0,
+        status_code: 401,
+        error: "API key rejected (HTTP 401)",
+        error_kind: "auth",
+      }),
+    ).toThrow("API key rejected (HTTP 401)");
+  });
+
+  it("falls back to a generic message when ok is false with no error text", () => {
+    expect(() =>
+      selectProviderModelIds({
+        ok: false,
+        models: [],
+        model_count: 0,
+        status_code: null,
+        error: null,
+        error_kind: null,
+      }),
+    ).toThrow("模型列表获取失败");
   });
 });

--- a/web/src/hooks/use-provider-models.ts
+++ b/web/src/hooks/use-provider-models.ts
@@ -1,26 +1,48 @@
 import { useQuery } from "@tanstack/react-query";
-import { ProviderModelsResponse } from "@hermes/protocol";
-import { fetchExternalJSON } from "@/lib/transport";
+import { ProviderModelsListResult } from "@hermes/protocol";
 
 export interface UseProviderModelsResult {
   models: string[];
   fetchedAt: number;
 }
 
-export function buildModelsUrl(baseUrl: string): string {
-  return `${baseUrl.replace(/\/+$/, "")}/models`;
+export type ListProviderModelsFn = (params: {
+  provider: string;
+  base_url?: string;
+  api_key?: string;
+}) => Promise<ProviderModelsListResult>;
+
+/**
+ * Normalize a `provider.models` RPC result into a sorted, de-duped id list,
+ * throwing the backend's error so TanStack Query surfaces it as a failure.
+ * Pure (no React) so it stays unit-testable without rendering the hook.
+ */
+export function selectProviderModelIds(result: ProviderModelsListResult): string[] {
+  if (!result.ok) {
+    throw new Error(result.error ?? "模型列表获取失败");
+  }
+  const ids = result.models.filter((id) => id.length > 0);
+  return Array.from(new Set(ids)).sort();
 }
 
-export function useProviderModels(baseUrl: string, apiKey: string | undefined) {
+/**
+ * Fetch a provider's model list through the gateway `provider.models` RPC
+ * rather than the desktop `external_request` proxy. The backend has no
+ * external-request SSRF guard, so a self-hosted provider on a LAN IP (e.g.
+ * http://192.168.x.x:11434/v1) is reachable, and the web shell sidesteps the
+ * browser CORS that blocked a direct fetch.
+ */
+export function useProviderModels(
+  provider: string,
+  baseUrl: string,
+  apiKey: string | undefined,
+  listModels: ListProviderModelsFn,
+) {
   return useQuery<UseProviderModelsResult>({
-    queryKey: ["provider-models", baseUrl],
+    queryKey: ["provider-models", provider, baseUrl],
     queryFn: async () => {
-      const url = buildModelsUrl(baseUrl);
-      const headers: Record<string, string> = { Accept: "application/json" };
-      if (apiKey) headers.Authorization = `Bearer ${apiKey}`;
-      const data = await fetchExternalJSON(url, { headers }, ProviderModelsResponse);
-      const models = data.data.map((m) => m.id).filter((id) => id.length > 0).sort();
-      return { models, fetchedAt: Date.now() };
+      const result = await listModels({ provider, base_url: baseUrl, api_key: apiKey });
+      return { models: selectProviderModelIds(result), fetchedAt: Date.now() };
     },
     enabled: false,
     staleTime: 15 * 60 * 1000,

--- a/web/src/routes/settings-models-section.tsx
+++ b/web/src/routes/settings-models-section.tsx
@@ -678,7 +678,7 @@ export function ModelsSection() {
   const setEnv = useSetEnv();
   const deleteEnv = useDeleteEnv();
   const revealEnv = useRevealEnv();
-  const { probeProvider, setRuntimeModel } = useGateway();
+  const { probeProvider, listProviderModels, setRuntimeModel } = useGateway();
   const navigate = useNavigate();
   const { catalog, message: catalogMessage, refresh: refreshCatalog } = useProviderCatalog();
   const resolvedEnvVars = envVars ?? EMPTY_ENV_VARS;
@@ -930,7 +930,12 @@ export function ModelsSection() {
   const liveApiKey = providerForm.apiKey.trim() ||
     (typeof selectedProviderEntry.api_key === "string" ? selectedProviderEntry.api_key : "");
   const supportsModelListing = selectedProvider?.supportsModelListing !== false;
-  const modelsQuery = useProviderModels(providerForm.baseUrl, liveApiKey || undefined);
+  const modelsQuery = useProviderModels(
+    selectedProvider?.id ?? "",
+    providerForm.baseUrl,
+    liveApiKey || undefined,
+    listProviderModels,
+  );
   const liveModelIds = supportsModelListing ? modelsQuery.data?.models ?? [] : [];
   const mergedModelOptions = useMemo(() => {
     const set = new Set<string>();


### PR DESCRIPTION
## 背景

用户本地部署时，自建 Ollama 跑在**局域网另一台机器**上（`http://192.168.31.11:11434/v1`）。配置该自定义服务商时，**测试连接成功**（`✓ 连接成功 · 可用 2 个模型`）但**刷新模型列表失败**：

> Invalid API request: external_request only allows https URLs; http is only allowed for local URLs

## 根因

两个按钮走不同链路：

- **测试连接** → 网关 `provider.probe` RPC，在**后端**发 `/models` GET，无 URL 限制，能到达局域网。
- **刷新** → `useProviderModels` 经 Rust `external_request` 代理（`src/commands/api_proxy.rs`）**直接从桌面壳**去拉。该代理的 SSRF 防护只放行 loopback 的 http，私网 IP（`192.168.x.x`）一律拒绝；纯 web 壳里同一请求还会被浏览器 CORS 拦掉。

## 改动

把刷新改走后端（探测已经能到达的地方）：

- `useProviderModels` 不再经 `external_request`，改调新的网关 RPC **`provider.models`**（见配套 Core PR / P-036），由后端列出完整模型列表。
- 新增 `useGateway().listProviderModels`（`provider.probe` 的姊妹）。
- 新增 protocol schema `ProviderModelsListResult`；移除仅此处使用、现已无引用的 `ProviderModelsResponse`。
- 取数逻辑抽成纯函数 `selectProviderModelIds`（排序 + 去重 + 失败抛后端错误），便于单测。

副作用：纯 web 壳的刷新也顺带绕开了浏览器 CORS。

## 测试

- `pnpm typecheck` 全绿。
- `pnpm test:unit` 全通过（protocol 61 + web 800）。
- 新增/改写：`use-provider-models.test.ts`（`selectProviderModelIds` 排序/去重/抛错）、`hermes-api.test.ts`（`ProviderModelsListResult` 解析与默认值）。
- Rust 侧零改动，`external_request` 未动。

## 配套与版本耦合

后端配套 PR：`Eynzof/Hermes-CN-Core#cn/P-036-provider-models-rpc`。沿用 `provider.probe`（P-011）一样「桌面端假定 runtime 兼容、无回退分支」的模式 —— **发版时本桌面端必须搭配含 P-036 的 Core runtime**，否则刷新会报 `unknown method: provider.models`。

🤖 Generated with [Claude Code](https://claude.com/claude-code)
