### PR TITLE
新增 Dracula 与 Catppuccin 主题

### DIFF
--- a/packages/shared-ui/src/hooks/use-theme.ts
+++ b/packages/shared-ui/src/hooks/use-theme.ts
@@ -1,6 +1,12 @@
 import { atom, useAtom } from "jotai";
 
-export type ThemeVariant = "light" | "light-modern" | "dark" | "dark-modern";
+export type ThemeVariant =
+  | "light"
+  | "light-modern"
+  | "dark"
+  | "dark-modern"
+  | "dracula"
+  | "catppuccin-mocha";
 export type DensityVariant = "comfortable" | "compact";
 /** Global interface scale steps. Maps to a single CSS `zoom` on the document
  *  root so text, spacing and icons enlarge together — see {@link SCALE_FACTORS}. */
@@ -33,7 +39,14 @@ export const SCALE_FACTORS: Record<ScaleVariant, number> = {
   "2xl": 1.5,
 };
 
-const THEME_VARIANTS = new Set<ThemeVariant>(["light", "light-modern", "dark", "dark-modern"]);
+const THEME_VARIANTS = new Set<ThemeVariant>([
+  "light",
+  "light-modern",
+  "dark",
+  "dark-modern",
+  "dracula",
+  "catppuccin-mocha",
+]);
 const SCALE_VARIANTS = new Set<ScaleVariant>(["sm", "md", "lg", "xl", "2xl"]);
 
 function isThemeVariant(value: unknown): value is ThemeVariant {

--- a/packages/shared-ui/src/tokens/colors.css
+++ b/packages/shared-ui/src/tokens/colors.css
@@ -166,3 +166,71 @@
   --moss: #89d185;
   --rust: #f48771;
 }
+
+[data-theme="dracula"] {
+  /* Dracula: deep violet surfaces with its familiar pink and purple accents. */
+  --h-bg-app: #282a36;
+  --h-bg-pane: #282a36;
+  --h-bg-soft: #44475a;
+  --h-bg-input: #44475a;
+  --h-bg-chip: #44475a;
+  --h-bg-code: #21222c;
+  --h-line: #6272a4;
+  --h-line-soft: #44475a;
+  --h-text: #f8f8f2;
+  --h-text-2: #e7e7df;
+  --h-text-3: #c2c4d2;
+  --h-text-4: #a2a5bb;
+  --h-ok: #50fa7b;
+  --h-ok-soft: rgba(80, 250, 123, 0.12);
+  --h-warn: #f1fa8c;
+  --h-warn-soft: rgba(241, 250, 140, 0.12);
+  --h-err: #ff5555;
+  --h-danger: #ff5555;
+  --h-shadow: 0 1px 2px rgba(0, 0, 0, 0.48);
+  --h-shadow-l: 0 18px 48px rgba(0, 0, 0, 0.64);
+  --h-sidebar-stripe: #282a36;
+  --h-accent: #bd93f9;
+  --h-accent-contrast: #282a36;
+  --h-accent-soft: rgba(189, 147, 249, 0.16);
+  --h-accent-border: rgba(189, 147, 249, 0.44);
+  --sky: #8be9fd;
+  --plum: #ff79c6;
+  --amber: #ffb86c;
+  --moss: #50fa7b;
+  --rust: #ff5555;
+}
+
+[data-theme="catppuccin-mocha"] {
+  /* Catppuccin Mocha: layered blue-grey neutrals with muted pastel accents. */
+  --h-bg-app: #1e1e2e;
+  --h-bg-pane: #181825;
+  --h-bg-soft: #313244;
+  --h-bg-input: #313244;
+  --h-bg-chip: #45475a;
+  --h-bg-code: #11111b;
+  --h-line: #45475a;
+  --h-line-soft: #313244;
+  --h-text: #cdd6f4;
+  --h-text-2: #bac2de;
+  --h-text-3: #a6adc8;
+  --h-text-4: #9399b2;
+  --h-ok: #a6e3a1;
+  --h-ok-soft: rgba(166, 227, 161, 0.12);
+  --h-warn: #f9e2af;
+  --h-warn-soft: rgba(249, 226, 175, 0.12);
+  --h-err: #f38ba8;
+  --h-danger: #f38ba8;
+  --h-shadow: 0 1px 2px rgba(0, 0, 0, 0.46);
+  --h-shadow-l: 0 18px 48px rgba(0, 0, 0, 0.62);
+  --h-sidebar-stripe: #181825;
+  --h-accent: #cba6f7;
+  --h-accent-contrast: #1e1e2e;
+  --h-accent-soft: rgba(203, 166, 247, 0.16);
+  --h-accent-border: rgba(203, 166, 247, 0.44);
+  --sky: #89dceb;
+  --plum: #f5c2e7;
+  --amber: #fab387;
+  --moss: #a6e3a1;
+  --rust: #f38ba8;
+}

--- a/web/src/components/app-shell/app-top-bar.module.css
+++ b/web/src/components/app-shell/app-top-bar.module.css
@@ -280,7 +280,9 @@
   color: var(--amber);
 }
 
-.iconBtn[data-theme-mode="dark-modern"] {
+.iconBtn[data-theme-mode="dark-modern"],
+.iconBtn[data-theme-mode="dracula"],
+.iconBtn[data-theme-mode="catppuccin-mocha"] {
   color: var(--h-accent);
 }
 

--- a/web/src/components/app-shell/app-top-bar.tsx
+++ b/web/src/components/app-shell/app-top-bar.tsx
@@ -12,12 +12,21 @@ import s from "./app-top-bar.module.css";
 
 const DESKTOP_VERSION_PARAM = versionLabel(DESKTOP_VERSION);
 const BRAND_URL = `https://hermesagent.org.cn?source=cn_desktop&version=${encodeURIComponent(DESKTOP_VERSION_PARAM)}`;
-const THEME_SEQUENCE: ThemeConfig["theme"][] = ["light", "light-modern", "dark", "dark-modern"];
+const THEME_SEQUENCE: ThemeConfig["theme"][] = [
+  "light",
+  "light-modern",
+  "dark",
+  "dark-modern",
+  "dracula",
+  "catppuccin-mocha",
+];
 const THEME_LABELS: Record<ThemeConfig["theme"], string> = {
   light: "浅色模式",
   "light-modern": "现代浅色模式",
   dark: "经典深色模式",
   "dark-modern": "现代深色模式",
+  dracula: "Dracula 主题",
+  "catppuccin-mocha": "Catppuccin Mocha 主题",
 };
 
 export function AppTopBar() {
@@ -28,7 +37,11 @@ export function AppTopBar() {
   const currentThemeIndex = THEME_SEQUENCE.indexOf(themeConfig.theme);
   const nextTheme = THEME_SEQUENCE[(currentThemeIndex + 1) % THEME_SEQUENCE.length] ?? DEFAULT_THEME_CONFIG.theme;
   const ThemeIcon =
-    themeConfig.theme === "dark-modern" ? Sun : themeConfig.theme === "dark" || themeConfig.theme === "light" ? Palette : Moon;
+    themeConfig.theme === "dark-modern" || themeConfig.theme === "catppuccin-mocha"
+      ? Sun
+      : themeConfig.theme === "dark" || themeConfig.theme === "dracula" || themeConfig.theme === "light"
+        ? Palette
+        : Moon;
   const themeToggleLabel = `切换到${THEME_LABELS[nextTheme]}`;
   const openBrandSite = (event: MouseEvent<HTMLAnchorElement>) => {
     event.preventDefault();

--- a/web/src/components/chat/message-timeline.module.css
+++ b/web/src/components/chat/message-timeline.module.css
@@ -547,7 +547,9 @@
 }
 
 :global([data-theme="dark"]) .messageText :global([data-streamdown="mermaid"] svg),
-:global([data-theme="dark-modern"]) .messageText :global([data-streamdown="mermaid"] svg) {
+:global([data-theme="dark-modern"]) .messageText :global([data-streamdown="mermaid"] svg),
+:global([data-theme="dracula"]) .messageText :global([data-streamdown="mermaid"] svg),
+:global([data-theme="catppuccin-mocha"]) .messageText :global([data-streamdown="mermaid"] svg) {
   color-scheme: light;
 }
 
@@ -599,12 +601,16 @@
 }
 
 :global([data-theme="dark"]) .messageText :global(.shiki),
-:global([data-theme="dark-modern"]) .messageText :global(.shiki) {
+:global([data-theme="dark-modern"]) .messageText :global(.shiki),
+:global([data-theme="dracula"]) .messageText :global(.shiki),
+:global([data-theme="catppuccin-mocha"]) .messageText :global(.shiki) {
   color: var(--shiki-dark) !important;
 }
 
 :global([data-theme="dark"]) .messageText :global(.shiki span),
-:global([data-theme="dark-modern"]) .messageText :global(.shiki span) {
+:global([data-theme="dark-modern"]) .messageText :global(.shiki span),
+:global([data-theme="dracula"]) .messageText :global(.shiki span),
+:global([data-theme="catppuccin-mocha"]) .messageText :global(.shiki span) {
   color: var(--shiki-dark) !important;
 }
 

--- a/web/src/lib/theme-defaults.test.ts
+++ b/web/src/lib/theme-defaults.test.ts
@@ -15,6 +15,8 @@ describe("theme defaults", () => {
   it("keeps supported stored skins instead of overwriting user preference", () => {
     expect(normalizeThemeConfig({ theme: "dark", density: "compact" })).toEqual({ theme: "dark", density: "compact", scale: "md" });
     expect(normalizeThemeConfig({ theme: "dark-modern" })).toEqual({ theme: "dark-modern", density: "comfortable", scale: "md" });
+    expect(normalizeThemeConfig({ theme: "dracula" })).toEqual({ theme: "dracula", density: "comfortable", scale: "md" });
+    expect(normalizeThemeConfig({ theme: "catppuccin-mocha" })).toEqual({ theme: "catppuccin-mocha", density: "comfortable", scale: "md" });
   });
 
   it("falls back to modern light for unsupported stored skins", () => {

--- a/web/src/routes/settings.tsx
+++ b/web/src/routes/settings.tsx
@@ -339,7 +339,7 @@ export function ThemeSection({ showHeading = true }: SettingsSectionProps) {
 
         <AppearanceRow
           label="主题"
-          sub="选择桌面端皮肤。现代主题采用更克制的工作台配色和蓝色主操作。"
+          sub="选择桌面端皮肤，包含现代工作台、Dracula 与 Catppuccin Mocha 色板。"
           right={
             <ThemeSkinPicker
               value={config.theme}
@@ -426,6 +426,26 @@ const THEME_SKINS: Array<{
     soft: "#252526",
     text: "#d4d4d4",
     accent: "#0078d4",
+  },
+  {
+    value: "dracula",
+    label: "Dracula",
+    sub: "紫粉高对比",
+    bg: "#282a36",
+    pane: "#44475a",
+    soft: "#21222c",
+    text: "#f8f8f2",
+    accent: "#bd93f9",
+  },
+  {
+    value: "catppuccin-mocha",
+    label: "Catppuccin Mocha",
+    sub: "柔和蓝灰",
+    bg: "#1e1e2e",
+    pane: "#181825",
+    soft: "#313244",
+    text: "#cdd6f4",
+    accent: "#cba6f7",
   },
 ];
 


### PR DESCRIPTION
## 变更

- 新增 Dracula 与 Catppuccin Mocha 两套可持久化的桌面端主题。
- 在主题设置卡片和顶部快速切换中提供入口。
- 为深色代码高亮与 Mermaid 输出补齐新主题适配。

## 验证

- `pnpm typecheck`
- `pnpm test:unit`（106 个测试文件、973 项测试通过）
- `cargo check`
- `pnpm --filter @hermes/web build`