### PR TITLE
feat: 移植上游 v0.18.0 MoA 展示（参考模型分块 + 聚合状态 + moa 模型选择）

### DIFF
--- a/packages/protocol/src/hermes-api.ts
+++ b/packages/protocol/src/hermes-api.ts
@@ -353,6 +353,17 @@ const HermesNoticeMessagePart = z.object({
   text: z.string(),
 });
 
+// MoA（Mixture of Agents）参考模型输出块：网关在聚合器回答之前，为每个
+// reference 模型 relay 一个完整的带标签文本块（moa.reference 事件）。仅存在
+// 于实时流；重载后的历史由后端持久化决定，不在此重建。
+const HermesMoaReferenceMessagePart = z.object({
+  type: z.literal("moa_reference"),
+  label: z.string(),
+  text: z.string(),
+  index: z.number().optional(),
+  count: z.number().optional(),
+});
+
 export const HermesMessagePart = z.discriminatedUnion("type", [
   HermesTextMessagePart,
   HermesReasoningMessagePart,
@@ -360,6 +371,7 @@ export const HermesMessagePart = z.discriminatedUnion("type", [
   HermesImageMessagePart,
   HermesToolMessagePart,
   HermesNoticeMessagePart,
+  HermesMoaReferenceMessagePart,
 ]);
 export type HermesMessagePart = z.infer<typeof HermesMessagePart>;
 
@@ -1399,6 +1411,26 @@ export const GatewayKnownEvent = z.discriminatedUnion("type", [
     session_id: z.string().optional(),
     payload: z.object({
       message: z.string().optional(),
+    }).passthrough().optional(),
+  }).passthrough(),
+  // MoA：每个 reference 模型的完整输出（label=槽位/模型名，text=全文，
+  // index/count=第几个/共几个）。非流式 delta，一个事件一整块。
+  z.object({
+    type: z.literal("moa.reference"),
+    session_id: z.string(),
+    payload: z.object({
+      label: z.string().optional(),
+      text: z.string().optional(),
+      index: z.number().optional(),
+      count: z.number().optional(),
+    }).passthrough().optional(),
+  }).passthrough(),
+  // MoA：references 齐了、聚合器开始综合（其回答走普通 message.delta 流）。
+  z.object({
+    type: z.literal("moa.aggregating"),
+    session_id: z.string(),
+    payload: z.object({
+      aggregator: z.string().optional(),
     }).passthrough().optional(),
   }).passthrough(),
 ]);

--- a/web/src/components/chat/message-adapter.ts
+++ b/web/src/components/chat/message-adapter.ts
@@ -514,6 +514,19 @@ function partsToBlocks(
       blocks.push({ type: "image", image: imagePartToEntry(part) });
       continue;
     }
+    if (part.type === "moa_reference") {
+      const text = normalizeContent(part.text);
+      if (text) {
+        blocks.push({
+          type: "moa_reference",
+          label: part.label,
+          text,
+          index: part.index,
+          count: part.count,
+        });
+      }
+      continue;
+    }
     if (part.type === "tool") {
       blocks.push({ type: "tool", tool: toolPartToToolEntry(part, message) });
     }

--- a/web/src/components/chat/message-timeline.tsx
+++ b/web/src/components/chat/message-timeline.tsx
@@ -229,6 +229,36 @@ function ReasoningBlock({ text, streaming }: { text: string; streaming?: boolean
   );
 }
 
+function MoaReferenceBlock({
+  label,
+  text,
+  index,
+  count,
+}: {
+  label: string;
+  text: string;
+  index?: number;
+  count?: number;
+}) {
+  const [open, setOpen] = useState(false);
+  const position = index !== undefined && count !== undefined ? `（${index + 1}/${count}）` : "";
+
+  return (
+    <div className={s.reasoning}>
+      <button
+        type="button"
+        className={s.disclosure}
+        onClick={() => setOpen((value) => !value)}
+        data-open={open}
+      >
+        <span className={s.chevron}>›</span>
+        <span>{`参考模型 ${label}${position}`}</span>
+      </button>
+      {open ? <pre className={s.reasoningBody}>{text}</pre> : null}
+    </div>
+  );
+}
+
 function formatToolElapsed(ms: number | undefined): string | null {
   if (ms === undefined || !Number.isFinite(ms) || ms <= 0) return null;
   if (ms < 100) return "<0.1s";
@@ -459,6 +489,21 @@ function MessageBlocks({ message, streaming, turnStartedAt, sessionUsage, progre
         <div key={`image-${index}`} className={s.imageBlock}>
           <MessageImage image={block.image} />
         </div>,
+      );
+      return;
+    }
+
+    if (block.type === "moa_reference") {
+      // MoA 参考模型输出块——不受 showReasoning 门控：它是委员会成员的
+      // 实际回答（MoA 的核心卖点），不是模型的内心独白；默认折叠不扰。
+      items.push(
+        <MoaReferenceBlock
+          key={`moa-ref-${index}`}
+          label={block.label}
+          text={block.text}
+          index={block.index}
+          count={block.count}
+        />,
       );
       return;
     }

--- a/web/src/lib/cn-provider-slugs.ts
+++ b/web/src/lib/cn-provider-slugs.ts
@@ -22,6 +22,10 @@ export const CN_BACKEND_PROVIDER_SLUGS = [
   "anthropic",   // ANTHROPIC_API_KEY widely used even in CN edition
   "openai-codex",
   "openrouter",  // kept as an explicit user-requested fallback aggregator
+  // v0.18.0：MoA（Mixture of Agents）虚拟 provider。仅当用户配置了 MoA
+  // preset 时网关才返回该行（models = preset 名列表），选中即把整个混合
+  // 集合当作一个模型使用。
+  "moa",
 ] as const;
 
 export type CnBackendProviderSlug = (typeof CN_BACKEND_PROVIDER_SLUGS)[number];

--- a/web/src/stores/chat.test.ts
+++ b/web/src/stores/chat.test.ts
@@ -1106,4 +1106,69 @@ describe("lastActivityAt (stall watchdog source)", () => {
     expect(next).toBe(interrupted);
     expect(next.lastActivityAt).toBe(1_000);
   });
+
+  it("appends moa.reference blocks and keeps them ordered before the aggregator text", () => {
+    const ref1 = reduceGatewayEvent(
+      createEmptyChatRuntime(1),
+      {
+        type: "moa.reference",
+        session_id: "s1",
+        payload: { label: "gpt-5", text: "GPT 的分析", index: 0, count: 2 },
+      },
+      10,
+    );
+    expect(ref1.statusKind).toBe("moa_reference");
+    expect(ref1.statusMessage).toContain("gpt-5");
+    expect(ref1.statusMessage).toContain("1/2");
+
+    const ref2 = reduceGatewayEvent(
+      ref1,
+      {
+        type: "moa.reference",
+        session_id: "s1",
+        payload: { label: "claude", text: "Claude 的分析", index: 1, count: 2 },
+      },
+      20,
+    );
+
+    const aggregating = reduceGatewayEvent(
+      ref2,
+      { type: "moa.aggregating", session_id: "s1", payload: { aggregator: "grok-4" } },
+      30,
+    );
+    expect(aggregating.statusKind).toBe("moa_aggregating");
+    expect(aggregating.statusMessage).toContain("grok-4");
+
+    const answered = reduceGatewayEvent(
+      aggregating,
+      { type: "message.delta", session_id: "s1", payload: { text: "综合结论" } },
+      40,
+    );
+    // 聚合器开始输出后，MoA 状态提示被 provider-status 清除逻辑收走。
+    expect(answered.statusKind).toBeUndefined();
+    expect(assistantMessage(answered).parts).toEqual([
+      { type: "moa_reference", label: "gpt-5", text: "GPT 的分析", index: 0, count: 2 },
+      { type: "moa_reference", label: "claude", text: "Claude 的分析", index: 1, count: 2 },
+      { type: "text", text: "综合结论" },
+    ]);
+  });
+
+  it("ignores empty moa.reference payloads and keeps thinking placeholders working", () => {
+    const noop = reduceGatewayEvent(
+      createEmptyChatRuntime(1),
+      { type: "moa.reference", session_id: "s1", payload: {} },
+      10,
+    );
+    expect(noop.messages).toHaveLength(0);
+
+    // 回归守卫：thinking.delta 仍走 reasoning.delta 的 fallthrough（历史上
+    // 在两者之间插分支会截胡 fallthrough）。
+    const placeholder = "ಠ_ಠ deliberating...";
+    const thinking = reduceGatewayEvent(
+      createEmptyChatRuntime(1),
+      { type: "thinking.delta", session_id: "s1", payload: { text: placeholder } },
+      10,
+    );
+    expect(assistantMessage(thinking).parts).toEqual([{ type: "progress", text: placeholder }]);
+  });
 });

--- a/web/src/stores/chat.ts
+++ b/web/src/stores/chat.ts
@@ -45,7 +45,8 @@ export type AssistantTurnBlock =
   | { type: "reasoning"; text: string }
   | { type: "progress"; text: string }
   | { type: "image"; image: ImageEntry }
-  | { type: "tool"; tool: ToolEntry };
+  | { type: "tool"; tool: ToolEntry }
+  | { type: "moa_reference"; label: string; text: string; index?: number; count?: number };
 
 export interface PendingApproval {
   requestId: string;
@@ -88,7 +89,13 @@ export const chatRuntimeBySessionAtom = atom<ChatRuntimeBySession>({});
 
 const GENERIC_TURN_FAILURE_TEXT =
   "模型服务调用未成功。常见原因：API Key 失效或不在模型权限范围、网络/服务不可达。请到 设置 → 模型 检查后重试。";
-const PROVIDER_STATUS_KINDS = new Set(["provider_wait", "provider_retry", "provider_stalled"]);
+const PROVIDER_STATUS_KINDS = new Set([
+  "provider_wait",
+  "provider_retry",
+  "provider_stalled",
+  "moa_reference",
+  "moa_aggregating",
+]);
 const OPTIMISTIC_ASSISTANT_PROGRESS = "正在启动Hermes Agent内核...";
 
 export function createEmptyChatRuntime(now = Date.now()): ChatSessionRuntime {
@@ -610,6 +617,59 @@ function reduceGatewayEventInner(
         }),
       );
       return next;
+    }
+
+    case "moa.reference": {
+      // 一个 reference 模型的完整输出块（label + 全文），在聚合器回答之前
+      // 逐个到达。追加为独立的 moa_reference part；同时用 provider-status
+      // 通道提示进度（message.delta 到达时自动清除）。
+      const label = typeof payload.label === "string" ? payload.label : "";
+      const text = typeof payload.text === "string" ? payload.text : "";
+      const index = typeof payload.index === "number" ? payload.index : undefined;
+      const count = typeof payload.count === "number" ? payload.count : undefined;
+      if (!label && !text) return runtime;
+      const id = activeAssistantId(runtime, now);
+      const progressLabel =
+        index !== undefined && count !== undefined
+          ? `参考模型 ${label || "?"} 已完成（${index + 1}/${count}）…`
+          : `参考模型 ${label || "?"} 已完成…`;
+      return updateActiveAssistant(
+        {
+          ...runtime,
+          streamStatus: "streaming",
+          activeAssistantId: id,
+          turnStartedAt: runtime.turnStartedAt ?? now,
+          statusMessage: progressLabel,
+          statusKind: "moa_reference",
+          statusUpdatedAt: now,
+          updatedAt: now,
+        },
+        sessionId,
+        now,
+        (message) => ({
+          ...message,
+          status: "streaming",
+          parts: [
+            ...message.parts,
+            { type: "moa_reference", label: label || "reference", text, index, count },
+          ],
+        }),
+      );
+    }
+
+    case "moa.aggregating": {
+      // references 齐了，聚合器开始综合；它的回答走普通 message.delta 流，
+      // 到达时 clearProviderStatus 会清掉这条状态。
+      const aggregator = typeof payload.aggregator === "string" ? payload.aggregator : "";
+      return {
+        ...runtime,
+        statusMessage: aggregator
+          ? `聚合器 ${aggregator} 正在综合各模型观点…`
+          : "聚合器正在综合各模型观点…",
+        statusKind: "moa_aggregating",
+        statusUpdatedAt: now,
+        updatedAt: now,
+      };
     }
 
     case "thinking.delta":


### PR DESCRIPTION
## 背景

上游 v0.18.0 把 MoA（Mixture of Agents）升级为一等公民：`moa` 虚拟 provider 出现在模型选择器（每个 preset 是一个可选"模型"），网关新增 `moa.reference`（每个参考模型的完整带标签输出块）与 `moa.aggregating`（聚合器开始综合）事件。本轮拍板将 MoA 展示纳入跟进范围（Core#85 同步 PR 的配套）。

## 改动

1. **协议层**（`hermes-api.ts`）：`GatewayKnownEvent` 新增 `moa.reference` / `moa.aggregating`；`HermesMessagePart` 新增 `moa_reference` 部件（label/text/index/count）
2. **chat store**：`moa.reference` 追加独立部件 + provider-status 进度提示（"参考模型 X 已完成 (1/3)…"）；`moa.aggregating` 提示"聚合器 X 正在综合…"，聚合器 `message.delta` 到达时自动清除；两个新 statusKind 纳入 `PROVIDER_STATUS_KINDS`
3. **渲染**（`message-timeline.tsx` + `message-adapter.ts`）：新增 `MoaReferenceBlock` 可折叠块（复用 reasoning 块样式，标题"参考模型 <label>（n/m）"）。**不受** showReasoning 门控——参考输出是委员会成员的实际回答（MoA 核心卖点），非内心独白；默认折叠不扰
4. **模型选择器**：`CN_BACKEND_PROVIDER_SLUGS` 放行 `moa`——网关仅在用户配置了 MoA preset 时返回该行（models = preset 名），选择路径完全走既有通用逻辑（provider=moa + model=preset，preset 持久选择由 Core 侧 #56417 修复保证）

## 不需要改的（已核实）

- **prompt.submit 超时**：上游桌面端修过长回合误报超时（#56411），但我们的架构里 `prompt.submit` 立即返回 `{"status":"streaming"}`（回合跑在后台线程、流式走事件），120s RPC 超时打不到长 MoA 回合
- 历史重载：MoA 参考块为实时流展示；持久化历史由后端决定，不在本 PR 重建

## 验证

- `pnpm typecheck` ✓、`pnpm test:unit` **817/817** ✓（新增 2 个 reducer 测试：参考块顺序 + 状态清除、空 payload 忽略 + thinking.delta fallthrough 回归守卫——开发中曾在 `thinking.delta:`/`reasoning.delta:` fallthrough 之间插分支截胡了 spinner 逻辑，被既有测试逮住后已修复并加守卫）
- Rust 未改动
- 端到端冒烟（`pnpm tauri:dev -- --source ../Hermes-CN-Core` 对新内核配 MoA preset 实测）待 Core#85 合并后补做

## 备注

与 #374（协议对齐）都改了 `hermes-api.ts` 与 `chat.ts` 的相邻区域，后合的一个可能要解琐碎冲突——两个都是我的分支，我来处理。

🤖 Generated with [Claude Code](https://claude.com/claude-code)