### PR TITLE
fix: 修复带工具回合的重复气泡与回合统计错位

### DIFF
--- a/web/src/components/chat/message-adapter.test.ts
+++ b/web/src/components/chat/message-adapter.test.ts
@@ -843,6 +843,49 @@ describe("message adapter", () => {
     expect(chat[1]?.stats?.ttftMs).toBe(500);
   });
 
+  it("attaches a split turn's stats to its final answer row, not the leading commentary", () => {
+    // ui_messages splits ONE agent turn into several assistant rows (leading
+    // commentary + tool, then the final answer). The turn's single stat carries
+    // turnIndex in live space (turn #1) and a whole-turn contentHash that
+    // matches no single stored row, so it falls to the turnIndex pass — which
+    // must land on the final answer row, not the opening commentary row.
+    const messages = [
+      uiMessage({ id: "u", role: "user", createdAt: 1_000, parts: [{ type: "text", text: "审查一下这个项目" }] }),
+      uiMessage({
+        id: "a-lead",
+        createdAt: 1_100,
+        parts: [
+          { type: "text", text: "好的，先从项目结构看起。" },
+          { type: "tool", toolCallId: "call-1", name: "read_file", state: "done", output: "ok" },
+        ],
+      }),
+      uiMessage({
+        id: "a-final",
+        createdAt: 1_500,
+        parts: [{ type: "text", text: "# 审查报告\n\n结论：整体质量良好。" }],
+      }),
+    ];
+
+    const enriched = attachTurnStatsMetadata(messages, [
+      {
+        id: "s1:live-assistant-1",
+        sessionId: "s1",
+        turnIndex: 1,
+        contentHash: stableTextHash("整条合并回合的哈希-对不上任何单行"),
+        ttftMs: 700,
+        durationMs: 61_000,
+        metadata: { usage: { tokensTotal: 4_509 } },
+      },
+    ]);
+    const chat = hermesUIMessagesToChatMessages(enriched);
+
+    const lead = chat.find((message) => (message.text ?? "").includes("先从项目结构"));
+    const final = chat.find((message) => (message.text ?? "").includes("审查报告"));
+    expect(lead?.stats?.ttftMs).toBeUndefined();
+    expect(final?.stats?.ttftMs).toBe(700);
+    expect(final?.stats?.tokensTotal).toBe(4_509);
+  });
+
   it("keeps scalar history stats when no local turn stats match", () => {
     // 非本机流式过的历史会话没有 ui-store 回合统计——服务端历史只有
     // token_count，统计栏应降级为只显示 tokens 而不是整体消失。

--- a/web/src/components/chat/message-adapter.test.ts
+++ b/web/src/components/chat/message-adapter.test.ts
@@ -651,6 +651,68 @@ describe("message adapter", () => {
     expect(merged).toHaveLength(2);
   });
 
+  it("drops a completed consolidated live turn already persisted across multiple stored assistant rows", () => {
+    // Backend persists ONE agent turn as SEVERAL assistant rows: leading
+    // commentary + a tool call, a tool-only middle row, then the final answer.
+    const stored = [
+      uiMessage({
+        id: "stored-lead",
+        createdAt: 1_000,
+        status: "complete",
+        parts: [
+          { type: "text", text: "好的，我来做一次全面的代码审查。先从项目结构开始。" },
+          { type: "tool", toolCallId: "call-read", name: "read_file", state: "done", output: "ok", startedAt: 1_000, completedAt: 1_200 },
+        ],
+        metadata: { persistedId: 516 },
+      }),
+      uiMessage({
+        id: "stored-mid",
+        createdAt: 1_300,
+        status: "complete",
+        parts: [
+          { type: "tool", toolCallId: "call-term", name: "terminal", state: "done", output: "ok", startedAt: 1_300, completedAt: 1_400 },
+        ],
+        metadata: { persistedId: 540 },
+      }),
+      uiMessage({
+        id: "stored-final",
+        createdAt: 1_500,
+        status: "complete",
+        parts: [{ type: "text", text: "# 代码审查报告\n\n概述：整体质量良好。" }],
+        metadata: { persistedId: 553 },
+      }),
+    ];
+    // The live runtime consolidated the WHOLE turn into ONE assistant bubble
+    // (a single live-assistant client id, all parts, completed). Its text is the
+    // lead + final answer concatenated, so it exact-matches NEITHER stored text
+    // row — the pre-fix duplicate that lands the report twice.
+    const live = [
+      uiMessage({
+        id: "live-assistant-1783430115706",
+        createdAt: 1_000,
+        status: "complete",
+        parts: [
+          { type: "text", text: "好的，我来做一次全面的代码审查。先从项目结构开始。" },
+          { type: "tool", toolCallId: "call-read", name: "read_file", state: "done", output: "ok", startedAt: 1_000, completedAt: 1_200 },
+          { type: "tool", toolCallId: "call-term", name: "terminal", state: "done", output: "ok", startedAt: 1_300, completedAt: 1_400 },
+          { type: "text", text: "# 代码审查报告\n\n概述：整体质量良好。" },
+        ],
+        metadata: { timing: { startedAt: 1_000, firstTokenAt: 1_050, completedAt: 1_600 } },
+      }),
+    ];
+
+    const merged = mergeHermesUIMessages(stored, live);
+    const chat = hermesUIMessagesToChatMessages(merged);
+
+    // The final report renders exactly once (pre-fix: twice — the stored answer
+    // row plus the un-deduped consolidated live bubble).
+    const reportBubbles = chat.filter((message) => (message.text ?? "").includes("代码审查报告"));
+    expect(reportBubbles).toHaveLength(1);
+    // The consolidated live bubble is dropped; the canonical stored rows win.
+    expect(merged.some((message) => message.id.startsWith("live-assistant"))).toBe(false);
+    expect(merged.map((message) => message.id)).toEqual(["stored-lead", "stored-mid", "stored-final"]);
+  });
+
   it("hides stale interrupted live replies once a later stored assistant answer exists", () => {
     const stored = legacySessionMessagesToHermesUIMessages([
       sessionMessage({

--- a/web/src/components/chat/message-adapter.ts
+++ b/web/src/components/chat/message-adapter.ts
@@ -644,13 +644,9 @@ export function attachTurnStatsMetadata(
   // 就贴错了消息（用户看到的"TTFT 时有时无"成因之一）。
   const used = new Set<number>();
   const statByMessage = new Map<number, number>();
-  const ordinalByMessage = new Map<number, number>();
 
-  let assistantIndex = 0;
   messages.forEach((message, messageIndex) => {
     if (message.role !== "assistant") return;
-    assistantIndex += 1;
-    ordinalByMessage.set(messageIndex, assistantIndex);
     const hash = statsHashFromMessage(message);
     if (!hash) return;
     const statIndex = stats.findIndex(
@@ -662,9 +658,19 @@ export function attachTurnStatsMetadata(
     }
   });
 
+  // turnIndex 兜底按"回合"计数：一个回合 = 一段连续的 assistant 消息（回合之间
+  // 隔着 user 消息）。写入侧 turnIndex 是在 live 空间打的——那里整回合被合并成
+  // 一条 assistant 消息——所以当后端把一个回合拆成多条 stored 行（ui_messages
+  // 路径不做合并）时，该回合的 TTFT/tokens/成本要落到这段的**最后一条**（最终
+  // 答复）行，而不是开场白行；逐条 assistant 序号兜底会把统计贴到开场白上。
+  // contentHash 精确命中仍优先（上一遍已占住）。
+  let turnOrdinal = 0;
   messages.forEach((message, messageIndex) => {
-    if (message.role !== "assistant" || statByMessage.has(messageIndex)) return;
-    const ordinal = ordinalByMessage.get(messageIndex);
+    if (message.role !== "assistant") return;
+    if (messages[messageIndex - 1]?.role !== "assistant") turnOrdinal += 1;
+    const endsTurn = messages[messageIndex + 1]?.role !== "assistant";
+    if (!endsTurn || statByMessage.has(messageIndex)) return;
+    const ordinal = turnOrdinal;
     const statIndex = stats.findIndex(
       (stat, index) => !used.has(index) && stat.turnIndex === ordinal,
     );

--- a/web/src/components/chat/message-adapter.ts
+++ b/web/src/components/chat/message-adapter.ts
@@ -922,6 +922,52 @@ function isReplayDuplicateLiveMessage(
   });
 }
 
+// A normally-completed agent turn is frequently persisted by the backend as
+// SEVERAL assistant rows — leading commentary + a tool call, tool-only middle
+// rows, then the final answer — whereas the live runtime consolidates the whole
+// turn into ONE assistant message (a single `live-assistant-*` id). That single
+// consolidated bubble's canonical text (commentary + final answer, concatenated)
+// then exact-matches NEITHER the stored commentary row NOR the stored answer row,
+// so isSameCanonicalMessage cannot merge it; it is not interrupted, and its tool
+// identity spans the whole turn so it is not a prefix replay of any single stored
+// row either. The un-matched live copy is appended, rendering the turn's text —
+// including the final answer — a second time next to the stored rows.
+//
+// Recognize it: a COMPLETE, non-interrupted live assistant whose tool-call
+// identity (`toolCallId:name`, backend-unique) is a contiguous run of the stored
+// assistant rows' identities, and whose text is contained in those same rows'
+// concatenated text, is already fully persisted — drop the live copy and let the
+// canonical stored rows render (mirrors how completion lets the stored turn win).
+function isSupersededByStoredTurn(
+  live: HermesUIMessage,
+  storedMessages: HermesUIMessage[],
+): boolean {
+  if (live.role !== "assistant" || live.status !== "complete") return false;
+  // Only multi-step (tool-bearing) turns get split across rows; a plain-text
+  // turn is one stored row and already dedupes via isSameCanonicalMessage.
+  const liveTools = canonicalToolIdentityComparable(live);
+  if (!liveTools) return false;
+  // Interrupted replays are handled by isStaleInterruptedLiveMessage / superset.
+  if (hasInterruptedCompletion(live, canonicalText(live))) return false;
+
+  const storedAssistants = storedMessages.filter((message) => message.role === "assistant");
+  const storedTools = storedAssistants
+    .map((message) => canonicalToolIdentityComparable(message))
+    .filter(Boolean)
+    .join("|");
+  // Every live tool call (unique ids) must already be persisted, in order.
+  if (!storedTools.includes(liveTools)) return false;
+
+  const liveText = looseComparableText(canonicalText(live));
+  if (liveText) {
+    const storedText = looseComparableText(
+      storedAssistants.map((message) => canonicalText(message)).join(" "),
+    );
+    if (!storedText.includes(liveText)) return false;
+  }
+  return true;
+}
+
 function isInterruptedLiveSuperset(
   stored: HermesUIMessage,
   live: HermesUIMessage,
@@ -1060,6 +1106,7 @@ export function mergeHermesUIMessages(
     if (usedLiveIndexes.has(index)) return;
     if (isStaleInterruptedLiveMessage(liveMessage, stored)) return;
     if (isReplayDuplicateLiveMessage(liveMessage, stored)) return;
+    if (isSupersededByStoredTurn(liveMessage, stored)) return;
     merged.push(liveMessage);
   });
 


### PR DESCRIPTION
## 问题

一次带工具的 agent 回合（开场白 + 工具调用 + 最终答复）在 live 运行时被合并为一条 assistant 消息，而后端持久化为多条 assistant 行，引发两个前端渲染 bug：

1. **最终答复渲染两次**：合并后的 live 消息文本既不等于 stored 开场白行也不等于 stored 答复行，`mergeHermesUIMessages` 无法配对，也不属于 interrupted/replay 情形，被当作独立气泡追加。
2. **回合统计贴错气泡**：`turn_stats` 的 `turnIndex` 在 live 空间（整回合一条消息）打点，而 `attachTurnStatsMetadata` 的兜底按"逐条 assistant 序号"匹配，把整回合的 TTFT/tokens/成本贴到了开场白行。

## 修复

- 新增 `isSupersededByStoredTurn`：已完成、非中断、带工具的 live assistant，若其工具身份（`toolCallId:name`，后端唯一）是 stored 行工具身份的**连续子串**、且文本被 stored 拼接文本覆盖，判定已完整持久化，丢弃 live 副本让规范 stored 行渲染
- `turnIndex` 兜底改为按"回合（连续 assistant 段）"计数并挂到段**末行**（最终答复）；contentHash 精确命中仍优先
- 补 105 行回归测试，覆盖"stored 拆多行、live 合一条"形态

## 校验（已并入最新 main 后）

- `pnpm typecheck` 通过；`pnpm test:unit` 95 文件 838 测试全过；`cargo check` 通过

🤖 Generated with [Claude Code](https://claude.com/claude-code)