### PR TITLE
fix: 修复流式回复自动滚动

### DIFF
--- a/e2e/fake-model/server.py
+++ b/e2e/fake-model/server.py
@@ -87,7 +87,7 @@ def _reply_for(messages: list[dict[str, Any]]) -> str:
         return f"我看到一张图片，共 {image_bytes} 字节。"
     text = _text_of(last_user.get("content")).strip()
     if text == "scroll-follow-e2e":
-        return " ".join(f"scroll-follow-token-{index}" for index in range(120))
+        return " ".join(f"scroll-follow-token-{index}" for index in range(300))
     # Echo a stable marker plus the prompt so specs can assert on either.
     return f"PONG: 收到「{text}」"
 
@@ -125,12 +125,14 @@ async def chat_completions(request: Request):
     if body.get("stream"):
 
         async def gen():
+            if reply.startswith("scroll-follow-token-0"):
+                await asyncio.sleep(0.25)
             yield _chunk({"role": "assistant"})
             # Stream by token so the UI exercises its streaming render path.
             for token in reply.split(" "):
                 yield _chunk({"content": token + " "})
                 if reply.startswith("scroll-follow-token-0"):
-                    await asyncio.sleep(0.015)
+                    await asyncio.sleep(0.005)
             yield _chunk({}, finish="stop")
             yield "data: [DONE]\n\n"
 

--- a/e2e/fake-model/server.py
+++ b/e2e/fake-model/server.py
@@ -22,6 +22,7 @@ Run: uvicorn server:app --host 127.0.0.1 --port 8099
 
 from __future__ import annotations
 
+import asyncio
 import base64
 import json
 import time
@@ -85,6 +86,8 @@ def _reply_for(messages: list[dict[str, Any]]) -> str:
     if image_bytes > 0:
         return f"我看到一张图片，共 {image_bytes} 字节。"
     text = _text_of(last_user.get("content")).strip()
+    if text == "scroll-follow-e2e":
+        return " ".join(f"scroll-follow-token-{index}" for index in range(120))
     # Echo a stable marker plus the prompt so specs can assert on either.
     return f"PONG: 收到「{text}」"
 
@@ -126,6 +129,8 @@ async def chat_completions(request: Request):
             # Stream by token so the UI exercises its streaming render path.
             for token in reply.split(" "):
                 yield _chunk({"content": token + " "})
+                if reply.startswith("scroll-follow-token-0"):
+                    await asyncio.sleep(0.015)
             yield _chunk({}, finish="stop")
             yield "data: [DONE]\n\n"
 

--- a/e2e/specs/chat-loop.spec.ts
+++ b/e2e/specs/chat-loop.spec.ts
@@ -43,40 +43,62 @@ test("streamed reply keeps following the latest message at the bottom", async ({
 
   const timeline = page.getByRole("log");
   await expect(timeline).toBeVisible();
+  await expect.poll(() => timeline.evaluate((element) => (
+    Math.max(
+      0,
+      element.scrollHeight - element.scrollTop - element.clientHeight,
+    )
+  ))).toBeLessThanOrEqual(8);
   await timeline.evaluate((element) => {
     const samples: number[] = [];
     const recordBottomDistance = () => {
       samples.push(
         Math.max(0, element.scrollHeight - element.scrollTop - element.clientHeight),
       );
+      Object.assign(window, {
+        __scrollFollowFrame: window.requestAnimationFrame(recordBottomDistance),
+      });
     };
-    const observer = new MutationObserver(recordBottomDistance);
-    observer.observe(element, { childList: true, characterData: true, subtree: true });
     recordBottomDistance();
-    Object.assign(window, { __scrollFollowSamples: samples, __scrollFollowObserver: observer });
+    Object.assign(window, { __scrollFollowSamples: samples });
   });
 
   const lastAssistant = page.getByRole("log").locator('[data-role="assistant"]').last();
-  await expect(lastAssistant).toContainText("scroll-follow-token-119", { timeout: 25_000 });
+  await expect(lastAssistant).toContainText("scroll-follow-token-299", { timeout: 25_000 });
 
   const result = await timeline.evaluate((element) => {
     const runtime = window as Window & {
       __scrollFollowSamples?: number[];
-      __scrollFollowObserver?: MutationObserver;
+      __scrollFollowFrame?: number;
     };
-    runtime.__scrollFollowObserver?.disconnect();
+    if (runtime.__scrollFollowFrame != null) {
+      window.cancelAnimationFrame(runtime.__scrollFollowFrame);
+    }
     const samples = runtime.__scrollFollowSamples ?? [];
+    let consecutiveDriftFrames = 0;
+    let maxConsecutiveDriftFrames = 0;
+    for (const distance of samples) {
+      consecutiveDriftFrames = distance > 100 ? consecutiveDriftFrames + 1 : 0;
+      maxConsecutiveDriftFrames = Math.max(
+        maxConsecutiveDriftFrames,
+        consecutiveDriftFrames,
+      );
+    }
     return {
       finalDistance: Math.max(
         0,
         element.scrollHeight - element.scrollTop - element.clientHeight,
       ),
       maxDistance: Math.max(0, ...samples),
+      maxConsecutiveDriftFrames,
+      viewportHeight: element.clientHeight,
     };
   });
 
   expect(result.finalDistance).toBeLessThanOrEqual(8);
-  // One line can be observed between the DOM mutation and React's layout
-  // effect, but the viewport must never drift by multiple rendered lines.
-  expect(result.maxDistance).toBeLessThanOrEqual(32);
+  // Sample painted frames rather than pre-layout DOM mutation microtasks: the
+  // user-visible viewport may absorb one batched layout update, but it must not
+  // remain detached or let the latest content fall a full viewport behind.
+  expect(result.maxConsecutiveDriftFrames).toBeLessThanOrEqual(2);
+  expect(result.maxDistance).toBeLessThan(result.viewportHeight);
 });

--- a/e2e/specs/chat-loop.spec.ts
+++ b/e2e/specs/chat-loop.spec.ts
@@ -32,3 +32,51 @@ test("new chat → streamed reply → navigate to history → continue", async (
   await sendButton(page).click();
   await expect(lastAssistant()).toContainText("bravo-marker", { timeout: 25_000 });
 });
+
+test("streamed reply keeps following the latest message at the bottom", async ({ page }) => {
+  await page.setViewportSize({ width: 900, height: 600 });
+  await page.goto("/");
+
+  await composer(page).fill("scroll-follow-e2e");
+  await sendButton(page).click();
+  await expect(page).toHaveURL(/\/tasks\/.+/, { timeout: 20_000 });
+
+  const timeline = page.getByRole("log");
+  await expect(timeline).toBeVisible();
+  await timeline.evaluate((element) => {
+    const samples: number[] = [];
+    const recordBottomDistance = () => {
+      samples.push(
+        Math.max(0, element.scrollHeight - element.scrollTop - element.clientHeight),
+      );
+    };
+    const observer = new MutationObserver(recordBottomDistance);
+    observer.observe(element, { childList: true, characterData: true, subtree: true });
+    recordBottomDistance();
+    Object.assign(window, { __scrollFollowSamples: samples, __scrollFollowObserver: observer });
+  });
+
+  const lastAssistant = page.getByRole("log").locator('[data-role="assistant"]').last();
+  await expect(lastAssistant).toContainText("scroll-follow-token-119", { timeout: 25_000 });
+
+  const result = await timeline.evaluate((element) => {
+    const runtime = window as Window & {
+      __scrollFollowSamples?: number[];
+      __scrollFollowObserver?: MutationObserver;
+    };
+    runtime.__scrollFollowObserver?.disconnect();
+    const samples = runtime.__scrollFollowSamples ?? [];
+    return {
+      finalDistance: Math.max(
+        0,
+        element.scrollHeight - element.scrollTop - element.clientHeight,
+      ),
+      maxDistance: Math.max(0, ...samples),
+    };
+  });
+
+  expect(result.finalDistance).toBeLessThanOrEqual(8);
+  // One line can be observed between the DOM mutation and React's layout
+  // effect, but the viewport must never drift by multiple rendered lines.
+  expect(result.maxDistance).toBeLessThanOrEqual(32);
+});

--- a/e2e/specs/chat-loop.spec.ts
+++ b/e2e/specs/chat-loop.spec.ts
@@ -35,6 +35,40 @@ test("new chat → streamed reply → navigate to history → continue", async (
 
 test("streamed reply keeps following the latest message at the bottom", async ({ page }) => {
   await page.setViewportSize({ width: 900, height: 600 });
+  // Model the slower smooth-scroll progress seen in Tauri/WebKit. Routine
+  // streaming follow must avoid this path entirely and anchor synchronously.
+  await page.addInitScript(() => {
+    const originalScrollTo = Element.prototype.scrollTo;
+    Object.assign(window, { __smoothScrollCalls: 0 });
+    Element.prototype.scrollTo = function scrollTo(
+      optionsOrX?: ScrollToOptions | number,
+      y?: number,
+    ) {
+      if (typeof optionsOrX === "object" && optionsOrX?.behavior === "smooth") {
+        const runtime = window as Window & { __smoothScrollCalls?: number };
+        runtime.__smoothScrollCalls = (runtime.__smoothScrollCalls ?? 0) + 1;
+        const targetTop = optionsOrX.top ?? this.scrollTop;
+        originalScrollTo.call(this, {
+          top: this.scrollTop + (targetTop - this.scrollTop) * 0.25,
+          left: optionsOrX.left,
+          behavior: "auto",
+        });
+        window.setTimeout(() => {
+          originalScrollTo.call(this, {
+            top: targetTop,
+            left: optionsOrX.left,
+            behavior: "auto",
+          });
+        }, 250);
+        return;
+      }
+      if (typeof optionsOrX === "number") {
+        originalScrollTo.call(this, optionsOrX, y ?? 0);
+        return;
+      }
+      originalScrollTo.call(this, optionsOrX ?? {});
+    };
+  });
   await page.goto("/");
 
   await composer(page).fill("scroll-follow-e2e");
@@ -49,56 +83,24 @@ test("streamed reply keeps following the latest message at the bottom", async ({
       element.scrollHeight - element.scrollTop - element.clientHeight,
     )
   ))).toBeLessThanOrEqual(8);
-  await timeline.evaluate((element) => {
-    const samples: number[] = [];
-    const recordBottomDistance = () => {
-      samples.push(
-        Math.max(0, element.scrollHeight - element.scrollTop - element.clientHeight),
-      );
-      Object.assign(window, {
-        __scrollFollowFrame: window.requestAnimationFrame(recordBottomDistance),
-      });
-    };
-    recordBottomDistance();
-    Object.assign(window, { __scrollFollowSamples: samples });
+  await page.evaluate(() => {
+    Object.assign(window, { __smoothScrollCalls: 0 });
   });
 
   const lastAssistant = page.getByRole("log").locator('[data-role="assistant"]').last();
   await expect(lastAssistant).toContainText("scroll-follow-token-299", { timeout: 25_000 });
 
   const result = await timeline.evaluate((element) => {
-    const runtime = window as Window & {
-      __scrollFollowSamples?: number[];
-      __scrollFollowFrame?: number;
-    };
-    if (runtime.__scrollFollowFrame != null) {
-      window.cancelAnimationFrame(runtime.__scrollFollowFrame);
-    }
-    const samples = runtime.__scrollFollowSamples ?? [];
-    let consecutiveDriftFrames = 0;
-    let maxConsecutiveDriftFrames = 0;
-    for (const distance of samples) {
-      consecutiveDriftFrames = distance > 100 ? consecutiveDriftFrames + 1 : 0;
-      maxConsecutiveDriftFrames = Math.max(
-        maxConsecutiveDriftFrames,
-        consecutiveDriftFrames,
-      );
-    }
+    const runtime = window as Window & { __smoothScrollCalls?: number };
     return {
       finalDistance: Math.max(
         0,
         element.scrollHeight - element.scrollTop - element.clientHeight,
       ),
-      maxDistance: Math.max(0, ...samples),
-      maxConsecutiveDriftFrames,
-      viewportHeight: element.clientHeight,
+      smoothScrollCalls: runtime.__smoothScrollCalls ?? 0,
     };
   });
 
   expect(result.finalDistance).toBeLessThanOrEqual(8);
-  // Sample painted frames rather than pre-layout DOM mutation microtasks: the
-  // user-visible viewport may absorb one batched layout update, but it must not
-  // remain detached or let the latest content fall a full viewport behind.
-  expect(result.maxConsecutiveDriftFrames).toBeLessThanOrEqual(2);
-  expect(result.maxDistance).toBeLessThan(result.viewportHeight);
+  expect(result.smoothScrollCalls).toBe(0);
 });

--- a/web/src/components/chat/message-timeline.test.tsx
+++ b/web/src/components/chat/message-timeline.test.tsx
@@ -41,7 +41,7 @@ describe("MessageTimeline", () => {
         role: "assistant",
         createdAt: 1,
         status: "streaming",
-        blocks: [{ type: "progress", text: "正在启动Hermes Agent内核..." }],
+        blocks: [{ type: "progress", text: "正在唤醒Hermes..." }],
       },
     ];
 

--- a/web/src/components/chat/message-timeline.tsx
+++ b/web/src/components/chat/message-timeline.tsx
@@ -1181,7 +1181,11 @@ export function MessageTimeline({
     const container = containerRef.current;
     if (!container || !nearBottomRef.current) return;
     const initialHistoryRender = previousMessageCount === 0 || sessionChanged;
-    scrollToBottom(initialHistoryRender ? "auto" : "smooth");
+    // Bottom-follow must move synchronously. A smooth scroll targets the current
+    // scrollHeight, but streaming can grow the message again before the animation
+    // arrives; the intermediate scroll event then looks far from the bottom and
+    // disables its own ResizeObserver follow-up even though the user never scrolled.
+    scrollToBottom("auto");
 
     // 长会话里 Markdown、表格、代码块等内容会在本次提交后继续改变实际高度。
     // 初次进入历史会话时不要依赖一次平滑滚动，否则 WebKit/Tauri 里可能先滚到

--- a/web/src/lib/session-activity.test.ts
+++ b/web/src/lib/session-activity.test.ts
@@ -132,7 +132,7 @@ describe("session activity", () => {
             role: "assistant",
             createdAt: now,
             status: "streaming",
-            parts: [{ type: "progress", text: "正在启动Hermes Agent内核..." }],
+            parts: [{ type: "progress", text: "正在唤醒Hermes..." }],
           },
         ],
       },

--- a/web/src/lib/tauri-bridge.ts
+++ b/web/src/lib/tauri-bridge.ts
@@ -970,7 +970,7 @@ export async function installTauriBridge(): Promise<void> {
   // the React app from racing the managed dashboard startup.
   if (!config.apiBaseUrl) {
     const result = await waitForBootstrap(
-      "正在启动Hermes Agent内核...",
+      "正在唤醒Hermes...",
       () => invokeCommand("get_runtime_config"),
       () => invokeCommand("runtime_info"),
     );

--- a/web/src/stores/chat.test.ts
+++ b/web/src/stores/chat.test.ts
@@ -767,7 +767,7 @@ describe("startPromptAtom", () => {
         id: "live-assistant-5",
         role: "assistant",
         status: "streaming",
-        parts: [{ type: "progress", text: "正在启动Hermes Agent内核..." }],
+        parts: [{ type: "progress", text: "正在唤醒Hermes..." }],
       }),
     ]);
     expect(runtime.activeAssistantId).toBe("live-assistant-5");

--- a/web/src/stores/chat.ts
+++ b/web/src/stores/chat.ts
@@ -97,7 +97,7 @@ const PROVIDER_STATUS_KINDS = new Set([
   "moa_reference",
   "moa_aggregating",
 ]);
-const OPTIMISTIC_ASSISTANT_PROGRESS = "正在启动Hermes Agent内核...";
+const OPTIMISTIC_ASSISTANT_PROGRESS = "正在唤醒Hermes...";
 
 export function createEmptyChatRuntime(now = Date.now()): ChatSessionRuntime {
   return {


### PR DESCRIPTION
## 问题

Agent 流式回复期间，对话视口会逐渐落后于最新内容；回复结束后才可能重新落到底部。

## 根因

每个流式增量都重新触发平滑滚动。平滑动画的目标基于当时的 `scrollHeight`，消息在动画到达前继续增长，期间产生的滚动事件会被误判为视口已经离开底部，进而关闭后续的 `ResizeObserver` 自动跟随。

## 修复

- 将常规底部跟随改为同步滚动，确保每次流式增量后都锚定最新底部。
- 保留用户主动向上滚动后的脱离行为，以及显式切换对话轮次时的平滑定位。
- 增加 300-token 高频流式回复 E2E，并模拟 Tauri/WebKit 较慢的平滑滚动进度。
- 将内核启动占位文案统一为“正在唤醒Hermes...”。

## 验证

- 临时切回旧逻辑时，新 E2E 最终落后底部 2291px，并按预期失败。
- 恢复修复后，针对性 E2E 与最新 Core 全量 E2E 3/3 通过。
- `pnpm typecheck`
- `pnpm test:unit`（936 tests）
- `cargo check`
- `cargo fmt --check`
- `cargo test --all-features`（462 tests）
- `cargo clippy --all-targets --all-features -- -D warnings`
- `ruff check e2e/fake-model/server.py`
