### PR TITLE
fix: read_workspace_file 越界防护改为 home 子树兜底 (#288)

### DIFF
--- a/src/commands/preview.rs
+++ b/src/commands/preview.rs
@@ -8,7 +8,8 @@
 // Two capabilities:
 // - `read_workspace_file`: read a single file from the session workspace,
 //   capped and binary-safe, with a containment guard so the renderer can't
-//   steer it outside the workspace root.
+//   steer it outside the workspace root (or, when the root is empty/stale,
+//   outside the user's home subtree — see `resolve_within_root`).
 // - `watch_preview_file` / `stop_preview_file_watch`: native fs watch that
 //   emits a `preview-file-changed` event on every change. The renderer
 //   debounces (matching the upstream 200ms FILE_RELOAD_DEBOUNCE_MS) before
@@ -46,9 +47,11 @@ const TEXT_WRITE_MAX_BYTES: usize = 1_000_000;
 #[derive(Deserialize)]
 #[serde(rename_all = "camelCase")]
 pub struct ReadWorkspaceFileInput {
-    /// File to read. Absolute or relative to `root`; must resolve inside `root`.
+    /// File to read. Absolute or relative to `root`; must resolve inside `root`
+    /// (or, when `root` is empty/stale, inside the user's home subtree).
     pub path: String,
-    /// Session workspace root. Reads are confined to this directory.
+    /// Session workspace root. Reads are confined to this directory; when it
+    /// cannot be resolved, they are confined to the home subtree instead.
     pub root: String,
 }
 
@@ -119,15 +122,28 @@ struct PreviewFileChangedPayload {
 }
 
 /// Resolve `path` (preferably absolute, as the renderer's file browser sends)
-/// to a canonical, existing file. Containment in `root` is **best-effort**: it
-/// is enforced only when `root` itself canonicalizes, so a workspace path the
-/// renderer could browse via the (more lenient) `/api/fs/list` endpoint never
-/// gets a valid file read rejected just because `canonicalize()` is stricter.
-/// Traversal/symlink escapes are still caught when containment applies.
+/// to a canonical, existing file, confined to an authorization boundary
+/// (#288):
+///
+/// - when `root` canonicalizes, the boundary is the workspace root;
+/// - when `root` is empty or stale (fails to canonicalize), the boundary
+///   falls back to the user's **home subtree** — the same gate the
+///   dashboard's `/api/fs/list` browser enforces, so everything the browser
+///   can list stays readable (the "no content" bug #265 fixed) without
+///   turning a stale root into an arbitrary absolute-path read primitive.
+///
+/// Traversal (`..`) and symlink escapes are always caught: both sides of the
+/// comparison are canonicalized.
 ///
 /// **Read path only.** Writes go through the strict
-/// [`resolve_within_root_strict`], which never skips containment.
+/// [`resolve_within_root_strict`], which never falls back past the root.
 fn resolve_within_root(root: &str, path: &str) -> AppResult<PathBuf> {
+    resolve_within_boundary(root, path, dirs::home_dir())
+}
+
+/// [`resolve_within_root`] with the home-subtree fallback injectable so tests
+/// stay hermetic (never touch the real `$HOME`).
+fn resolve_within_boundary(root: &str, path: &str, home: Option<PathBuf>) -> AppResult<PathBuf> {
     let raw = path.trim();
     if raw.is_empty() {
         return Err(AppError::InvalidRequest("Empty path".to_string()));
@@ -151,19 +167,24 @@ fn resolve_within_root(root: &str, path: &str) -> AppResult<PathBuf> {
         .canonicalize()
         .map_err(|e| AppError::FileError(format!("Path not accessible: {e}")))?;
 
-    // Enforce containment only when the workspace root canonicalizes. The file
-    // browser is already gated to the user's home subtree by the dashboard, so
-    // skipping the check for an un-canonicalizable root is safe and avoids a
-    // spurious rejection that surfaces to the user as "no content".
-    if !root.is_empty() {
-        if let Ok(root_real) = PathBuf::from(root).canonicalize() {
-            if !real.starts_with(&root_real) {
-                return Err(AppError::OriginViolation(format!(
-                    "Path escapes workspace: {}",
-                    real.display()
-                )));
-            }
-        }
+    let root_boundary = if root.is_empty() {
+        None
+    } else {
+        PathBuf::from(root).canonicalize().ok()
+    };
+    let boundary = root_boundary
+        .or_else(|| home.and_then(|h| h.canonicalize().ok()))
+        .ok_or_else(|| {
+            AppError::FileError(
+                "Workspace root is not accessible and no home directory could be resolved"
+                    .to_string(),
+            )
+        })?;
+    if !real.starts_with(&boundary) {
+        return Err(AppError::OriginViolation(format!(
+            "Path escapes workspace: {}",
+            real.display()
+        )));
     }
 
     Ok(real)
@@ -539,16 +560,86 @@ mod tests {
     }
 
     #[test]
-    fn reads_absolute_file_when_root_uncanonicalizable() {
+    fn stale_root_falls_back_to_home_subtree_for_reads() {
         // The file browser always sends an absolute path; a workspace root that
-        // canonicalize() can't resolve must not block a valid read (the bug
-        // that surfaced as "no content"). Containment is skipped, not fatal.
+        // canonicalize() can't resolve must not block a valid read of a file
+        // the browser can list (the "no content" bug, #265). The browser is
+        // gated to the home subtree, so that is the fallback boundary (#288).
+        let home = tempfile::tempdir().unwrap();
+        let file = home.path().join("a.txt");
+        std::fs::write(&file, b"hello").unwrap();
+
+        let resolved = resolve_within_boundary(
+            "/no/such/root-xyz-404",
+            &file.to_string_lossy(),
+            Some(home.path().to_path_buf()),
+        )
+        .unwrap();
+        assert_eq!(resolved, file.canonicalize().unwrap());
+    }
+
+    #[test]
+    fn stale_root_rejects_absolute_path_outside_home() {
+        // A stale/missing root must NOT grant arbitrary absolute-path reads
+        // (#288): outside the home-subtree fallback boundary → hard error.
+        let home = tempfile::tempdir().unwrap();
+        let outside = tempfile::tempdir().unwrap();
+        let secret = outside.path().join("secret.txt");
+        std::fs::write(&secret, b"nope").unwrap();
+
+        let err = resolve_within_boundary(
+            "/no/such/root-xyz-404",
+            &secret.to_string_lossy(),
+            Some(home.path().to_path_buf()),
+        )
+        .unwrap_err();
+        assert!(
+            matches!(err, AppError::OriginViolation(_)),
+            "expected OriginViolation, got {err:?}"
+        );
+    }
+
+    #[test]
+    fn empty_root_confines_absolute_reads_to_home() {
+        let home = tempfile::tempdir().unwrap();
+        let inside = home.path().join("ok.txt");
+        std::fs::write(&inside, b"ok").unwrap();
+        let outside = tempfile::tempdir().unwrap();
+        let secret = outside.path().join("secret.txt");
+        std::fs::write(&secret, b"nope").unwrap();
+
+        let resolved = resolve_within_boundary(
+            "",
+            &inside.to_string_lossy(),
+            Some(home.path().to_path_buf()),
+        )
+        .unwrap();
+        assert_eq!(resolved, inside.canonicalize().unwrap());
+
+        let err = resolve_within_boundary(
+            "",
+            &secret.to_string_lossy(),
+            Some(home.path().to_path_buf()),
+        )
+        .unwrap_err();
+        assert!(
+            matches!(err, AppError::OriginViolation(_)),
+            "expected OriginViolation, got {err:?}"
+        );
+    }
+
+    #[test]
+    fn stale_root_without_home_is_a_hard_error() {
         let dir = tempfile::tempdir().unwrap();
         let file = dir.path().join("a.txt");
         std::fs::write(&file, b"hello").unwrap();
 
-        let preview = read_file_preview("/no/such/root-xyz-404", &file.to_string_lossy()).unwrap();
-        assert_eq!(preview.text.as_deref(), Some("hello"));
+        let err = resolve_within_boundary("/no/such/root-xyz-404", &file.to_string_lossy(), None)
+            .unwrap_err();
+        assert!(
+            matches!(err, AppError::FileError(_)),
+            "expected FileError, got {err:?}"
+        );
     }
 
     #[test]

--- a/web/src/lib/runtime.ts
+++ b/web/src/lib/runtime.ts
@@ -238,9 +238,15 @@ export interface TerminalEventPayload {
 // Right-rail rich preview (issue #233). Mirrors the Rust commands in
 // src/commands/preview.rs and the upstream Electron preload API.
 export interface ReadWorkspaceFileInput {
-  /** Absolute path, or relative to `root`. Must resolve inside `root`. */
+  /**
+   * Absolute path, or relative to `root`. Must resolve inside `root` (or,
+   * when `root` is empty/stale, inside the user's home subtree).
+   */
   path: string;
-  /** Session workspace root; reads are confined to this directory. */
+  /**
+   * Session workspace root; reads are confined to this directory. When it
+   * cannot be resolved, reads are confined to the home subtree instead.
+   */
   root: string;
 }
 


### PR DESCRIPTION
## 根因

#265 为修「文件浏览器能列出、点开却读不到（no content）」把 `read_workspace_file` 的越界防护改成了**尽力而为**：workspace root 无法 canonicalize 时直接跳过包含性校验。#288 正确指出这与文档承诺的 root 约束矛盾，并构成越界读取原语：renderer 传一个已失效/不存在的 root + 任意存在的绝对路径，即可读到进程可触达的任何文件（`/etc/passwd`、home 之外的凭据等）。空 root + 绝对路径同样全放行。

## 修复

读取侧解析改为**双层授权边界**（`resolve_within_boundary`）：

- root 可 canonicalize → 维持原约束（只允许 root 子树内）；
- root 为空或失效 → 回退到**用户 home 子树**边界——这正是 dashboard `/api/fs/list` 文件浏览器本来的授权边界，#265 要保住的合法读取（浏览器能列出的文件都在 home 内）全部保留，但任意绝对路径读取被堵死；
- 两个边界都解析不出 → 硬错误。

遍历（..）与符号链接逃逸维持两侧 canonicalize 校验。写入侧 `resolve_within_root_strict` 不变（本就无兜底）。home 目录通过参数注入，测试不触碰真实 $HOME（遵守仓库测试约定）。

同步更新 Rust/TS 两侧接口文档注释。`watch_preview_file`（只发变更事件、内容重读仍走本防护）的边界收紧作为后续跟进。

## 测试

- 改写钉住旧行为的 `reads_absolute_file_when_root_uncanonicalizable` → `stale_root_falls_back_to_home_subtree_for_reads`；
- 新增：失效 root + home 外绝对路径 → OriginViolation；空 root 限定 home 子树（内读外拒）；失效 root 且无 home → 硬错误；
- `cargo test --lib commands::preview` 20/20 ✅、`cargo clippy --all-targets -- -D warnings` 0 warning ✅、`cargo fmt --check` ✅、`pnpm typecheck` ✅。

Fixes #288

🤖 Generated with [Claude Code](https://claude.com/claude-code)