### PR TITLE
fix: 修复 CLI 自定义模型在桌面端缺失

### DIFF
--- a/e2e/specs/models-cli-custom-provider.spec.ts
+++ b/e2e/specs/models-cli-custom-provider.spec.ts
@@ -1,0 +1,55 @@
+import { expect, test } from "@playwright/test";
+
+test("CLI custom endpoint appears and follows the runtime provider selection", async ({ page }) => {
+  await page.route("**/api/config", async (route) => {
+    if (route.request().method() !== "GET") {
+      await route.continue();
+      return;
+    }
+    await route.fulfill({
+      contentType: "application/json",
+      body: JSON.stringify({
+        model: "claude-opus-4-8",
+        model_context_length: 0,
+        providers: {},
+        custom_providers: [
+          {
+            name: "zijian",
+            base_url: "https://example.test/anthropic",
+            api_key: "test-key",
+            api_mode: "anthropic_messages",
+          },
+        ],
+      }),
+    });
+  });
+  await page.route("**/api/model/info", async (route) => {
+    await route.fulfill({
+      contentType: "application/json",
+      body: JSON.stringify({
+        model: "claude-opus-4-8",
+        provider: "custom:zijian",
+        auto_context_length: 1_000_000,
+        config_context_length: 0,
+        effective_context_length: 1_000_000,
+      }),
+    });
+  });
+
+  await page.goto("/models");
+
+  await expect(page.getByText("当前模型:").locator("..")).toContainText(
+    "claude-opus-4-8 (custom:zijian)",
+  );
+  await expect(page.getByText(/自定义 1 个/)).toBeVisible();
+
+  const zijianCard = page.locator('[id="provider-custom:zijian"]');
+  await expect(zijianCard).toBeVisible();
+  await expect(zijianCard).toHaveAttribute("data-active", "true");
+  await expect(zijianCard).toHaveAttribute("data-current", "true");
+  await expect(zijianCard).toContainText("zijian");
+  await expect(zijianCard).toContainText("Claude");
+  await expect(zijianCard).toContainText("当前");
+
+  await expect(page.locator("#provider-deepseek")).toHaveAttribute("data-active", "false");
+});

--- a/web/src/lib/provider-catalog.test.ts
+++ b/web/src/lib/provider-catalog.test.ts
@@ -10,6 +10,7 @@ import {
   apiModeBadgeLabel,
   apiModeDisplayName,
   chatEndpointPreviewUrl,
+  customProviderPresetsFromConfig,
   detectCustomApiModeFromUrl,
   fetchRemoteProviderCatalog,
   mergeProviderCatalog,
@@ -20,6 +21,7 @@ import {
   parseContextWindowInput,
   providerApiKeyLabels,
   providerHasSavedCredentials,
+  resolveSelectedProvider,
   sortProvidersForCnEdition,
   sortProvidersForModelsPage,
   TOP5_PROVIDER_IDS,
@@ -37,6 +39,124 @@ beforeEach(() => {
 });
 
 describe("provider catalog config updates", () => {
+  it("shows CLI custom_providers and uses the active model when the entry has no model", () => {
+    const config = {
+      model: "claude-opus-4-8",
+      providers: {},
+      custom_providers: [
+        {
+          name: "zijian",
+          base_url: "https://example.test/anthropic",
+          api_key: "test-key",
+          api_mode: "anthropic_messages",
+        },
+      ],
+    };
+
+    const presets = customProviderPresetsFromConfig(
+      config,
+      BUILTIN_PROVIDER_CATALOG.providers,
+      { provider: "custom:zijian", model: "claude-opus-4-8" },
+    );
+
+    expect(presets).toHaveLength(1);
+    expect(presets[0]).toMatchObject({
+      id: "custom:zijian",
+      name: "zijian",
+      apiMode: "anthropic_messages",
+      transport: "anthropic_messages",
+      defaultModel: "claude-opus-4-8",
+      isCustom: true,
+    });
+    expect(getProviderEntry(config, "custom:zijian")).toMatchObject({
+      name: "zijian",
+      api_key: "test-key",
+    });
+    expect(providerHasSavedCredentials(config, "custom:zijian", {}, presets[0])).toBe(true);
+  });
+
+  it("normalizes bare providers keys to the runtime custom slug and deduplicates legacy entries", () => {
+    const presets = customProviderPresetsFromConfig(
+      {
+        providers: {
+          zijian: {
+            name: "Zijian New",
+            base_url: "https://example.test/v1",
+            default_model: "new-model",
+          },
+        },
+        custom_providers: [
+          {
+            name: "zijian",
+            base_url: "https://legacy.example.test/v1",
+            model: "legacy-model",
+          },
+        ],
+      },
+      BUILTIN_PROVIDER_CATALOG.providers,
+    );
+
+    expect(presets).toHaveLength(1);
+    expect(presets[0]).toMatchObject({
+      id: "custom:zijian",
+      name: "Zijian New",
+      defaultModel: "new-model",
+    });
+  });
+
+  it("prefers the runtime provider until the user explicitly selects a card", () => {
+    const custom = customProviderPresetsFromConfig(
+      {
+        custom_providers: [{ name: "zijian", base_url: "https://example.test/v1" }],
+      },
+      BUILTIN_PROVIDER_CATALOG.providers,
+      { provider: "custom:zijian", model: "claude-opus-4-8" },
+    )[0]!;
+    const providers = [...BUILTIN_PROVIDER_CATALOG.providers, custom];
+
+    expect(resolveSelectedProvider(providers, "", "custom:zijian")?.id).toBe("custom:zijian");
+    expect(resolveSelectedProvider(providers, "deepseek", "custom:zijian")?.id).toBe("deepseek");
+  });
+
+  it("updates and deletes a legacy custom provider without creating a duplicate providers entry", () => {
+    const config = {
+      model: "claude-opus-4-8",
+      providers: {},
+      custom_providers: [
+        {
+          name: "zijian",
+          base_url: "https://old.example.test/anthropic",
+          api_key: "existing-key",
+          api_mode: "anthropic_messages",
+        },
+      ],
+    };
+    const preset = customProviderPresetsFromConfig(
+      config,
+      BUILTIN_PROVIDER_CATALOG.providers,
+      { provider: "custom:zijian", model: "claude-opus-4-8" },
+    )[0]!;
+
+    const updated = buildProviderSettingsUpdate(config, preset, {
+      apiKey: "",
+      baseUrl: "https://new.example.test/anthropic",
+      model: "claude-opus-4-8",
+    });
+
+    expect(updated.providers).toEqual({});
+    expect(updated.custom_providers).toHaveLength(1);
+    expect(updated.custom_providers[0]).toMatchObject({
+      name: "zijian",
+      base_url: "https://new.example.test/anthropic",
+      api_key: "existing-key",
+      model: "claude-opus-4-8",
+    });
+
+    const removed = buildCustomProviderDeleteUpdate(updated, "custom:zijian");
+    expect(removed.custom_providers).toEqual([]);
+    expect(removed.providers).toEqual({});
+  });
+
   it("writes catalog providers as canonical providers instead of custom slugs", () => {
     const preset = BUILTIN_PROVIDER_CATALOG.providers.find((provider) => provider.id === "cp.compshare.cn");
     expect(preset).toBeTruthy();

--- a/web/src/lib/provider-catalog.ts
+++ b/web/src/lib/provider-catalog.ts
@@ -54,6 +54,11 @@ export interface ProviderCatalog {
   providers: ProviderPreset[];
 }
 
+export interface CurrentProviderSelection {
+  provider?: string;
+  model?: string;
+}
+
 /**
  * 用户可读的接口格式名。目录里 Claude Code 中转与 OpenAI 兼容服务混排，
  * 界面必须把请求格式讲明白，用户才知道一个供应商到底按什么协议被请求。
@@ -237,11 +242,21 @@ export function buildCustomProviderDeleteUpdate(
   const providers = asRecord(config.providers);
   const nextProviders = { ...providers };
   delete nextProviders[providerId];
+  delete nextProviders[providerId.replace(/^custom:/i, "")];
+
+  const legacyProviders = Array.isArray(config.custom_providers)
+    ? config.custom_providers
+    : [];
+  const nextLegacyProviders = legacyProviders.filter((raw) => {
+    const entry = asRecord(raw);
+    return normalizeCustomProviderId(entry.provider_key ?? entry.name) !== providerId;
+  });
 
   let nextConfig = buildProviderOrderUpdate(
     {
       ...config,
       providers: nextProviders,
+      ...(legacyProviders.length > 0 ? { custom_providers: nextLegacyProviders } : {}),
     },
     getProviderOrder(config).filter((id) => id !== providerId),
   );
@@ -1042,6 +1057,124 @@ function asRecord(value: unknown): Record<string, any> {
     : {};
 }
 
+function normalizeCustomProviderId(value: unknown): string {
+  const name = String(value ?? "")
+    .trim()
+    .replace(/^custom:/i, "")
+    .toLowerCase()
+    .replace(/\s+/g, "-");
+  return name ? `custom:${name}` : "";
+}
+
+function configuredProviderApiMode(entry: Record<string, any>): ProviderApiMode {
+  const mode = String(entry.api_mode ?? entry.transport ?? "").trim();
+  if (mode === "anthropic_messages" || mode === "codex_responses") return mode;
+  return "chat_completions";
+}
+
+function configuredProviderModels(entry: Record<string, any>): ProviderCatalogModel[] {
+  const models = asRecord(entry.models);
+  return Object.entries(models).map(([id, raw]) => {
+    const metadata = asRecord(raw);
+    const contextWindow = Number(metadata.context_length ?? metadata.contextWindow ?? 0);
+    return {
+      id,
+      ...(Number.isFinite(contextWindow) && contextWindow > 0 ? { contextWindow } : {}),
+      ...(typeof metadata.supports_vision === "boolean" ? { supportsVision: metadata.supports_vision } : {}),
+      ...(typeof metadata.supports_tools === "boolean" ? { supportsTools: metadata.supports_tools } : {}),
+      ...(typeof metadata.supports_reasoning === "boolean" ? { supportsReasoning: metadata.supports_reasoning } : {}),
+    };
+  });
+}
+
+function configuredProviderBaseUrl(entry: Record<string, any>): string {
+  return String(entry.base_url ?? entry.url ?? entry.api ?? "").trim();
+}
+
+function customProviderPreset(
+  id: string,
+  entry: Record<string, any>,
+  current: CurrentProviderSelection | undefined,
+): ProviderPreset {
+  const models = configuredProviderModels(entry);
+  const currentModel = current?.provider === id ? String(current.model ?? "").trim() : "";
+  const defaultModel = String(entry.model ?? entry.default_model ?? "").trim()
+    || currentModel
+    || models[0]?.id
+    || "";
+  if (defaultModel && !models.some((model) => model.id === defaultModel)) {
+    models.unshift({ id: defaultModel, supportsTools: true });
+  }
+  const apiMode = configuredProviderApiMode(entry);
+  const baseUrl = configuredProviderBaseUrl(entry);
+
+  return {
+    id,
+    name: String(entry.name ?? "").trim() || id.replace(/^custom:/, ""),
+    vendor: isLocalProviderBaseUrl(baseUrl) ? "本地部署" : "自定义",
+    region: "cn",
+    baseUrl,
+    apiMode,
+    transport: apiMode === "anthropic_messages"
+      ? "anthropic_messages"
+      : apiMode === "codex_responses"
+        ? "codex_responses"
+        : "openai_chat",
+    apiKeyLabel: "API Key",
+    defaultModel,
+    models,
+    isCustom: true,
+  };
+}
+
+/**
+ * Build the Models-page custom cards from both Core config generations.
+ *
+ * CLI-created endpoints still live in the list-shaped `custom_providers`, while
+ * newer dashboard saves use the keyed `providers` map. Core deliberately reads
+ * both; the desktop must do the same or a working CLI endpoint disappears here.
+ */
+export function customProviderPresetsFromConfig(
+  config: Record<string, any> | undefined,
+  catalogProviders: ProviderPreset[],
+  current?: CurrentProviderSelection,
+): ProviderPreset[] {
+  const knownIds = new Set(catalogProviders.map((provider) => provider.id));
+  const result = new Map<string, ProviderPreset>();
+
+  for (const [key, raw] of Object.entries(asRecord(config?.providers))) {
+    if (knownIds.has(key)) continue;
+    const entry = asRecord(raw);
+    if (!configuredProviderBaseUrl(entry)) continue;
+    const id = normalizeCustomProviderId(key);
+    if (!id || knownIds.has(id)) continue;
+    result.set(id, customProviderPreset(id, entry, current));
+  }
+
+  const legacyProviders = Array.isArray(config?.custom_providers)
+    ? config.custom_providers
+    : [];
+  for (const raw of legacyProviders) {
+    const entry = asRecord(raw);
+    if (!configuredProviderBaseUrl(entry)) continue;
+    const id = normalizeCustomProviderId(entry.provider_key ?? entry.name);
+    if (!id || knownIds.has(id) || result.has(id)) continue;
+    result.set(id, customProviderPreset(id, entry, current));
+  }
+
+  return Array.from(result.values());
+}
+
+export function resolveSelectedProvider(
+  providers: ProviderPreset[],
+  selectedProviderId: string,
+  currentProviderId: string,
+): ProviderPreset | undefined {
+  return providers.find((provider) => provider.id === selectedProviderId)
+    ?? providers.find((provider) => provider.id === currentProviderId)
+    ?? providers[0];
+}
+
 function cleanModels(models: ProviderCatalogModel[]): Record<string, Record<string, unknown>> {
   return Object.fromEntries(
     models.map((model) => [
@@ -1056,8 +1189,27 @@ function cleanModels(models: ProviderCatalogModel[]): Record<string, Record<stri
   );
 }
 
+function providerConfigKey(config: Record<string, any> | undefined, providerId: string): string | undefined {
+  const providers = asRecord(config?.providers);
+  if (Object.hasOwn(providers, providerId)) return providerId;
+  const bareId = providerId.replace(/^custom:/i, "");
+  if (bareId !== providerId && Object.hasOwn(providers, bareId)) return bareId;
+  return undefined;
+}
+
+function legacyCustomProviderIndex(config: Record<string, any> | undefined, providerId: string): number {
+  const providers = Array.isArray(config?.custom_providers) ? config.custom_providers : [];
+  return providers.findIndex((raw) => {
+    const entry = asRecord(raw);
+    return normalizeCustomProviderId(entry.provider_key ?? entry.name) === providerId;
+  });
+}
+
 export function getProviderEntry(config: Record<string, any> | undefined, providerId: string): Record<string, any> {
-  return asRecord(asRecord(config?.providers)[providerId]);
+  const configKey = providerConfigKey(config, providerId);
+  if (configKey) return asRecord(asRecord(config?.providers)[configKey]);
+  const legacyIndex = legacyCustomProviderIndex(config, providerId);
+  return legacyIndex >= 0 ? asRecord(config?.custom_providers[legacyIndex]) : {};
 }
 
 export function maskSecretPreview(value: string): string {
@@ -1146,7 +1298,9 @@ export function buildProviderSettingsUpdate(
   input: ProviderConfigInput,
 ): Record<string, any> {
   const providers = asRecord(config.providers);
-  const existingProvider = asRecord(providers[preset.id]);
+  const configKey = providerConfigKey(config, preset.id);
+  const legacyIndex = configKey ? -1 : legacyCustomProviderIndex(config, preset.id);
+  const existingProvider = getProviderEntry(config, preset.id);
   const existingModel = asRecord(config.model);
   const nextApiKey =
     input.apiKey.trim() ||
@@ -1166,11 +1320,20 @@ export function buildProviderSettingsUpdate(
   if (nextApiKey) providerEntry.api_key = nextApiKey;
   else delete providerEntry.api_key;
 
+  if (legacyIndex >= 0) {
+    const customProviders = [...config.custom_providers];
+    customProviders[legacyIndex] = providerEntry;
+    return {
+      ...config,
+      custom_providers: customProviders,
+    };
+  }
+
   return {
     ...config,
     providers: {
       ...providers,
-      [preset.id]: providerEntry,
+      [configKey ?? preset.id]: providerEntry,
     },
   };
 }
@@ -1180,8 +1343,7 @@ export function buildCurrentModelConfigUpdate(
   preset: ProviderPreset,
   input: ProviderConfigInput,
 ): Record<string, any> {
-  const providers = asRecord(config.providers);
-  const existingProvider = asRecord(providers[preset.id]);
+  const existingProvider = getProviderEntry(config, preset.id);
   const existingModel = asRecord(config.model);
   const nextApiKey =
     input.apiKey.trim() ||

--- a/web/src/routes/settings-models-section.tsx
+++ b/web/src/routes/settings-models-section.tsx
@@ -31,12 +31,14 @@ import {
   buildProviderOrderUpdate,
   buildProviderSettingsUpdate,
   chatEndpointPreviewUrl,
+  customProviderPresetsFromConfig,
   detectCustomApiModeFromUrl,
   getProviderCredentialPreview,
   getProviderEntry,
   parseContextWindowInput,
   providerApiKeyLabels,
   providerHasSavedCredentials,
+  resolveSelectedProvider,
   sortProvidersForModelsPage,
   TOP5_PROVIDER_IDS,
   type ProviderPreset,
@@ -627,7 +629,9 @@ export function ModelsSection() {
   const initialProvider =
     BUILTIN_PROVIDER_CATALOG.providers.find((p) => p.id === TOP5_PROVIDER_IDS[0]) ??
     BUILTIN_PROVIDER_CATALOG.providers[0];
-  const [selectedProviderId, setSelectedProviderId] = useState(initialProvider?.id ?? "");
+  // Empty means "follow the runtime's current provider". A concrete id is
+  // stored only after the user explicitly opens a different card.
+  const [selectedProviderId, setSelectedProviderId] = useState("");
   const [providerPanelLoading, setProviderPanelLoading] = useState(false);
   const selectedProviderIdRef = useRef(selectedProviderId);
   const [providerForm, setProviderForm] = useState({
@@ -720,35 +724,17 @@ export function ModelsSection() {
     return () => window.removeEventListener("keydown", handler);
   }, [showCustomForm, closeCustomForm]);
 
-  const customProviders = useMemo<ProviderPreset[]>(() => {
-    const providers = config && typeof config === "object" && !Array.isArray(config)
-      ? (config as Record<string, any>).providers
-      : null;
-    if (!providers || typeof providers !== "object") return [];
-    const knownIds = new Set(catalog.providers.map((p) => p.id));
-    const customs: ProviderPreset[] = [];
-    for (const [id, raw] of Object.entries(providers)) {
-      if (knownIds.has(id) || !id.startsWith("custom:")) continue;
-      const v = raw && typeof raw === "object" ? raw as Record<string, any> : {};
-      const model = typeof v.model === "string" ? v.model : "";
-      customs.push({
-        id,
-        name: typeof v.name === "string" && v.name ? v.name : id.replace(/^custom:/, ""),
-        vendor: isLocalProviderBaseUrl(typeof v.base_url === "string" ? v.base_url : "") ? "本地部署" : "自定义",
-        region: "cn",
-        baseUrl: typeof v.base_url === "string" ? v.base_url : "",
-        apiMode: v.api_mode === "anthropic_messages" || v.api_mode === "codex_responses"
-          ? v.api_mode : "chat_completions",
-        transport: v.transport === "anthropic_messages" || v.transport === "codex_responses"
-          ? v.transport : "openai_chat",
-        apiKeyLabel: "API Key",
-        defaultModel: model,
-        models: model ? [{ id: model, supportsTools: true }] : [],
-        isCustom: true,
-      });
-    }
-    return customs;
-  }, [config, catalog.providers]);
+  const currentProviderId = modelInfo?.provider ||
+    (config?.model && typeof config.model === "object" && !Array.isArray(config.model)
+      ? String((config.model as Record<string, unknown>).provider ?? "")
+      : "");
+  const customProviders = useMemo(
+    () => customProviderPresetsFromConfig(config, catalog.providers, {
+      provider: currentProviderId,
+      model: modelInfo?.model,
+    }),
+    [catalog.providers, config, currentProviderId, modelInfo?.model],
+  );
 
   const allProviders = useMemo(
     () => [...catalog.providers, ...customProviders],
@@ -777,8 +763,8 @@ export function ModelsSection() {
     return Array.from(options.values());
   }, [allProviders, auxForm.provider]);
   const selectedProvider = useMemo<ProviderPreset | undefined>(
-    () => allProviders.find((provider) => provider.id === selectedProviderId) ?? allProviders[0],
-    [allProviders, selectedProviderId],
+    () => resolveSelectedProvider(allProviders, selectedProviderId, currentProviderId),
+    [allProviders, currentProviderId, selectedProviderId],
   );
   const providerOrderConfig = useMemo(
     () => providerOrderOverride && config
@@ -825,10 +811,6 @@ export function ModelsSection() {
     if (!normalized) return undefined;
     return allProviders.find((provider) => normalizeProviderBaseUrl(provider.baseUrl) === normalized);
   }, [allProviders, customBaseUrl]);
-  const currentProviderId = modelInfo?.provider ||
-    (config?.model && typeof config.model === "object" && !Array.isArray(config.model)
-      ? String((config.model as Record<string, unknown>).provider ?? "")
-      : "");
   const configuredAuxiliaryCount = useMemo(
     () => AUXILIARY_TASKS.filter((task) => {
       const slot = getAuxiliarySlot(config, task.id);


### PR DESCRIPTION
## 问题

CLI 创建的自定义端点仍保存在列表型 custom_providers 中，但桌面端模型页只扫描映射型 providers，因此运行中的 custom:zijian 不显示，界面还默认高亮 DeepSeek。

## 修复

- 同时兼容 Core 的 providers 与 custom_providers 两种配置结构
- 用 /api/model/info 返回的运行时服务商和模型补齐并默认选中当前自定义端点
- 编辑和删除 CLI 端点时原地更新旧结构，避免生成重复配置
- 新增单元测试和 Playwright 页面回归

## 验证

- pnpm typecheck
- pnpm test:unit
- cargo check
- cargo test --all-features
- cargo fmt --check
- cargo clippy --all-targets --all-features -- -D warnings
- pnpm --filter @hermes/web build:desktop
- 最新 Core worktree 下 Playwright E2E：4/4 通过
- 本机 9119 实例只读复验：Zijian 为当前且选中，DeepSeek 未选中