### PR TITLE
fix: 修复聊天图片本地路径预览失败

### DIFF
--- a/web/src/components/chat/message-image.tsx
+++ b/web/src/components/chat/message-image.tsx
@@ -1,6 +1,7 @@
-import { useMemo, useState } from "react";
+import { useEffect, useMemo, useState } from "react";
 import { ImageOff } from "lucide-react";
-import { safeImageSrc } from "@/lib/message-images";
+import { isLikelyLocalFilePath, safeImageSrc } from "@/lib/message-images";
+import { fetchMediaDataUrl } from "@/lib/transport";
 import type { ChatImageItem } from "./chat-types";
 import s from "./message-timeline.module.css";
 
@@ -22,7 +23,7 @@ function ImagePlaceholder({
   reason,
 }: {
   image: ChatImageItem;
-  reason: "unsupported" | "failed";
+  reason: "loading" | "unsupported" | "failed";
 }) {
   const label = imageLabel(image);
   const source = image.url?.trim();
@@ -33,7 +34,11 @@ function ImagePlaceholder({
       <ImageOff size={18} strokeWidth={1.8} aria-hidden="true" />
       <span className={s.imageFallbackBody}>
         <span className={s.imageFallbackTitle}>
-          {reason === "failed" ? "图片加载失败" : "图片暂不能直接预览"}
+          {reason === "loading"
+            ? "图片加载中"
+            : reason === "failed"
+              ? "图片加载失败"
+              : "图片暂不能直接预览"}
         </span>
         <span className={s.imageFallbackMeta}>{label}</span>
         {source ? (
@@ -51,12 +56,49 @@ function ImagePlaceholder({
 }
 
 export function MessageImage({ image }: MessageImageProps) {
-  const [failed, setFailed] = useState(false);
-  const src = useMemo(() => safeImageSrc(image.url), [image.url]);
+  const [failedSrc, setFailedSrc] = useState<string>();
+  const [localImage, setLocalImage] = useState<{
+    path: string;
+    src?: string;
+    failed?: boolean;
+  }>();
+  const directSrc = useMemo(() => safeImageSrc(image.url), [image.url]);
+  const localPath = useMemo(() => {
+    const source = image.url?.trim();
+    return !directSrc && source && isLikelyLocalFilePath(source) ? source : undefined;
+  }, [directSrc, image.url]);
   const label = imageLabel(image);
 
-  if (!src) return <ImagePlaceholder image={image} reason="unsupported" />;
-  if (failed) return <ImagePlaceholder image={image} reason="failed" />;
+  useEffect(() => {
+    if (!localPath) {
+      setLocalImage(undefined);
+      return;
+    }
+
+    let active = true;
+    setLocalImage({ path: localPath });
+    void fetchMediaDataUrl(localPath).then((dataUrl) => {
+      if (!active) return;
+      const src = safeImageSrc(dataUrl);
+      setLocalImage(src ? { path: localPath, src } : { path: localPath, failed: true });
+    }).catch(() => {
+      if (active) setLocalImage({ path: localPath, failed: true });
+    });
+    return () => {
+      active = false;
+    };
+  }, [localPath]);
+
+  const resolvedLocal = localImage?.path === localPath ? localImage : undefined;
+  const src = directSrc || resolvedLocal?.src;
+
+  if (localPath && !resolvedLocal?.failed && !src) {
+    return <ImagePlaceholder image={image} reason="loading" />;
+  }
+  if (!src) {
+    return <ImagePlaceholder image={image} reason={resolvedLocal?.failed ? "failed" : "unsupported"} />;
+  }
+  if (failedSrc === src) return <ImagePlaceholder image={image} reason="failed" />;
 
   return (
     <a
@@ -71,7 +113,7 @@ export function MessageImage({ image }: MessageImageProps) {
         alt={label}
         loading="lazy"
         decoding="async"
-        onError={() => setFailed(true)}
+        onError={() => setFailedSrc(src)}
       />
     </a>
   );

--- a/web/src/components/chat/message-timeline.test.tsx
+++ b/web/src/components/chat/message-timeline.test.tsx
@@ -211,7 +211,7 @@ describe("MessageTimeline", () => {
     expect(html).toContain("\\(x_1\\)");
   });
 
-  it("shows a readable fallback for unsupported local image URLs", () => {
+  it("starts resolving local image URLs through the gateway media endpoint", () => {
     const messages: ChatMessage[] = [
       {
         id: "user-image",
@@ -225,7 +225,7 @@ describe("MessageTimeline", () => {
       <MessageTimeline messages={messages} />,
     );
 
-    expect(html).toContain("图片暂不能直接预览");
+    expect(html).toContain("图片加载中");
     expect(html).toContain("chart.png");
     expect(html).toContain("/Users/enzo/Downloads/chart.png");
   });

--- a/web/src/lib/transport.test.ts
+++ b/web/src/lib/transport.test.ts
@@ -4,6 +4,7 @@ import {
   downloadExternalImageFile,
   fetchExternalJSON,
   fetchJSON,
+  fetchMediaDataUrl,
   uploadAttachmentFile,
 } from "./transport";
 
@@ -83,6 +84,24 @@ describe("transport · debug-bus integration", () => {
 
     const restPushes = restPushesFrom(pushSpy);
     expect(restPushes.length).toBe(0);
+  });
+
+  it("fetchMediaDataUrl loads an encoded gateway image path", async () => {
+    stubFetch(() => makeResponse(200, '{"data_url":"data:image/png;base64,QUJD"}'));
+
+    await expect(fetchMediaDataUrl("/Users/me/Hermes images/a 1.png"))
+      .resolves.toBe("data:image/png;base64,QUJD");
+
+    expect(globalThis.fetch).toHaveBeenCalledWith(
+      "/api/media?path=%2FUsers%2Fme%2FHermes%20images%2Fa%201.png",
+      expect.objectContaining({ headers: { "Content-Type": "application/json" } }),
+    );
+  });
+
+  it("fetchMediaDataUrl rejects a malformed media response", async () => {
+    stubFetch(() => makeResponse(200, '{"data_url":"https://example.com/not-inline.png"}'));
+
+    await expect(fetchMediaDataUrl("/tmp/a.png")).rejects.toThrow(/image data URL/);
   });
 
   it("fetchExternalJSON pushes a REST entry on non-ok response", async () => {

--- a/web/src/lib/transport.ts
+++ b/web/src/lib/transport.ts
@@ -152,6 +152,24 @@ export async function fetchJSON<T>(
   return parser ? parser.parse(data) : data as T;
 }
 
+/**
+ * Resolve an image path on the gateway into a browser-safe data URL.
+ *
+ * Chat history stores the path returned by `image.attach(_bytes)`. A webview
+ * cannot load that absolute path directly (and must not be given broad
+ * `file://` access), so route it through Core's authenticated, media-root
+ * confined `/api/media` endpoint.
+ */
+export async function fetchMediaDataUrl(path: string): Promise<string> {
+  const result = await fetchJSON<{ data_url?: unknown }>(
+    `/api/media?path=${encodeURIComponent(path)}`,
+  );
+  if (typeof result.data_url !== "string" || !result.data_url.startsWith("data:image/")) {
+    throw new Error("Media response did not contain an image data URL");
+  }
+  return result.data_url;
+}
+
 const EXTERNAL_FETCH_TIMEOUT_MS = 15_000;
 
 function timeoutSignal(parent?: AbortSignal): AbortSignal {


### PR DESCRIPTION
## 变更内容

- 识别聊天消息中的本机图片绝对路径
- 通过 Core 的鉴权媒体接口读取图片并转成安全的 data URL
- 增加加载态、失败态和媒体响应回归测试

## 根因

聊天历史保存了 image.attach 返回的本机绝对路径。WebView 安全策略禁止直接加载本地文件路径，导致发送后或恢复会话时图片预览失败。

## 用户影响

聊天框粘贴、拖入或选择图片后，发送消息及重新打开会话都可以正常显示图片；网络图片和原有安全限制保持不变。

## 验证

- pnpm typecheck
- pnpm test:unit（98 个测试文件，872 条 Web 测试；3 个测试文件，64 条协议测试）
- cargo check
- cargo test --all-features（414 条 Rust 单测和 31 条集成测试）
- pnpm --filter @hermes/web build:desktop
- 使用用户截图中的真实图片路径调用本地 /api/media，成功返回 data:image 数据