### PR TITLE
feat: 对话历史新增已归档对话查看与取消归档

### DIFF
--- a/packages/protocol/src/hermes-api.ts
+++ b/packages/protocol/src/hermes-api.ts
@@ -177,6 +177,10 @@ export const SessionSummary = z.object({
   actual_cost_usd: z.number().nullable().optional(),
   is_active: z.boolean().optional(),
   api_call_count: z.number().optional(),
+  // Desktop-only UI state injected by the Rust proxy when a request carries
+  // ?include_archived=true. Absent on the default (active) list — the proxy
+  // strips archived sessions there. See src/session_archive.rs.
+  archived: z.boolean().optional(),
 });
 export type SessionSummary = z.infer<typeof SessionSummary>;
 
@@ -388,6 +392,8 @@ export const SearchResult = z.object({
   source: NullishString,
   model: NullishString,
   session_started: NullishNumber,
+  // Desktop-only; see SessionSummary.archived.
+  archived: z.boolean().optional(),
 });
 export type SearchResult = z.infer<typeof SearchResult>;
 

--- a/src/session_archive.rs
+++ b/src/session_archive.rs
@@ -90,7 +90,16 @@ pub fn handle_archive_request(
     ))
 }
 
-/// Filter archived sessions from a /api/sessions or /api/sessions/search response.
+/// Filter or annotate archived sessions in a /api/sessions or
+/// /api/sessions/search response.
+///
+/// Default (no `include_archived=true`): archived sessions are removed from the
+/// list (and `total` adjusted), hiding them from the active view.
+///
+/// With `include_archived=true`: archived sessions are kept and each is
+/// annotated with `"archived": true` so the desktop UI can present a dedicated
+/// "archived" scope. Non-archived items are left untouched (an absent field
+/// means "not archived" on the frontend).
 pub fn filter_archived_from_response(
     path: &str,
     method: &str,
@@ -101,18 +110,15 @@ pub fn filter_archived_from_response(
         return body.to_string();
     }
 
-    let url_path = if let Ok(url) = url::Url::parse(&format!("http://x{}", path)) {
-        // Check for include_archived=true query param
-        if url
-            .query_pairs()
-            .any(|(k, v)| k == "include_archived" && v == "true")
-        {
+    let (url_path, include_archived) =
+        if let Ok(url) = url::Url::parse(&format!("http://x{}", path)) {
+            let include_archived = url
+                .query_pairs()
+                .any(|(k, v)| k == "include_archived" && v == "true");
+            (url.path().to_string(), include_archived)
+        } else {
             return body.to_string();
-        }
-        url.path().to_string()
-    } else {
-        return body.to_string();
-    };
+        };
 
     let is_sessions = url_path == "/api/sessions";
     let is_search = url_path == "/api/sessions/search";
@@ -122,6 +128,7 @@ pub fn filter_archived_from_response(
 
     let archived = read_archive_state(hermes_home);
     if archived.is_empty() {
+        // Nothing to strip or annotate, in either mode.
         return body.to_string();
     }
 
@@ -132,17 +139,21 @@ pub fn filter_archived_from_response(
 
     if is_sessions {
         if let Some(sessions) = data.get_mut("sessions").and_then(|s| s.as_array_mut()) {
-            let before = sessions.len();
-            sessions.retain(|s| {
-                s.get("id")
-                    .and_then(|id| id.as_str())
-                    .map(|id| !archived.contains(id))
-                    .unwrap_or(true)
-            });
-            let removed = before - sessions.len();
-            if removed > 0 {
-                if let Some(total) = data.get_mut("total").and_then(|t| t.as_i64()) {
-                    data["total"] = serde_json::json!(std::cmp::max(0, total - removed as i64));
+            if include_archived {
+                annotate_archived(sessions, "id", &archived);
+            } else {
+                let before = sessions.len();
+                sessions.retain(|s| {
+                    s.get("id")
+                        .and_then(|id| id.as_str())
+                        .map(|id| !archived.contains(id))
+                        .unwrap_or(true)
+                });
+                let removed = before - sessions.len();
+                if removed > 0 {
+                    if let Some(total) = data.get_mut("total").and_then(|t| t.as_i64()) {
+                        data["total"] = serde_json::json!(std::cmp::max(0, total - removed as i64));
+                    }
                 }
             }
         }
@@ -150,16 +161,37 @@ pub fn filter_archived_from_response(
 
     if is_search {
         if let Some(results) = data.get_mut("results").and_then(|r| r.as_array_mut()) {
-            results.retain(|r| {
-                r.get("session_id")
-                    .and_then(|id| id.as_str())
-                    .map(|id| !archived.contains(id))
-                    .unwrap_or(true)
-            });
+            if include_archived {
+                annotate_archived(results, "session_id", &archived);
+            } else {
+                results.retain(|r| {
+                    r.get("session_id")
+                        .and_then(|id| id.as_str())
+                        .map(|id| !archived.contains(id))
+                        .unwrap_or(true)
+                });
+            }
         }
     }
 
     serde_json::to_string(&data).unwrap_or_else(|_| body.to_string())
+}
+
+/// Set `"archived": true` on each object whose `id_field` value is in the
+/// archived set. Objects not in the set are left untouched.
+fn annotate_archived(items: &mut [serde_json::Value], id_field: &str, archived: &HashSet<String>) {
+    for item in items.iter_mut() {
+        let is_archived = item
+            .get(id_field)
+            .and_then(|id| id.as_str())
+            .map(|id| archived.contains(id))
+            .unwrap_or(false);
+        if is_archived {
+            if let Some(obj) = item.as_object_mut() {
+                obj.insert("archived".to_string(), serde_json::Value::Bool(true));
+            }
+        }
+    }
 }
 
 #[cfg(test)]
@@ -411,9 +443,52 @@ mod tests {
     }
 
     #[test]
-    fn filter_passes_through_when_include_archived_set() {
+    fn filter_annotates_archived_when_include_archived_set() {
+        let dir = TempDir::new().unwrap();
+        archive(home_str(&dir), &["s2"]);
+        let out = filter_archived_from_response(
+            "/api/sessions?include_archived=true",
+            "GET",
+            home_str(&dir),
+            &sessions_body(),
+        );
+        let v: serde_json::Value = serde_json::from_str(&out).unwrap();
+        let sessions = v["sessions"].as_array().unwrap();
+        // Nothing is removed: all three sessions remain, total untouched.
+        let ids: Vec<&str> = sessions.iter().map(|s| s["id"].as_str().unwrap()).collect();
+        assert_eq!(ids, vec!["s1", "s2", "s3"]);
+        assert_eq!(v["total"], 3);
+        // The archived one carries archived:true; the others have no such field.
+        assert_eq!(sessions[0].get("archived"), None);
+        assert_eq!(sessions[1]["archived"], serde_json::json!(true));
+        assert_eq!(sessions[2].get("archived"), None);
+    }
+
+    #[test]
+    fn filter_annotates_archived_search_results_when_include_archived_set() {
         let dir = TempDir::new().unwrap();
         archive(home_str(&dir), &["s1"]);
+        let out = filter_archived_from_response(
+            "/api/sessions/search?include_archived=true",
+            "GET",
+            home_str(&dir),
+            &search_body(),
+        );
+        let v: serde_json::Value = serde_json::from_str(&out).unwrap();
+        let results = v["results"].as_array().unwrap();
+        // Both results kept; only the archived one is annotated.
+        let ids: Vec<&str> = results
+            .iter()
+            .map(|r| r["session_id"].as_str().unwrap())
+            .collect();
+        assert_eq!(ids, vec!["s1", "s2"]);
+        assert_eq!(results[0]["archived"], serde_json::json!(true));
+        assert_eq!(results[1].get("archived"), None);
+    }
+
+    #[test]
+    fn filter_include_archived_with_empty_set_is_unchanged() {
+        let dir = TempDir::new().unwrap();
         let body = sessions_body();
         let out = filter_archived_from_response(
             "/api/sessions?include_archived=true",

--- a/web/src/components/session-actions/session-row-menu.tsx
+++ b/web/src/components/session-actions/session-row-menu.tsx
@@ -1,27 +1,34 @@
 import { Popover } from "@hermes/shared-ui";
-import { Archive, Edit3, Pin, PinOff, Trash2 } from "lucide-react";
+import { Archive, ArchiveRestore, Edit3, Pin, PinOff, Trash2 } from "lucide-react";
 import s from "./session-actions.module.css";
 
 export interface SessionRowMenuProps {
   pinned: boolean;
   disabled?: boolean;
+  /** When true, the row is archived: show "取消归档" wired to onUnarchive. */
+  archived?: boolean;
   onTogglePin: () => void;
   onRename: () => void;
   onArchive: () => void;
+  /** Restore an archived session. Required when `archived` is true. */
+  onUnarchive?: () => void;
   onDelete: () => void;
 }
 
 /**
  * Dropdown body for a single session's actions (pin / rename / archive /
  * delete). Render it inside a `Popover.Root` whose `Popover.Trigger` is the
- * "⋯" button — shared by the history list and the workbench sidebar.
+ * "⋯" button — shared by the history list and the workbench sidebar. In the
+ * history page's archived scope the archive item flips to "取消归档".
  */
 export function SessionRowMenu({
   pinned,
   disabled,
+  archived,
   onTogglePin,
   onRename,
   onArchive,
+  onUnarchive,
   onDelete,
 }: SessionRowMenuProps) {
   return (
@@ -46,9 +53,15 @@ export function SessionRowMenu({
           </button>
         </Popover.Close>
         <Popover.Close asChild>
-          <button type="button" onClick={onArchive} role="menuitem" disabled={disabled}>
-            <Archive size={13} /> 归档
-          </button>
+          {archived ? (
+            <button type="button" onClick={onUnarchive} role="menuitem" disabled={disabled}>
+              <ArchiveRestore size={13} /> 取消归档
+            </button>
+          ) : (
+            <button type="button" onClick={onArchive} role="menuitem" disabled={disabled}>
+              <Archive size={13} /> 归档
+            </button>
+          )}
         </Popover.Close>
         <Popover.Close asChild>
           <button

--- a/web/src/hooks/use-sessions.ts
+++ b/web/src/hooks/use-sessions.ts
@@ -58,11 +58,24 @@ async function fetchSessionMessages(id: string, signal?: AbortSignal): Promise<M
   return await fetchSessionLogMessages(id, signal) ?? result;
 }
 
-export function useSessions(limit = 50, offset = 0) {
+export interface UseSessionsOptions {
+  // When true, ask the Rust proxy to keep archived sessions (annotated with
+  // `archived: true`) instead of stripping them. Defaults to false so the
+  // sidebar and other callers keep the active-only list. See history page.
+  includeArchived?: boolean;
+}
+
+export function useSessions(limit = 50, offset = 0, opts: UseSessionsOptions = {}) {
   const profile = useActiveProfileName();
+  const includeArchived = opts.includeArchived ?? false;
   return useQuery<SessionsResponse>({
-    queryKey: ["sessions", profile, limit, offset],
-    queryFn: ({ signal }) => fetchJSON(`/api/sessions?limit=${limit}&offset=${offset}`, { signal }, SessionsResponse),
+    queryKey: ["sessions", profile, limit, offset, includeArchived ? "all" : "active"],
+    queryFn: ({ signal }) =>
+      fetchJSON(
+        `/api/sessions?limit=${limit}&offset=${offset}${includeArchived ? "&include_archived=true" : ""}`,
+        { signal },
+        SessionsResponse,
+      ),
   });
 }
 
@@ -280,6 +293,49 @@ export function useArchiveSession() {
     },
     onSuccess: (_result, id) => {
       unpinSessions([id]);
+    },
+    onError: (_error, _id, context) => {
+      for (const [queryKey, data] of context?.sessionSnapshots ?? []) {
+        qc.setQueryData(queryKey, data);
+      }
+      for (const [queryKey, data] of context?.searchSnapshots ?? []) {
+        qc.setQueryData(queryKey, data);
+      }
+    },
+    onSettled: () => {
+      invalidateSessionLists(qc);
+    },
+  });
+}
+
+// Inverse of useArchiveSession: DELETE /api/sessions/{id}/archive un-archives a
+// session (see handle_archive_request DELETE branch). The mutation optimistically
+// drops the row from the archived view; onSettled re-fetches so it reappears in
+// the active list. The caller is on the archived scope, so the brief removal is
+// only ever observed where the row should disappear.
+export function useUnarchiveSession() {
+  const qc = useQueryClient();
+  return useMutation({
+    mutationFn: (id: string) =>
+      deleteJSON(`/api/sessions/${encodeURIComponent(id)}/archive`, undefined, MutationOkResponse),
+    onMutate: async (id) => {
+      await Promise.all([
+        qc.cancelQueries({ queryKey: ["sessions"] }),
+        qc.cancelQueries({ queryKey: ["sessions-search"] }),
+      ]);
+      const sessionSnapshots = qc.getQueriesData<SessionsResponse>({ queryKey: ["sessions"] });
+      const searchSnapshots = qc.getQueriesData<{ results: SearchResult[] }>({
+        queryKey: ["sessions-search"],
+      });
+
+      qc.setQueriesData<SessionsResponse>({ queryKey: ["sessions"] }, (data) =>
+        withoutSessions(data, [id]),
+      );
+      qc.setQueriesData<{ results: SearchResult[] }>({ queryKey: ["sessions-search"] }, (data) =>
+        withoutSearchResults(data, [id]),
+      );
+
+      return { sessionSnapshots, searchSnapshots };
     },
     onError: (_error, _id, context) => {
       for (const [queryKey, data] of context?.sessionSnapshots ?? []) {

--- a/web/src/routes/history.tsx
+++ b/web/src/routes/history.tsx
@@ -4,6 +4,8 @@ import { useQueryClient } from "@tanstack/react-query";
 import { useNavigate } from "react-router-dom";
 import { Popover } from "@hermes/shared-ui";
 import {
+  Archive,
+  ArchiveRestore,
   ChevronDown,
   MoreHorizontal,
   Pin,
@@ -21,6 +23,7 @@ import {
   useArchiveSession,
   useDeleteSessions,
   useSessions,
+  useUnarchiveSession,
 } from "@/hooks/use-sessions";
 import { useGateway } from "@/hooks/use-gateway";
 import { isSessionRunning } from "@/lib/session-activity";
@@ -72,6 +75,11 @@ const STATUS_LABELS: Record<StatusFilter, string> = {
   done: "已完成",
   failed: "失败",
 };
+
+// Archive scope partitions the list orthogonally to status: "active" is the
+// default (archived sessions hidden, matching the rest of the app); "archived"
+// shows only the sessions the user has tucked away, with restore actions.
+type ArchiveScope = "active" | "archived";
 
 function shortId(id: string): string {
   return id.slice(-6);
@@ -223,11 +231,17 @@ function SourcePopover({
 export function HistoryRoute() {
   const navigate = useNavigate();
   const runtimeBySession = useAtomValue(chatRuntimeBySessionAtom);
-  const { data, isLoading, isError } = useSessions(PAGE_SIZE, 0);
+  // Always fetch with archived sessions included (annotated `archived: true` by
+  // the Rust proxy) so both scopes share one query and their counts are always
+  // known; we split client-side by `archived`. The sidebar keeps the default
+  // active-only query, so archived sessions never leak there.
+  const { data, isLoading, isError } = useSessions(PAGE_SIZE, 0, { includeArchived: true });
   const archiveSession = useArchiveSession();
+  const unarchiveSession = useUnarchiveSession();
   const deleteSessions = useDeleteSessions();
   const { setSessionTitle, resumeSession } = useGateway();
 
+  const [archiveScope, setArchiveScope] = useState<ArchiveScope>("active");
   const [statusFilter, setStatusFilter] = useState<StatusFilter>("all");
   const [selectedSource, setSelectedSource] = useState<string | null>(null);
   const [searchQuery, setSearchQuery] = useState("");
@@ -273,6 +287,20 @@ export function HistoryRoute() {
     [data?.sessions, titleOverrides],
   );
 
+  // Counts for the scope toggle, derived from the single archived-inclusive set.
+  const activeCount = useMemo(() => sessions.filter((x) => !x.archived).length, [sessions]);
+  const archivedCount = useMemo(() => sessions.filter((x) => x.archived).length, [sessions]);
+
+  // Everything below (status/source counts, filtering, grouping) operates on the
+  // sessions in the current scope only.
+  const scopedSessions = useMemo(
+    () =>
+      sessions.filter((session) =>
+        archiveScope === "archived" ? !!session.archived : !session.archived,
+      ),
+    [archiveScope, sessions],
+  );
+
   useEffect(() => {
     if (!data || data.total > sessions.length || pinnedSessionIds.size === 0) return;
     const liveIds = new Set(sessions.map((session) => session.id));
@@ -283,20 +311,20 @@ export function HistoryRoute() {
   // status counts (across all sessions, ignoring source/search filters)
   const statusCounts = useMemo(() => {
     const counts: Record<StatusFilter, number> = { all: 0, running: 0, done: 0, failed: 0 };
-    for (const session of sessions) {
+    for (const session of scopedSessions) {
       counts.all += 1;
       const live = isSessionRunning(session, runtimeBySession);
       const status = classifySession(session, live).kind;
       counts[status] += 1;
     }
     return counts;
-  }, [runtimeBySession, sessions]);
+  }, [runtimeBySession, scopedSessions]);
 
   // source counts (across sessions matching status + search, ignoring source filter)
   const sourceCounts = useMemo(() => {
     const counts = new Map<string, number>();
     const q = searchQuery.trim().toLowerCase();
-    for (const session of sessions) {
+    for (const session of scopedSessions) {
       const live = isSessionRunning(session, runtimeBySession);
       const status = classifySession(session, live).kind;
       if (statusFilter !== "all" && status !== statusFilter) continue;
@@ -309,7 +337,7 @@ export function HistoryRoute() {
       counts.set(key, (counts.get(key) ?? 0) + 1);
     }
     return counts;
-  }, [runtimeBySession, searchQuery, sessions, statusFilter]);
+  }, [runtimeBySession, searchQuery, scopedSessions, statusFilter]);
 
   // inline sources: pinned first (sorted by count), then top remaining by count, capped to INLINE_SOURCE_LIMIT
   const inlineSourceKeys = useMemo(() => {
@@ -330,7 +358,7 @@ export function HistoryRoute() {
   const filtered = useMemo(() => {
     const q = searchQuery.trim().toLowerCase();
     const matches: SessionSummary[] = [];
-    for (const session of sessions) {
+    for (const session of scopedSessions) {
       const live = isSessionRunning(session, runtimeBySession);
       const status = classifySession(session, live).kind;
       if (statusFilter !== "all" && status !== statusFilter) continue;
@@ -347,7 +375,7 @@ export function HistoryRoute() {
     }
     matches.sort((a, b) => lastActivitySec(b) - lastActivitySec(a));
     return matches;
-  }, [runtimeBySession, searchQuery, selectedSource, sessions, statusFilter]);
+  }, [runtimeBySession, searchQuery, selectedSource, scopedSessions, statusFilter]);
 
   const dayGroups = useMemo(() => {
     const groups = new Map<string, { label: string; sessions: SessionSummary[]; sortKey: number }>();
@@ -485,6 +513,14 @@ export function HistoryRoute() {
     [archiveSession],
   );
 
+  const handleUnarchive = useCallback(
+    (session: SessionSummary) => {
+      setOpenMenuId(null);
+      unarchiveSession.mutate(session.id);
+    },
+    [unarchiveSession],
+  );
+
   const openDeleteDialog = useCallback((targets: SessionSummary[]) => {
     const uniqueTargets = Array.from(new Map(targets.map((session) => [session.id, session])).values());
     if (uniqueTargets.length === 0) return;
@@ -546,7 +582,7 @@ export function HistoryRoute() {
     <main className={s.page}>
       <TopBar
         title="对话历史"
-        sub={isLoading ? "加载中…" : `${filtered.length} / ${sessions.length} 个会话`}
+        sub={isLoading ? "加载中…" : `${filtered.length} / ${scopedSessions.length} 个会话`}
         right={
           <>
             <span className={s.headerStat}>
@@ -650,6 +686,32 @@ export function HistoryRoute() {
             onChange={(event) => setSearchQuery(event.target.value)}
           />
         </div>
+
+        <div className={s.seg} role="tablist" aria-label="归档筛选">
+          <button
+            type="button"
+            role="tab"
+            aria-selected={archiveScope === "active"}
+            className={s.segItem}
+            data-active={archiveScope === "active" ? "true" : undefined}
+            onClick={() => setArchiveScope("active")}
+          >
+            活跃中
+            <span className={s.segCount}>{activeCount}</span>
+          </button>
+          <button
+            type="button"
+            role="tab"
+            aria-selected={archiveScope === "archived"}
+            className={s.segItem}
+            data-active={archiveScope === "archived" ? "true" : undefined}
+            onClick={() => setArchiveScope("archived")}
+          >
+            <Archive size={12} />
+            已归档
+            <span className={s.segCount}>{archivedCount}</span>
+          </button>
+        </div>
       </div>
 
       {bulkDeleteMode ? (
@@ -687,7 +749,11 @@ export function HistoryRoute() {
           <div className={s.emptyState}>加载会话中…</div>
         ) : dayGroups.length === 0 ? (
           <div className={s.emptyState}>
-            {sessions.length === 0 ? "暂无会话" : "没有匹配当前筛选的会话"}
+            {scopedSessions.length === 0
+              ? archiveScope === "archived"
+                ? "暂无已归档会话"
+                : "暂无会话"
+              : "没有匹配当前筛选的会话"}
           </div>
         ) : (
           dayGroups.map((group, groupIdx) => {
@@ -796,9 +862,11 @@ export function HistoryRoute() {
                         <SessionRowMenu
                           pinned={pinned}
                           disabled={menuDisabled}
+                          archived={archiveScope === "archived"}
                           onTogglePin={() => onTogglePinSession(session.id)}
                           onRename={() => startRename(session)}
                           onArchive={() => handleArchive(session)}
+                          onUnarchive={() => handleUnarchive(session)}
                           onDelete={() => openDeleteDialog([session])}
                         />
                       </Popover.Root>


### PR DESCRIPTION
## 背景

对话历史页此前只有「归档」动作（把会话收起来），但归档后**没有任何入口能再看到这些会话** —— 它们从默认列表里消失且无法找回。本 PR 补上「查看已归档对话 + 取消归档」这条闭环。

这套改动早先以未提交的 WIP 形式停留在一个落后于 main 的 worktree 里（所以前端一直看不到）。本 PR 将其整理、rebase 到最新 main 并补齐验证后落地。

## 改动

- **历史页新增「活跃中 / 已归档」范围切换**（`history.tsx`）：复用现有 `.seg` 分段控件，两个范围共用同一份请求，客户端按 `archived` 字段拆分；状态/来源/搜索筛选都只作用于当前范围。各范围带数量徽标。
- **取消归档**：`useUnarchiveSession`（`DELETE /api/sessions/{id}/archive`，乐观更新）+ 行菜单在已归档范围下把「归档」翻转为「取消归档」（`ArchiveRestore` 图标）。
- **会话列表支持 `includeArchived`**（`use-sessions.ts`）：带 `?include_archived=true` 时保留归档项；侧边栏仍用默认 active-only 查询，归档项不会泄漏过去。
- **Rust 代理注入归档标记**（`session_archive.rs`）：`filter_archived_from_response` 在 `include_archived=true` 时不再剥离归档会话，而是给命中项打上 `"archived": true`（`/api/sessions` 与 `/api/sessions/search` 均覆盖），并新增 3 个单元测试。归档/取消归档（POST/DELETE）的后端管道此前已具备。
- **协议**：`SessionSummary` 与 `SearchResult` 新增可选 `archived` 字段（`hermes-api.ts`）。

纯 Desktop 改动，不涉及 Core。

## 验证

- `pnpm typecheck` ✅
- `pnpm test:unit` ✅（protocol 61 + web 802，全过）
- `cargo test --lib session_archive` ✅（25 通过，含 3 个新增注入测试）
- `cargo fmt --check` ✅

🤖 Generated with [Claude Code](https://claude.com/claude-code)
