### PR TITLE
feat(process): 端口锁协调多实例端口占用（port shifting）

### DIFF
--- a/src/main.rs
+++ b/src/main.rs
@@ -38,6 +38,7 @@ fn external_dev_handle(api_base_url: String) -> DashboardHandle {
         job_handle: None,
         attached_pid: None,
         child: None,
+        port_locks: None,
     }
 }
 

--- a/src/process/dashboard.rs
+++ b/src/process/dashboard.rs
@@ -20,6 +20,7 @@ use regex::Regex;
 use serde::{Deserialize, Serialize};
 
 use crate::error::AppError;
+use crate::process::port_lock::{claim_port_set, release_orphaned_port_locks, PortLock};
 use crate::state::{DashboardHandle, DashboardJobHandle};
 
 // A freshly installed onefile runtime can spend tens of seconds on macOS
@@ -77,6 +78,10 @@ pub struct DashboardOwnershipMarker {
     pub started_at_ms: u128,
     #[serde(skip_serializing_if = "Option::is_none")]
     pub runtime_version: Option<String>,
+    /// Ports this desktop instance has claimed via the shared lock file.
+    /// Used to break orphaned locks when adopting a stale marker.
+    #[serde(default, skip_serializing_if = "Vec::is_empty")]
+    pub claimed_ports: Vec<u16>,
 }
 
 #[derive(Debug, Clone, Copy, PartialEq, Eq)]
@@ -109,6 +114,23 @@ fn fallback_ports(start: u16) -> Vec<u16> {
         ports.push(port);
     }
     ports
+}
+
+/// The well-known satellite ports that a desktop-managed dashboard tree may
+/// bind (webhook, proxy). These are reserved alongside the dashboard API port.
+const WELL_KNOWN_DASHBOARD_PORTS: &[u16] = &[8644, 8645];
+
+/// Build the full set of ports to claim for a dashboard at ``dashboard_port``.
+fn ports_to_claim(dashboard_port: u16) -> Vec<u16> {
+    let mut ports = Vec::with_capacity(WELL_KNOWN_DASHBOARD_PORTS.len() + 1);
+    ports.push(dashboard_port);
+    ports.extend_from_slice(WELL_KNOWN_DASHBOARD_PORTS);
+    ports
+}
+
+/// Try to claim the full port set for a candidate dashboard port.
+fn try_claim_dashboard_ports(dashboard_port: u16, hermes_home: &str) -> Option<Vec<PortLock>> {
+    claim_port_set(&ports_to_claim(dashboard_port), Path::new(hermes_home))
 }
 
 fn now_millis() -> u128 {
@@ -147,6 +169,7 @@ fn rewrite_ownership_marker_for_current_desktop(
         gateway_runtime_dir: marker.gateway_runtime_dir.clone(),
         started_at_ms: now_millis(),
         runtime_version: marker.runtime_version.clone(),
+        claimed_ports: marker.claimed_ports.clone(),
     };
     write_ownership_marker(&next)?;
     Ok(next)
@@ -905,7 +928,10 @@ fn resolve_hermes_command(allow_external_agent: bool) -> Result<(String, Vec<Str
 }
 
 /// Spawn the hermes dashboard subprocess.
-fn spawn_dashboard(options: &EnsureDashboardOptions) -> Result<SpawnedDashboard, AppError> {
+fn spawn_dashboard(
+    options: &EnsureDashboardOptions,
+    claimed_ports: Vec<u16>,
+) -> Result<SpawnedDashboard, AppError> {
     let (program, mut prefix_args) = resolve_hermes_command(options.allow_external_agent)?;
 
     let api_args = vec![
@@ -1080,6 +1106,7 @@ fn spawn_dashboard(options: &EnsureDashboardOptions) -> Result<SpawnedDashboard,
         gateway_runtime_dir: gateway_runtime_dir.to_string_lossy().to_string(),
         started_at_ms: now_millis(),
         runtime_version,
+        claimed_ports: claimed_ports.clone(),
     };
     if let Err(err) = write_ownership_marker(&marker) {
         log::warn!("Failed to write dashboard ownership marker: {}", err);
@@ -1254,7 +1281,41 @@ async fn wait_for_spawned_dashboard(
 pub async fn ensure_hermes_dashboard(
     options: EnsureDashboardOptions,
 ) -> Result<DashboardHandle, AppError> {
-    let api_base_url = dashboard_base_url(&options.host, options.port);
+    // Coordinate port usage with other Hermes instances (desktop, CLI
+    // dashboards, gateways, proxies) before doing any network probes. We claim
+    // the dashboard API port plus the well-known satellite ports (webhook,
+    // proxy) as an atomic set. If the primary set is claimed by another live
+    // instance, shift to the next free set when fallback is allowed.
+    let (effective_port, mut port_locks) = {
+        if let Some(locks) = try_claim_dashboard_ports(options.port, &options.hermes_home) {
+            (options.port, locks)
+        } else if options.allow_port_fallback {
+            let mut found = None;
+            for candidate_port in fallback_ports(options.port) {
+                if let Some(locks) = try_claim_dashboard_ports(candidate_port, &options.hermes_home)
+                {
+                    found = Some((candidate_port, locks));
+                    break;
+                }
+            }
+            match found {
+                Some(pair) => pair,
+                None => {
+                    return Err(AppError::DashboardStartup(format!(
+                        "No available port from {} to {} — all dashboard ports are claimed by other Hermes instances.",
+                        options.port,
+                        options.port.saturating_add(DASHBOARD_PORT_FALLBACK_LIMIT)
+                    )));
+                }
+            }
+        } else {
+            return Err(AppError::DashboardStartup(format!(
+                "Port {} (or associated webhook/proxy ports) is already claimed by another Hermes instance. Stop the other instance, or enable port fallback.",
+                options.port
+            )));
+        }
+    };
+    let api_base_url = dashboard_base_url(&options.host, effective_port);
 
     // Reuse an existing dashboard only after the compatibility probe proves it
     // is serving the same isolated runtime HERMES_HOME and supports the
@@ -1313,6 +1374,12 @@ pub async fn ensure_hermes_dashboard(
                             marker.clone()
                         }
                     };
+                    // The previous desktop is dead; break any port locks it left
+                    // behind so the new instance owns them cleanly.
+                    release_orphaned_port_locks(
+                        &adopted_marker.claimed_ports,
+                        Path::new(&options.hermes_home),
+                    );
                     let gateway_runtime_dir = adopted_marker.gateway_runtime_dir.clone();
                     let gateway_lock_dir = PathBuf::from(&gateway_runtime_dir)
                         .join("token-locks")
@@ -1331,6 +1398,7 @@ pub async fn ensure_hermes_dashboard(
                         job_handle: None,
                         attached_pid: Some(adopted_marker.dashboard_pid),
                         child: None,
+                        port_locks: Some(port_locks),
                     });
                 }
 
@@ -1408,66 +1476,28 @@ pub async fn ensure_hermes_dashboard(
             job_handle: None,
             attached_pid: None,
             child: None,
+            port_locks: Some(port_locks),
         });
     }
 
-    // Try port fallbacks if the primary port has an incompatible dashboard
+    // The effective port set is lock-claimed by us, yet something incompatible
+    // still answers on it: an uncoordinated process (non-Hermes service, or a
+    // Hermes runtime predating port locks) is bound there. Shifting away
+    // silently would leak such collisions forever, so surface the conflict.
+    if primary_occupied {
+        return Err(AppError::DashboardStartup(format!(
+            "{} is already occupied by another service. Stop the process on port {} so the desktop can spawn its managed runtime dashboard.",
+            api_base_url, effective_port
+        )));
+    }
+
     let mut spawn_options = EnsureDashboardOptions {
         host: options.host.clone(),
-        port: options.port,
+        port: effective_port,
         hermes_home: options.hermes_home.clone(),
         allow_external_agent: options.allow_external_agent,
         allow_port_fallback: options.allow_port_fallback,
     };
-
-    if primary_occupied {
-        if !options.allow_port_fallback {
-            return Err(AppError::DashboardStartup(format!(
-                "{} is already occupied by another dashboard. Stop the process on port {} so the desktop can spawn its managed runtime dashboard.",
-                api_base_url, options.port
-            )));
-        }
-        log::warn!(
-            "Dashboard at {} is not compatible; trying alternate ports",
-            api_base_url
-        );
-        let mut found = false;
-        for candidate_port in fallback_ports(options.port) {
-            let candidate_url = dashboard_base_url(&options.host, candidate_port);
-            if probe_dashboard_port(&candidate_url) {
-                if options.allow_external_agent
-                    && dashboard_is_compatible(&candidate_url, &options.hermes_home).await
-                {
-                    let session_token = known_session_token_for_existing(&candidate_url).await;
-                    return Ok(DashboardHandle {
-                        api_base_url: candidate_url,
-                        session_token,
-                        owns_process: false,
-                        command_program: None,
-                        command_args: vec![],
-                        gateway_runtime_dir: None,
-                        gateway_lock_dir: None,
-                        ownership_marker_path: Some(ownership_marker_path_display()),
-                        ownership_state: Some("attached-compatible-fallback".to_string()),
-                        job_handle: None,
-                        attached_pid: None,
-                        child: None,
-                    });
-                }
-                continue;
-            }
-            spawn_options.port = candidate_port;
-            found = true;
-            break;
-        }
-        if !found {
-            return Err(AppError::DashboardStartup(format!(
-                "No available port from {} to {}",
-                options.port,
-                options.port.saturating_add(DASHBOARD_PORT_FALLBACK_LIMIT)
-            )));
-        }
-    }
 
     // Spawn a new dashboard, retrying on a lost bind race. The pre-scan
     // above picked a free port, but between that probe and the child's
@@ -1480,20 +1510,30 @@ pub async fn ensure_hermes_dashboard(
     for attempt in 1..=SPAWN_ATTEMPT_LIMIT {
         if attempt > 1 {
             // Re-scan for the next candidate, skipping burned ports and
-            // anything that became occupied since the previous scan.
+            // anything that became occupied or lock-claimed since the previous
+            // scan. Release the old claim first — the new candidate (possibly
+            // the same port) gets a fresh atomic claim of its full port set.
+            drop(std::mem::take(&mut port_locks));
             let next = std::iter::once(options.port)
                 .chain(fallback_ports(options.port))
-                .find(|port| {
+                .filter(|port| {
                     !tried_ports.contains(port)
                         && !probe_dashboard_port(&dashboard_base_url(&options.host, *port))
+                })
+                .find_map(|port| {
+                    try_claim_dashboard_ports(port, &options.hermes_home).map(|locks| (port, locks))
                 });
             match next {
-                Some(port) => spawn_options.port = port,
+                Some((port, locks)) => {
+                    spawn_options.port = port;
+                    port_locks = locks;
+                }
                 None => break,
             }
         }
         tried_ports.push(spawn_options.port);
 
+        let claimed_ports: Vec<u16> = port_locks.iter().map(|lock| lock.port()).collect();
         let SpawnedDashboard {
             mut child,
             session_token,
@@ -1504,7 +1544,7 @@ pub async fn ensure_hermes_dashboard(
             ownership_marker_path,
             job_handle,
             ready_file,
-        } = spawn_dashboard(&spawn_options)?;
+        } = spawn_dashboard(&spawn_options, claimed_ports)?;
         let child_url = dashboard_base_url(&spawn_options.host, spawn_options.port);
 
         let outcome = wait_for_spawned_dashboard(
@@ -1539,6 +1579,7 @@ pub async fn ensure_hermes_dashboard(
                     job_handle,
                     attached_pid: None,
                     child: Some(child),
+                    port_locks: Some(std::mem::take(&mut port_locks)),
                 });
             }
             WaitOutcome::TimedOut => {
@@ -1727,6 +1768,7 @@ mod tests {
             gateway_runtime_dir: "/tmp/hermes-runtime-test/gateway".to_string(),
             started_at_ms: 1,
             runtime_version: Some("test".to_string()),
+            claimed_ports: vec![],
         }
     }
 

--- a/src/process/mod.rs
+++ b/src/process/mod.rs
@@ -1,4 +1,5 @@
 pub mod dashboard;
 pub mod gateway;
 pub mod instance;
+pub mod port_lock;
 pub mod runtime;

--- a/src/process/port_lock.rs
+++ b/src/process/port_lock.rs
@@ -1,0 +1,387 @@
+//! Cross-process port coordination via advisory lock files.
+//!
+//! Multiple Hermes instances (CLI dashboards, desktop-managed dashboards,
+//! gateways, proxies) use a lock file under
+//! `$HERMES_HOME/.port-locks/<port>.lock` to reserve ports before binding.
+//! The lock is advisory and released automatically when the holding process
+//! exits.
+
+use std::collections::HashSet;
+use std::fs::{self, File, OpenOptions};
+use std::io::Read;
+use std::path::{Path, PathBuf};
+use std::sync::Mutex;
+use std::time::{SystemTime, UNIX_EPOCH};
+
+use fs2::FileExt;
+
+/// Tracks ports this process has already claimed. Because OS advisory locks are
+/// per-process on POSIX, claiming the same port twice from the same process
+/// would create two PortLock handles whose drops interfere with each other.
+static LOCAL_CLAIMS: Mutex<Option<HashSet<u16>>> = Mutex::new(None);
+
+fn local_claims_insert(port: u16) -> bool {
+    let mut guard = LOCAL_CLAIMS.lock().unwrap_or_else(|e| e.into_inner());
+    let set = guard.get_or_insert_with(HashSet::new);
+    set.insert(port)
+}
+
+fn local_claims_remove(port: u16) {
+    let mut guard = LOCAL_CLAIMS.lock().unwrap_or_else(|e| e.into_inner());
+    if let Some(set) = guard.as_mut() {
+        set.remove(&port);
+    }
+}
+
+/// Opaque handle representing a held port lock.
+pub struct PortLock {
+    port: u16,
+    /// `None` for a no-op lock (same process already holds the real lock, or
+    /// the lock file is unavailable). `Some(File)` for the real OS lock.
+    file: Option<File>,
+    /// Whether this handle owns the local bookkeeping entry and should clear
+    /// it on release.
+    owns_local_claim: bool,
+}
+
+impl PortLock {
+    /// Return the port this lock guards.
+    pub fn port(&self) -> u16 {
+        self.port
+    }
+
+    /// Explicitly release the lock. Safe to call multiple times.
+    pub fn release(self) {
+        if let Some(file) = self.file.as_ref() {
+            let _ = fs2::FileExt::unlock(file);
+        }
+        if self.owns_local_claim {
+            local_claims_remove(self.port);
+        }
+    }
+}
+
+impl Drop for PortLock {
+    fn drop(&mut self) {
+        if let Some(file) = self.file.as_ref() {
+            let _ = fs2::FileExt::unlock(file);
+        }
+        if self.owns_local_claim {
+            local_claims_remove(self.port);
+        }
+    }
+}
+
+/// Return the lock directory for a given HERMES_HOME.
+fn lock_dir(hermes_home: impl AsRef<Path>) -> PathBuf {
+    hermes_home.as_ref().join(".port-locks")
+}
+
+/// Return the lock file path for a given port.
+fn lock_file_path(port: u16, hermes_home: impl AsRef<Path>) -> PathBuf {
+    lock_dir(hermes_home).join(format!("{}.lock", port))
+}
+
+/// Read the owner PID stored in a lock file, if any.
+fn read_lock_owner(path: &Path) -> Option<u32> {
+    let mut content = String::new();
+    File::open(path).ok()?.read_to_string(&mut content).ok()?;
+    content.lines().next()?.trim().parse().ok()
+}
+
+/// Write the current owner PID into the lock file.
+fn write_lock_owner(path: &Path, pid: u32) {
+    let _ = fs::write(path, format!("{}\n", pid));
+}
+
+/// Best-effort PID liveness check.
+#[cfg(unix)]
+fn pid_is_running(pid: u32) -> bool {
+    if pid == 0 {
+        return false;
+    }
+    let rc = unsafe { libc::kill(pid as libc::pid_t, 0) };
+    rc == 0 || std::io::Error::last_os_error().raw_os_error() == Some(libc::EPERM)
+}
+
+#[cfg(windows)]
+fn pid_is_running(pid: u32) -> bool {
+    if pid == 0 {
+        return false;
+    }
+    use std::os::raw::c_void;
+
+    const PROCESS_QUERY_LIMITED_INFORMATION: u32 = 0x1000;
+    const PROCESS_QUERY_INFORMATION: u32 = 0x0400;
+    const STILL_ACTIVE: u32 = 259;
+
+    // Use raw extern because windows-sys re-exports vary by feature set.
+    extern "system" {
+        fn OpenProcess(dwDesiredAccess: u32, bInheritHandle: i32, dwProcessId: u32) -> *mut c_void;
+        fn GetExitCodeProcess(hProcess: *mut c_void, lpExitCode: *mut u32) -> i32;
+        fn CloseHandle(hObject: *mut c_void) -> i32;
+    }
+
+    unsafe {
+        let mut handle = OpenProcess(PROCESS_QUERY_LIMITED_INFORMATION, 0, pid);
+        if handle.is_null() {
+            handle = OpenProcess(PROCESS_QUERY_INFORMATION, 0, pid);
+        }
+        if handle.is_null() {
+            return false;
+        }
+        let mut exit_code: u32 = 0;
+        let result = GetExitCodeProcess(handle, &mut exit_code);
+        CloseHandle(handle);
+        if result != 0 {
+            exit_code == STILL_ACTIVE
+        } else {
+            // Could not read exit code; be conservative.
+            true
+        }
+    }
+}
+
+#[cfg(not(any(unix, windows)))]
+fn pid_is_running(_pid: u32) -> bool {
+    false
+}
+
+fn now_millis() -> u128 {
+    SystemTime::now()
+        .duration_since(UNIX_EPOCH)
+        .unwrap_or_default()
+        .as_millis()
+}
+
+/// Try to claim a port via lock file.
+///
+/// Returns `Some(PortLock)` on success. The lock is released when the handle
+/// is dropped or `release()` is called. Returns `None` when the port is already
+/// locked by another live process.
+///
+/// If the lock file cannot be created (read-only filesystem, permission
+/// denied), returns a no-op `PortLock` so Hermes can still start.
+pub fn try_claim_port(port: u16, hermes_home: impl AsRef<Path>) -> Option<PortLock> {
+    let path = lock_file_path(port, &hermes_home);
+
+    // Same-process deduplication: return a no-op handle if we already hold
+    // this port. This prevents double-locking during respawn and makes the
+    // Rust behavior match the Python implementation.
+    let already_claimed_locally = !local_claims_insert(port);
+    if already_claimed_locally {
+        return Some(PortLock {
+            port,
+            file: None,
+            owns_local_claim: false,
+        });
+    }
+
+    if let Some(parent) = path.parent() {
+        if let Err(err) = fs::create_dir_all(parent) {
+            log::debug!(
+                "Cannot create port lock directory {}: {}; falling back to no-lock",
+                parent.display(),
+                err
+            );
+            return Some(PortLock {
+                port,
+                file: None,
+                owns_local_claim: true,
+            });
+        }
+    }
+
+    let file = match OpenOptions::new()
+        .create(true)
+        .truncate(false)
+        .read(true)
+        .write(true)
+        .open(&path)
+    {
+        Ok(f) => f,
+        Err(err) => {
+            log::debug!(
+                "Cannot open port lock file {}: {}; falling back to no-lock",
+                path.display(),
+                err
+            );
+            return Some(PortLock {
+                port,
+                file: None,
+                owns_local_claim: true,
+            });
+        }
+    };
+
+    if file.try_lock_exclusive().is_ok() {
+        write_lock_owner(&path, std::process::id());
+        return Some(PortLock {
+            port,
+            file: Some(file),
+            owns_local_claim: true,
+        });
+    }
+
+    // Lock is held. Check whether the owner is still alive.
+    if let Some(owner) = read_lock_owner(&path) {
+        if !pid_is_running(owner) {
+            // Break stale lock. Close our failed handle first to avoid holding
+            // a conflicting view, then reopen and claim.
+            drop(file);
+            // Small, deterministic backoff to reduce thundering herd when many
+            // instances race to break a stale lock.
+            std::thread::sleep(std::time::Duration::from_millis(10));
+            let fresh = OpenOptions::new()
+                .create(true)
+                .truncate(false)
+                .read(true)
+                .write(true)
+                .open(&path)
+                .ok()?;
+            if fresh.try_lock_exclusive().is_ok() {
+                write_lock_owner(&path, std::process::id());
+                return Some(PortLock {
+                    port,
+                    file: Some(fresh),
+                    owns_local_claim: true,
+                });
+            }
+        }
+    }
+
+    // Lock failed and the owner appears alive. Undo the local claim so a
+    // future attempt in this process can try again.
+    local_claims_remove(port);
+    None
+}
+
+/// Atomically claim a set of ports, or none at all.
+///
+/// On failure, any locks already acquired are released and `None` is returned.
+pub fn claim_port_set(ports: &[u16], hermes_home: impl AsRef<Path>) -> Option<Vec<PortLock>> {
+    let mut locks = Vec::with_capacity(ports.len());
+    for port in ports {
+        match try_claim_port(*port, hermes_home.as_ref()) {
+            Some(lock) => locks.push(lock),
+            None => {
+                for lock in locks {
+                    lock.release();
+                }
+                return None;
+            }
+        }
+    }
+    Some(locks)
+}
+
+/// Release any orphaned port locks whose owner PID is dead.
+///
+/// This is used when adopting a stale dashboard marker: the marker records the
+/// ports it claimed, and a new desktop instance can break locks left behind by
+/// a crashed process.
+pub fn release_orphaned_port_locks(ports: &[u16], hermes_home: impl AsRef<Path>) {
+    for port in ports {
+        let path = lock_file_path(*port, hermes_home.as_ref());
+        if let Some(owner) = read_lock_owner(&path) {
+            if !pid_is_running(owner) {
+                if let Ok(file) = OpenOptions::new()
+                    .create(true)
+                    .truncate(false)
+                    .read(true)
+                    .write(true)
+                    .open(&path)
+                {
+                    if file.try_lock_exclusive().is_ok() {
+                        log::info!(
+                            "Broke stale port lock for {} (previous owner pid {})",
+                            port,
+                            owner
+                        );
+                        // We hold the lock briefly; dropping releases it.
+                    }
+                }
+            }
+        }
+    }
+}
+
+/// Return a deterministic owner identifier for lock-file bookkeeping.
+pub fn owner_identifier() -> String {
+    format!("{}-{}", std::process::id(), now_millis())
+}
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+    use tempfile::TempDir;
+
+    #[test]
+    fn can_claim_and_release_port() {
+        let dir = TempDir::new().unwrap();
+        let lock = try_claim_port(50000, dir.path()).expect("claim should succeed");
+        assert_eq!(lock.port(), 50000);
+        lock.release();
+    }
+
+    #[test]
+    fn double_claim_in_same_process_succeeds_no_op() {
+        let dir = TempDir::new().unwrap();
+        let first = try_claim_port(50001, dir.path()).expect("first claim should succeed");
+        let second =
+            try_claim_port(50001, dir.path()).expect("second claim in same process should succeed");
+        second.release();
+        first.release();
+    }
+
+    #[test]
+    fn claim_set_releases_on_failure() {
+        let dir = TempDir::new().unwrap();
+        let home = dir.path();
+
+        // Claim a free port so the set has something to release on failure.
+        let _free = try_claim_port(50003, home).unwrap();
+
+        // Manually occupy 50004 with the maximum possible PID. Because the
+        // file is not actually locked by a live process, try_claim_port will
+        // treat it as stale and recover it. To make the test deterministic
+        // without spawning a subprocess, we hold the underlying file lock
+        // ourselves and verify the set release logic.
+        let path = lock_file_path(50004, home);
+        fs::create_dir_all(path.parent().unwrap()).unwrap();
+        let occupying = OpenOptions::new()
+            .create(true)
+            .truncate(false)
+            .read(true)
+            .write(true)
+            .open(&path)
+            .unwrap();
+        occupying.lock_exclusive().unwrap();
+
+        let result = claim_port_set(&[50005, 50004], home);
+        assert!(
+            result.is_none(),
+            "claim set should fail because 50004 is locked"
+        );
+
+        // 50005 must not remain locked after the failed atomic claim.
+        let recovered = try_claim_port(50005, home);
+        assert!(
+            recovered.is_some(),
+            "failed claim set should release partial locks"
+        );
+        recovered.unwrap().release();
+    }
+
+    #[test]
+    fn stale_lock_is_recovered() {
+        let dir = TempDir::new().unwrap();
+        let home = dir.path();
+        let path = lock_file_path(50006, home);
+        fs::create_dir_all(path.parent().unwrap()).unwrap();
+        fs::write(&path, "999999999\n").unwrap();
+
+        let lock = try_claim_port(50006, home).expect("should recover stale lock");
+        lock.release();
+    }
+}

--- a/src/process/runtime.rs
+++ b/src/process/runtime.rs
@@ -3696,6 +3696,7 @@ mod tests {
 
     #[tokio::test]
     #[serial]
+    #[cfg(unix)]
     async fn install_bundled_runtime_does_not_overwrite_local_source_runtime() {
         use std::os::unix::fs::PermissionsExt;
 
@@ -3784,6 +3785,7 @@ mod tests {
 
     #[tokio::test]
     #[serial]
+    #[cfg(unix)]
     async fn install_bundled_runtime_migrates_local_source_when_not_preserved() {
         use std::os::unix::fs::PermissionsExt;
 

--- a/src/state.rs
+++ b/src/state.rs
@@ -13,6 +13,8 @@ use std::sync::Mutex;
 use tokio::sync::mpsc;
 use tokio::sync::Notify;
 
+use crate::process::port_lock::PortLock;
+
 /// Handle to the live Rust→runtime `/api/ws` relay (see commands/ws_proxy.rs).
 /// Holds only std/tokio types so this module stays decoupled from the WS crate.
 pub struct GatewayWsHandle {
@@ -91,6 +93,9 @@ pub struct DashboardHandle {
     pub attached_pid: Option<u32>,
     /// The child process, if we own it.
     pub child: Option<Child>,
+    /// Port locks held by this desktop instance for the dashboard API port and
+    /// its associated satellite ports. Released when the handle is dropped.
+    pub port_locks: Option<Vec<PortLock>>,
 }
 
 impl DashboardHandle {
@@ -125,6 +130,7 @@ impl DashboardHandle {
             job_handle: None,
             attached_pid: None,
             child: None,
+            port_locks: None,
         }
     }
 
@@ -158,6 +164,13 @@ impl DashboardHandle {
         crate::process::dashboard::remove_ownership_marker_path(
             self.ownership_marker_path.as_deref(),
         );
+        // Explicitly release port locks so another Hermes instance can claim
+        // the ports immediately instead of waiting for the handle to drop.
+        if let Some(locks) = self.port_locks.take() {
+            for lock in locks {
+                lock.release();
+            }
+        }
         self.ownership_state = Some("stopped".to_string());
     }
 }

--- a/src/supervisor.rs
+++ b/src/supervisor.rs
@@ -22,6 +22,18 @@ use crate::commands::restart;
 use crate::connection::ConnectionMode;
 use crate::state::AppState;
 
+fn release_dashboard_port_locks(state: &AppState) {
+    if let Ok(mut inner) = state.inner.lock() {
+        if let Some(handle) = inner.dashboard_handle.as_mut() {
+            if let Some(locks) = handle.port_locks.take() {
+                for lock in locks {
+                    lock.release();
+                }
+            }
+        }
+    }
+}
+
 const POLL_INTERVAL: Duration = Duration::from_secs(5);
 /// A respawn is "consecutive" (part of a crash loop) when the previous one was
 /// more recent than this. A dashboard that stays up longer resets the counter.
@@ -71,6 +83,15 @@ pub async fn supervise_managed_dashboard(app: tauri::AppHandle) {
                 continue;
             }
             inner.dashboard_restart_in_flight = true;
+            // Release port locks held by the dying handle before respawn so
+            // ensure_hermes_dashboard can reclaim the same port set.
+            if let Some(handle) = inner.dashboard_handle.as_mut() {
+                if let Some(locks) = handle.port_locks.take() {
+                    for lock in locks {
+                        lock.release();
+                    }
+                }
+            }
             inner.hermes_home.clone()
         };
 
@@ -92,6 +113,9 @@ pub async fn supervise_managed_dashboard(app: tauri::AppHandle) {
                         .to_string(),
                 );
             }
+            // Crash-loop abort: release port locks so a manual restart can
+            // reclaim the ports without waiting for the desktop to exit.
+            release_dashboard_port_locks(&state);
             return;
         }
 


### PR DESCRIPTION
## 来源

@MaxwellGeng 的 `dev-fix` 分支（原始提交 37db170f「Add port shifting, fix multi process.」），rebase 到最新 main 之后的版本。作者署名保留。

## 做了什么

多个 Hermes 实例（桌面端、CLI dashboard、gateway、proxy）通过 `HERMES_HOME/.port-locks/` 下的共享锁文件协调端口占用：

- 新增 `src/process/port_lock.rs`：基于 `fs2` 文件锁的端口声明（PID 记录、死主检测破锁、同进程去重、RAII 自动释放）
- `ensure_hermes_dashboard` 在任何网络探测之前先原子申领「dashboard 端口 + 周边端口（8644/8645 webhook/proxy）」整组锁；主端口组被其他活实例占用时按 fallback 顺移申领
- ownership marker 记录 `claimedPorts`，adopt 陈旧 marker 时释放死实例遗留的孤儿锁
- `DashboardHandle` 携带锁句柄，supervisor 退出路径统一释放

## ⚠️ 这是一次语义级 rebase，不是纯文本换基

原始提交基于 #400 合并前的 main，而 #400 重写了同一段 spawn 流程（ready-file 身份验证 + spawn 重试循环），与本分支的端口锁属于互补机制（一个管"谁占坑"，一个管"确认坑里是自己"）。整合决策如下，请重点 review：

1. **claim-first 前移**：进入 ensure 即申领端口组，之后 #400 的 sweep / marker / adopt / reuse 流程原样跑在 effective port 上
2. **保留 #400 的 spawn 重试循环**：TOCTOU 输掉 bind race（ExitedEarly / PortStolen）换端口重试时，先释放旧锁组、对新候选端口重新原子申领
3. **primary_occupied 语义采用 dev-fix 的硬错误**：锁已申领却仍有服务占着端口 = 不受协调的进程，直接报错而不是静默顺移（#400 原来的 probe-based fallback 扫描被 claim-based 申领取代，其中的 attached-compatible-fallback 复用路径随之移除——复用判定现在只发生在锁申领成功的 effective port 上）
4. rebase 修正：`PortLock.path` 死字段移除、`OpenOptions` 补 `truncate(false)`（原分支会挂 clippy -D warnings）、marker 测试夹具补 `claimed_ports`

## 已验证

- `cargo fmt` ✅ `cargo clippy --all-targets --all-features`（0 warning）✅
- `cargo test --all-features`：402 单测 + 全部集成测试通过 ✅

## 建议的人工验证

- 双开桌面端（同一 HERMES_HOME）：第二个实例应顺移到 9121 且 webhook/proxy 端口不打架
- 杀掉第一个实例后重启：孤儿锁被破除、dashboard 被 adopt 或干净重生

🤖 Generated with [Claude Code](https://claude.com/claude-code)