### PR TITLE
fix(release): macOS portable 打包扑空与跨平台 zip 同名覆盖

### DIFF
--- a/.github/workflows/release-desktop.yml
+++ b/.github/workflows/release-desktop.yml
@@ -320,6 +320,20 @@ jobs:
           set -euo pipefail
           app="target/${{ matrix.target }}/release/bundle/macos/Hermes Agent CN Desktop.app"
 
+          # Tauri's updater bundler compresses the .app into the .app.tar.gz
+          # updater artifact and then REMOVES the plain .app ("Cleaning …"),
+          # so by the time this step runs the bundle dir may only hold the
+          # tarball. Re-extract the .app from the final notarized DMG — the
+          # exact bits users download, covered by the notarization ticket.
+          if [ ! -d "$app" ]; then
+            dmgs=(target/${{ matrix.target }}/release/bundle/dmg/*.dmg)
+            mnt="$(mktemp -d)"
+            hdiutil attach "${dmgs[0]}" -mountpoint "$mnt" -nobrowse -quiet
+            mkdir -p "$(dirname "$app")"
+            ditto "$mnt/Hermes Agent CN Desktop.app" "$app"
+            hdiutil detach "$mnt" -quiet
+          fi
+
           # The DMG notarization above produced a ticket covering the nested
           # .app; staple the .app itself so the portable copy also validates
           # offline. If Apple's ticket lookup ever fails here, the fallback is

--- a/scripts/package-portable-macos.mjs
+++ b/scripts/package-portable-macos.mjs
@@ -61,7 +61,7 @@ if (!existsSync(appPath)) {
 const archLabel = (target ?? "aarch64").startsWith("x86_64") ? "x64" : "aarch64";
 const stagingName = `${productName} Portable`;
 const stagingDir = join(outRoot, stagingName);
-const zipName = `${productName.replaceAll(" ", ".")}_${version}_${archLabel}-portable.zip`;
+const zipName = `${productName.replaceAll(" ", ".")}_${version}_${archLabel}-macos-portable.zip`;
 const zipPath = join(outRoot, zipName);
 
 function ditto(args) {

--- a/scripts/package-portable-windows.mjs
+++ b/scripts/package-portable-windows.mjs
@@ -87,7 +87,7 @@ const resourceDests = Object.values(tauriConf.bundle.resources).map((dest) =>
 const archLabel = (target ?? "x86_64").startsWith("aarch64") ? "arm64" : "x64";
 const stagingName = `${productName} Portable`;
 const stagingDir = join(outRoot, stagingName);
-const zipName = `${productName.replaceAll(" ", ".")}_${version}_${archLabel}-portable.zip`;
+const zipName = `${productName.replaceAll(" ", ".")}_${version}_${archLabel}-windows-portable.zip`;
 const zipPath = join(outRoot, zipName);
 
 rmSync(outRoot, { recursive: true, force: true });


### PR DESCRIPTION
## 背景

v0.6.0 首次发版（run 29077425117）中 Windows job 成功，**两个 macOS job 在 portable 打包步骤失败**（#394 的 portable 链路首次实战暴露）：

1. **`.app` 扑空**：Tauri 更新器打包生成 `.app.tar.gz` 后清掉了 `bundle/macos` 下的 `.app`（日志 `Cleaning …`），其后的 portable 步骤 `stapler staple` 直接 exit 66。DMG 因在失败点之前已完成公证上传，不受影响。
2. **同名覆盖陷阱**：macOS Intel portable 与 Windows x64 portable 均命名 `…_x64-portable.zip`，`gh release upload --clobber` 下谁后传谁覆盖。

## 修复

- 工作流 portable 步骤前：`.app` 缺失时从**公证后的 DMG**（`hdiutil attach` + `ditto`）重新提取——与用户下载的 DMG 同源比特，公证票据覆盖，装订/验证照常
- zip 命名平台显式化：`_x64-windows-portable.zip`、`_aarch64-macos-portable.zip`、`_x64-macos-portable.zip`（docs/README 未硬编码旧名）

## 合并后动作

workflow_dispatch 以 `tag=v0.6.0` 重跑发版补齐 macOS 产物；删除既有歧义命名的 `_x64-portable.zip`（由新名 Windows 包替代）。

🤖 Generated with [Claude Code](https://claude.com/claude-code)