### PR TITLE
fix: 持久化 UI 设置挂载时重读并订阅 ui-store，修复重启后设置回退默认 (#294 问题B)

### DIFF
--- a/web/src/stores/ui.test.ts
+++ b/web/src/stores/ui.test.ts
@@ -313,3 +313,52 @@ describe("assistant display profile atoms (persisted)", () => {
     expect(uiStore.readUiValue("hermes.assistant-avatar-data-url", "fallback")).toBe("");
   });
 });
+
+// issue #294 问题B：stores/ui 经 main.tsx → debug-install → transport 的静态
+// import 链在 initUiStore() hydrate SQLite 之前就被求值，持久化 atom 把默认值
+// 烙进 init 且从不重读——Ctrl+Enter / 聊天宽度等设置重启后回落默认。这组测试
+// 复现"模块先求值、快照后到达"的真实时序。
+describe("persisted atoms follow late ui-store hydration (#294)", () => {
+  it("re-reads mounted atoms when the snapshot lands after module evaluation", async () => {
+    // 模块在空缓存（未 hydrate）状态下求值——复现真实启动时序。
+    const { composerSubmitShortcutAtom, conversationWidthModeAtom, uiStore } = await loadUi();
+    const store = createStore();
+    const unsubs = [
+      store.sub(composerSubmitShortcutAtom, () => {}),
+      store.sub(conversationWidthModeAtom, () => {}),
+    ];
+    expect(store.get(composerSubmitShortcutAtom)).toBe("enter");
+    expect(store.get(conversationWidthModeAtom)).toBe("medium");
+
+    // 模拟 initUiStore() 完成：SQLite 快照落进 kv 缓存并 notify。
+    uiStore.__resetUiStoreForTests({
+      "hermes.composer-submit-shortcut": "ctrl-enter",
+      "hermes.conversation-width": "large",
+    });
+
+    expect(store.get(composerSubmitShortcutAtom)).toBe("ctrl-enter");
+    expect(store.get(conversationWidthModeAtom)).toBe("large");
+    unsubs.forEach((unsub) => unsub());
+  });
+
+  it("reads the hydrated value on first mount without an extra notify", async () => {
+    const { conversationWidthModeAtom, uiStore } = await loadUi();
+    // hydrate 发生在模块求值之后、组件首次挂载之前。
+    uiStore.__resetUiStoreForTests({ "hermes.conversation-width": "small" });
+
+    const store = createStore();
+    const unsub = store.sub(conversationWidthModeAtom, () => {});
+    expect(store.get(conversationWidthModeAtom)).toBe("small");
+    unsub();
+  });
+
+  it("keeps user writes authoritative over a later identical notify", async () => {
+    const { conversationWidthModeAtom, uiStore } = await loadUi();
+    const store = createStore();
+    const unsub = store.sub(conversationWidthModeAtom, () => {});
+    store.set(conversationWidthModeAtom, "full");
+    expect(store.get(conversationWidthModeAtom)).toBe("full");
+    expect(uiStore.readUiValue("hermes.conversation-width", "")).toBe("full");
+    unsub();
+  });
+});

--- a/web/src/stores/ui.ts
+++ b/web/src/stores/ui.ts
@@ -1,6 +1,22 @@
 import { atom } from "jotai";
 import type { ComposerSubmitShortcut } from "@/lib/composer-submit-shortcut";
-import { readUiValue, writeUiValue } from "@/lib/ui-store";
+import { readUiValue, subscribeUiStore, writeUiValue } from "@/lib/ui-store";
+
+// 持久化 base atom 工厂（issue #294 问题B）。这些 atom 的初始值在**模块求值时**
+// 同步读 ui-store 的 kv 缓存，而本模块经 main.tsx → debug-install → transport
+// 的静态 import 链在 initUiStore() hydrate SQLite **之前**就被求值——此时缓存
+// 为空，默认值被烙进 atom，且此前从不重读，导致 Ctrl+Enter / 聊天宽度等设置
+// 重启后"回落默认"。挂载时重读一次并订阅 ui-store 通知（hydrate、reloadUiStore、
+// profile 切换、备份恢复），保证 atom 始终跟随持久层。
+function persistedUiBaseAtom<T>(key: string, fallback: T, normalize: (value: unknown) => T) {
+  const read = () => normalize(readUiValue<unknown>(key, fallback));
+  const base = atom<T>(read());
+  base.onMount = (set) => {
+    set(read());
+    return subscribeUiStore(() => set(read()));
+  };
+  return base;
+}
 
 export const activeSessionIdAtom = atom<string | null>(null);
 
@@ -78,8 +94,10 @@ export function normalizeAssistantAvatarDataUrl(value: unknown): string {
   return /^data:image\/(?:png|jpe?g|gif|webp|svg\+xml);base64,/i.test(text) ? text : "";
 }
 
-const conversationWidthModeBaseAtom = atom<ConversationWidthMode>(
-  normalizeConversationWidthMode(readUiValue(CONVERSATION_WIDTH_KEY, DEFAULT_CONVERSATION_WIDTH_MODE)),
+const conversationWidthModeBaseAtom = persistedUiBaseAtom<ConversationWidthMode>(
+  CONVERSATION_WIDTH_KEY,
+  DEFAULT_CONVERSATION_WIDTH_MODE,
+  normalizeConversationWidthMode,
 );
 export const conversationWidthModeAtom = atom(
   (get) => get(conversationWidthModeBaseAtom),
@@ -90,8 +108,10 @@ export const conversationWidthModeAtom = atom(
   },
 );
 
-const conversationFontSizeBaseAtom = atom<ConversationFontSizeMode>(
-  normalizeConversationFontSizeMode(readUiValue(CONVERSATION_FONT_SIZE_KEY, DEFAULT_CONVERSATION_FONT_SIZE_MODE)),
+const conversationFontSizeBaseAtom = persistedUiBaseAtom<ConversationFontSizeMode>(
+  CONVERSATION_FONT_SIZE_KEY,
+  DEFAULT_CONVERSATION_FONT_SIZE_MODE,
+  normalizeConversationFontSizeMode,
 );
 export const conversationFontSizeAtom = atom(
   (get) => get(conversationFontSizeBaseAtom),
@@ -112,7 +132,11 @@ export const conversationFontSizeAtom = atom(
 // Desktop 模式 (Electron) 下主进程 own dashboard 子进程，切换走 IPC →
 // stop + spawn，真正即时生效（direction B）。X-Hermes-Profile header 是给
 // 未来 fork 改造支持 per-request 路由用的占位（direction C）。
-const activeProfileBaseAtom = atom<string>(readUiValue("hermes.active-profile", "default"));
+const activeProfileBaseAtom = persistedUiBaseAtom<string>(
+  "hermes.active-profile",
+  "default",
+  (value) => (typeof value === "string" && value ? value : "default"),
+);
 export const activeProfileAtom = atom(
   (get) => get(activeProfileBaseAtom),
   (_get, set, next: string) => {
@@ -127,8 +151,10 @@ export const activeProfileAtom = atom(
 // 切换活跃档案时清空。对齐官方 dashboard 的 management-profile scope。
 export const managementProfileAtom = atom<string | null>(null);
 
-const assistantDisplayNameBaseAtom = atom<string>(
-  normalizeAssistantDisplayName(readUiValue(ASSISTANT_DISPLAY_NAME_KEY, DEFAULT_ASSISTANT_DISPLAY_NAME)),
+const assistantDisplayNameBaseAtom = persistedUiBaseAtom<string>(
+  ASSISTANT_DISPLAY_NAME_KEY,
+  DEFAULT_ASSISTANT_DISPLAY_NAME,
+  normalizeAssistantDisplayName,
 );
 export const assistantDisplayNameAtom = atom(
   (get) => get(assistantDisplayNameBaseAtom),
@@ -143,8 +169,10 @@ export const assistantDisplayNameAtom = atom(
   },
 );
 
-const assistantAvatarDataUrlBaseAtom = atom<string>(
-  normalizeAssistantAvatarDataUrl(readUiValue(ASSISTANT_AVATAR_KEY, "")),
+const assistantAvatarDataUrlBaseAtom = persistedUiBaseAtom<string>(
+  ASSISTANT_AVATAR_KEY,
+  "",
+  normalizeAssistantAvatarDataUrl,
 );
 export const assistantAvatarDataUrlAtom = atom(
   (get) => get(assistantAvatarDataUrlBaseAtom),
@@ -155,7 +183,11 @@ export const assistantAvatarDataUrlAtom = atom(
   },
 );
 
-const showReasoningBaseAtom = atom<boolean>(readUiValue("hermes.show-reasoning", false));
+const showReasoningBaseAtom = persistedUiBaseAtom<boolean>(
+  "hermes.show-reasoning",
+  false,
+  (value) => value === true,
+);
 export const showReasoningAtom = atom(
   (get) => get(showReasoningBaseAtom),
   (_get, set, next: boolean) => {
@@ -168,7 +200,11 @@ export const showReasoningAtom = atom(
 // so the user's last choice survives reload; ⌘B toggles it. The active tab
 // lives in the `?panel=` query, not here (see lib/preview-rail.ts).
 const RIGHT_RAIL_VISIBLE_KEY = "hermes.right-rail-visible";
-const rightRailVisibleBaseAtom = atom<boolean>(readUiValue<unknown>(RIGHT_RAIL_VISIBLE_KEY, false) === true);
+const rightRailVisibleBaseAtom = persistedUiBaseAtom<boolean>(
+  RIGHT_RAIL_VISIBLE_KEY,
+  false,
+  (value) => value === true,
+);
 export const rightRailVisibleAtom = atom(
   (get) => get(rightRailVisibleBaseAtom),
   (_get, set, next: boolean) => {
@@ -183,8 +219,10 @@ function normalizeComposerSubmitShortcut(value: unknown): ComposerSubmitShortcut
   return value === "ctrl-enter" ? "ctrl-enter" : "enter";
 }
 
-const composerSubmitShortcutBaseAtom = atom<ComposerSubmitShortcut>(
-  normalizeComposerSubmitShortcut(readUiValue(COMPOSER_SUBMIT_SHORTCUT_KEY, "enter")),
+const composerSubmitShortcutBaseAtom = persistedUiBaseAtom<ComposerSubmitShortcut>(
+  COMPOSER_SUBMIT_SHORTCUT_KEY,
+  "enter",
+  normalizeComposerSubmitShortcut,
 );
 export const composerSubmitShortcutAtom = atom(
   (get) => get(composerSubmitShortcutBaseAtom),
@@ -209,7 +247,7 @@ function readNotifyFlag(key: string): boolean {
 }
 
 function makeNotifyFlagAtom(key: string) {
-  const baseAtom = atom<boolean>(readNotifyFlag(key));
+  const baseAtom = persistedUiBaseAtom<boolean>(key, true, (value) => value !== false);
   return atom(
     (get) => get(baseAtom),
     (_get, set, next: boolean) => {


### PR DESCRIPTION
## 根因

`stores/ui.ts` 的持久化 atom（发送快捷键、聊天宽度、字号、助手名/头像、通知开关等）在**模块求值时**用 `readUiValue` 同步捕获初始值。而 `main.tsx → debug-install → transport → stores/ui` 这条**静态 import 链**使该模块在 `initUiStore()` 从 SQLite hydrate kv 缓存**之前**就被求值——此时缓存为空，默认值被烙进 atom 的 init，且此后从不重读。hydrate 完成后 `kvCache` 里有正确值并 `notify()`，但这些 atom 没有订阅 `subscribeUiStore`。

这就是 #294 问题B 的确切机制：SQLite `ui_kv` 里 `hermes.composer-submit-shortcut = "ctrl-enter"` 持久化正确、未被覆盖，但 UI/行为回落 `enter`；评论区补充的「聊天宽度设为大、重启回中」同根因。是**确定性 bug**（ES 模块求值顺序），非渲染竞态；写入路径无污染，纯粹只读不刷新。

## 修复

新增 `persistedUiBaseAtom` 工厂：初始值照旧同步读取（兼容测试里先 seed 后 import 的场景），并通过 `onMount` 在**首次挂载时重读一次** + **订阅 ui-store 通知**（initUiStore hydrate、reloadUiStore、profile 切换、备份恢复都会触发），atom 永远跟随持久层。全部 10 个持久化 base atom（宽度/字号/活跃档案/助手名/头像/推理过程/右栏可见/发送快捷键/5 个通知开关）迁移到该工厂。

主题（themeAtom）已有 main.tsx 显式重种路径，不在本次范围。

## 测试

- 新增 3 个回归测试，精确复现「模块先求值 → 快照后到达」时序：挂载中的 atom 在 hydrate 通知后跟新值；hydrate 后首挂载直接读到持久值；用户写入不被后续通知覆盖。
- `pnpm typecheck` ✅、`pnpm test:unit` 95 个测试文件全绿 ✅。

Fixes #294 的问题B（问题A 微信状态由内核 P-034 修复，随 runtime 发布）。

🤖 Generated with [Claude Code](https://claude.com/claude-code)