### PR TITLE
fix: 会话工作区不再回退全局 last-used 值，杜绝跨会话静默继承 (#365/#372)

### DIFF
--- a/web/src/components/chat/goose-composer.test.tsx
+++ b/web/src/components/chat/goose-composer.test.tsx
@@ -90,3 +90,33 @@ describe("GooseComposer workspace picker", () => {
     expect(html).not.toContain("不指定默认工作区：");
   });
 });
+
+// issue #365/#372：composer 曾在会话没有自己工作区时回退显示"上次使用的全局
+// 工作区"，把上一个会话的目录静默画到（并在发送时写到）毫不相干的会话上。
+describe("GooseComposer workspace isolation (#365/#372)", () => {
+  it("不继承全局 last-used 工作区：无 initialWorkspacePath 时显示为未选择", async () => {
+    const { __resetUiStoreForTests } = await import("@/lib/ui-store");
+    __resetUiStoreForTests({
+      "hermes-cn-ui.workspacePath": "/Users/enzo/OtherSessionProject",
+    });
+
+    const html = renderComposer(<GooseComposer />);
+
+    expect(html).not.toContain("OtherSessionProject");
+    expect(html).not.toContain("不指定默认工作区：");
+  });
+
+  it("仍显示会话自己的工作区（initialWorkspacePath）", async () => {
+    const { __resetUiStoreForTests } = await import("@/lib/ui-store");
+    __resetUiStoreForTests({
+      "hermes-cn-ui.workspacePath": "/Users/enzo/OtherSessionProject",
+    });
+
+    const html = renderComposer(
+      <GooseComposer initialWorkspacePath="/Users/enzo/OwnProject" />,
+    );
+
+    expect(html).toContain("OwnProject");
+    expect(html).not.toContain("OtherSessionProject");
+  });
+});

--- a/web/src/components/chat/goose-composer.tsx
+++ b/web/src/components/chat/goose-composer.tsx
@@ -67,9 +67,7 @@ import {
 } from "@/lib/voice";
 import {
   normalizeWorkspacePath,
-  readWorkspacePath,
   rememberWorkspaceProject,
-  writeWorkspacePath,
 } from "@/lib/workspaces";
 import {
   ComposerAttachmentError,
@@ -229,8 +227,12 @@ export function GooseComposer({
   const [attachments, setAttachments] = useState<ComposerAttachment[]>([]);
   const [selectionStart, setSelectionStart] = useState(initial.length);
   const [selectionEnd, setSelectionEnd] = useState(initial.length);
+  // 只用会话自己的工作区初始化，不再回退到"上次使用的全局工作区"：那个
+  // 隐式 fallback 会把上一个会话的目录静默显示/写到毫不相干的新会话上
+  // （issue #365/#372）。没有工作区就显示空，让用户显式选择（最近项目
+  // 列表仍在工作区选择器里一键可选）。
   const [workspacePath, setWorkspacePath] = useState(
-    () => normalizeWorkspacePath(initialWorkspacePath) || readWorkspacePath(),
+    () => normalizeWorkspacePath(initialWorkspacePath),
   );
   const [submitError, setSubmitError] = useState("");
   const [workspacePickerOpen, setWorkspacePickerOpen] = useState(false);
@@ -497,7 +499,6 @@ export function GooseComposer({
     const nextPath = normalizeWorkspacePath(initialWorkspacePath);
     if (!nextPath) return;
     setWorkspacePath(nextPath);
-    writeWorkspacePath(nextPath);
     rememberWorkspaceProject(nextPath);
   }, [initialWorkspacePath]);
 
@@ -714,7 +715,6 @@ export function GooseComposer({
     const nextPath = normalizeWorkspacePath(path);
     if (!nextPath) return;
     setWorkspacePath(nextPath);
-    writeWorkspacePath(nextPath);
     rememberWorkspaceProject(nextPath);
   };
 
@@ -722,7 +722,6 @@ export function GooseComposer({
     if (controlsDisabled) return;
     setSubmitError("");
     setWorkspacePath("");
-    writeWorkspacePath("");
     setWorkspacePickerOpen(false);
   };
 

--- a/web/src/components/panel/panel-composer.tsx
+++ b/web/src/components/panel/panel-composer.tsx
@@ -15,7 +15,6 @@ import { composerSubmitShortcutHint } from "@/lib/composer-submit-shortcut";
 import {
   normalizeWorkspacePath,
   rememberWorkspaceProject,
-  writeWorkspacePath,
 } from "@/lib/workspaces";
 import { composerPrefillAtom } from "@/stores/panel";
 import { composerSubmitShortcutAtom } from "@/stores/ui";
@@ -66,7 +65,6 @@ export function PanelComposer() {
 
   useEffect(() => {
     if (!initialWorkspacePath) return;
-    writeWorkspacePath(initialWorkspacePath);
     rememberWorkspaceProject(initialWorkspacePath);
   }, [initialWorkspacePath]);
 

--- a/web/src/lib/workspaces.ts
+++ b/web/src/lib/workspaces.ts
@@ -225,8 +225,9 @@ export function rememberSessionWorkspace(sessionId: string | null | undefined, p
  *      (gateway / persistent), for sessions the backend has no explicit cwd for
  *      (legacy sessions, or ones where the user never picked a folder).
  *
- * Returns "" when no workspace is known for the session, so the caller can fall
- * back to its own default (e.g. the last-used global workspace).
+ * Returns "" when no workspace is known for the session. Callers must treat
+ * that as "no workspace" — NOT substitute the last-used global workspace,
+ * which silently attributed another session's folder to this one (#365/#372).
  */
 export function resolveSessionWorkspace(
   backendCwd: string | null | undefined,

--- a/web/src/routes/detail.tsx
+++ b/web/src/routes/detail.tsx
@@ -176,7 +176,9 @@ export function DetailRoute() {
 
   // Workspace bound to *this* session (#216): prefer the backend's stored cwd
   // (source of truth), then the client-side session→workspace map. Empty string
-  // lets the composer fall back to its own default (last-used global workspace).
+  // means "no workspace" and renders as such — the composer no longer falls
+  // back to the last-used global workspace (#365/#372: that silently painted
+  // another session's folder onto this one).
   const sessionWorkspace = useMemo(
     () => resolveSessionWorkspace(sessionData?.cwd ?? sessionSummary?.cwd, [restSessionId, taskId]),
     [sessionData?.cwd, sessionSummary?.cwd, restSessionId, taskId],


### PR DESCRIPTION
## 根因

composer 的工作区状态初始化带一个隐式全局兜底：`normalizeWorkspacePath(initialWorkspacePath) || readWorkspacePath()`（`hermes-cn-ui.workspacePath`，每次选目录都会写入）。后果是确定性的跨会话泄漏：

1. **#365 的全部硬证据由此解释**：新会话 `state.db` 里 `cwd = NULL`、`/api/sessions` 返回 workspace NOT SET，但 UI 仍显示上一个 Pack 的目录——composer 画的是全局兜底值，不是会话真实（空）工作区。
2. **#372 症状 2（下一个新会话继承）**：新任务 composer 用全局值当默认工作区，用户未选择也未收到提示。
3. 更糟：detail 页发送时会把 payload 里这个泄漏值 `rememberSessionWorkspace` 写到当前会话的映射上，把错误目录固化。文件操作可能指向错误目录，属实际风险。

会话真实工作区的解析链（后端 cwd → 会话映射 → 别名镜像）本身是健全的（`resolveSessionWorkspace` + `mirrorSessionWorkspaceMapping`），问题只在这个兜底把没有工作区渲染成上一个会话的工作区。

## 修复

- composer 初始化/选择/清除不再读写全局 `workspacePath` 键：会话有自己的工作区就显示它，没有就显示未选择，由用户显式选择（工作区选择器的「最近项目」列表不受影响，快捷选择的便利保留）。
- `panel-composer` / `goose-composer` 移除全部 `writeWorkspacePath` 写入；该键从此无读取方。
- 同步修正 `detail.tsx` / `workspaces.ts` 中把兜底行为写成预期的注释，防止回归。

## 测试

- 新增回归测试：全局键有他会话目录时，无 `initialWorkspacePath` 的 composer 不显示它；有自己工作区的 composer 只显示自己的。
- `pnpm typecheck` ✅、`pnpm test:unit` 95 个测试文件全绿 ✅。

Fixes #365；#372 若为纯 TUI（hermes --tui）复现路径，则属 Core 仓另查，本 PR 修复的是桌面端同族症状。

🤖 Generated with [Claude Code](https://claude.com/claude-code)