### PR TITLE
fix: 界面缩放改用原生 webview page zoom 修复窗口溢出裁切

### DIFF
--- a/capabilities/default.json
+++ b/capabilities/default.json
@@ -6,6 +6,7 @@
   "permissions": [
     "core:default",
     "core:window:allow-start-dragging",
+    "core:webview:allow-set-webview-zoom",
     "dialog:default",
     "dialog:allow-open",
     "clipboard-manager:allow-read-image"

--- a/packages/shared-ui/src/hooks/use-theme.ts
+++ b/packages/shared-ui/src/hooks/use-theme.ts
@@ -71,15 +71,33 @@ export const themeWriteAtom = atom(null, (_get, set, update: Partial<ThemeConfig
   });
 });
 
+/** The desktop bridge surface this module needs, kept local so shared-ui stays
+ *  free of a hard dependency on the web app's global typings. */
+type DesktopZoomBridge = { setUiZoom?: (factor: number) => void };
+
 export function applyThemeToDOM(config: ThemeConfig) {
   const root = document.documentElement;
   root.setAttribute("data-theme", config.theme);
   root.setAttribute("data-density", config.density);
   root.setAttribute("data-scale", config.scale);
-  // Single global scaling knob: enlarge the entire interface via `zoom` on the
-  // root element. Skip the property at 1× so default rendering is untouched.
+
   const factor = SCALE_FACTORS[config.scale] ?? 1;
-  if (factor === 1) {
+  const desktop = (globalThis as unknown as { hermesDesktop?: DesktopZoomBridge })
+    .hermesDesktop;
+
+  // Prefer the native webview page zoom on the desktop. Page zoom reflows the
+  // layout AND shrinks the layout viewport, so `100vw`/`100vh` keep tracking the
+  // OS window (which never resizes) — the whole UI enlarges with nothing clipped.
+  //
+  // The CSS `zoom` property is the wrong tool here: it scales painting but leaves
+  // the layout viewport untouched, so full-window containers (the app shell) get
+  // painted `factor`× larger than the window and overflow — exactly the reported
+  // bug where the right edge and bottom status bar are cut off at 150%. Use it
+  // only as a fallback in a plain browser, where native zoom isn't reachable.
+  if (desktop?.setUiZoom) {
+    root.style.removeProperty("zoom");
+    desktop.setUiZoom(factor);
+  } else if (factor === 1) {
     root.style.removeProperty("zoom");
   } else {
     root.style.setProperty("zoom", String(factor));

--- a/web/src/lib/runtime.ts
+++ b/web/src/lib/runtime.ts
@@ -354,6 +354,10 @@ declare global {
       onPreviewFileChanged?(handler: (payload: PreviewFileChangedPayload) => void): () => void;
       onFileDrop?(handler: (payload: DesktopFileDropPayload) => void): () => void;
       onSystemResume?(handler: () => void): () => void;
+      /** Native webview page zoom (reflows layout + viewport) for the interface
+       *  scale setting. Fire-and-forget; far better than CSS `zoom`, which leaves
+       *  viewport units un-scaled and overflows the fixed window. */
+      setUiZoom?(factor: number): void;
     };
   }
 }

--- a/web/src/lib/tauri-bridge.ts
+++ b/web/src/lib/tauri-bridge.ts
@@ -508,6 +508,18 @@ const tauriBridge = {
       safeUnlisten(unlisten);
     };
   },
+
+  setUiZoom(factor: number): void {
+    // Native webview page zoom (WKWebView setPageZoom / WebView2 ZoomFactor /
+    // WebKitGTK zoom_level). Unlike CSS `zoom`, page zoom reflows the layout and
+    // scales the viewport, so `100vw`/`100vh` keep matching the window and the
+    // interface-scale setting no longer clips the right edge / bottom status bar.
+    import("@tauri-apps/api/webview")
+      .then(({ getCurrentWebview }) => getCurrentWebview().setZoom(factor))
+      .catch((error) => {
+        console.warn("Failed to apply webview zoom", error);
+      });
+  },
 };
 
 // Overlay shown while the Rust side prepares the managed runtime and

--- a/web/src/lib/theme-defaults.test.ts
+++ b/web/src/lib/theme-defaults.test.ts
@@ -1,5 +1,10 @@
-import { describe, expect, it } from "vitest";
-import { DEFAULT_THEME_CONFIG, normalizeThemeConfig } from "@hermes/shared-ui";
+import { afterEach, beforeEach, describe, expect, it } from "vitest";
+import {
+  DEFAULT_THEME_CONFIG,
+  SCALE_FACTORS,
+  applyThemeToDOM,
+  normalizeThemeConfig,
+} from "@hermes/shared-ui";
 
 describe("theme defaults", () => {
   it("defaults to modern light when no skin is stored", () => {
@@ -19,5 +24,54 @@ describe("theme defaults", () => {
   it("keeps a supported interface scale and falls back for unknown values", () => {
     expect(normalizeThemeConfig({ scale: "xl" }).scale).toBe("xl");
     expect(normalizeThemeConfig({ scale: "huge" as never }).scale).toBe("md");
+  });
+});
+
+describe("applyThemeToDOM interface scaling", () => {
+  const style = new Map<string, string>();
+  const attrs = new Map<string, string>();
+  const root = {
+    setAttribute: (key: string, value: string) => attrs.set(key, value),
+    style: {
+      setProperty: (key: string, value: string) => style.set(key, value),
+      removeProperty: (key: string) => style.delete(key),
+    },
+  };
+
+  beforeEach(() => {
+    style.clear();
+    attrs.clear();
+    (globalThis as { document?: unknown }).document = { documentElement: root };
+  });
+
+  afterEach(() => {
+    delete (globalThis as { document?: unknown }).document;
+    delete (globalThis as { hermesDesktop?: unknown }).hermesDesktop;
+  });
+
+  it("drives the native webview page zoom (not CSS zoom) when the desktop bridge is present", () => {
+    const zooms: number[] = [];
+    (globalThis as { hermesDesktop?: unknown }).hermesDesktop = {
+      setUiZoom: (factor: number) => zooms.push(factor),
+    };
+
+    applyThemeToDOM({ theme: "light-modern", density: "comfortable", scale: "2xl" });
+
+    // Native page zoom reflows the viewport, so the bug-prone CSS `zoom` must NOT
+    // be set — otherwise the two would compound and the shell would still overflow.
+    expect(zooms).toEqual([SCALE_FACTORS["2xl"]]); // 1.5
+    expect(style.has("zoom")).toBe(false);
+    expect(attrs.get("data-scale")).toBe("2xl");
+  });
+
+  it("falls back to CSS zoom only in a plain browser (no desktop bridge)", () => {
+    applyThemeToDOM({ theme: "light-modern", density: "comfortable", scale: "2xl" });
+    expect(style.get("zoom")).toBe(String(SCALE_FACTORS["2xl"]));
+  });
+
+  it("removes the CSS zoom override at 100%", () => {
+    style.set("zoom", "1.5");
+    applyThemeToDOM({ theme: "light-modern", density: "comfortable", scale: "md" });
+    expect(style.has("zoom")).toBe(false);
   });
 });


### PR DESCRIPTION
## 问题

「高级 → 主题 → 界面缩放」放大到 110%/125%/150% 后，界面和字体确实变大了，但**窗口尺寸不变**，导致右侧面板和底部状态栏被挤出窗口、被裁掉（见用户反馈截图）。

## 根因

缩放此前用根节点 CSS `zoom`（`packages/shared-ui/src/hooks/use-theme.ts`）。CSS `zoom` 只放大**绘制**、不缩放 **layout viewport**：app shell 的 `100vw×100vh`（`app-shell.module.css` 的 `.shell` grid）仍按原窗口解析、再被 ×factor 绘制 → shell 比窗口大 `factor` 倍，底部状态栏（grid 第 3 行）和右栏溢出后被 `overflow:hidden` 裁切。

> 注：纯 CSS「把 `.shell` 视口单位 ÷ factor」不可取——CSS `zoom` 与视口单位的交互在 WebKit（macOS/Linux）与新版 Chromium（Windows WebView2）**不一致**，会在 Windows 上反向留白。

## 方案：原生 webview page zoom

改用 Tauri 的原生 webview 缩放（等价浏览器 Ctrl +）。page zoom 会 reflow 布局**并**缩放 viewport，`100vw`/`100vh` 始终等于窗口、跨引擎一致、零裁切。已读 wry 0.55.1 源码确认三大平台都是真·page zoom：

- macOS：`WKWebView.setPageZoom`
- Linux：`webkit_web_view_set_zoom_level`
- Windows：WebView2 `put_ZoomFactor`

## 改动

- `capabilities/default.json`：授予 `core:webview:allow-set-webview-zoom`
- `web/src/lib/tauri-bridge.ts`：新增 `setUiZoom(factor)` → `getCurrentWebview().setZoom()`
- `web/src/lib/runtime.ts`：`hermesDesktop` 接口补 `setUiZoom` 类型
- `packages/shared-ui/src/hooks/use-theme.ts`：`applyThemeToDOM` 桌面端优先原生 zoom，纯浏览器（无 bridge）才回退 CSS `zoom`
- `web/src/lib/theme-defaults.test.ts`：+3 测试覆盖原生 / 回退两条路径

## 验证

- `pnpm typecheck` ✅
- `pnpm test:unit` ✅（protocol 61 + web 805）
- `cargo check` ✅（capability 被 Tauri 构建接受）
- 实机 GUI 未在 CI 环境跑；建议 `pnpm tauri:dev` 调 150% 冒烟一眼。

🤖 Generated with [Claude Code](https://claude.com/claude-code)