### PR TITLE
feat: 新增 portable（免安装）版本构建能力

### DIFF
--- a/.github/workflows/release-desktop.yml
+++ b/.github/workflows/release-desktop.yml
@@ -16,6 +16,10 @@
 #      pipeline.
 #   6. tauri-action uploads .exe / .dmg to the GitHub Release
 #      it creates on first run, or appends to an existing tag's release.
+#   7. Extra portable (unzip-and-run) zip artifacts are packaged from the same
+#      build output and uploaded alongside the installers: Windows collects
+#      exe + resources from the cargo target dir; macOS staples the already
+#      notarized .app and zips it with ditto. See docs/portable-mode.md.
 
 name: release-desktop
 
@@ -223,11 +227,25 @@ jobs:
             Windows 和 macOS 安装包同时内置 Hermes-CN-Core runtime
             ${{ steps.runtime_manifest.outputs.runtime_version }}，安装后可直接启动本地内核。
 
+            另附免安装（portable）压缩包：解压即用，全部数据保存在解压目录的
+            data 文件夹内，详见压缩包内 README-portable.txt。
+
             如需覆盖 runtime 更新源，可设置 HERMES_RUNTIME_UPDATE_* 环境变量。
           releaseDraft: false
           # Mark SemVer prerelease tags as prerelease on GitHub Releases.
           prerelease: ${{ contains(github.ref_name, '-alpha') || contains(github.ref_name, '-beta') || contains(github.ref_name, '-rc') }}
           args: --target ${{ matrix.target }}
+
+      - name: Package + upload Windows portable zip
+        if: matrix.runtime_platform == 'win32'
+        shell: bash
+        env:
+          GH_TOKEN: ${{ secrets.RELEASE_TOKEN || github.token }}
+          RELEASE_TAG: ${{ github.event.inputs.tag || github.ref_name }}
+        run: |
+          set -euo pipefail
+          node scripts/package-portable-windows.mjs --target ${{ matrix.target }}
+          gh release upload "$RELEASE_TAG" target/portable/*-portable.zip --clobber
 
       - name: Notarize, staple, verify, and reupload macOS DMG
         if: matrix.runtime_platform == 'darwin'
@@ -291,3 +309,25 @@ jobs:
             # final notarized + stapled DMG so the release asset is the one users download.
             gh release upload "$RELEASE_TAG" "$dmg" --clobber
           done
+
+      - name: Package + upload macOS portable zip
+        if: matrix.runtime_platform == 'darwin'
+        shell: bash
+        env:
+          GH_TOKEN: ${{ secrets.RELEASE_TOKEN || github.token }}
+          RELEASE_TAG: ${{ github.event.inputs.tag || github.ref_name }}
+        run: |
+          set -euo pipefail
+          app="target/${{ matrix.target }}/release/bundle/macos/Hermes Agent CN Desktop.app"
+
+          # The DMG notarization above produced a ticket covering the nested
+          # .app; staple the .app itself so the portable copy also validates
+          # offline. If Apple's ticket lookup ever fails here, the fallback is
+          # to notarize the portable zip separately:
+          #   ditto -c -k --keepParent "$app" app.zip && xcrun notarytool submit app.zip ...
+          xcrun stapler staple "$app"
+          xcrun stapler validate "$app"
+          spctl -a -vvv --type exec "$app"
+
+          node scripts/package-portable-macos.mjs --target ${{ matrix.target }}
+          gh release upload "$RELEASE_TAG" target/portable/*-portable.zip --clobber

--- a/CLAUDE.md
+++ b/CLAUDE.md
@@ -126,9 +126,14 @@ pnpm tauri:build:debug     # Debug：带调试信息的 .app / .dmg
 pnpm tauri:build:bundled-windows         # NSIS
 pnpm tauri:build:bundled-macos-arm64     # dmg (aarch64)
 pnpm tauri:build:bundled-macos-intel     # dmg (x86_64)
+
+# 免安装（portable）zip：在上面对应平台 bundled 构建之后追加打包（见 docs/portable-mode.md）
+pnpm portable:package-windows            # Windows 上运行
+pnpm portable:package-macos-arm64
+pnpm portable:package-macos-intel
 ```
 
-产物在 `target/release/bundle/` 或 `target/debug/bundle/`。`scripts/stage-bundled-runtime.mjs`、`stage-bundled-skills.mjs`、`stage-bundled-plugins.mjs`、`stage-dashboard-web-dist.mjs` 负责把后端 runtime、dashboard web dist、skills、plugins 拷进 `static/` 打包目录。
+产物在 `target/release/bundle/` 或 `target/debug/bundle/`（portable zip 在 `target/portable/`）。`scripts/stage-bundled-runtime.mjs`、`stage-bundled-skills.mjs`、`stage-bundled-plugins.mjs`、`stage-dashboard-web-dist.mjs` 负责把后端 runtime、dashboard web dist、skills、plugins 拷进 `static/` 打包目录。portable 模式通过解压目录内的 `portable.marker` 把整棵数据树锚定到 `<解压目录>/data`（`src/process/runtime.rs`）。
 
 ## 架构约定
 

--- a/docs/portable-mode.md
+++ b/docs/portable-mode.md
@@ -1,0 +1,75 @@
+# Portable（免安装）模式
+
+桌面端在安装版（NSIS / DMG）之外额外提供免安装 zip：解压即用，全部数据收敛在解压目录，
+不写注册表、不留 AppData / `~/Library`（macOS 的 WKWebView 存储除外，见「已知限制」）。
+安装版流程完全不受影响——portable 只是同一构建产物的另一种打包与数据锚定方式。
+
+## 工作原理
+
+### marker 文件
+
+zip 内预置 `portable.marker`（Windows 在 exe 同级；macOS 在 `.app` 同级——marker 不能放进
+`.app`，会破坏代码签名）。应用启动时探测一次（`src/process/runtime.rs` 的
+`PORTABLE_ANCHOR`）：marker 存在 → 整棵数据树锚定到 `<解压目录>/data`。
+只判存在性，不读内容；增删 marker 需重启应用后生效。
+
+### 数据根优先级
+
+`runtime_root()` 的决策顺序（`src/process/runtime.rs::decide_non_override_root`）：
+
+1. `HERMES_DESKTOP_RUNTIME_ROOT` 环境变量（逃生舱，始终最高）
+2. **portable marker**（全平台、含 debug 构建；且**无视** legacy AppData 旧数据——
+   portable 副本绝不触碰安装版的数据）
+3. Windows release 全新安装的 `<安装目录>\data` 锚定（原有行为）
+4. legacy AppData（`dirs::data_dir()/cn.org.hermesagent.desktop/<runtime|dev-runtime>`）
+
+marker 存在但 `data/` 不可写（如只读介质）时记录 warning 并回退到常规策略。
+
+### `data/` 里有什么
+
+`versions/`（CN-Core 冻结 runtime，自带 Python）、`downloads/`、`gateway-runtime/`、
+`hermes-home/`（会话、`config.yaml`、`.env` 凭据、memory、cron、日志、skills、plugins、
+`cache/`——含 `HERMES_DESKTOP_MANAGED=1` 重定向进来的 HF/torch/playwright/临时目录等
+第三方缓存）、`current.json`、`connection.json`、`desktop-owner.json`；Windows 还包括
+`webview2/`（WebView2 用户数据，`main.rs` 通过 `WEBVIEW2_USER_DATA_FOLDER` 重定向）。
+
+内核（CN-Core）的检查更新 / 安装 / 回滚本来就在 `runtime_root` 内原地进行，portable 下
+照常工作。桌面外壳自更新维持「仅提示」：portable 用户下载新 zip 覆盖解压（`data/` 保留
+即无损升级）；更新弹窗与设置页会根据 `RuntimeConfig.portable` 显示对应引导。
+
+## 打包
+
+```bash
+# 先完成对应平台的 bundled 构建（与安装版共用产物），再：
+pnpm portable:package-windows        # target/portable/*.zip（在 Windows 上运行）
+pnpm portable:package-macos-arm64    # ditto 保签名打 zip
+pnpm portable:package-macos-intel
+```
+
+- Windows：`scripts/package-portable-windows.mjs` 直接从 `target/<triple>/release/`
+  收集 exe + Tauri resources（Windows 上 `resource_dir()` 即 exe 目录，cargo target 目录
+  的布局与 NSIS 安装目录一致），附上 marker / README / `data/` 占位后压 zip。
+- macOS：`scripts/package-portable-macos.mjs` 用 `ditto` 拷贝 `.app`（保 symlink 与签名），
+  同级放 marker / README 后 `ditto -c -k` 压 zip。
+- CI：`release-desktop.yml` 在安装包上传后追加 portable zip（macOS 先对公证过的 `.app`
+  执行 `stapler staple`，让 portable 副本离线可验）。
+
+## 已知限制
+
+- **macOS WKWebView 存储**：cookie / localStorage / 网页缓存由系统管理，仍写
+  `~/Library/WebKit` 等（应用主数据不受影响、全部在 `data/`）。WKWebView 无重定向机制。
+- **macOS App Translocation**：从下载目录直接双击 quarantined `.app` 时，系统会把它搬到
+  随机临时路径运行，marker 不可见 → 静默退化为普通模式。应用检测到 Translocation 路径时
+  会弹提示；用户把解压文件夹移动一次或 `xattr -dr com.apple.quarantine <目录>` 即可解除。
+- **多开**：每个解压目录数据独立。同时启动多个实例（或与安装版同开）时，后启动的实例走
+  既有端口回退逻辑（9120 起最多 +20）；`desktop-owner.json` 与 HERMES_HOME 匹配校验保证
+  互不接管。
+- **误删 marker**：Windows 上全新目录仍会落到 `<exe 目录>\data`（与原 fresh-install 锚定
+  同构，近乎无感）；macOS 上会退化到 `~/Library`——README 已提示勿删。
+
+## 发版牵连（后续工作，不随本仓库 CI 自动完成）
+
+官网清单 `https://desktop.hermesagent.org.cn/latest.json`（landing 仓库
+`Eynzof/hermes-agent-cn-desktop-landing`）需为 portable zip 追加资产条目后，桌面端更新
+提示才能引导 portable 用户到对应下载；Rust 端 `DesktopUpdateAsset.assets` 是
+`BTreeMap<String, _>`，新增 key 无需桌面端改动。

--- a/package.json
+++ b/package.json
@@ -40,7 +40,10 @@
     "bundle:stage-macos-arm64": "pnpm run runtime:stage-bundled-macos-arm64 && pnpm run dashboard:stage-web-dist && pnpm run skills:stage-bundled && pnpm run plugins:stage-bundled",
     "bundle:stage-macos-intel": "pnpm run runtime:stage-bundled-macos-intel && pnpm run dashboard:stage-web-dist && pnpm run skills:stage-bundled && pnpm run plugins:stage-bundled",
     "tauri:build:bundled-macos-arm64": "pnpm run license:sync && pnpm run version:sync && pnpm run bundle:stage-macos-arm64 && pnpm exec tauri build --bundles dmg --target aarch64-apple-darwin",
-    "tauri:build:bundled-macos-intel": "pnpm run license:sync && pnpm run version:sync && pnpm run bundle:stage-macos-intel && pnpm exec tauri build --bundles dmg --target x86_64-apple-darwin"
+    "tauri:build:bundled-macos-intel": "pnpm run license:sync && pnpm run version:sync && pnpm run bundle:stage-macos-intel && pnpm exec tauri build --bundles dmg --target x86_64-apple-darwin",
+    "portable:package-windows": "node scripts/package-portable-windows.mjs --target x86_64-pc-windows-msvc",
+    "portable:package-macos-arm64": "node scripts/package-portable-macos.mjs --target aarch64-apple-darwin",
+    "portable:package-macos-intel": "node scripts/package-portable-macos.mjs --target x86_64-apple-darwin"
   },
   "devDependencies": {
     "@tauri-apps/cli": "^2.5.0"

--- a/scripts/package-portable-macos.mjs
+++ b/scripts/package-portable-macos.mjs
@@ -1,0 +1,134 @@
+#!/usr/bin/env node
+import { existsSync, mkdirSync, readFileSync, rmSync, writeFileSync } from "node:fs";
+import { dirname, join, resolve } from "node:path";
+import { fileURLToPath } from "node:url";
+import { spawnSync } from "node:child_process";
+
+function usage() {
+  console.log(`Usage: node scripts/package-portable-macos.mjs [options]
+
+Packages the built (and ideally signed + notarized + stapled) .app bundle into
+a portable zip: the .app plus portable.marker next to it, so the app anchors
+all data to <unzip dir>/data instead of ~/Library. Uses \`ditto\` throughout to
+preserve symlinks and code signatures (Python.framework inside the runtime).
+
+Run after \`pnpm tauri:build:bundled-macos-*\` (or tauri-action + notarization).
+The DMG pipeline is untouched; this only adds an extra artifact.
+
+Options:
+  --target <triple>   Cargo target triple (aarch64-apple-darwin or
+                      x86_64-apple-darwin). Default: no triple (target/release).
+  --out <dir>         Output dir for staging + zip (default: target/portable)
+`);
+}
+
+function argValue(flag, fallback = null) {
+  const index = process.argv.indexOf(flag);
+  if (index === -1) return fallback;
+  const value = process.argv[index + 1];
+  if (!value || value.startsWith("--")) {
+    throw new Error(`${flag} requires a value`);
+  }
+  return value;
+}
+
+function hasFlag(flag) {
+  return process.argv.includes(flag);
+}
+
+if (hasFlag("--help") || hasFlag("-h")) {
+  usage();
+  process.exit(0);
+}
+
+const repoRoot = resolve(dirname(fileURLToPath(import.meta.url)), "..");
+const pkg = JSON.parse(readFileSync(join(repoRoot, "package.json"), "utf8"));
+const tauriConf = JSON.parse(readFileSync(join(repoRoot, "tauri.conf.json"), "utf8"));
+
+const version = pkg.version;
+const productName = tauriConf.productName;
+const target = argValue("--target", null);
+const bundleMacosDir = target
+  ? join(repoRoot, "target", target, "release", "bundle", "macos")
+  : join(repoRoot, "target", "release", "bundle", "macos");
+const outRoot = resolve(repoRoot, argValue("--out", join("target", "portable")));
+
+const appPath = join(bundleMacosDir, `${productName}.app`);
+if (!existsSync(appPath)) {
+  throw new Error(`.app bundle not found (build first): ${appPath}`);
+}
+
+const archLabel = (target ?? "aarch64").startsWith("x86_64") ? "x64" : "aarch64";
+const stagingName = `${productName} Portable`;
+const stagingDir = join(outRoot, stagingName);
+const zipName = `${productName.replaceAll(" ", ".")}_${version}_${archLabel}-portable.zip`;
+const zipPath = join(outRoot, zipName);
+
+function ditto(args) {
+  const result = spawnSync("ditto", args, { stdio: "inherit", shell: false });
+  if (result.status !== 0) {
+    throw new Error(`ditto ${args.join(" ")} failed with status ${result.status}`);
+  }
+}
+
+rmSync(outRoot, { recursive: true, force: true });
+mkdirSync(stagingDir, { recursive: true });
+
+// ditto (not cpSync) keeps symlinks, resource forks, and code signatures
+// intact — the runtime zip inside Resources embeds a signed Python.framework.
+ditto([appPath, join(stagingDir, `${productName}.app`)]);
+
+writeFileSync(
+  join(stagingDir, "portable.marker"),
+  [
+    "Hermes Agent CN Desktop portable marker.",
+    "此文件与 .app 同级存在时，应用会把全部数据保存到本目录下的 data/ 文件夹。",
+    "请勿删除此文件，否则应用会退回 ~/Library 下的系统默认数据目录。",
+    "",
+  ].join("\n"),
+);
+
+writeFileSync(
+  join(stagingDir, "README-portable.txt"),
+  [
+    `Hermes Agent 中文社区桌面版 免安装版 v${version} (macOS ${archLabel})`,
+    "",
+    "使用方法：",
+    `  双击 ${productName}.app 直接运行，无需拖入「应用程序」。`,
+    "  全部主数据（会话、配置、内核、缓存）都保存在本目录的 data/ 文件夹。",
+    "",
+    "首次运行（重要）：",
+    "  macOS 会对下载的应用施加隔离（App Translocation），导致应用从临时",
+    "  路径启动、找不到本目录。若启动后弹出相关提示，请任选其一：",
+    "  1. 把解压出的整个文件夹移动到别的位置（例如从「下载」移到「文稿」），",
+    "     然后重新打开；或",
+    "  2. 在终端执行：xattr -dr com.apple.quarantine \"<本目录路径>\"",
+    "",
+    "升级：",
+    "  退出应用后，下载新版免安装压缩包，覆盖解压到本目录即可。",
+    "  data/ 文件夹会被保留，会话与配置不会丢失。",
+    "",
+    "已知限制：",
+    "  - 网页视图（WKWebView）的 cookie 与本地存储由 macOS 管理，仍会写入",
+    "    ~/Library；应用主数据不受影响。",
+    "  - 请勿删除 portable.marker 文件，它是免安装模式的开关。",
+    "  - 同时打开多个副本时，后启动的实例会自动改用其他端口。",
+    "",
+  ].join("\n"),
+);
+
+mkdirSync(join(stagingDir, "data"), { recursive: true });
+writeFileSync(
+  join(stagingDir, "data", "README.txt"),
+  "应用的全部数据保存在这里。升级覆盖解压时请保留此文件夹。\n",
+);
+
+// --keepParent keeps the "<productName> Portable/" folder as the zip's single
+// top-level entry so extraction is tidy; --sequesterRsrc preserves metadata.
+ditto(["-c", "-k", "--sequesterRsrc", "--keepParent", stagingDir, zipPath]);
+
+if (!existsSync(zipPath)) {
+  throw new Error(`portable zip was not created: ${zipPath}`);
+}
+console.log(`packaged portable zip: ${zipPath}`);
+console.log(`from: ${appPath}`);

--- a/scripts/package-portable-windows.mjs
+++ b/scripts/package-portable-windows.mjs
@@ -1,0 +1,173 @@
+#!/usr/bin/env node
+import {
+  cpSync,
+  existsSync,
+  mkdirSync,
+  readFileSync,
+  readdirSync,
+  rmSync,
+  writeFileSync,
+} from "node:fs";
+import { basename, dirname, join, resolve } from "node:path";
+import { fileURLToPath } from "node:url";
+import { spawnSync } from "node:child_process";
+
+function usage() {
+  console.log(`Usage: node scripts/package-portable-windows.mjs [options]
+
+Collects the built Windows executable and its Tauri resources from the cargo
+target directory into a self-contained portable folder (with portable.marker
+so the app anchors all data to <unzip dir>\\data), then zips it.
+
+Run after \`pnpm tauri:build:bundled-windows\` (or tauri-action) on Windows.
+The installer (NSIS) pipeline is untouched; this only adds an extra artifact.
+
+Options:
+  --target <triple>   Cargo target triple (e.g. x86_64-pc-windows-msvc).
+                      Default: no triple (target/release).
+  --out <dir>         Output dir for staging + zip (default: target/portable)
+`);
+}
+
+function argValue(flag, fallback = null) {
+  const index = process.argv.indexOf(flag);
+  if (index === -1) return fallback;
+  const value = process.argv[index + 1];
+  if (!value || value.startsWith("--")) {
+    throw new Error(`${flag} requires a value`);
+  }
+  return value;
+}
+
+function hasFlag(flag) {
+  return process.argv.includes(flag);
+}
+
+if (hasFlag("--help") || hasFlag("-h")) {
+  usage();
+  process.exit(0);
+}
+
+const repoRoot = resolve(dirname(fileURLToPath(import.meta.url)), "..");
+const pkg = JSON.parse(readFileSync(join(repoRoot, "package.json"), "utf8"));
+const tauriConf = JSON.parse(readFileSync(join(repoRoot, "tauri.conf.json"), "utf8"));
+
+const version = pkg.version;
+const productName = tauriConf.productName;
+const target = argValue("--target", null);
+const releaseDir = target
+  ? join(repoRoot, "target", target, "release")
+  : join(repoRoot, "target", "release");
+const outRoot = resolve(repoRoot, argValue("--out", join("target", "portable")));
+
+if (!existsSync(releaseDir)) {
+  throw new Error(`release dir not found (build first): ${releaseDir}`);
+}
+
+// The Tauri CLI may leave the executable under its cargo name or rename it to
+// the product name depending on version — probe both.
+const exeCandidates = [`${productName}.exe`, `${pkg.name}.exe`];
+const exeName = exeCandidates.find((name) => existsSync(join(releaseDir, name)));
+if (!exeName) {
+  const listing = readdirSync(releaseDir).join("\n  ");
+  throw new Error(
+    `no executable found in ${releaseDir} (tried: ${exeCandidates.join(", ")});\n` +
+      `directory contents:\n  ${listing}`,
+  );
+}
+
+// Resource layout mirrors tauri.conf.json bundle.resources: tauri-build copies
+// each mapping's destination into the cargo target dir, and on Windows
+// resource_dir() == the exe's directory, so the portable folder reproduces the
+// NSIS install layout exactly.
+const resourceDests = Object.values(tauriConf.bundle.resources).map((dest) =>
+  dest.replace(/\/+$/, ""),
+);
+
+const archLabel = (target ?? "x86_64").startsWith("aarch64") ? "arm64" : "x64";
+const stagingName = `${productName} Portable`;
+const stagingDir = join(outRoot, stagingName);
+const zipName = `${productName.replaceAll(" ", ".")}_${version}_${archLabel}-portable.zip`;
+const zipPath = join(outRoot, zipName);
+
+rmSync(outRoot, { recursive: true, force: true });
+mkdirSync(stagingDir, { recursive: true });
+
+cpSync(join(releaseDir, exeName), join(stagingDir, `${productName}.exe`));
+// Some Tauri/wry versions link WebView2Loader statically, others ship the DLL.
+const webview2Loader = join(releaseDir, "WebView2Loader.dll");
+if (existsSync(webview2Loader)) {
+  cpSync(webview2Loader, join(stagingDir, "WebView2Loader.dll"));
+}
+
+for (const dest of resourceDests) {
+  const source = join(releaseDir, dest);
+  if (!existsSync(source)) {
+    throw new Error(`bundled resource missing from target dir: ${source}`);
+  }
+  cpSync(source, join(stagingDir, dest), { recursive: true });
+}
+
+writeFileSync(
+  join(stagingDir, "portable.marker"),
+  [
+    "Hermes Agent CN Desktop portable marker.",
+    "此文件存在时，应用将把全部数据保存到本目录下的 data\\ 文件夹。",
+    "请勿删除此文件，否则应用会退回系统默认数据目录。",
+    "",
+  ].join("\r\n"),
+);
+
+writeFileSync(
+  join(stagingDir, "README-portable.txt"),
+  [
+    `Hermes Agent 中文社区桌面版 免安装版 v${version} (Windows ${archLabel})`,
+    "",
+    "使用方法：",
+    `  双击 ${productName}.exe 直接运行，无需安装。`,
+    "  全部数据（会话、配置、内核、缓存）都保存在本目录的 data\\ 文件夹。",
+    "",
+    "升级：",
+    "  退出应用后，下载新版免安装压缩包，覆盖解压到本目录即可。",
+    "  data\\ 文件夹会被保留，会话与配置不会丢失。",
+    "",
+    "注意事项：",
+    "  - 请先把压缩包解压到一个可写目录再运行（不要在压缩软件里直接双击）。",
+    "  - 首次运行需要系统已安装 WebView2 运行时（Windows 11 及多数 Windows 10",
+    "    已自带）；缺失时应用会提示联网安装。",
+    "  - 请勿删除 portable.marker 文件，它是免安装模式的开关。",
+    "  - 同时打开多个副本时，后启动的实例会自动改用其他端口。",
+    "",
+  ].join("\r\n"),
+);
+
+mkdirSync(join(stagingDir, "data"), { recursive: true });
+writeFileSync(
+  join(stagingDir, "data", "README.txt"),
+  "应用的全部数据保存在这里。升级覆盖解压时请保留此文件夹。\r\n",
+);
+
+// Prefer 7z (present on GitHub runners); fall back to Windows bsdtar.
+function compress() {
+  const sevenZip = spawnSync("7z", ["a", "-tzip", zipPath, stagingDir], {
+    stdio: "inherit",
+    cwd: outRoot,
+    shell: false,
+  });
+  if (sevenZip.status === 0) return;
+  const tar = spawnSync(
+    "tar.exe",
+    ["-a", "-cf", zipPath, "-C", outRoot, stagingName],
+    { stdio: "inherit", shell: false },
+  );
+  if (tar.status !== 0) {
+    throw new Error("failed to create portable zip: both 7z and tar.exe failed");
+  }
+}
+compress();
+
+if (!existsSync(zipPath)) {
+  throw new Error(`portable zip was not created: ${zipPath}`);
+}
+console.log(`packaged portable zip: ${zipPath}`);
+console.log(`from: ${releaseDir} (${basename(exeName)})`);

--- a/src/commands/gateway.rs
+++ b/src/commands/gateway.rs
@@ -14,6 +14,9 @@ pub struct RuntimeConfig {
     pub current_profile: String,
     /// "managed", "local" or "remote".
     pub connection_mode: String,
+    /// Running as the portable (unzip-and-run) distribution — the desktop
+    /// update dialog switches to "download the zip and re-extract" guidance.
+    pub portable: bool,
 }
 
 #[tauri::command]
@@ -25,6 +28,7 @@ pub fn get_runtime_config(state: State<'_, AppState>) -> Result<RuntimeConfig, A
         session_token: inner.session_token.clone(),
         current_profile: inner.current_profile.clone(),
         connection_mode: inner.connection_mode.as_str().to_string(),
+        portable: crate::process::runtime::portable_mode_active(),
     })
 }
 

--- a/src/main.rs
+++ b/src/main.rs
@@ -145,6 +145,40 @@ fn main() {
                 }
             }
 
+            // Data-root diagnostics: one line so support logs show where the
+            // tree is anchored and whether the portable marker was honored.
+            log::info!(
+                "runtime root: {} (portable: {})",
+                runtime::runtime_root().display(),
+                runtime::portable_mode_active()
+            );
+
+            // macOS Gatekeeper App Translocation runs a quarantined app from a
+            // randomized read-only path, which hides the portable marker next
+            // to the real .app — a portable unzip would silently fall back to
+            // ~/Library. One non-blocking heads-up tells the user how to fix
+            // it (harmless generic advice for DMG installs too).
+            #[cfg(target_os = "macos")]
+            if std::env::current_exe()
+                .map(|p| p.components().any(|c| c.as_os_str() == "AppTranslocation"))
+                .unwrap_or(false)
+            {
+                use tauri_plugin_dialog::DialogExt;
+                log::warn!(
+                    "running from an App Translocation path; a portable marker (if any) is invisible"
+                );
+                app.dialog()
+                    .message(
+                        "应用正被 macOS 隔离机制（App Translocation）从临时路径运行。\n\n\
+                         如果你使用的是免安装版（portable）：数据将无法保存到解压目录。\n\
+                         请把解压出来的整个文件夹移动到其他位置后重新启动，\n\
+                         或在终端执行：xattr -dr com.apple.quarantine <解压目录>\n\n\
+                         普通安装版用户请将应用拖入「应用程序」文件夹后重新打开。",
+                    )
+                    .title("检测到 macOS 应用隔离")
+                    .show(|_| {});
+            }
+
             // 1. Resolve HERMES_HOME
             let hermes_home_base = resolve_hermes_home();
             let base_str = hermes_home_base.to_string_lossy().to_string();

--- a/src/process/runtime.rs
+++ b/src/process/runtime.rs
@@ -23,6 +23,11 @@ const RUNTIME_SUBDIR_RELEASE: &str = "runtime";
 /// poison the packaged app's `current.json`.
 const RUNTIME_SUBDIR_DEV: &str = "dev-runtime";
 const LOCAL_SOURCE_ARCHIVE_FILE: &str = "current.json.local-source.bak";
+/// Marker file shipped inside the portable zip, next to the executable (next
+/// to the `.app` bundle on macOS — it cannot live inside the bundle without
+/// breaking code signing). Its presence — not its content — switches the app
+/// into portable mode: the whole runtime tree anchors to `<anchor>/data`.
+const PORTABLE_MARKER_FILE: &str = "portable.marker";
 const CURRENT_FILE: &str = "current.json";
 const MANIFEST_FILE: &str = "manifest.json";
 const DEFAULT_CHANNEL: &str = "stable";
@@ -304,6 +309,41 @@ pub fn runtime_root() -> PathBuf {
 static NON_OVERRIDE_RUNTIME_ROOT: LazyLock<PathBuf> =
     LazyLock::new(|| resolve_non_override_runtime_root(cfg!(all(windows, not(debug_assertions)))));
 
+/// Portable anchor, resolved once per process: `Some(unzip dir)` when the
+/// portable marker file sits next to the executable / app bundle. Probing
+/// touches current_exe + the filesystem, so memoize it like
+/// `NON_OVERRIDE_RUNTIME_ROOT` (adding/removing the marker needs a restart,
+/// consistent with the root itself being fixed for the process lifetime).
+static PORTABLE_ANCHOR: LazyLock<Option<PathBuf>> = LazyLock::new(|| {
+    let exe = std::env::current_exe().ok()?;
+    let anchor = portable_anchor_dir_from_exe(&exe)?;
+    anchor
+        .join(PORTABLE_MARKER_FILE)
+        .is_file()
+        .then_some(anchor)
+});
+
+/// Whether this process runs as the portable (unzip-and-run) distribution.
+pub fn portable_mode_active() -> bool {
+    PORTABLE_ANCHOR.is_some()
+}
+
+/// Directory the portable marker (and the `data` tree) is expected in: the
+/// folder the user unzipped. On macOS the executable lives inside
+/// `<unzip dir>/<name>.app/Contents/MacOS/`, so the anchor is the `.app`'s
+/// parent; everywhere else it is simply the executable's own directory.
+fn portable_anchor_dir_from_exe(exe: &Path) -> Option<PathBuf> {
+    for ancestor in exe.ancestors() {
+        if ancestor
+            .extension()
+            .is_some_and(|ext| ext.eq_ignore_ascii_case("app"))
+        {
+            return ancestor.parent().map(Path::to_path_buf);
+        }
+    }
+    exe.parent().map(Path::to_path_buf)
+}
+
 /// The historical anchor: `<OS data dir>/cn.org.hermesagent.desktop/<runtime>`.
 /// Used for existing Windows installs, all non-Windows platforms, and dev.
 fn legacy_appdata_runtime_root() -> PathBuf {
@@ -321,10 +361,30 @@ fn legacy_appdata_runtime_root() -> PathBuf {
 fn resolve_non_override_runtime_root(win_release: bool) -> PathBuf {
     let legacy_root = legacy_appdata_runtime_root();
 
+    // Portable distribution (marker next to the executable / .app): anchor the
+    // whole tree to `<unzip dir>/data` on every platform, debug builds
+    // included, so a portable unzip never touches the installed copy's data.
+    // Without the marker this is zero-side-effect.
+    let portable_data_root: Option<PathBuf> =
+        PORTABLE_ANCHOR.as_deref().map(|anchor| anchor.join("data"));
+    let portable_writable = portable_data_root
+        .as_deref()
+        .map(dir_is_writable)
+        .unwrap_or(false);
+    if let (Some(root), false) = (portable_data_root.as_deref(), portable_writable) {
+        // Read-only media (e.g. running from a mounted archive): portable
+        // intent cannot be honored — fall through to the regular policy.
+        log::warn!(
+            "portable.marker found but portable data dir is not writable, \
+             falling back to the default data location: {}",
+            root.display()
+        );
+    }
+
     // Off the Windows-release path there is nothing to anchor to the install
     // directory — keep the legacy root and avoid any filesystem side effects
     // (byte-for-byte the historic behavior on macOS / Linux / dev).
-    if !win_release {
+    if !win_release && portable_data_root.is_none() {
         return legacy_root;
     }
 
@@ -348,6 +408,8 @@ fn resolve_non_override_runtime_root(win_release: bool) -> PathBuf {
 
     decide_non_override_root(
         win_release,
+        portable_data_root.as_deref(),
+        portable_writable,
         legacy_has_data,
         install_data_root.as_deref(),
         install_writable,
@@ -355,16 +417,26 @@ fn resolve_non_override_runtime_root(win_release: bool) -> PathBuf {
     )
 }
 
-/// Pure runtime-root policy (no I/O). Anchor under the install directory only
+/// Pure runtime-root policy (no I/O). A writable portable anchor wins
+/// unconditionally (explicit opt-in via marker file, every platform, even over
+/// an existing legacy tree — the portable copy must never be diverted to the
+/// installed copy's data). Otherwise anchor under the install directory only
 /// for a fresh Windows-release install whose target dir is writable; otherwise
 /// fall back to the legacy AppData root. Cross-platform & fully unit tested.
 fn decide_non_override_root(
     win_release: bool,
+    portable_data_root: Option<&Path>,
+    portable_writable: bool,
     legacy_has_data: bool,
     install_data_root: Option<&Path>,
     install_writable: bool,
     legacy_root: PathBuf,
 ) -> PathBuf {
+    if portable_writable {
+        if let Some(root) = portable_data_root {
+            return root.to_path_buf();
+        }
+    }
     if win_release && !legacy_has_data && install_writable {
         if let Some(root) = install_data_root {
             return root.to_path_buf();
@@ -2568,7 +2640,9 @@ mod tests {
         let install = PathBuf::from(r"D:\Hermes\data");
         assert_eq!(
             decide_non_override_root(
-                true,  // win_release
+                true, // win_release
+                None, // no portable marker
+                false,
                 false, // legacy_has_data
                 Some(install.as_path()),
                 true, // install_writable
@@ -2585,6 +2659,8 @@ mod tests {
         assert_eq!(
             decide_non_override_root(
                 true,
+                None,
+                false,
                 true, // legacy_has_data
                 Some(Path::new(r"D:\Hermes\data")),
                 true,
@@ -2600,6 +2676,8 @@ mod tests {
         assert_eq!(
             decide_non_override_root(
                 true,
+                None,
+                false,
                 false,
                 Some(Path::new(r"C:\Program Files\Hermes\data")),
                 false, // not writable -> fall back to AppData (no regression)
@@ -2615,6 +2693,8 @@ mod tests {
         assert_eq!(
             decide_non_override_root(
                 false, // not win_release (macOS / Linux / dev)
+                None,
+                false,
                 false,
                 Some(Path::new("/opt/app/data")),
                 true,
@@ -2628,9 +2708,108 @@ mod tests {
     fn decide_root_unresolvable_exe_falls_back_to_appdata() {
         let legacy = PathBuf::from(r"C:\AppData\Roaming\cn.org.hermesagent.desktop\runtime");
         assert_eq!(
-            decide_non_override_root(true, false, None, true, legacy.clone()),
+            decide_non_override_root(true, None, false, false, None, true, legacy.clone()),
             legacy,
         );
+    }
+
+    // -------- portable mode (marker file next to the exe / .app) --------
+
+    #[test]
+    fn decide_root_portable_wins_over_existing_legacy_data() {
+        // A portable unzip on a machine that also has an installed copy must
+        // use its own `data` dir, never the installed copy's AppData tree.
+        let portable = PathBuf::from(r"E:\HermesPortable\data");
+        assert_eq!(
+            decide_non_override_root(
+                true,
+                Some(portable.as_path()),
+                true,
+                true, // legacy_has_data — portable still wins
+                Some(Path::new(r"E:\HermesPortable\data")),
+                true,
+                PathBuf::from(r"C:\AppData\Roaming\cn.org.hermesagent.desktop\runtime"),
+            ),
+            portable,
+        );
+    }
+
+    #[test]
+    fn decide_root_portable_applies_on_all_platforms() {
+        // macOS / Linux / debug builds: the marker is an explicit opt-in and
+        // overrides the non-Windows legacy-only policy.
+        let portable = PathBuf::from("/Users/u/Desktop/HermesPortable/data");
+        assert_eq!(
+            decide_non_override_root(
+                false, // not win_release
+                Some(portable.as_path()),
+                true,
+                false,
+                None,
+                false,
+                PathBuf::from("/home/u/.local/share/cn.org.hermesagent.desktop/runtime"),
+            ),
+            portable,
+        );
+    }
+
+    #[test]
+    fn decide_root_portable_not_writable_falls_back() {
+        // Read-only media (zip mounted, locked folder): fall back to the
+        // regular policy instead of failing.
+        let legacy = PathBuf::from("/home/u/.local/share/cn.org.hermesagent.desktop/runtime");
+        assert_eq!(
+            decide_non_override_root(
+                false,
+                Some(Path::new("/Volumes/ro/HermesPortable/data")),
+                false, // not writable
+                false,
+                None,
+                false,
+                legacy.clone(),
+            ),
+            legacy,
+        );
+    }
+
+    #[test]
+    fn portable_anchor_plain_exe_uses_exe_dir() {
+        // Separator-parsing test: use `/` paths so it behaves identically on
+        // every host platform (the Windows layout is the same shape).
+        assert_eq!(
+            portable_anchor_dir_from_exe(Path::new(
+                "/unzip/HermesPortable/Hermes Agent CN Desktop.exe"
+            )),
+            Some(PathBuf::from("/unzip/HermesPortable")),
+        );
+    }
+
+    #[test]
+    fn portable_anchor_macos_app_bundle_uses_app_parent() {
+        // The marker cannot live inside the signed .app, so the anchor is the
+        // bundle's parent (the unzip folder).
+        assert_eq!(
+            portable_anchor_dir_from_exe(Path::new(
+                "/Users/u/HermesPortable/Hermes Agent CN Desktop.app/Contents/MacOS/hermes-agent-cn-desktop"
+            )),
+            Some(PathBuf::from("/Users/u/HermesPortable")),
+        );
+    }
+
+    #[test]
+    fn portable_marker_detection_requires_marker_file() {
+        // End-to-end anchor probing logic (mirrors PORTABLE_ANCHOR init): a
+        // marker beside the exe activates the anchor; its absence does not.
+        let tmp = TempDir::new().unwrap();
+        let exe = tmp.path().join("hermes.exe");
+        fs::write(&exe, b"stub").unwrap();
+
+        let anchor = portable_anchor_dir_from_exe(&exe).unwrap();
+        assert!(!anchor.join(PORTABLE_MARKER_FILE).is_file());
+
+        fs::write(anchor.join(PORTABLE_MARKER_FILE), b"portable").unwrap();
+        assert!(anchor.join(PORTABLE_MARKER_FILE).is_file());
+        assert_eq!(anchor, tmp.path());
     }
 
     #[test]

--- a/web/src/components/desktop-update-notifier.tsx
+++ b/web/src/components/desktop-update-notifier.tsx
@@ -81,7 +81,9 @@ export function DesktopUpdateNotifier() {
             发现 Hermes Agent 桌面端新版本
           </Dialog.Title>
           <Dialog.Description id="desktop-update-desc" className={s.body}>
-            已发布 {versionLabel(result?.latestVersion)}，建议前往官网下载并安装新版。
+            {runtime.isPortable()
+              ? `已发布 ${versionLabel(result?.latestVersion)}，请前往官网下载免安装版压缩包，退出应用后覆盖解压即可（data 目录中的会话与配置会保留）。`
+              : `已发布 ${versionLabel(result?.latestVersion)}，建议前往官网下载并安装新版。`}
           </Dialog.Description>
           <div className={s.versionPanel} aria-label="桌面端版本信息">
             <div>

--- a/web/src/lib/runtime.ts
+++ b/web/src/lib/runtime.ts
@@ -434,6 +434,8 @@ declare global {
       currentProfile?: string;
       /** "managed" for desktop-owned runtime, "local"/"remote" for attached backends. */
       connectionMode?: ConnectionMode;
+      /** Running as the portable (unzip-and-run) desktop distribution. */
+      portable?: boolean;
     };
     hermesDesktop?: {
       windowType: "electron" | "tauri";
@@ -564,6 +566,11 @@ export const runtime = {
   /** True for either attached backend where process/profile lifecycle is external. */
   isAttached(): boolean {
     return this.getConnectionMode() !== "managed";
+  },
+
+  /** True when running as the portable (unzip-and-run) desktop distribution. */
+  isPortable(): boolean {
+    return window.__HERMES_RUNTIME__?.portable ?? false;
   },
 
   getApiUrl(path: string): string {

--- a/web/src/lib/tauri-bridge.ts
+++ b/web/src/lib/tauri-bridge.ts
@@ -924,6 +924,7 @@ export async function installTauriBridge(): Promise<void> {
     sessionToken?: string;
     currentProfile: string;
     connectionMode?: "managed" | "local" | "remote";
+    portable?: boolean;
   }>("get_runtime_config");
 
   // Dev mode: WebView loads from Vite dev server (http://localhost:9545).
@@ -976,6 +977,7 @@ export async function installTauriBridge(): Promise<void> {
     sessionToken: config.sessionToken,
     currentProfile: config.currentProfile,
     connectionMode,
+    portable: config.portable ?? false,
   };
 
   (window as any).hermesDesktop = tauriBridge;

--- a/web/src/routes/settings.tsx
+++ b/web/src/routes/settings.tsx
@@ -61,7 +61,7 @@ import {
 } from "@/stores/ui";
 import { playChime, shouldPlayFallbackSound } from "@/lib/notifications";
 import { openExternalUrl } from "@/lib/external-links";
-import { detectHostOS } from "@/lib/runtime";
+import { detectHostOS, runtime } from "@/lib/runtime";
 import { checkDesktopUpdate, DESKTOP_UPDATE_DOWNLOAD_URL } from "@/lib/desktop-update";
 import { DESKTOP_VERSION, versionLabel } from "@/lib/build-info";
 import {
@@ -1583,7 +1583,9 @@ export function AboutSection({ showHeading = true }: SettingsSectionProps) {
             </Button>
           </div>
           <p className={s.desc}>
-            这里提醒的是桌面壳版本。下载新版安装包后，请按系统提示覆盖安装；应用不会自动下载安装包或替换正在运行的程序。
+            {runtime.isPortable()
+              ? "这里提醒的是桌面壳版本。免安装版请下载新版压缩包，退出应用后覆盖解压到当前目录（data 目录中的数据会保留）；应用不会自动下载或替换正在运行的程序。"
+              : "这里提醒的是桌面壳版本。下载新版安装包后，请按系统提示覆盖安装；应用不会自动下载安装包或替换正在运行的程序。"}
           </p>
         </DebugCard>
 
@@ -1801,7 +1803,9 @@ function formatDesktopUpdateMessage(
   if (!result) return "点击“检查更新”可手动读取官网最新版本。";
   if (!result.ok) return result.error ?? "桌面端更新检查失败。";
   if (result.updateAvailable) {
-    return `发现新版本 ${versionLabel(result.latestVersion)}，可前往官网下载新版安装包覆盖安装。`;
+    return runtime.isPortable()
+      ? `发现新版本 ${versionLabel(result.latestVersion)}，可前往官网下载免安装版压缩包，退出应用后覆盖解压（data 目录会保留）。`
+      : `发现新版本 ${versionLabel(result.latestVersion)}，可前往官网下载新版安装包覆盖安装。`;
   }
   return `当前已是最新版本 ${versionLabel(result.currentVersion)}。`;
 }


### PR DESCRIPTION
## 背景

调研确认桌面端做免安装（绿色）版完全可行：所有持久化已收敛在单一锚点 `runtime_root()` 之下，CN-Core 完全尊重 `HERMES_HOME`（含 `HERMES_DESKTOP_MANAGED=1` 时的第三方缓存重定向），无注册表/keychain/自启动等系统级残留。本 PR 在**不改动任何安装版（NSIS/DMG）流程**的前提下，追加 portable 构建能力。

## 实现

- **数据锚定**（`src/process/runtime.rs`）：exe（macOS 为 `.app`）同级存在 `portable.marker` 时，整棵数据树锚定到 `<解压目录>/data`。优先级：`HERMES_DESKTOP_RUNTIME_ROOT` env > portable marker（全平台、无视 legacy AppData 数据）> Windows release fresh-install 锚定 > legacy。marker 缺席时决策路径与历史行为完全一致（现有 5 个策略单测原语义保持，新增 6 个 portable 用例）。
- **macOS Translocation 缓解**（`src/main.rs`）：检测到从 App Translocation 临时路径启动时弹一次性提示（移动目录或去 quarantine），并输出 runtime root 诊断日志。
- **前端引导差异化**：`get_runtime_config` 透出 `portable` 标志，更新弹窗/设置页对 portable 用户显示「下载 zip 覆盖解压、data 保留即无损升级」。
- **打包**：`scripts/package-portable-windows.mjs`（收集 target 目录 exe+resources，布局与 NSIS 安装目录一致）、`scripts/package-portable-macos.mjs`（ditto 保签名）。
- **CI**：`release-desktop.yml` 在安装包上传后追加 portable zip（macOS 先对公证过的 .app staple）。

## 验证

- `cargo fmt --check` / `cargo clippy --all-targets -D warnings` / `cargo test --all-features`（386+ 全过）
- `pnpm typecheck` / `pnpm test:unit`（protocol 61 + web 836 全过）
- 本机 macOS debug 冒烟：marker 存在 → 日志 `portable: true`、`hermes-home`/`gateway-runtime` 生成于 `target/debug/data/`；删除 marker → 回退 legacy 路径 `~/Library/.../dev-runtime`（`portable: false`）
- Windows 产物布局待 CI/Windows 机验证（脚本对 exe 双名探测，失败会列目录内容尽早暴露）

## 后续（不在本 PR）

官网 `latest.json`（landing 仓库）需在正式发版时为 portable zip 追加资产条目；`DesktopUpdateAsset.assets` 为 `BTreeMap`，桌面端无需再改。

🤖 Generated with [Claude Code](https://claude.com/claude-code)