### PR TITLE
fix(chat): drop reconnect/resume replay duplicates of completed Hermes turns

### DIFF
--- a/web/src/components/chat/message-adapter.test.ts
+++ b/web/src/components/chat/message-adapter.test.ts
@@ -589,6 +589,68 @@ describe("message adapter", () => {
     expect(chat[0]?.stats?.finishReason).toBe("interrupted");
   });
 
+  it("drops a reconnect/replay duplicate live turn against the stored canonical turn", () => {
+    // 16:09 canonical turn — persisted with text + a tool call.
+    const stored = [
+      uiMessage({
+        id: "stored-canonical",
+        createdAt: 1_000,
+        status: "complete",
+        parts: [
+          { type: "text", text: "Now let me dig into the core source files." },
+          { type: "tool", toolCallId: "call-read-1", name: "read_file", state: "done", output: "ok", startedAt: 1_000, completedAt: 1_500 },
+        ],
+        metadata: { persistedId: 42 },
+      }),
+    ];
+    // 16:10 reconnect/session.resume replay: a fresh client id, only the SAME
+    // tool call so far (no text streamed yet), still streaming — the recurring
+    // duplicate that text-based matching and the interrupted-only drop miss.
+    const live = [
+      uiMessage({
+        id: "live-replay-2",
+        createdAt: 2_000,
+        status: "streaming",
+        parts: [
+          { type: "tool", toolCallId: "call-read-1", name: "read_file", state: "running", startedAt: 2_000 },
+        ],
+      }),
+    ];
+
+    const merged = mergeHermesUIMessages(stored, live);
+
+    expect(merged).toHaveLength(1);
+    expect(merged[0]?.id).toBe("stored-canonical");
+  });
+
+  it("keeps a genuinely new turn whose tool ids differ from the stored turn", () => {
+    const stored = [
+      uiMessage({
+        id: "stored-canonical",
+        createdAt: 1_000,
+        status: "complete",
+        parts: [
+          { type: "tool", toolCallId: "call-A", name: "read_file", state: "done", output: "ok", startedAt: 1_000, completedAt: 1_500 },
+        ],
+      }),
+    ];
+    // Same tool NAME but a fresh tool id → a real follow-up turn, not a replay.
+    const live = [
+      uiMessage({
+        id: "live-new-turn",
+        createdAt: 2_000,
+        status: "streaming",
+        parts: [
+          { type: "tool", toolCallId: "call-B", name: "read_file", state: "running", startedAt: 2_000 },
+        ],
+      }),
+    ];
+
+    const merged = mergeHermesUIMessages(stored, live);
+
+    expect(merged).toHaveLength(2);
+  });
+
   it("hides stale interrupted live replies once a later stored assistant answer exists", () => {
     const stored = legacySessionMessagesToHermesUIMessages([
       sessionMessage({

--- a/web/src/components/chat/message-adapter.ts
+++ b/web/src/components/chat/message-adapter.ts
@@ -883,6 +883,45 @@ function isStaleInterruptedLiveMessage(
   );
 }
 
+// A reconnect / session.resume can re-stream a turn whose canonical copy is
+// already persisted. Gateway events carry no stable turn id (see
+// packages/protocol message.start/complete), so the reducer mints a fresh
+// client id and a *duplicate* assistant bubble appears. While that replay is
+// mid-stream it often has only tool calls and no text yet, so
+// isSameCanonicalMessage (which needs a text match once the stored turn has
+// text) can't match it, and isStaleInterruptedLiveMessage ignores it because a
+// reconnect replay is not "interrupted" — that is the recurring duplicate.
+//
+// Drop it by matching tool-call IDENTITY (`toolCallId:name`) against a stored
+// COMPLETE assistant turn it is a prefix of. toolCallId is a reliable replay
+// discriminator: a replay re-sends the SAME tool ids, whereas a genuinely new
+// turn mints new ones — so this won't drop a real follow-up turn. Mirrors how
+// the official desktop lets the canonical stored turn win after completion.
+function isReplayDuplicateLiveMessage(
+  live: HermesUIMessage,
+  storedMessages: HermesUIMessage[],
+): boolean {
+  if (live.role !== "assistant") return false;
+  const liveTools = canonicalToolIdentityComparable(live);
+  if (!liveTools) return false;
+  const liveText = looseComparableText(canonicalText(live));
+  return storedMessages.some((stored) => {
+    if (stored.role !== "assistant" || stored.status !== "complete") return false;
+    const storedTools = canonicalToolIdentityComparable(stored);
+    if (!storedTools) return false;
+    const toolsArePrefix = storedTools === liveTools || storedTools.startsWith(`${liveTools}|`);
+    if (!toolsArePrefix) return false;
+    // If the replay has already streamed some text, it must be a faithful
+    // prefix of the stored canonical text — otherwise treat it as a genuinely
+    // different turn and keep it.
+    if (liveText) {
+      const storedText = looseComparableText(canonicalText(stored));
+      if (!storedText.startsWith(liveText)) return false;
+    }
+    return true;
+  });
+}
+
 function isInterruptedLiveSuperset(
   stored: HermesUIMessage,
   live: HermesUIMessage,
@@ -1020,6 +1059,7 @@ export function mergeHermesUIMessages(
   consolidatedLive.forEach((liveMessage, index) => {
     if (usedLiveIndexes.has(index)) return;
     if (isStaleInterruptedLiveMessage(liveMessage, stored)) return;
+    if (isReplayDuplicateLiveMessage(liveMessage, stored)) return;
     merged.push(liveMessage);
   });
 


### PR DESCRIPTION
## fix(chat): drop reconnect/resume replay duplicates of completed Hermes turns

Fixes the recurring "一条 Hermes 消息被分成两条、内容基本一样" duplicate (one bubble at 16:09 complete + a near-identical still-streaming bubble at 16:10).

### Root cause (traced end-to-end)
Gateway events carry **no stable turn/message id** — `packages/protocol` `message.start`/`message.complete` payloads have no `message_id`/`turn_id`, only `session_id`. So `stores/chat.ts` mints a **client-side id** per turn (`activeAssistantId`) and clears it on `message.complete`. A **WebSocket reconnect / `session.resume`** can re-stream a turn whose canonical copy is already persisted; with `activeAssistantId` cleared, those replayed events spawn a **fresh-id duplicate bubble**.

`mergeHermesUIMessages` already dedupes live-vs-stored, but this duplicate slips through:
- while the replay is **mid-stream it often has only tool calls and no text yet**, so `isSameCanonicalMessage` (which requires a text match once the stored turn has text) can't match it;
- `isStaleInterruptedLiveMessage` ignores it because a reconnect replay is **not "interrupted"**.

That's exactly why the earlier interrupt-only fixes (`d7c5629 fix: 修复中断后重复显示 Hermes 消息`, `#209`) never caught this path and it kept recurring.

### Fix
`isReplayDuplicateLiveMessage`: in the merge's unmatched-live pass, drop a live assistant turn whose **tool-call identity** (`toolCallId:name`) is a prefix of a stored **COMPLETE** assistant turn it duplicates.

- `toolCallId` is a **reliable replay discriminator** — a replay re-sends the *same* tool ids, while a genuinely new turn mints *new* ones — so a real follow-up turn (same tool name, fresh id) is **kept**.
- If the replay already streamed text, it must be a faithful **prefix** of the stored text (otherwise treat as a distinct turn and keep it).

This mirrors how the **official desktop** (`apps/desktop`) lets the canonical stored turn win after completion (it re-hydrates from the persisted session post-complete), done here at the **pure merge layer** — no reducer state-machine surgery, so it's contained and unit-testable.

### Why not a "stable gateway id" (the obvious durable fix)
Confirmed the official desktop **also** uses a client-generated `streamId` (`apps/desktop/.../use-message-stream.ts`, `chat-runtime.ts streamId: null`), not a gateway id — so adding a protocol-level turn id would diverge from the official architecture this repo aligns to (#201). The official approach is canonical-stored-wins reconciliation, which this PR brings to the failing path.

### Tests
`web/src/components/chat/message-adapter.test.ts` — drops the tool-only replay duplicate against the stored canonical turn; keeps a genuinely new turn whose tool ids differ. Full suite green: **web 803, protocol 58**; `pnpm typecheck` clean. (eslint not runnable in this env — relying on CI.)

🤖 Generated with [Claude Code](https://claude.com/claude-code)
