### PR TITLE
test: E2E 增加全局预热，消除首个用例撞冷启动的假失败

### DIFF
--- a/e2e/harness/global-warmup.mjs
+++ b/e2e/harness/global-warmup.mjs
@@ -1,0 +1,36 @@
+// Playwright globalSetup：在任何 spec 执行前把整条链路预热一遍。
+//
+// 为什么需要：两个 webServer（后端 + Vite dev）就绪探针只保证「端口在服务」，
+// 不保证「首个页面加载已经便宜」。第一次真实加载要同时付两笔冷启动账：
+//   1. Vite dev 按需转换整个 app（约 700 个模块，冷缓存机器上可超 15s）；
+//   2. 后端若干端点的首调冷路径（模块导入/编译，见 Core P-040 的背景）。
+// 这些成本落在第一个 spec 的第一条 expect 上（默认 15s 超时），导致「首测
+// 必挂、复跑就绿」的假失败。生产桌面端不受此影响（打包产物 + 冻结运行时
+// 无按需转换），所以在 harness 预热而不是放宽断言超时。
+import { chromium } from "@playwright/test";
+import { VITE_PORT } from "./config.mjs";
+
+const WARMUP_BUDGET_MS = 120_000;
+
+export default async function globalWarmup() {
+  const started = Date.now();
+  const browser = await chromium.launch();
+  try {
+    const page = await browser.newPage();
+    await page.goto(`http://localhost:${VITE_PORT}/`, {
+      waitUntil: "domcontentloaded",
+      timeout: WARMUP_BUDGET_MS,
+    });
+    // 等到 app 真正完成首屏（composer 出现），或预算耗尽——超时不让整个
+    // 套件失败，只是把冷启动账尽量在这里付掉。
+    await page
+      .getByRole("textbox", { name: "输入消息" })
+      .waitFor({ state: "visible", timeout: WARMUP_BUDGET_MS })
+      .catch(() => {});
+    console.log(
+      `[warmup] first paint settled in ${((Date.now() - started) / 1000).toFixed(1)}s`,
+    );
+  } finally {
+    await browser.close();
+  }
+}

--- a/e2e/playwright.config.ts
+++ b/e2e/playwright.config.ts
@@ -13,6 +13,8 @@ import {
 // Tests then drive the actual UI exactly as a user would.
 export default defineConfig({
   testDir: "./specs",
+  // 首个 spec 前预热整条链路（Vite 冷转换 + 后端冷端点），见该文件头注释。
+  globalSetup: "./harness/global-warmup.mjs",
   // One backend + shared session store -> keep tests serial and deterministic.
   fullyParallel: false,
   workers: 1,


### PR DESCRIPTION
## 背景

对全新 v0.18.0 内核在本机跑 E2E 时，首个 spec 稳定失败（composer 15s 不出现）、复跑即绿。两笔冷启动账都落在第一条断言上：Vite dev 首次按需转换整个 app（冷缓存机器 >15s）+ 后端若干端点首调冷路径（Core#86 / P-040 修掉了其中会卡事件循环的那笔；不卡循环的导入耗时仍在）。

## 改动

`playwright.config.ts` 增加 `globalSetup: harness/global-warmup.mjs`：webServer 就绪后、spec 开始前，无头加载一次首页并等 composer 出现（预算 120s，超时不阻塞套件）。生产桌面端不受这些冷启动影响（打包产物 + 冻结运行时），所以在 harness 预热而非放宽断言超时。

## 验证

本机冷启动全链路（真实 v0.18.0 后端 + fake model）：`[warmup] first paint settled in 43.0s` → chat-loop ✓ 39.5s、image-paste ✓ 18.7s，**2/2 通过**。

🤖 Generated with [Claude Code](https://claude.com/claude-code)