### PR TITLE
修复流式回复重复渲染并补充端到端回归

### DIFF
--- a/e2e/README.md
+++ b/e2e/README.md
@@ -10,7 +10,7 @@ repeatable, so it can gate every PR.
 
 | Loop | Spec | Asserts |
 |------|------|---------|
-| New chat → streamed reply → navigate to history → continue | `specs/chat-loop.spec.ts` | a session is created, the URL moves to `/tasks/:id`, the assistant reply streams in, and a follow-up turn works |
+| New chat → long streamed reply → navigate to history → continue | `specs/chat-loop.spec.ts` | a session is created, the URL moves to `/tasks/:id`, every delta lands before completion, persisted/live rows render once, and a follow-up turn works |
 | Paste an image → the model reads it | `specs/image-paste.spec.ts` | the pasted image attaches, and the model's reply embeds the **decoded image byte count** (proof the bytes really reached the model) |
 
 ## Architecture
@@ -85,7 +85,7 @@ e2e/
 ├── harness/
 │   ├── config.mjs              shared paths/ports + the Core config.yaml it writes
 │   ├── start-backend.mjs       spawns fake model + Core dashboard, waits for ready
-│   ├── protocol-smoke.mjs      browserless WS proof of all three loops
+│   ├── protocol-smoke.mjs      browserless WS proof of all four loops
 │   └── wait.mjs                tiny poll/readiness helpers
 ├── fixtures/red-square.mjs     the 1×1 PNG shared by smoke + image spec
 └── specs/

--- a/e2e/fake-model/server.py
+++ b/e2e/fake-model/server.py
@@ -22,6 +22,7 @@ Run: uvicorn server:app --host 127.0.0.1 --port 8099
 
 from __future__ import annotations
 
+import asyncio
 import base64
 import json
 import time
@@ -34,6 +35,12 @@ from fastapi.responses import JSONResponse, StreamingResponse
 app = FastAPI()
 
 MODEL_ID = "fake-model"
+STREAM_ORDER_MARKER = "stream-order-marker"
+STREAM_ORDER_REPLY = (
+    "STREAM-ORDER-BEGIN|"
+    + "".join(f"{index:02d}|" for index in range(64))
+    + "STREAM-ORDER-END"
+)
 
 
 def _extract_image_bytes(content: Any) -> int:
@@ -85,6 +92,8 @@ def _reply_for(messages: list[dict[str, Any]]) -> str:
     if image_bytes > 0:
         return f"我看到一张图片，共 {image_bytes} 字节。"
     text = _text_of(last_user.get("content")).strip()
+    if STREAM_ORDER_MARKER in text:
+        return STREAM_ORDER_REPLY
     # Echo a stable marker plus the prompt so specs can assert on either.
     return f"PONG: 收到「{text}」"
 
@@ -123,6 +132,16 @@ async def chat_completions(request: Request):
 
         async def gen():
             yield _chunk({"role": "assistant"})
+            if reply == STREAM_ORDER_REPLY:
+                # Span many 33ms Core coalescing windows. Two-character chunks
+                # plus a small delay make overlapping timer/completion batches
+                # likely in the real gateway while keeping the test fast.
+                for offset in range(0, len(reply), 2):
+                    yield _chunk({"content": reply[offset : offset + 2]})
+                    await asyncio.sleep(0.004)
+                yield _chunk({}, finish="stop")
+                yield "data: [DONE]\n\n"
+                return
             # Stream by token so the UI exercises its streaming render path.
             for token in reply.split(" "):
                 yield _chunk({"content": token + " "})

--- a/e2e/harness/protocol-smoke.mjs
+++ b/e2e/harness/protocol-smoke.mjs
@@ -83,25 +83,46 @@ function connect() {
           }, 30_000);
         });
       },
-      // Collect streamed text for a turn until message.complete.
-      waitForTurn(timeoutMs = 30_000) {
+      eventCursor: () => events.length,
+      // Collect one session turn and briefly observe the socket after
+      // message.complete so a late, overtaken delta cannot escape detection.
+      waitForTurn(sessionId, start, timeoutMs = 30_000) {
         return new Promise((res, rej) => {
-          const start = events.length;
           const timer = setTimeout(() => rej(new Error("turn timeout")), timeoutMs);
           const tick = () => {
-            const since = events.slice(start);
+            const since = events.slice(start).filter((event) => event.session_id === sessionId);
             if (since.some((e) => e.type === "error")) {
               clearTimeout(timer);
               const e = since.find((x) => x.type === "error");
               return rej(new Error(`gateway error: ${JSON.stringify(e.payload)}`));
             }
-            if (since.some((e) => e.type === "message.complete")) {
+            const completeIndex = since.findIndex((e) => e.type === "message.complete");
+            if (completeIndex !== -1) {
               clearTimeout(timer);
-              const text = since
-                .filter((e) => e.type === "message.delta")
-                .map((e) => e.payload?.text ?? "")
-                .join("");
-              return res(text);
+              setTimeout(() => {
+                const settled = events
+                  .slice(start)
+                  .filter((event) => event.session_id === sessionId);
+                const settledCompleteIndex = settled.findIndex(
+                  (event) => event.type === "message.complete",
+                );
+                const streamedText = settled
+                  .filter((event) => event.type === "message.delta")
+                  .map((event) => event.payload?.text ?? "")
+                  .join("");
+                const finalText = settled[settledCompleteIndex]?.payload?.text ?? "";
+                const lateStreamEvents = settled
+                  .slice(settledCompleteIndex + 1)
+                  .filter((event) => event.type.endsWith(".delta"))
+                  .map((event) => event.type);
+                res({
+                  streamedText,
+                  finalText,
+                  lateStreamEvents,
+                  eventTypes: settled.map((event) => event.type),
+                });
+              }, 150);
+              return;
             }
             setTimeout(tick, 100);
           };
@@ -126,18 +147,41 @@ async function main() {
   assert(session_id, "session.create returned a session_id");
   console.log("session:", session_id);
 
+  let cursor = api.eventCursor();
   await api.submit({ session_id, text: "ping" });
-  const reply1 = await api.waitForTurn();
+  const turn1 = await api.waitForTurn(session_id, cursor);
+  const reply1 = turn1.streamedText;
   console.log("text reply:", JSON.stringify(reply1));
   assert(reply1.includes("PONG"), `text reply should contain PONG, got: ${reply1}`);
 
   // --- Loop 2: continue in same session ---
+  cursor = api.eventCursor();
   await api.submit({ session_id, text: "again" });
-  const reply2 = await api.waitForTurn();
+  const turn2 = await api.waitForTurn(session_id, cursor);
+  const reply2 = turn2.streamedText;
   assert(reply2.includes("PONG"), `follow-up reply should contain PONG, got: ${reply2}`);
   console.log("continue-conversation reply OK");
 
-  // --- Loop 3: vision (image bytes must reach the fake model) ---
+  // --- Loop 3: long stream ordering across many coalescing windows ---
+  cursor = api.eventCursor();
+  await api.submit({ session_id, text: "stream-order-marker" });
+  const orderedTurn = await api.waitForTurn(session_id, cursor);
+  assert(
+    orderedTurn.lateStreamEvents.length === 0,
+    `stream deltas arrived after completion: ${orderedTurn.eventTypes.join(" -> ")}`,
+  );
+  assert(
+    orderedTurn.streamedText === orderedTurn.finalText,
+    "concatenated message.delta text must exactly match message.complete.text",
+  );
+  assert(
+    orderedTurn.finalText.startsWith("STREAM-ORDER-BEGIN|") &&
+      orderedTurn.finalText.endsWith("STREAM-ORDER-END"),
+    `stream-order reply markers missing: ${orderedTurn.finalText}`,
+  );
+  console.log("long stream ordering OK — completion stayed behind every delta");
+
+  // --- Loop 4: vision (image bytes must reach the fake model) ---
   mkdirSync(UPLOAD_DIR, { recursive: true });
   const imgPath = resolve(UPLOAD_DIR, "smoke.png");
   writeFileSync(imgPath, Buffer.from(PNG_BASE64, "base64"));
@@ -145,21 +189,23 @@ async function main() {
   console.log("image.attach:", JSON.stringify(attach));
   assert(attach.attached !== false, "image.attach should succeed");
 
+  cursor = api.eventCursor();
   await api.submit({ session_id, text: "图里是什么？" });
-  const reply3 = await api.waitForTurn(40_000);
-  console.log("vision reply:", JSON.stringify(reply3));
+  const turn4 = await api.waitForTurn(session_id, cursor, 40_000);
+  const reply4 = turn4.streamedText;
+  console.log("vision reply:", JSON.stringify(reply4));
   assert(
-    reply3.includes("我看到一张图片"),
-    `vision reply should acknowledge the image, got: ${reply3}`,
+    reply4.includes("我看到一张图片"),
+    `vision reply should acknowledge the image, got: ${reply4}`,
   );
   assert(
-    reply3.includes(String(PNG_BYTE_LENGTH)),
-    `vision reply should report ${PNG_BYTE_LENGTH} decoded bytes (proves bytes reached the model), got: ${reply3}`,
+    reply4.includes(String(PNG_BYTE_LENGTH)),
+    `vision reply should report ${PNG_BYTE_LENGTH} decoded bytes (proves bytes reached the model), got: ${reply4}`,
   );
   console.log("vision round-trip OK — model received", PNG_BYTE_LENGTH, "bytes");
 
   api.close();
-  console.log("\n✅ ALL THREE LOOPS PASSED at the protocol level");
+  console.log("\n✅ ALL FOUR LOOPS PASSED at the protocol level");
 }
 
 main().catch((err) => {

--- a/e2e/specs/chat-loop.spec.ts
+++ b/e2e/specs/chat-loop.spec.ts
@@ -3,8 +3,8 @@ import { test, expect, type Page } from "@playwright/test";
 // The core chat closed loop, driven through the real UI:
 //   new-chat page  ->  type  ->  send  ->  navigate to /tasks/:id
 //   ->  streamed assistant reply  ->  continue the conversation in history.
-// Backed by the real Core gateway + the deterministic fake model (replies start
-// with "PONG"), so this asserts behavior, not LLM wording.
+// Backed by the real Core gateway + the deterministic fake model, so this
+// asserts behavior, not LLM wording.
 
 const composer = (page: Page) => page.getByRole("textbox", { name: "输入消息" });
 const sendButton = (page: Page) => page.getByRole("button", { name: "发送消息" });
@@ -12,23 +12,36 @@ const sendButton = (page: Page) => page.getByRole("button", { name: "发送消�
 test("new chat → streamed reply → navigate to history → continue", async ({ page }) => {
   await page.goto("/");
 
-  // 1. New-conversation page: type and send. Distinctive tokens let us tell the
-  //    two turns apart (the fake model echoes the prompt back in its reply).
+  // 1. New-conversation page: the marker selects a deliberately long fake
+  //    response that spans many Core token-coalescing windows.
   await expect(composer(page)).toBeVisible();
-  await composer(page).fill("alpha-marker");
+  await composer(page).fill("stream-order-marker");
   await sendButton(page).click();
 
   // 2. App creates a session and routes to the conversation-history page.
   await expect(page).toHaveURL(/\/tasks\/.+/, { timeout: 20_000 });
 
-  // 3. The assistant's streamed reply (echoing turn 1) lands in the message log.
+  // 3. The assistant's long streamed reply lands in the message log.
   const lastAssistant = () => page.getByRole("log").locator('[data-role="assistant"]').last();
-  await expect(lastAssistant()).toContainText("PONG", { timeout: 25_000 });
-  await expect(lastAssistant()).toContainText("alpha-marker");
+  await expect(lastAssistant()).toContainText("STREAM-ORDER-BEGIN", { timeout: 25_000 });
+  await expect(lastAssistant()).toContainText("STREAM-ORDER-END");
+
+  // Let the canonical history refetch merge with the completed live row. The
+  // regression rendered both rows because the corrupt live stream differed
+  // from the persisted final text.
+  const assistantRows = page
+    .getByRole("log")
+    .locator('[data-role="assistant"]:has(button[title="朗读回复"])');
+  await page.waitForTimeout(750);
+  await expect(assistantRows).toHaveCount(1);
+  const firstReplyText = await assistantRows.first().innerText();
+  expect(firstReplyText.match(/STREAM-ORDER-BEGIN/g)).toHaveLength(1);
+  expect(firstReplyText.match(/STREAM-ORDER-END/g)).toHaveLength(1);
 
   // 4. Continue the conversation in the same session: a fresh reply that echoes
   //    turn 2 proves the history page keeps the loop alive.
   await composer(page).fill("bravo-marker");
   await sendButton(page).click();
   await expect(lastAssistant()).toContainText("bravo-marker", { timeout: 25_000 });
+  await expect(assistantRows).toHaveCount(2);
 });

--- a/web/src/components/chat/message-adapter.test.ts
+++ b/web/src/components/chat/message-adapter.test.ts
@@ -450,6 +450,44 @@ describe("message adapter", () => {
     });
   });
 
+  it("lets the persisted completion replace a corrupt live prefix plus final duplicate", () => {
+    const finalText = "这是数据库中唯一正确的最终回复。";
+    const reasoning = "同一段完整推理";
+    const stored = [
+      uiMessage({
+        id: "stored-assistant-5874",
+        createdAt: 10_000,
+        status: "complete",
+        parts: [
+          { type: "text", text: finalText },
+          { type: "reasoning", text: reasoning },
+        ],
+        metadata: { persistedId: 5_874 },
+      }),
+    ];
+    const live = [
+      uiMessage({
+        id: "live-assistant-corrupt",
+        createdAt: 1_000,
+        status: "complete",
+        parts: [
+          { type: "reasoning", text: reasoning },
+          { type: "text", text: `乱序流式前缀${finalText}` },
+        ],
+        metadata: {
+          timing: { startedAt: 1_000, firstTokenAt: 1_100, completedAt: 10_100 },
+        },
+      }),
+    ];
+
+    const merged = mergeHermesUIMessages(stored, live);
+
+    expect(merged).toHaveLength(1);
+    expect(merged[0]?.id).toBe("stored-assistant-5874");
+    expect(merged[0]?.parts).toEqual(stored[0]?.parts);
+    expect(merged[0]?.metadata?.timing).toEqual(live[0]?.metadata?.timing);
+  });
+
   // Regression for issue #98: once a reply completes the stored refetch carries
   // the persisted assistant turn, but the live user prompt can fail to match a
   // stored row (its canonical text diverged), so it was appended *after* the

--- a/web/src/components/chat/message-adapter.ts
+++ b/web/src/components/chat/message-adapter.ts
@@ -1012,9 +1012,35 @@ function hasSamePersistedId(stored: HermesUIMessage, live: HermesUIMessage): boo
   return storedPersisted !== undefined && livePersisted !== undefined && storedPersisted === livePersisted;
 }
 
+function isCorruptedLiveCompletionSupersededByStored(
+  stored: HermesUIMessage,
+  live: HermesUIMessage,
+): boolean {
+  if (stored.role !== "assistant" || live.role !== "assistant") return false;
+  if (stored.status !== "complete" || live.status !== "complete") return false;
+  if (stored.metadata?.persistedId === undefined || live.metadata?.persistedId !== undefined) return false;
+
+  const completedAt = live.metadata?.timing?.completedAt;
+  if (typeof completedAt !== "number" || Math.abs(completedAt - stored.createdAt) > 5_000) return false;
+
+  const storedText = looseComparableText(canonicalText(stored));
+  const liveText = looseComparableText(canonicalText(live));
+  if (!storedText || liveText.length <= storedText.length || !liveText.endsWith(storedText)) return false;
+
+  return canonicalReasoning(stored) === canonicalReasoning(live) &&
+    canonicalImages(stored) === canonicalImages(live) &&
+    canonicalToolIdentityComparable(stored) === canonicalToolIdentityComparable(live);
+}
+
 function isSameCanonicalMessage(stored: HermesUIMessage, live: HermesUIMessage): boolean {
   if (stored.id === live.id || hasSamePersistedId(stored, live)) return true;
   if (stored.role !== live.role) return false;
+
+  // Older Core runtimes could interleave a token batch with message.complete.
+  // The reducer then appended the authoritative final text behind the corrupt
+  // partial stream. Match that exact artifact to its persisted canonical row;
+  // mergeMatchedMessage deliberately lets the stored text win below.
+  if (isCorruptedLiveCompletionSupersededByStored(stored, live)) return true;
 
   const storedText = canonicalText(stored);
   const liveText = canonicalText(live);
@@ -1078,7 +1104,11 @@ function consolidateAssistantMessages(messages: HermesUIMessage[]): HermesUIMess
 }
 
 function mergeMatchedMessage(storedMessage: HermesUIMessage, liveMessage: HermesUIMessage): HermesUIMessage {
-  const liveWins = !(
+  const storedCompletionWins = isCorruptedLiveCompletionSupersededByStored(
+    storedMessage,
+    liveMessage,
+  );
+  const liveWins = !storedCompletionWins && !(
     storedMessage.role === "assistant" &&
     storedMessage.status === "complete" &&
     liveMessage.status === "streaming"

--- a/web/src/stores/chat.test.ts
+++ b/web/src/stores/chat.test.ts
@@ -70,6 +70,40 @@ describe("chat runtime reducer", () => {
     expect(next.streamStatus).toBe("complete");
   });
 
+  it("replaces a corrupt streamed prefix with the authoritative completion text", () => {
+    let runtime = reduceGatewayEvent(
+      createEmptyChatRuntime(1),
+      {
+        type: "reasoning.delta",
+        session_id: "s1",
+        payload: { text: "同一段推理" },
+      },
+      10,
+    );
+    runtime = reduceGatewayEvent(runtime, {
+      type: "message.delta",
+      session_id: "s1",
+      payload: { text: "乱序流式前缀" },
+    }, 20);
+    runtime = reduceGatewayEvent(runtime, {
+      type: "message.complete",
+      session_id: "s1",
+      payload: {
+        text: "这是唯一正确的最终回复。",
+        reasoning: "同一段推理",
+        status: "complete",
+      },
+    }, 30);
+
+    const message = assistantMessage(runtime);
+    expect(textFromParts(message.parts)).toBe("这是唯一正确的最终回复。");
+    expect(textFromParts(message.parts)).not.toContain("乱序流式前缀");
+    expect(message.parts).toEqual([
+      { type: "reasoning", text: "同一段推理" },
+      { type: "text", text: "这是唯一正确的最终回复。" },
+    ]);
+  });
+
   it("keeps one assistant id from stream start through completion", () => {
     const started = reduceGatewayEvent(
       createEmptyChatRuntime(1),
@@ -364,6 +398,48 @@ describe("chat runtime reducer", () => {
       { type: "text", text: "结论如下。" },
     ]);
     expect(textFromParts(message.parts)).toBe("我先检查。结论如下。");
+  });
+
+  it("preserves pre-tool commentary while replacing a corrupt final segment", () => {
+    let runtime = reduceGatewayEvent(
+      createEmptyChatRuntime(1),
+      {
+        type: "message.delta",
+        session_id: "s1",
+        payload: { text: "我先检查。" },
+      },
+      10,
+    );
+    runtime = reduceGatewayEvent(runtime, {
+      type: "tool.start",
+      session_id: "s1",
+      payload: { tool_id: "read-1", name: "read_file" },
+    }, 20);
+    runtime = reduceGatewayEvent(runtime, {
+      type: "tool.complete",
+      session_id: "s1",
+      payload: { tool_id: "read-1", summary: "ok" },
+    }, 30);
+    runtime = reduceGatewayEvent(runtime, {
+      type: "message.delta",
+      session_id: "s1",
+      payload: { text: "损坏的尾部" },
+    }, 40);
+    runtime = reduceGatewayEvent(runtime, {
+      type: "message.complete",
+      session_id: "s1",
+      payload: { text: "最终结论。", status: "complete" },
+    }, 50);
+
+    expect(assistantMessage(runtime).parts).toEqual([
+      { type: "text", text: "我先检查。" },
+      expect.objectContaining({
+        type: "tool",
+        toolCallId: "read-1",
+        state: "done",
+      }),
+      { type: "text", text: "最终结论。" },
+    ]);
   });
 
   it("records usage and timing metadata on complete", () => {

--- a/web/src/stores/chat.ts
+++ b/web/src/stores/chat.ts
@@ -308,16 +308,30 @@ function appendToolPart(parts: HermesMessagePart[], tool: HermesToolPart): Herme
 
 function mergeFinalTextPart(parts: HermesMessagePart[], finalText: string): HermesMessagePart[] {
   if (!finalText) return parts;
-  const existingText = textFromParts(parts);
-  const last = parts[parts.length - 1];
+  const next = withoutProgressParts(parts);
+  let lastToolIndex = -1;
+  next.forEach((part, index) => {
+    if (part.type === "tool") lastToolIndex = index;
+  });
+  const finalSegmentStart = lastToolIndex + 1;
+  const existingFinalSegment = textFromParts(next.slice(finalSegmentStart));
 
-  if (!existingText) return appendTextPart(parts, finalText);
-  if (existingText === finalText) return parts;
-  if (finalText.startsWith(existingText)) {
-    return appendTextPart(parts, finalText.slice(existingText.length));
-  }
-  if (last?.type === "text" && last.text.endsWith(finalText)) return parts;
-  return appendTextPart(parts, finalText);
+  if (existingFinalSegment === finalText) return next;
+
+  // message.complete.text is the authoritative final assistant response. In a
+  // tool-bearing turn it represents only the text after the final tool call;
+  // earlier commentary must remain intact. Replace that trailing text segment
+  // instead of appending when streamed deltas diverge: an out-of-order WS batch
+  // can otherwise produce "corrupt partial + complete final" in one live row.
+  let inserted = false;
+  const reconciled = next.flatMap((part, index) => {
+    if (index < finalSegmentStart || part.type !== "text") return [part];
+    if (inserted) return [];
+    inserted = true;
+    return [{ ...part, text: finalText }];
+  });
+
+  return inserted ? reconciled : [...reconciled, { type: "text", text: finalText }];
 }
 
 function findToolMatch(tool: HermesToolPart, payload: Record<string, any>): boolean {
@@ -525,7 +539,7 @@ function finalizeAssistantParts(
   payload: Record<string, any>,
 ): HermesMessagePart[] {
   let parts = withoutProgressParts(message.parts);
-  const finalText = typeof payload.text === "string" ? payload.text : textFromParts(parts);
+  const finalText = typeof payload.text === "string" ? payload.text : "";
   const finalReasoning = normalizeReasoningText(
     typeof payload.reasoning === "string" ? payload.reasoning : reasoningFromParts(parts),
   );

--- a/web/vite.config.ts
+++ b/web/vite.config.ts
@@ -271,7 +271,7 @@ export default defineConfig({
     },
   },
   server: {
-    port: 9545,
+    port: Number(process.env.E2E_VITE_PORT || 9545),
     strictPort: true,
     proxy: {
       "/api": {


### PR DESCRIPTION
## 根因\n\nCore 旧实现可能让 message.complete 越过更早的 message.delta。Desktop 随后把完整完成文本追加到已经损坏的流式前缀后面；历史记录刷新时，实时行与持久化行文本不同，因此界面同时保留两条助手回复。\n\nCore 根修复：https://github.com/Eynzof/Hermes-CN-Core/pull/100\n\n## 修复\n\n- message.complete.text 作为最终回答权威值，替换最后一次工具调用后的流式文本段\n- 保留工具调用前的思考、说明、图片和工具结果\n- 对旧 Core 已产生的严格特征乱序记录增加保守合并兜底\n- 增加长流式假模型和协议顺序检查\n- UI E2E 在历史刷新后断言每轮只存在一条助手消息\n- E2E Vite 端口支持 E2E_VITE_PORT，避免与并行 worktree 冲突\n\n## 验证\n\n- pnpm typecheck\n- pnpm test:unit：939 项通过\n- cargo check\n- cargo test --all-features：462 项通过\n- Playwright 完整闭环：2 项通过，覆盖长流式、单行合并、继续会话与图片\n- 协议闭环：4 轮通过，覆盖文本、继续会话、长流式顺序与图片字节