### PR TITLE
fix: 多开端口打架与同根双开冲突（closes #366）

### DIFF
--- a/src/main.rs
+++ b/src/main.rs
@@ -18,7 +18,7 @@ use hermes_agent_cn::bootstrap::{
 use hermes_agent_cn::commands;
 use hermes_agent_cn::commands::profiles::read_active_profile_sticky;
 use hermes_agent_cn::connection::{self, ConnectionBackend, ConnectionMode};
-use hermes_agent_cn::process::{dashboard, runtime};
+use hermes_agent_cn::process::{dashboard, instance, runtime};
 use hermes_agent_cn::state::{AppState, DashboardHandle};
 use hermes_agent_cn::tray;
 
@@ -119,6 +119,27 @@ fn main() {
         std::env::set_var("WEBVIEW2_USER_DATA_FOLDER", &webview_dir);
     }
 
+    // Single-instance guard per runtime root (issue #366): a second launch
+    // against the SAME data root focuses the incumbent window and exits;
+    // distinct roots (portable copies side by side) keep coexisting. The
+    // guard lives on main's stack so the lock is held until process exit.
+    let _instance_guard = match instance::try_acquire() {
+        instance::SingleInstance::Acquired(guard) => Some(guard),
+        instance::SingleInstance::AlreadyRunning => {
+            log::info!(
+                "another desktop instance owns {}; requesting focus and exiting",
+                runtime::runtime_root().display()
+            );
+            instance::notify_running_instance();
+            return;
+        }
+        instance::SingleInstance::Unavailable(reason) => {
+            // Fail open: the guard must never lock users out of their app.
+            log::warn!("single-instance lock unavailable ({reason}); continuing");
+            None
+        }
+    };
+
     let app_state = AppState::new();
     let quit_requested = Arc::new(AtomicBool::new(false));
     let close_quit_requested = Arc::clone(&quit_requested);
@@ -135,6 +156,13 @@ fn main() {
             use tauri::Manager;
             let state = app.state::<AppState>();
             let bundled_resource_dir = app.path().resource_dir().ok();
+
+            // Focus channel for the single-instance guard: consume any stale
+            // request from a previous run, then watch for new ones. Armed
+            // before dashboard bootstrap so a second launch gets its focus
+            // handoff even while the kernel is still starting.
+            instance::clear_stale_focus_request();
+            instance::spawn_focus_watcher(app.handle().clone());
 
             match tray::install(app) {
                 Ok(()) => {

--- a/src/process/dashboard.rs
+++ b/src/process/dashboard.rs
@@ -37,6 +37,10 @@ const FORCE_SHUTDOWN_TIMEOUT: Duration = Duration::from_millis(1200);
 const OWNERSHIP_MARKER_SCHEMA_VERSION: u32 = 1;
 pub const DEFAULT_DESKTOP_DASHBOARD_PORT: u16 = 9120;
 const DASHBOARD_PORT_FALLBACK_LIMIT: u16 = 20;
+/// How many spawn attempts (initial + retries on a lost bind race) before
+/// giving up — bounds the damage of a crash-looping runtime, which would
+/// otherwise burn the entire fallback range one kernel at a time.
+const SPAWN_ATTEMPT_LIMIT: usize = 3;
 static SESSION_TOKEN_RE: LazyLock<Regex> = LazyLock::new(|| {
     Regex::new(r#"__HERMES_SESSION_TOKEN__="([^"]+)""#).expect("valid session token regex")
 });
@@ -736,6 +740,59 @@ struct SpawnedDashboard {
     gateway_lock_dir: String,
     ownership_marker_path: String,
     job_handle: Option<DashboardJobHandle>,
+    /// Unique path this spawn's kernel writes `{"port": N}` to once its
+    /// socket is bound (`HERMES_DESKTOP_READY_FILE`). Only this shell and
+    /// this child know the path, so its appearance is an identity-proving
+    /// readiness signal — unlike an HTTP probe of the port, which any
+    /// process that stole the port could answer.
+    ready_file: PathBuf,
+}
+
+/// Ready files live in the runtime root as `dashboard-ready-<pid>-<ms>.json`.
+const READY_FILE_PREFIX: &str = "dashboard-ready-";
+
+fn new_ready_file_path() -> PathBuf {
+    crate::process::runtime::runtime_root().join(format!(
+        "{READY_FILE_PREFIX}{}-{}.json",
+        std::process::id(),
+        now_millis()
+    ))
+}
+
+/// Remove leftover ready files from crashed shells. Called on the ensure
+/// path while holding the single-instance lock, so no sibling shell on this
+/// runtime root can be mid-spawn.
+fn sweep_stale_ready_files() {
+    let root = crate::process::runtime::runtime_root();
+    let Ok(entries) = fs::read_dir(&root) else {
+        return;
+    };
+    for entry in entries.flatten() {
+        let name = entry.file_name();
+        let name = name.to_string_lossy();
+        if name.starts_with(READY_FILE_PREFIX) && name.ends_with(".json") {
+            if let Err(err) = fs::remove_file(entry.path()) {
+                log::debug!("stale ready-file cleanup {}: {err}", name);
+            }
+        }
+    }
+}
+
+fn remove_ready_file(path: &Path) {
+    match fs::remove_file(path) {
+        Ok(()) => {}
+        Err(err) if err.kind() == std::io::ErrorKind::NotFound => {}
+        Err(err) => log::debug!("ready-file cleanup {}: {err}", path.display()),
+    }
+}
+
+/// Parse the kernel-written ready payload (`{"port": N}`). Written
+/// atomically by Core (`_write_dashboard_ready_file`) after the socket is
+/// bound, so a readable file means the dashboard is serving.
+fn read_ready_file_port(path: &Path) -> Option<u16> {
+    let body = fs::read_to_string(path).ok()?;
+    let value: serde_json::Value = serde_json::from_str(&body).ok()?;
+    value.get("port")?.as_u64()?.try_into().ok()
 }
 
 fn env_flag(name: &str) -> bool {
@@ -943,6 +1000,12 @@ fn spawn_dashboard(options: &EnsureDashboardOptions) -> Result<SpawnedDashboard,
         .env("HERMES_GATEWAY_RUNTIME_DIR", &gateway_runtime_dir)
         .env("HERMES_DESKTOP_MANAGED", "1")
         .env("HERMES_GATEWAY_DETACHED", "1");
+    // Identity-proving readiness channel: the kernel atomically writes
+    // {"port": N} here once its socket is bound (Core:
+    // _write_dashboard_ready_file). The unique path doubles as the identity
+    // check — no other process can know it.
+    let ready_file = new_ready_file_path();
+    cmd.env("HERMES_DESKTOP_READY_FILE", &ready_file);
 
     // YOLO mode: the backend freezes HERMES_YOLO_MODE at import time, so it can
     // only be toggled by (re)launching the runtime. Drive it from the persisted
@@ -1031,6 +1094,7 @@ fn spawn_dashboard(options: &EnsureDashboardOptions) -> Result<SpawnedDashboard,
         gateway_lock_dir: gateway_lock_dir.to_string_lossy().to_string(),
         ownership_marker_path: marker_path,
         job_handle,
+        ready_file,
     })
 }
 
@@ -1073,24 +1137,115 @@ where
         });
 }
 
-/// Wait until the dashboard is ready enough to accept browser/API traffic or
-/// timeout.
-async fn wait_for_dashboard(api_base_url: &str, child: &mut Option<std::process::Child>) -> bool {
-    let start = Instant::now();
-    while start.elapsed() < DASHBOARD_READY_TIMEOUT {
-        if probe_spawned_dashboard_ready(api_base_url).await {
-            return true;
-        }
-        // If the child has exited, bail early
-        if let Some(ref mut c) = child {
-            if let Ok(Some(status)) = c.try_wait() {
-                log::error!("Dashboard process exited before ready: {}", status);
-                return false;
+/// Outcome of waiting for a freshly spawned dashboard.
+#[derive(Debug, PartialEq, Eq)]
+enum WaitOutcome {
+    /// The kernel is serving AND proven to be ours (ready file appeared, or
+    /// the HTML-embedded session token matches the one we minted).
+    Ready {
+        actual_port: Option<u16>,
+    },
+    /// Our child died before becoming ready — the port-bind OSError path
+    /// exits within moments, so this fires fast instead of a 120s stall.
+    ExitedEarly(String),
+    /// Something answers on the port but its session token differs from the
+    /// one we minted: another process won the bind race. Our child cannot
+    /// bind the same port, so give up on it immediately and move on.
+    PortStolen,
+    TimedOut,
+}
+
+/// What the HTTP identity probe saw this tick.
+#[derive(Debug, Clone, Copy, PartialEq, Eq)]
+enum HttpProbeState {
+    /// `/` served the exact token we minted for this spawn.
+    OursReady,
+    /// `/` served a DIFFERENT token — foreign dashboard owns the port.
+    Foreign,
+    /// Nothing conclusive (connection refused, page not up yet, no token).
+    Silent,
+}
+
+/// Pure per-tick decision, ordered by signal strength: a dead child beats
+/// everything; the ready file is identity-proving and authoritative; the
+/// HTTP token comparison covers runtimes that predate the ready file; only
+/// then does the timeout fire. Returns `None` to keep waiting.
+fn classify_wait_tick(
+    child_exit: Option<String>,
+    ready_port: Option<u16>,
+    http: HttpProbeState,
+    timed_out: bool,
+) -> Option<WaitOutcome> {
+    if let Some(status) = child_exit {
+        return Some(WaitOutcome::ExitedEarly(status));
+    }
+    if let Some(port) = ready_port {
+        return Some(WaitOutcome::Ready {
+            actual_port: Some(port),
+        });
+    }
+    match http {
+        HttpProbeState::OursReady => Some(WaitOutcome::Ready { actual_port: None }),
+        HttpProbeState::Foreign => Some(WaitOutcome::PortStolen),
+        HttpProbeState::Silent => {
+            if timed_out {
+                Some(WaitOutcome::TimedOut)
+            } else {
+                None
             }
+        }
+    }
+}
+
+/// HTTP identity probe: fetch the session token the dashboard embeds in its
+/// loopback index page and compare byte-for-byte with the token this shell
+/// minted for the spawn. 32 random bytes — equality means "our child",
+/// inequality means the port was stolen. With no expected token (getrandom
+/// failure — extreme edge) degrade to the legacy liveness probe.
+async fn http_identity_probe(api_base_url: &str, expected_token: Option<&str>) -> HttpProbeState {
+    let Some(expected) = expected_token.filter(|token| !token.is_empty()) else {
+        return if probe_spawned_dashboard_ready(api_base_url).await {
+            HttpProbeState::OursReady
+        } else {
+            HttpProbeState::Silent
+        };
+    };
+    match fetch_session_token(api_base_url).await {
+        Some(found) if found == expected => HttpProbeState::OursReady,
+        Some(_) => HttpProbeState::Foreign,
+        None => HttpProbeState::Silent,
+    }
+}
+
+/// Wait until the spawned dashboard is ready — with identity verification —
+/// or fails. Replaces the old boolean wait that treated any HTTP answer
+/// (even a 401 from a foreign dashboard) as success.
+async fn wait_for_spawned_dashboard(
+    api_base_url: &str,
+    child: &mut Child,
+    ready_file: &Path,
+    expected_token: Option<&str>,
+) -> WaitOutcome {
+    let start = Instant::now();
+    loop {
+        let child_exit = match child.try_wait() {
+            Ok(Some(status)) => Some(status.to_string()),
+            Ok(None) => None,
+            Err(err) => Some(format!("try_wait failed: {err}")),
+        };
+        let ready_port = read_ready_file_port(ready_file);
+        // Skip the HTTP round-trip when a stronger signal already decides.
+        let http = if child_exit.is_none() && ready_port.is_none() {
+            http_identity_probe(api_base_url, expected_token).await
+        } else {
+            HttpProbeState::Silent
+        };
+        let timed_out = start.elapsed() >= DASHBOARD_READY_TIMEOUT;
+        if let Some(outcome) = classify_wait_tick(child_exit, ready_port, http, timed_out) {
+            return outcome;
         }
         tokio::time::sleep(Duration::from_millis(350)).await;
     }
-    false
 }
 
 /// Ensure a hermes dashboard is running. Probes existing instances first,
@@ -1105,6 +1260,11 @@ pub async fn ensure_hermes_dashboard(
     // is serving the same isolated runtime HERMES_HOME and supports the
     // desktop-required routes. This keeps hot reload / second launch usable
     // without falling back to a user-installed ~/.hermes or PATH runtime.
+    // Crashed shells can leave ready files behind; while we hold the
+    // per-root single-instance lock no sibling shell can be mid-spawn, so
+    // everything matching the prefix is stale.
+    sweep_stale_ready_files();
+
     let mut primary_occupied = probe_dashboard_port(&api_base_url);
     let ownership_marker = read_ownership_marker();
     let primary_marker_state = marker_owner_state(
@@ -1112,6 +1272,28 @@ pub async fn ensure_hermes_dashboard(
         &api_base_url,
         &options.hermes_home,
     );
+    // While this process holds the per-root single-instance lock, no OTHER
+    // live shell can own this runtime root — a marker naming a live foreign
+    // desktop_pid can only be OS PID reuse. Treat it as stale so the orphan
+    // kernel gets adopted or cleaned instead of lingering unmanaged forever.
+    // Our own pid stays Live (legitimate during in-process respawns).
+    let primary_marker_state = if primary_marker_state == MarkerOwnerState::LiveDesktopOwner
+        && ownership_marker
+            .as_ref()
+            .map(|marker| marker.desktop_pid != std::process::id())
+            .unwrap_or(false)
+    {
+        log::warn!(
+            "ownership marker claims a live desktop owner (pid {}) while this process holds the instance lock; treating it as stale — PID reuse suspected",
+            ownership_marker
+                .as_ref()
+                .map(|marker| marker.desktop_pid)
+                .unwrap_or(0)
+        );
+        MarkerOwnerState::StaleDesktopOwner
+    } else {
+        primary_marker_state
+    };
     if primary_occupied && primary_marker_state == MarkerOwnerState::StaleDesktopOwner {
         if let Some(marker) = ownership_marker.as_ref() {
             let stale_dashboard_compatible =
@@ -1287,39 +1469,126 @@ pub async fn ensure_hermes_dashboard(
         }
     }
 
-    // Spawn a new dashboard
-    let spawned = spawn_dashboard(&spawn_options)?;
-    let child_url = dashboard_base_url(&spawn_options.host, spawn_options.port);
-
-    let mut child_opt = Some(spawned.child);
-    let ready = wait_for_dashboard(&child_url, &mut child_opt).await;
-    if !ready {
-        if let Some(ref mut c) = child_opt {
-            terminate_owned_dashboard_tree(&child_url, Some(c), None, None);
+    // Spawn a new dashboard, retrying on a lost bind race. The pre-scan
+    // above picked a free port, but between that probe and the child's
+    // bind() another process can win the port (TOCTOU): our child then
+    // exits with a bind error (ExitedEarly), or a foreign dashboard answers
+    // on our port (PortStolen). Either way pick the next free port and
+    // respawn — bounded by SPAWN_ATTEMPT_LIMIT.
+    let mut tried_ports: Vec<u16> = Vec::new();
+    let mut last_failure = String::from("no spawn attempted");
+    for attempt in 1..=SPAWN_ATTEMPT_LIMIT {
+        if attempt > 1 {
+            // Re-scan for the next candidate, skipping burned ports and
+            // anything that became occupied since the previous scan.
+            let next = std::iter::once(options.port)
+                .chain(fallback_ports(options.port))
+                .find(|port| {
+                    !tried_ports.contains(port)
+                        && !probe_dashboard_port(&dashboard_base_url(&options.host, *port))
+                });
+            match next {
+                Some(port) => spawn_options.port = port,
+                None => break,
+            }
         }
-        remove_ownership_marker_path(Some(&spawned.ownership_marker_path));
-        return Err(AppError::DashboardStartup(format!(
-            "Not ready at {} within {}s",
+        tried_ports.push(spawn_options.port);
+
+        let SpawnedDashboard {
+            mut child,
+            session_token,
+            command_program,
+            command_args,
+            gateway_runtime_dir,
+            gateway_lock_dir,
+            ownership_marker_path,
+            job_handle,
+            ready_file,
+        } = spawn_dashboard(&spawn_options)?;
+        let child_url = dashboard_base_url(&spawn_options.host, spawn_options.port);
+
+        let outcome = wait_for_spawned_dashboard(
+            &child_url,
+            &mut child,
+            &ready_file,
+            session_token.as_deref(),
+        )
+        .await;
+
+        let failure_reason = match outcome {
+            WaitOutcome::Ready { actual_port } => {
+                remove_ready_file(&ready_file);
+                // Trust the kernel-reported bound port when present (today it
+                // always equals the requested one; forward-compatible with
+                // `--port 0`).
+                let final_url = actual_port
+                    .filter(|port| *port != spawn_options.port)
+                    .map(|port| dashboard_base_url(&spawn_options.host, port))
+                    .unwrap_or(child_url);
+                log::info!("Dashboard started at {}", final_url);
+                return Ok(DashboardHandle {
+                    api_base_url: final_url,
+                    session_token,
+                    owns_process: true,
+                    command_program: Some(command_program),
+                    command_args,
+                    gateway_runtime_dir: Some(gateway_runtime_dir),
+                    gateway_lock_dir: Some(gateway_lock_dir),
+                    ownership_marker_path: Some(ownership_marker_path),
+                    ownership_state: Some("owned".to_string()),
+                    job_handle,
+                    attached_pid: None,
+                    child: Some(child),
+                });
+            }
+            WaitOutcome::TimedOut => {
+                terminate_owned_dashboard_tree(&child_url, Some(&mut child), None, None);
+                remove_ownership_marker_path(Some(&ownership_marker_path));
+                remove_ready_file(&ready_file);
+                // A kernel that is alive but not serving after 120s is not a
+                // bind race — retrying elsewhere would just take another 120s.
+                return Err(AppError::DashboardStartup(format!(
+                    "Not ready at {} within {}s",
+                    child_url,
+                    DASHBOARD_READY_TIMEOUT.as_secs()
+                )));
+            }
+            WaitOutcome::ExitedEarly(status) => {
+                format!("dashboard exited before ready ({status})")
+            }
+            WaitOutcome::PortStolen => {
+                "port answered with a foreign session token (bind race lost)".to_string()
+            }
+        };
+
+        terminate_owned_dashboard_tree(&child_url, Some(&mut child), None, None);
+        remove_ownership_marker_path(Some(&ownership_marker_path));
+        remove_ready_file(&ready_file);
+
+        if !options.allow_port_fallback {
+            // Dev semantics: the Vite proxy target is fixed, so surface the
+            // conflict instead of drifting to another port.
+            return Err(AppError::DashboardStartup(format!(
+                "{} — {}. Stop the process on port {} so the desktop can spawn its managed runtime dashboard.",
+                child_url, failure_reason, spawn_options.port
+            )));
+        }
+        log::warn!(
+            "Dashboard spawn on {} failed ({}); retrying on another port (attempt {}/{})",
             child_url,
-            DASHBOARD_READY_TIMEOUT.as_secs()
-        )));
+            failure_reason,
+            attempt,
+            SPAWN_ATTEMPT_LIMIT
+        );
+        last_failure = failure_reason;
     }
 
-    log::info!("Dashboard started at {}", child_url);
-    Ok(DashboardHandle {
-        api_base_url: child_url,
-        session_token: spawned.session_token,
-        owns_process: true,
-        command_program: Some(spawned.command_program),
-        command_args: spawned.command_args,
-        gateway_runtime_dir: Some(spawned.gateway_runtime_dir),
-        gateway_lock_dir: Some(spawned.gateway_lock_dir),
-        ownership_marker_path: Some(spawned.ownership_marker_path),
-        ownership_state: Some("owned".to_string()),
-        job_handle: spawned.job_handle,
-        attached_pid: None,
-        child: child_opt,
-    })
+    Err(AppError::DashboardStartup(format!(
+        "Failed to start the dashboard after {} attempt(s) on ports {:?} — last failure: {}",
+        tried_ports.len(),
+        tried_ports,
+        last_failure
+    )))
 }
 
 #[cfg(test)]
@@ -1646,6 +1915,153 @@ mod tests {
 
         assert!(err.contains("incompatible dashboard"));
         assert!(read_ownership_marker().is_none());
+        std::env::remove_var("HERMES_DESKTOP_RUNTIME_ROOT");
+    }
+
+    #[test]
+    fn classify_wait_tick_child_exit_beats_everything() {
+        let out = classify_wait_tick(
+            Some("exit status: 1".into()),
+            Some(9121),
+            HttpProbeState::OursReady,
+            true,
+        );
+        assert_eq!(out, Some(WaitOutcome::ExitedEarly("exit status: 1".into())));
+    }
+
+    #[test]
+    fn classify_wait_tick_ready_file_is_authoritative() {
+        let out = classify_wait_tick(None, Some(9121), HttpProbeState::Foreign, false);
+        assert_eq!(
+            out,
+            Some(WaitOutcome::Ready {
+                actual_port: Some(9121)
+            })
+        );
+    }
+
+    #[test]
+    fn classify_wait_tick_http_token_decides_identity() {
+        assert_eq!(
+            classify_wait_tick(None, None, HttpProbeState::OursReady, false),
+            Some(WaitOutcome::Ready { actual_port: None })
+        );
+        assert_eq!(
+            classify_wait_tick(None, None, HttpProbeState::Foreign, false),
+            Some(WaitOutcome::PortStolen)
+        );
+    }
+
+    #[test]
+    fn classify_wait_tick_silent_keeps_waiting_until_timeout() {
+        assert_eq!(
+            classify_wait_tick(None, None, HttpProbeState::Silent, false),
+            None
+        );
+        assert_eq!(
+            classify_wait_tick(None, None, HttpProbeState::Silent, true),
+            Some(WaitOutcome::TimedOut)
+        );
+    }
+
+    #[tokio::test]
+    async fn http_identity_probe_accepts_our_token_and_rejects_foreign() {
+        let server = MockServer::start().await;
+        Mock::given(method("GET"))
+            .and(path("/"))
+            .respond_with(
+                ResponseTemplate::new(200).set_body_string(
+                    r#"<script>window.__HERMES_SESSION_TOKEN__="token-A"</script>"#,
+                ),
+            )
+            .mount(&server)
+            .await;
+        let url = server.uri();
+
+        assert_eq!(
+            http_identity_probe(&url, Some("token-A")).await,
+            HttpProbeState::OursReady
+        );
+        assert_eq!(
+            http_identity_probe(&url, Some("token-B")).await,
+            HttpProbeState::Foreign
+        );
+    }
+
+    #[tokio::test]
+    async fn http_identity_probe_is_silent_when_no_token_served() {
+        let server = MockServer::start().await;
+        Mock::given(method("GET"))
+            .and(path("/"))
+            .respond_with(ResponseTemplate::new(200).set_body_string("<html>booting</html>"))
+            .mount(&server)
+            .await;
+        assert_eq!(
+            http_identity_probe(&server.uri(), Some("token-A")).await,
+            HttpProbeState::Silent
+        );
+    }
+
+    #[test]
+    #[serial]
+    fn ready_file_roundtrip_and_sweep() {
+        let runtime = tempfile::tempdir().expect("runtime root");
+        std::env::set_var("HERMES_DESKTOP_RUNTIME_ROOT", runtime.path());
+
+        let path = new_ready_file_path();
+        std::fs::write(&path, r#"{"port": 9123}"#).expect("write ready file");
+        assert_eq!(read_ready_file_port(&path), Some(9123));
+
+        // Torn / invalid payloads read as "not ready", never panic.
+        std::fs::write(&path, "{\"po").expect("write torn file");
+        assert_eq!(read_ready_file_port(&path), None);
+
+        std::fs::write(&path, r#"{"port": 9123}"#).expect("rewrite");
+        sweep_stale_ready_files();
+        assert!(!path.exists(), "sweep must remove stale ready files");
+
+        remove_ready_file(&path); // idempotent on missing files
+        std::env::remove_var("HERMES_DESKTOP_RUNTIME_ROOT");
+    }
+
+    /// A marker naming a live pid that is NOT this process must be treated
+    /// as stale while the single-instance lock is held (PID reuse): the
+    /// compatible orphan gets adopted instead of being attached as if a
+    /// sibling desktop owned it.
+    #[cfg(unix)]
+    #[tokio::test]
+    #[serial]
+    async fn live_foreign_marker_is_collapsed_to_stale_and_adopted() {
+        let runtime = tempfile::tempdir().expect("runtime root");
+        std::env::set_var("HERMES_DESKTOP_RUNTIME_ROOT", runtime.path());
+        let home = runtime.path().join("hermes-home");
+        std::fs::create_dir_all(&home).expect("home");
+        let home = home.to_string_lossy().to_string();
+
+        let server = MockServer::start().await;
+        mount_dashboard_mock(&server, &home, true).await;
+        let (host, port) = host_port_from_uri(&server.uri());
+        let api_base_url = dashboard_base_url(&host, port);
+
+        // pid 1 (launchd/init) is always alive and never this process.
+        let marker = test_marker(1, &api_base_url, &home);
+        write_ownership_marker(&marker).expect("write live-foreign marker");
+
+        let handle = ensure_hermes_dashboard(EnsureDashboardOptions {
+            host,
+            port,
+            hermes_home: home,
+            allow_external_agent: false,
+            allow_port_fallback: false,
+        })
+        .await
+        .expect("compatible orphan must be adopted");
+
+        assert_eq!(
+            handle.ownership_state.as_deref(),
+            Some("attached-stale-compatible"),
+            "live-foreign marker must collapse to stale adoption, not live attach"
+        );
         std::env::remove_var("HERMES_DESKTOP_RUNTIME_ROOT");
     }
 }

--- a/src/process/instance.rs
+++ b/src/process/instance.rs
@@ -1,0 +1,253 @@
+//! Per-runtime-root single-instance guard (issue #366).
+//!
+//! Two desktop shells sharing one runtime root would fight over the same
+//! managed kernel (each respawn/quit tears down the other's backend), so a
+//! second launch against the SAME root must hand focus to the incumbent and
+//! exit — WeChat-style. Distinct roots (two portable extractions, or a
+//! portable copy next to an installed build) are a supported scenario and
+//! must keep coexisting, which is why this is an advisory file lock scoped
+//! to `runtime_root()` rather than `tauri-plugin-single-instance` (that
+//! plugin keys on the app identifier and would veto legitimate portable
+//! side-by-side launches).
+//!
+//! Lock-file semantics: the file carries no content and is never deleted.
+//! Both `flock` (Unix) and `LockFileEx` (Windows, via `fs2`) release the
+//! lock when the owning process dies, so a leftover file from a crashed
+//! shell can never deadlock the next launch; writing into a locked region
+//! is also a known Windows footgun we avoid entirely. Diagnostics about the
+//! owner live in `desktop-owner.json`, not here.
+
+use std::fs::{self, OpenOptions};
+use std::path::PathBuf;
+use std::time::Duration;
+
+use fs2::FileExt;
+
+use crate::process::runtime;
+
+const INSTANCE_LOCK_FILENAME: &str = "desktop-instance.lock";
+const FOCUS_REQUEST_FILENAME: &str = "focus-request.json";
+/// Poll cadence for the focus watcher. A 1s stat of one small file is
+/// negligible, and polling (unlike `notify` watches) behaves identically on
+/// network volumes and every Windows filesystem.
+const FOCUS_WATCH_INTERVAL: Duration = Duration::from_secs(1);
+/// Escape hatch for QA / development multi-open against one root.
+const SINGLE_INSTANCE_ENV: &str = "HERMES_DESKTOP_SINGLE_INSTANCE";
+
+/// Holding this guard means holding the exclusive instance lock; keep it
+/// alive for the whole process (a `main()` local outliving `app.run()`).
+pub struct InstanceGuard {
+    _file: std::fs::File,
+}
+
+pub enum SingleInstance {
+    /// We own the runtime root; proceed with startup.
+    Acquired(InstanceGuard),
+    /// A live shell already owns this runtime root.
+    AlreadyRunning,
+    /// The lock could not be evaluated (exotic filesystem, permissions…).
+    /// Callers must FAIL OPEN — never let the guard itself block startup.
+    Unavailable(String),
+}
+
+fn instance_lock_path() -> PathBuf {
+    runtime::runtime_root().join(INSTANCE_LOCK_FILENAME)
+}
+
+fn focus_request_path() -> PathBuf {
+    runtime::runtime_root().join(FOCUS_REQUEST_FILENAME)
+}
+
+fn single_instance_disabled() -> bool {
+    std::env::var(SINGLE_INSTANCE_ENV)
+        .map(|v| {
+            let v = v.trim();
+            v == "0" || v.eq_ignore_ascii_case("false") || v.eq_ignore_ascii_case("off")
+        })
+        .unwrap_or(false)
+}
+
+/// Try to become the single desktop instance for the current runtime root.
+pub fn try_acquire() -> SingleInstance {
+    if single_instance_disabled() {
+        log::warn!(
+            "{SINGLE_INSTANCE_ENV} disables the single-instance guard; \
+             concurrent shells on one runtime root are unsupported"
+        );
+        return SingleInstance::Unavailable(format!("disabled via {SINGLE_INSTANCE_ENV}"));
+    }
+
+    let lock_path = instance_lock_path();
+    if let Some(parent) = lock_path.parent() {
+        if let Err(err) = fs::create_dir_all(parent) {
+            return SingleInstance::Unavailable(format!(
+                "create runtime root {}: {err}",
+                parent.display()
+            ));
+        }
+    }
+
+    let file = match OpenOptions::new()
+        .read(true)
+        .write(true)
+        .create(true)
+        .truncate(false)
+        .open(&lock_path)
+    {
+        Ok(file) => file,
+        Err(err) => {
+            return SingleInstance::Unavailable(format!("open {}: {err}", lock_path.display()));
+        }
+    };
+
+    match file.try_lock_exclusive() {
+        Ok(()) => SingleInstance::Acquired(InstanceGuard { _file: file }),
+        Err(err) if err.kind() == std::io::ErrorKind::WouldBlock => SingleInstance::AlreadyRunning,
+        Err(err) => SingleInstance::Unavailable(format!("lock {}: {err}", lock_path.display())),
+    }
+}
+
+/// Ask the incumbent instance to bring its main window to the foreground.
+/// Atomic write (temp file + rename) so the watcher never reads a torn file.
+pub fn notify_running_instance() {
+    let path = focus_request_path();
+    let Some(parent) = path.parent().map(PathBuf::from) else {
+        return;
+    };
+    let payload = format!(
+        "{{\"pid\":{},\"at_ms\":{}}}\n",
+        std::process::id(),
+        std::time::SystemTime::now()
+            .duration_since(std::time::UNIX_EPOCH)
+            .map(|d| d.as_millis())
+            .unwrap_or(0)
+    );
+    let write = || -> std::io::Result<()> {
+        let mut tmp = tempfile::NamedTempFile::new_in(&parent)?;
+        use std::io::Write;
+        tmp.write_all(payload.as_bytes())?;
+        tmp.persist(&path).map_err(|e| e.error)?;
+        Ok(())
+    };
+    if let Err(err) = write() {
+        log::warn!("failed to write focus request {}: {err}", path.display());
+    }
+}
+
+/// Remove a leftover focus request from a previous run. Called by the lock
+/// holder during startup — its window is about to show anyway, so consuming
+/// a racing request here is equivalent to honoring it.
+pub fn clear_stale_focus_request() {
+    let path = focus_request_path();
+    match fs::remove_file(&path) {
+        Ok(()) => log::debug!("cleared stale focus request {}", path.display()),
+        Err(err) if err.kind() == std::io::ErrorKind::NotFound => {}
+        Err(err) => log::debug!("focus request cleanup {}: {err}", path.display()),
+    }
+}
+
+/// Watch for focus requests from would-be second instances and raise the
+/// main window. Delete-then-show ordering: showing is idempotent, so a
+/// failed show never leaves the file behind to storm the loop.
+pub fn spawn_focus_watcher(app: tauri::AppHandle) {
+    std::thread::Builder::new()
+        .name("instance-focus-watcher".into())
+        .spawn(move || loop {
+            let path = focus_request_path();
+            if path.exists() {
+                match fs::remove_file(&path) {
+                    Ok(()) => {
+                        log::info!("focus requested by another launch; raising main window");
+                        crate::tray::show_main_window(&app);
+                    }
+                    Err(err) if err.kind() == std::io::ErrorKind::NotFound => {}
+                    Err(err) => {
+                        log::debug!("focus request consume {}: {err}", path.display());
+                    }
+                }
+            }
+            std::thread::sleep(FOCUS_WATCH_INTERVAL);
+        })
+        .map(|_| ())
+        .unwrap_or_else(|err| log::warn!("failed to spawn focus watcher: {err}"));
+}
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+    use serial_test::serial;
+
+    fn with_runtime_root<T>(f: impl FnOnce(&std::path::Path) -> T) -> T {
+        let dir = tempfile::TempDir::new().expect("tempdir");
+        std::env::set_var("HERMES_DESKTOP_RUNTIME_ROOT", dir.path());
+        let out = f(dir.path());
+        std::env::remove_var("HERMES_DESKTOP_RUNTIME_ROOT");
+        out
+    }
+
+    #[test]
+    #[serial]
+    fn second_acquire_returns_already_running() {
+        with_runtime_root(|_root| {
+            let first = try_acquire();
+            let guard = match first {
+                SingleInstance::Acquired(g) => g,
+                _ => panic!("first acquire should succeed"),
+            };
+            // flock/LockFileEx exclude a second descriptor even within one
+            // process, so this models a second shell faithfully.
+            match try_acquire() {
+                SingleInstance::AlreadyRunning => {}
+                SingleInstance::Acquired(_) => panic!("second acquire must be blocked"),
+                SingleInstance::Unavailable(err) => panic!("unexpected: {err}"),
+            }
+            drop(guard);
+        });
+    }
+
+    #[test]
+    #[serial]
+    fn drop_guard_releases_lock() {
+        with_runtime_root(|_root| {
+            match try_acquire() {
+                SingleInstance::Acquired(guard) => drop(guard),
+                _ => panic!("first acquire should succeed"),
+            }
+            match try_acquire() {
+                SingleInstance::Acquired(_) => {}
+                _ => panic!("lock must be reacquirable after drop"),
+            }
+        });
+    }
+
+    #[test]
+    #[serial]
+    fn focus_request_roundtrip() {
+        with_runtime_root(|root| {
+            notify_running_instance();
+            let path = root.join(FOCUS_REQUEST_FILENAME);
+            let body = std::fs::read_to_string(&path).expect("focus request written");
+            assert!(body.contains("\"pid\""), "payload has pid: {body}");
+            clear_stale_focus_request();
+            assert!(!path.exists(), "cleared focus request must be gone");
+            // Clearing again is a no-op, not an error.
+            clear_stale_focus_request();
+        });
+    }
+
+    #[test]
+    #[serial]
+    fn env_escape_hatch_disables_lock() {
+        with_runtime_root(|_root| {
+            std::env::set_var(SINGLE_INSTANCE_ENV, "0");
+            let out = try_acquire();
+            std::env::remove_var(SINGLE_INSTANCE_ENV);
+            match out {
+                SingleInstance::Unavailable(reason) => {
+                    assert!(reason.contains(SINGLE_INSTANCE_ENV), "{reason}");
+                }
+                _ => panic!("escape hatch must report Unavailable (fail-open)"),
+            }
+        });
+    }
+}

--- a/src/process/mod.rs
+++ b/src/process/mod.rs
@@ -1,3 +1,4 @@
 pub mod dashboard;
 pub mod gateway;
+pub mod instance;
 pub mod runtime;

--- a/tests/dashboard_spawn_retry.rs
+++ b/tests/dashboard_spawn_retry.rs
@@ -1,0 +1,171 @@
+//! Spawn-retry integration tests: drive `ensure_hermes_dashboard` against a
+//! fake managed runtime (a shell script recorded in `current.json`) and
+//! assert the readiness state machine's behavior end to end — no real
+//! backend, no network beyond loopback probes of unbound ports.
+
+#![cfg(unix)]
+
+use std::os::unix::fs::PermissionsExt;
+use std::path::Path;
+
+use hermes_agent_cn::process::dashboard::{ensure_hermes_dashboard, EnsureDashboardOptions};
+use hermes_agent_cn::process::runtime::RuntimeInstallRecord;
+use serial_test::serial;
+
+fn free_port() -> u16 {
+    let listener = std::net::TcpListener::bind("127.0.0.1:0").expect("bind ephemeral");
+    listener.local_addr().expect("local addr").port()
+}
+
+fn current_platform() -> &'static str {
+    if cfg!(target_os = "macos") {
+        "darwin"
+    } else {
+        "linux"
+    }
+}
+
+fn current_arch() -> &'static str {
+    if cfg!(target_arch = "aarch64") {
+        "arm64"
+    } else {
+        "x64"
+    }
+}
+
+/// Install a fake runtime whose "kernel" is the given shell script body.
+fn install_fake_runtime(root: &Path, script_body: &str) {
+    let script = root.join("fake-hermes.sh");
+    std::fs::write(&script, script_body).expect("write fake runtime script");
+    let mut perms = std::fs::metadata(&script)
+        .expect("script metadata")
+        .permissions();
+    perms.set_mode(0o755);
+    std::fs::set_permissions(&script, perms).expect("chmod script");
+
+    let record = RuntimeInstallRecord {
+        schema_version: 2,
+        runtime_version: "0.0.0-test".to_string(),
+        kernel_version: "0.0.0-test".to_string(),
+        runtime_flavor: "test".to_string(),
+        runtime_revision: 1,
+        platform: current_platform().to_string(),
+        arch: current_arch().to_string(),
+        path: root.to_string_lossy().to_string(),
+        executable_path: script.to_string_lossy().to_string(),
+        source: "test".to_string(),
+        installed_at: "1970-01-01T00:00:00Z".to_string(),
+        source_repo: None,
+        source_commit: None,
+        local_dirty_hash: None,
+        artifact_sha256: None,
+        previous_runtime_version: None,
+    };
+    std::fs::write(
+        root.join("current.json"),
+        serde_json::to_string_pretty(&record).expect("serialize record"),
+    )
+    .expect("write current.json");
+}
+
+fn ready_file_leftovers(root: &Path) -> Vec<String> {
+    std::fs::read_dir(root)
+        .map(|entries| {
+            entries
+                .flatten()
+                .map(|e| e.file_name().to_string_lossy().to_string())
+                .filter(|name| name.starts_with("dashboard-ready-"))
+                .collect()
+        })
+        .unwrap_or_default()
+}
+
+#[tokio::test]
+#[serial]
+async fn crash_looping_runtime_retries_then_fails_cleanly() {
+    let runtime = tempfile::TempDir::new().expect("runtime root");
+    std::env::set_var("HERMES_DESKTOP_RUNTIME_ROOT", runtime.path());
+    let home = runtime.path().join("hermes-home");
+    std::fs::create_dir_all(&home).expect("home");
+
+    // A kernel that dies immediately — models the port-bind OSError exit.
+    install_fake_runtime(runtime.path(), "#!/bin/sh\nexit 7\n");
+
+    let result = ensure_hermes_dashboard(EnsureDashboardOptions {
+        host: "127.0.0.1".to_string(),
+        port: free_port(),
+        hermes_home: home.to_string_lossy().to_string(),
+        allow_external_agent: false,
+        allow_port_fallback: true,
+    })
+    .await;
+    let err = match result {
+        Ok(_) => panic!("crash-looping runtime must not become ready"),
+        Err(err) => err.to_string(),
+    };
+
+    assert!(
+        err.contains("attempt"),
+        "error should mention bounded attempts: {err}"
+    );
+    assert!(
+        err.contains("exited before ready"),
+        "error should carry the child-exit reason: {err}"
+    );
+    assert!(
+        ready_file_leftovers(runtime.path()).is_empty(),
+        "failed spawns must not leak ready files"
+    );
+    assert!(
+        !runtime.path().join("desktop-owner.json").exists(),
+        "failed spawns must not leak ownership markers"
+    );
+    std::env::remove_var("HERMES_DESKTOP_RUNTIME_ROOT");
+}
+
+#[tokio::test]
+#[serial]
+async fn ready_file_completes_spawn_without_http() {
+    let runtime = tempfile::TempDir::new().expect("runtime root");
+    std::env::set_var("HERMES_DESKTOP_RUNTIME_ROOT", runtime.path());
+    let home = runtime.path().join("hermes-home");
+    std::fs::create_dir_all(&home).expect("home");
+
+    // A kernel that never serves HTTP but writes the ready file exactly like
+    // Core's _write_dashboard_ready_file — proving the identity channel alone
+    // completes the wait. argv: dashboard --host H --port P --no-open → $5.
+    install_fake_runtime(
+        runtime.path(),
+        "#!/bin/sh\nprintf '{\"port\": %s}' \"$5\" > \"$HERMES_DESKTOP_READY_FILE\"\nsleep 30\n",
+    );
+
+    let port = free_port();
+    let mut handle = ensure_hermes_dashboard(EnsureDashboardOptions {
+        host: "127.0.0.1".to_string(),
+        port,
+        hermes_home: home.to_string_lossy().to_string(),
+        allow_external_agent: false,
+        allow_port_fallback: true,
+    })
+    .await
+    .expect("ready file must complete the spawn");
+
+    assert_eq!(handle.api_base_url, format!("http://127.0.0.1:{port}"));
+    assert_eq!(handle.ownership_state.as_deref(), Some("owned"));
+    assert!(handle.owns_process);
+    assert!(
+        handle.session_token.is_some(),
+        "spawn must mint a session token"
+    );
+    assert!(
+        ready_file_leftovers(runtime.path()).is_empty(),
+        "consumed ready file must be deleted"
+    );
+
+    // Reap the fake kernel so the sleep doesn't outlive the test.
+    if let Some(mut child) = handle.child.take() {
+        let _ = child.kill();
+        let _ = child.wait();
+    }
+    std::env::remove_var("HERMES_DESKTOP_RUNTIME_ROOT");
+}


### PR DESCRIPTION
## 问题

portable 版让多开成为常态，暴露两类缺陷：

1. **同数据根双开**（#366）：第二个壳"兼容复用"第一个壳的内核（判定仅看同 HERMES_HOME），两个窗口共享一个内核互相打断。
2. **端口错认**：就绪探测把 401 当就绪且无身份校验、不监听子进程退出——探测与 spawn 之间端口被抢时，自己的内核秒退（壳傻等 120s），别人的 dashboard 被认领。（注：探索证实内核端口被占是**直接退出**而非 +1，+1..+20 回退一直在壳侧。）

## 修复

**同根单实例（微信式）**：`runtime_root()/desktop-instance.lock` fs2 排他锁；第二实例写 `focus-request.json` 唤起已有窗口后静默退出；持锁方 1s 轮询消费并 `show_main_window`。不同数据根各持各锁正常并存。锁文件零内容、从不删除（进程死亡 OS 自动释放，无死锁）；异常一律 fail-open。逃生舱 `HERMES_DESKTOP_SINGLE_INSTANCE=0`。

**就绪状态机（身份化）**：
- 子进程退出监听最高优先 → `ExitedEarly` 秒级感知绑失败
- 启用 Core 已有的 `HERMES_DESKTOP_READY_FILE` 原子就绪文件（唯一路径即身份证明；Windows pythonw 无 stdout 场景覆盖）
- HTTP 回退：取回首页 HTML 内嵌 session token 与本次铸造值比对——不等即 `PortStolen`
- `ExitedEarly/PortStolen` → 换下一空闲端口重 spawn（上限 3），dev 保留固定端口报错语义

**marker 收紧**：持锁时 Live 外来 desktop_pid 只能是 PID 复用 → 并入 Stale 收养/清理路径（顺带修复孤儿内核永不回收）。

**Core 零改动**（ready file 与 HTML token 注入均为既有能力）。

## 测试

- 单测：instance 锁 4 项、状态机纯函数矩阵/wiremock 身份探测/ready file 往返/Live-marker 收紧 8 项、既有收养回归原样通过
- 集成：假 runtime 脚本——崩溃循环有界重试且无 marker/ready file 残留；就绪文件独立完成 spawn
- `cargo test` 446 全过、`pnpm test:unit` 838 全过、fmt/clippy 干净

## 手工验证建议（合并后打包版）

① 同根双开→B 静默退、A 聚焦；② kill -9 A 壳→开 B→孤儿收养；③ `python3 -m http.server 9120` 占口→壳落 9121 不错认；④ 双 portable 目录并存；⑤ dev 双开聚焦、逃生舱可双开。

🤖 Generated with [Claude Code](https://claude.com/claude-code)