### PR TITLE
feat: 默认开启开发者模式并支持快捷键打开 DevTools

### DIFF
--- a/Cargo.toml
+++ b/Cargo.toml
@@ -10,7 +10,11 @@ homepage = "https://hermesagent.org.cn"
 name = "hermes_agent_cn"
 
 [dependencies]
-tauri = { version = "2", features = ["tray-icon"] }
+# `devtools` keeps the WebView inspector available in release builds too, so the
+# desktop ships in developer mode by default (toggled via a keyboard shortcut —
+# see commands/devtools.rs). On macOS this uses a private API, which is fine for
+# our dmg distribution since we don't publish through the App Store.
+tauri = { version = "2", features = ["tray-icon", "devtools"] }
 tauri-plugin-dialog = "2"
 tauri-plugin-notification = "2"
 serde = { version = "1", features = ["derive"] }

--- a/src/commands/devtools.rs
+++ b/src/commands/devtools.rs
@@ -1,0 +1,27 @@
+//! WebView devtools toggle.
+//!
+//! The desktop ships with the inspector enabled in release builds too (the
+//! `devtools` Cargo feature on the `tauri` crate — see Cargo.toml), so it is in
+//! "developer mode" by default. The renderer binds a keyboard shortcut that
+//! calls this command to open / close the inspector for the main window — see
+//! `registerDevtoolsShortcut` in web/src/lib/tauri-bridge.ts and the shortcut
+//! hint on the About page (web/src/routes/settings.tsx, AboutSection).
+
+use tauri::{AppHandle, Manager};
+
+use crate::tray::MAIN_WINDOW_LABEL;
+
+/// Toggle the WebView devtools for the main window. No-op if the window is gone.
+#[tauri::command]
+pub fn toggle_devtools(app: AppHandle) {
+    let Some(webview) = app.get_webview_window(MAIN_WINDOW_LABEL) else {
+        log::warn!("toggle_devtools: main window not found");
+        return;
+    };
+
+    if webview.is_devtools_open() {
+        webview.close_devtools();
+    } else {
+        webview.open_devtools();
+    }
+}

--- a/src/commands/mod.rs
+++ b/src/commands/mod.rs
@@ -4,6 +4,7 @@ pub mod config_migration;
 pub mod connection;
 pub mod debug_bundle;
 pub mod desktop_update;
+pub mod devtools;
 pub mod environment;
 pub mod file_dialogs;
 pub mod gateway;

--- a/src/main.rs
+++ b/src/main.rs
@@ -423,6 +423,7 @@ fn main() {
             commands::log_export::export_log_snapshot,
             commands::debug_bundle::export_debug_bundle,
             commands::desktop_update::desktop_check_update,
+            commands::devtools::toggle_devtools,
             commands::environment::environment_check,
             commands::api_proxy::api_request,
             commands::api_proxy::external_request,

--- a/web/src/lib/tauri-bridge.ts
+++ b/web/src/lib/tauri-bridge.ts
@@ -247,6 +247,10 @@ const tauriBridge = {
     return invokeCommand("open_external_url", { input });
   },
 
+  async toggleDevtools(): Promise<void> {
+    return invokeCommand("toggle_devtools");
+  },
+
   async exportLogSnapshot(input: ExportLogSnapshotInput): Promise<ExportLogSnapshotResult> {
     return invokeCommand("export_log_snapshot", { input });
   },
@@ -761,6 +765,41 @@ async function waitForBootstrap(
   });
 }
 
+// Developer mode ships enabled in release builds (the `devtools` Cargo feature),
+// so the WebView inspector can be opened at runtime. Bind it to the keyboard
+// shortcuts every browser already uses so users can pop devtools without a menu:
+//   - F12                        (all platforms)
+//   - Cmd + Option + I  on macOS
+//   - Ctrl + Shift + I  on Windows / Linux
+// The matching hint lives on the About page (web/src/routes/settings.tsx).
+function isDevtoolsShortcut(event: KeyboardEvent): boolean {
+  if (event.key === "F12") return true;
+  if (event.key.toLowerCase() !== "i") return false;
+  const macCombo = event.metaKey && event.altKey;
+  const winCombo = event.ctrlKey && event.shiftKey;
+  return macCombo || winCombo;
+}
+
+let devtoolsShortcutBound = false;
+
+function registerDevtoolsShortcut(): void {
+  if (devtoolsShortcutBound || typeof window === "undefined") return;
+  if (typeof window.addEventListener !== "function") return;
+  devtoolsShortcutBound = true;
+  window.addEventListener(
+    "keydown",
+    (event) => {
+      if (!isDevtoolsShortcut(event)) return;
+      event.preventDefault();
+      void invokeCommand("toggle_devtools").catch((error) => {
+        console.warn("Failed to toggle devtools", error);
+      });
+    },
+    // Capture phase so app-level key handlers can't swallow the shortcut first.
+    { capture: true },
+  );
+}
+
 export async function installTauriBridge(): Promise<void> {
   let config = await invokeCommand<{
     apiBaseUrl: string;
@@ -823,4 +862,6 @@ export async function installTauriBridge(): Promise<void> {
   };
 
   (window as any).hermesDesktop = tauriBridge;
+
+  registerDevtoolsShortcut();
 }

--- a/web/src/routes/settings.tsx
+++ b/web/src/routes/settings.tsx
@@ -61,6 +61,7 @@ import {
 } from "@/stores/ui";
 import { playChime, shouldPlayFallbackSound } from "@/lib/notifications";
 import { openExternalUrl } from "@/lib/external-links";
+import { detectHostOS } from "@/lib/runtime";
 import { checkDesktopUpdate, DESKTOP_UPDATE_DOWNLOAD_URL } from "@/lib/desktop-update";
 import { DESKTOP_VERSION, versionLabel } from "@/lib/build-info";
 import {
@@ -1526,6 +1527,11 @@ export function AboutSection({ showHeading = true }: SettingsSectionProps) {
     void openExternalUrl(desktopUpdateResult?.downloadUrl ?? DESKTOP_UPDATE_DOWNLOAD_URL);
   };
 
+  // Developer mode ships enabled; the shortcut to open devtools follows the
+  // platform's browser convention (registered in web/src/lib/tauri-bridge.ts).
+  const devtoolsShortcut =
+    detectHostOS() === "macos" ? "F12 或 ⌘ + ⌥ + I" : "F12 或 Ctrl + Shift + I";
+
   return (
     <div>
       {showHeading && <h2 className={s.heading}>关于</h2>}
@@ -1578,6 +1584,17 @@ export function AboutSection({ showHeading = true }: SettingsSectionProps) {
           </div>
           <p className={s.desc}>
             这里提醒的是桌面壳版本。下载新版安装包后，请按系统提示覆盖安装；应用不会自动下载安装包或替换正在运行的程序。
+          </p>
+        </DebugCard>
+
+        <DebugCard icon={<Bug size={15} />} title="开发者工具" sub="默认开启开发者模式，可用快捷键打开 DevTools" wide>
+          <div className={s.runtimeGrid}>
+            <RuntimeField label="开发者模式" value="已默认开启" />
+            <RuntimeField label="打开快捷键" value={devtoolsShortcut} mono />
+          </div>
+          <p className={s.desc}>
+            本桌面端默认开启开发者模式，按上述快捷键即可打开 / 关闭浏览器开发者工具（DevTools），
+            用于查看控制台日志、网络请求等，方便排查问题或向社区反馈。再次按下快捷键可以关闭。
           </p>
         </DebugCard>
 


### PR DESCRIPTION
## 背景

中文社区桌面端需要让用户在安装后即可方便地打开开发者工具（DevTools），用于查看控制台日志、网络请求等，便于自助排查与向社区反馈问题。

## 改动

- **默认开启开发者模式**：给 `tauri` 依赖加上 `devtools` feature，使 Release 构建（安装包）里 WebView 检查器也常驻可用，而不仅是 debug 构建。
- **快捷键打开/关闭 DevTools**：新增 `toggle_devtools` 命令；前端在桥接初始化时注册全局 `keydown` 监听（capture 阶段，避免被业务快捷键吞掉），命中即切换 DevTools。快捷键沿用浏览器习惯：
  - `F12`（全平台）
  - `⌘ + ⌥ + I`（macOS）
  - `Ctrl + Shift + I`（Windows / Linux）
- **关于页面新增提示**：在「关于」页加一张「开发者工具」卡片，显示“开发者模式：已默认开启”和当前平台对应的「打开快捷键」，并附中文说明。

> 说明：macOS 上 `devtools` 走私有 API，因本应用经 dmg 分发、不上 App Store，无影响（已在 `Cargo.toml` 注释说明）。

## 验证

- `pnpm --filter @hermes/web typecheck` ✅
- `cargo check`（dev）与 `cargo check --release` ✅（release 确认无 `debug_assertions` 时 `devtools` feature 让 `open_devtools/close_devtools/is_devtools_open` 正常解析）
- `cargo clippy` 无告警 ✅
- web 单元测试 802 个全过 ✅
- Rust lib 单元测试 337 个全过 ✅

🤖 Generated with [Claude Code](https://claude.com/claude-code)
