### PR TITLE
refactor: 统一弹窗与操作菜单基础组件

### DIFF
--- a/packages/shared-ui/src/composites/dropdown-menu/dropdown-menu.module.css
+++ b/packages/shared-ui/src/composites/dropdown-menu/dropdown-menu.module.css
@@ -1,0 +1,32 @@
+.content {
+  z-index: var(--h-z-popover);
+  background: var(--h-bg-pane);
+  color: var(--h-text);
+  border: 1px solid var(--h-line);
+  border-radius: var(--h-r-md);
+  box-shadow: var(--h-shadow-l);
+  outline: none;
+  overflow: hidden;
+  animation: hermesDropdownMenuIn 120ms ease-out;
+  transform-origin: var(--radix-dropdown-menu-content-transform-origin);
+}
+
+.content[data-state="closed"] {
+  animation: hermesDropdownMenuOut 80ms ease-in;
+}
+
+.arrow {
+  fill: var(--h-bg-pane);
+  stroke: var(--h-line);
+  stroke-width: 1px;
+}
+
+@keyframes hermesDropdownMenuIn {
+  from { opacity: 0; transform: scale(0.96); }
+  to { opacity: 1; transform: scale(1); }
+}
+
+@keyframes hermesDropdownMenuOut {
+  from { opacity: 1; transform: scale(1); }
+  to { opacity: 0; transform: scale(0.97); }
+}

--- a/packages/shared-ui/src/composites/dropdown-menu/dropdown-menu.tsx
+++ b/packages/shared-ui/src/composites/dropdown-menu/dropdown-menu.tsx
@@ -1,0 +1,41 @@
+import { forwardRef } from "react";
+import * as RadixDropdownMenu from "@radix-ui/react-dropdown-menu";
+import { cn } from "../../utils/cn";
+import s from "./dropdown-menu.module.css";
+
+export const Root = RadixDropdownMenu.Root;
+export const Trigger = RadixDropdownMenu.Trigger;
+export const Portal = RadixDropdownMenu.Portal;
+export const Group = RadixDropdownMenu.Group;
+export const Label = RadixDropdownMenu.Label;
+export const Item = RadixDropdownMenu.Item;
+export const CheckboxItem = RadixDropdownMenu.CheckboxItem;
+export const RadioGroup = RadixDropdownMenu.RadioGroup;
+export const RadioItem = RadixDropdownMenu.RadioItem;
+export const ItemIndicator = RadixDropdownMenu.ItemIndicator;
+export const Separator = RadixDropdownMenu.Separator;
+export const Sub = RadixDropdownMenu.Sub;
+export const SubTrigger = RadixDropdownMenu.SubTrigger;
+export const SubContent = RadixDropdownMenu.SubContent;
+
+type ContentProps = React.ComponentPropsWithoutRef<typeof RadixDropdownMenu.Content>;
+export const Content = forwardRef<HTMLDivElement, ContentProps>(
+  ({ className, sideOffset = 6, collisionPadding = 8, ...rest }, ref) => (
+    <RadixDropdownMenu.Content
+      ref={ref}
+      className={cn(s.content, className)}
+      sideOffset={sideOffset}
+      collisionPadding={collisionPadding}
+      {...rest}
+    />
+  ),
+);
+Content.displayName = "HermesDropdownMenu.Content";
+
+type ArrowProps = React.ComponentPropsWithoutRef<typeof RadixDropdownMenu.Arrow>;
+export const Arrow = forwardRef<SVGSVGElement, ArrowProps>(
+  ({ className, ...rest }, ref) => (
+    <RadixDropdownMenu.Arrow ref={ref} className={cn(s.arrow, className)} {...rest} />
+  ),
+);
+Arrow.displayName = "HermesDropdownMenu.Arrow";

--- a/packages/shared-ui/src/composites/dropdown-menu/index.ts
+++ b/packages/shared-ui/src/composites/dropdown-menu/index.ts
@@ -1,0 +1,1 @@
+export * from "./dropdown-menu";

--- a/packages/shared-ui/src/index.ts
+++ b/packages/shared-ui/src/index.ts
@@ -13,4 +13,5 @@ export { usePlatform, applyPlatformToDOM } from "./hooks/use-platform";
 export { cn, type ClassValue } from "./utils/cn";
 export * from "./components";
 export * as Dialog from "./composites/dialog";
+export * as DropdownMenu from "./composites/dropdown-menu";
 export * as Popover from "./composites/popover";

--- a/web/src/components/app-shell/workbench-sidebar.tsx
+++ b/web/src/components/app-shell/workbench-sidebar.tsx
@@ -2,7 +2,7 @@ import { useCallback, useEffect, useMemo, useState } from "react";
 import { useAtomValue, useSetAtom } from "jotai";
 import { useQueryClient } from "@tanstack/react-query";
 import { useNavigate, useLocation } from "react-router-dom";
-import { Popover } from "@hermes/shared-ui";
+import { DropdownMenu } from "@hermes/shared-ui";
 import { Folder, MessageSquare, MoreHorizontal, Plus } from "lucide-react";
 import { chatRuntimeBySessionAtom } from "@/stores/chat";
 import { activeSessionIdAtom } from "@/stores/ui";
@@ -146,13 +146,13 @@ function SessionRow({
           ) : null}
         </div>
       </div>
-      <Popover.Root
+      <DropdownMenu.Root
         open={!actionMenuDisabled && actions.openMenuId === session.id}
         onOpenChange={(open) => {
           actions.setOpenMenuId(open && !actionMenuDisabled ? session.id : null);
         }}
       >
-        <Popover.Trigger asChild>
+        <DropdownMenu.Trigger asChild>
           <button
             type="button"
             className={s.rowMore}
@@ -164,7 +164,7 @@ function SessionRow({
           >
             <MoreHorizontal size={14} />
           </button>
-        </Popover.Trigger>
+        </DropdownMenu.Trigger>
         <SessionRowMenu
           pinned={pinned}
           disabled={actionMenuDisabled}
@@ -173,7 +173,7 @@ function SessionRow({
           onArchive={() => actions.handleArchive(session)}
           onDelete={() => actions.openDeleteDialog([session])}
         />
-      </Popover.Root>
+      </DropdownMenu.Root>
     </div>
   );
 }

--- a/web/src/components/chat/goose-composer-model-picker.tsx
+++ b/web/src/components/chat/goose-composer-model-picker.tsx
@@ -1,16 +1,15 @@
 import {
   useCallback,
   useEffect,
-  useId,
   useMemo,
   useRef,
   useState,
   type ReactNode,
   type RefObject,
 } from "react";
-import { createPortal } from "react-dom";
 import { ArrowRight, Brain, Check, ChevronRight, Image as ImageIcon, RotateCcw, Sparkles, Wrench, X, Zap } from "lucide-react";
 import type { GatewayModelProvider, ModelOptionsResult } from "@hermes/protocol";
+import { Dialog } from "@hermes/shared-ui";
 import {
   BUILTIN_PROVIDER_CATALOG,
   TOP5_PROVIDER_IDS,
@@ -737,84 +736,39 @@ export function ModelPickerPanel({ onClose, ...props }: ModelPickerPanelProps) {
 }
 
 export function ModelPickerModal({ onClose, ...props }: ModelPickerPanelProps) {
-  const titleId = useId();
-  const modalRef = useRef<HTMLDivElement>(null);
   const searchInputRef = useRef<HTMLInputElement>(null);
-
-  useEffect(() => {
-    const previousActiveElement = document.activeElement instanceof HTMLElement
-      ? document.activeElement
-      : null;
-    const previousOverflow = document.body.style.overflow;
-    const focusTimer = window.requestAnimationFrame(() => {
-      searchInputRef.current?.focus();
-    });
-    const handleKeyDown = (event: KeyboardEvent) => {
-      if (event.key === "Escape") {
-        onClose();
-        return;
-      }
-      if (event.key !== "Tab") return;
-
-      const focusable = Array.from(
-        modalRef.current?.querySelectorAll<HTMLElement>(
-          'button:not(:disabled), input:not(:disabled), [href], [tabindex]:not([tabindex="-1"])',
-        ) ?? [],
-      ).filter((element) => element.offsetParent !== null);
-      if (!focusable.length) return;
-
-      const first = focusable[0];
-      const last = focusable[focusable.length - 1];
-      if (event.shiftKey && document.activeElement === first) {
-        event.preventDefault();
-        last.focus();
-      } else if (!event.shiftKey && document.activeElement === last) {
-        event.preventDefault();
-        first.focus();
-      }
-    };
-
-    document.body.style.overflow = "hidden";
-    window.addEventListener("keydown", handleKeyDown);
-    return () => {
-      window.cancelAnimationFrame(focusTimer);
-      window.removeEventListener("keydown", handleKeyDown);
-      document.body.style.overflow = previousOverflow;
-      previousActiveElement?.focus();
-    };
-  }, [onClose]);
 
   if (typeof document === "undefined") return null;
 
-  return createPortal(
-    <div
-      className={s.modelModalBackdrop}
-      onMouseDown={(event) => {
-        if (event.target === event.currentTarget) onClose();
-      }}
-    >
-      <div
-        ref={modalRef}
+  return (
+    <Dialog.Root open onOpenChange={(open) => { if (!open) onClose(); }}>
+      <Dialog.Portal>
+        <Dialog.Overlay className={s.modelModalBackdrop} />
+        <Dialog.Content
         className={s.modelModal}
-        role="dialog"
-        aria-modal="true"
-        aria-labelledby={titleId}
-        onMouseDown={(event) => event.stopPropagation()}
+        aria-describedby={undefined}
+        onOpenAutoFocus={(event) => {
+          event.preventDefault();
+          searchInputRef.current?.focus();
+        }}
       >
         <div className={s.modelModalTitleBar}>
-          <h2 id={titleId}>选择模型</h2>
-          <button
-            type="button"
-            className={s.modelModalClose}
-            onClick={onClose}
-            aria-label="关闭模型选择"
-          >
-            <X aria-hidden="true" />
-          </button>
+          <Dialog.Title asChild>
+            <h2>选择模型</h2>
+          </Dialog.Title>
+          <Dialog.Close asChild>
+            <button
+              type="button"
+              className={s.modelModalClose}
+              aria-label="关闭模型选择"
+            >
+              <X aria-hidden="true" />
+            </button>
+          </Dialog.Close>
         </div>
         <ModelPickerBody {...props} searchInputRef={searchInputRef} />
-      </div>
-    </div>,
-    document.body,
+        </Dialog.Content>
+      </Dialog.Portal>
+    </Dialog.Root>
   );
 }

--- a/web/src/components/chat/goose-composer.module.css
+++ b/web/src/components/chat/goose-composer.module.css
@@ -717,7 +717,7 @@
 .modelModalBackdrop {
   position: fixed;
   inset: 0;
-  z-index: 100;
+  z-index: var(--h-z-dialog-overlay);
   display: flex;
   align-items: center;
   justify-content: center;
@@ -729,6 +729,7 @@
   display: flex;
   flex-direction: column;
   width: min(760px, calc(100vw - 32px));
+  max-width: none;
   height: min(720px, calc(100vh - 48px));
   border: 1px solid var(--h-line);
   border-radius: 18px;

--- a/web/src/components/composer/reasoning-effort-menu.module.css
+++ b/web/src/components/composer/reasoning-effort-menu.module.css
@@ -98,8 +98,10 @@
   cursor: pointer;
 }
 
-.menuItem:hover {
+.menuItem:hover,
+.menuItem[data-highlighted] {
   background: var(--h-line-soft);
+  outline: none;
 }
 
 .menuItem[data-active="true"] {

--- a/web/src/components/composer/reasoning-effort-menu.tsx
+++ b/web/src/components/composer/reasoning-effort-menu.tsx
@@ -1,6 +1,6 @@
 import { useState } from "react";
 import { Brain, Check } from "lucide-react";
-import { Popover } from "@hermes/shared-ui";
+import { DropdownMenu } from "@hermes/shared-ui";
 import {
   DEFAULT_REASONING_EFFORT,
   REASONING_EFFORTS,
@@ -44,8 +44,8 @@ export function ReasoningEffortMenu({ value, onSelect, disabled }: ReasoningEffo
   };
 
   return (
-    <Popover.Root open={open} onOpenChange={setOpen}>
-      <Popover.Trigger asChild>
+    <DropdownMenu.Root open={open} onOpenChange={setOpen}>
+      <DropdownMenu.Trigger asChild>
         <button
           type="button"
           className={s.trigger}
@@ -60,29 +60,33 @@ export function ReasoningEffortMenu({ value, onSelect, disabled }: ReasoningEffo
           <span>思考</span>
           <small>{triggerHint}</small>
         </button>
-      </Popover.Trigger>
-      <Popover.Portal>
-        <Popover.Content className={s.menu} side="top" align="start">
+      </DropdownMenu.Trigger>
+      <DropdownMenu.Portal>
+        <DropdownMenu.Content className={s.menu} side="top" align="start">
           <div className={s.menuTitle}>思考强度</div>
-          <div className={s.menuList} role="menu" aria-label="思考强度">
+          <DropdownMenu.RadioGroup
+            className={s.menuList}
+            value={value ?? ""}
+            onValueChange={(effort) => handleSelect(effort as ReasoningEffort)}
+            aria-label="思考强度"
+          >
             {REASONING_EFFORTS.map((effort) => {
               const isActive = effort === value;
               return (
-                <button
+                <DropdownMenu.RadioItem
                   key={effort}
-                  type="button"
-                  role="menuitemradio"
-                  aria-checked={isActive}
+                  value={effort}
                   className={s.menuItem}
                   data-active={isActive ? "true" : undefined}
-                  onClick={() => handleSelect(effort)}
                 >
                   <span className={s.menuItemLabel}>{REASONING_EFFORT_LABELS[effort]}</span>
-                  {isActive && <Check className={s.menuCheck} aria-hidden="true" />}
-                </button>
+                  <DropdownMenu.ItemIndicator asChild>
+                    <Check className={s.menuCheck} aria-hidden="true" />
+                  </DropdownMenu.ItemIndicator>
+                </DropdownMenu.RadioItem>
               );
             })}
-          </div>
+          </DropdownMenu.RadioGroup>
           <div className={s.menuFoot}>
             {thinkingOn
               ? "模型会进行推理；强度越高越慢、越耗 Token。"
@@ -90,8 +94,8 @@ export function ReasoningEffortMenu({ value, onSelect, disabled }: ReasoningEffo
                 ? "已关闭推理，响应更快、更省 Token。"
                 : `未设置时默认按「${REASONING_EFFORT_LABELS[DEFAULT_REASONING_EFFORT]}」运行。`}
           </div>
-        </Popover.Content>
-      </Popover.Portal>
-    </Popover.Root>
+        </DropdownMenu.Content>
+      </DropdownMenu.Portal>
+    </DropdownMenu.Root>
   );
 }

--- a/web/src/components/composer/url-dialog.module.css
+++ b/web/src/components/composer/url-dialog.module.css
@@ -1,7 +1,7 @@
 .backdrop {
   position: fixed;
   inset: 0;
-  z-index: 100;
+  z-index: var(--h-z-dialog-overlay);
   display: flex;
   align-items: center;
   justify-content: center;

--- a/web/src/components/composer/url-dialog.tsx
+++ b/web/src/components/composer/url-dialog.tsx
@@ -1,6 +1,6 @@
-import { useEffect, useId, useRef, useState } from "react";
-import { createPortal } from "react-dom";
+import { useEffect, useRef, useState } from "react";
 import { Globe, ImagePlus, Link2, X } from "lucide-react";
+import { Dialog } from "@hermes/shared-ui";
 import {
   fetchLinkMetadata,
   isLikelyImageUrl,
@@ -34,7 +34,6 @@ export function UrlDialog({
   onAttachImage,
   onCancel,
 }: UrlDialogProps) {
-  const titleId = useId();
   const [metadata, setMetadata] = useState<LinkMetadata | null>(null);
   const [loadingMetadata, setLoadingMetadata] = useState(false);
   const [previewObjectUrl, setPreviewObjectUrl] = useState("");
@@ -86,22 +85,6 @@ export function UrlDialog({
     };
   }, [open, previewSource]);
 
-  useEffect(() => {
-    if (!open) return;
-    insertRef.current?.focus();
-    const onKey = (event: KeyboardEvent) => {
-      if (event.key === "Escape") {
-        event.preventDefault();
-        onCancel();
-      } else if (event.key === "Enter") {
-        event.preventDefault();
-        onInsertReference();
-      }
-    };
-    window.addEventListener("keydown", onKey);
-    return () => window.removeEventListener("keydown", onKey);
-  }, [open, onCancel, onInsertReference]);
-
   if (!open || typeof document === "undefined") return null;
 
   const imageCandidate = isLikelyImageUrl(url) ? url : metadata?.imageUrl;
@@ -127,28 +110,30 @@ export function UrlDialog({
     }
   };
 
-  return createPortal(
-    <div
-      className={s.backdrop}
-      onMouseDown={(event) => {
-        if (event.target === event.currentTarget) onCancel();
-      }}
-    >
-      <div
+  return (
+    <Dialog.Root open={open} onOpenChange={(nextOpen) => { if (!nextOpen) onCancel(); }}>
+      <Dialog.Portal>
+        <Dialog.Overlay className={s.backdrop} />
+        <Dialog.Content
         className={s.modal}
-        role="dialog"
-        aria-modal="true"
-        aria-labelledby={titleId}
-        onMouseDown={(event) => event.stopPropagation()}
+        aria-describedby={undefined}
+        onOpenAutoFocus={(event) => {
+          event.preventDefault();
+          insertRef.current?.focus();
+        }}
       >
         <div className={s.titleBar}>
-          <h2 id={titleId}>
-            <Globe aria-hidden="true" />
-            添加链接引用
-          </h2>
-          <button type="button" className={s.close} onClick={onCancel} aria-label="关闭">
-            <X aria-hidden="true" />
-          </button>
+          <Dialog.Title asChild>
+            <h2>
+              <Globe aria-hidden="true" />
+              添加链接引用
+            </h2>
+          </Dialog.Title>
+          <Dialog.Close asChild>
+            <button type="button" className={s.close} aria-label="关闭">
+              <X aria-hidden="true" />
+            </button>
+          </Dialog.Close>
         </div>
         <div className={s.body}>
           <div className={s.urlText}>{url}</div>
@@ -197,8 +182,8 @@ export function UrlDialog({
             插入引用
           </button>
         </div>
-      </div>
-    </div>,
-    document.body,
+        </Dialog.Content>
+      </Dialog.Portal>
+    </Dialog.Root>
   );
 }

--- a/web/src/components/composer/workspace-picker/workspace-picker-modal.module.css
+++ b/web/src/components/composer/workspace-picker/workspace-picker-modal.module.css
@@ -1,7 +1,7 @@
 .wpBackdrop {
   position: fixed;
   inset: 0;
-  z-index: 100;
+  z-index: var(--h-z-dialog-overlay);
   display: flex;
   align-items: center;
   justify-content: center;
@@ -13,6 +13,7 @@
   display: flex;
   flex-direction: column;
   width: min(640px, calc(100vw - 32px));
+  max-width: none;
   max-height: min(680px, calc(100vh - 48px));
   border: 1px solid var(--h-line);
   border-radius: 18px;

--- a/web/src/components/composer/workspace-picker/workspace-picker-modal.tsx
+++ b/web/src/components/composer/workspace-picker/workspace-picker-modal.tsx
@@ -1,15 +1,14 @@
 import {
   useCallback,
   useEffect,
-  useId,
   useMemo,
   useRef,
   useState,
   type KeyboardEvent as ReactKeyboardEvent,
 } from "react";
-import { createPortal } from "react-dom";
 import { ArrowUp, Folder, X } from "lucide-react";
 import type { FsEntry } from "@hermes/protocol";
+import { Dialog } from "@hermes/shared-ui";
 import { useFsList } from "@/hooks/use-fs-list";
 import { parentDir } from "@/lib/preview-rail";
 import s from "./workspace-picker-modal.module.css";
@@ -68,8 +67,6 @@ export function WorkspacePickerModal({
   onConfirm,
   onCancel,
 }: WorkspacePickerModalProps) {
-  const titleId = useId();
-  const modalRef = useRef<HTMLDivElement>(null);
   const manualInputRef = useRef<HTMLInputElement>(null);
   const listRef = useRef<HTMLDivElement>(null);
 
@@ -154,116 +151,63 @@ export function WorkspacePickerModal({
     });
   }, [directoryEntries]);
 
-  // Modal lifecycle: focus trap, body lock, keyboard.
-  useEffect(() => {
-    if (!open) return undefined;
-    const previousActiveElement = document.activeElement instanceof HTMLElement
-      ? document.activeElement
-      : null;
-    const previousOverflow = document.body.style.overflow;
-    document.body.style.overflow = "hidden";
-
-    const focusTimer = window.requestAnimationFrame(() => {
-      manualInputRef.current?.focus();
-    });
-
-    const handleKeyDown = (event: KeyboardEvent) => {
-      if (event.key === "Escape") {
-        event.preventDefault();
-        onCancel();
-        return;
-      }
-      const focusInsideManualInput = document.activeElement === manualInputRef.current;
-      if (event.key === "ArrowDown" && !focusInsideManualInput) {
-        event.preventDefault();
-        moveSelection(1);
-        return;
-      }
-      if (event.key === "ArrowUp" && !focusInsideManualInput) {
-        event.preventDefault();
-        moveSelection(-1);
-        return;
-      }
-      if (event.key === "Enter" && !focusInsideManualInput) {
-        if (selectedName) {
-          const target = directoryEntries.find((e) => e.name === selectedName);
-          if (target) {
-            event.preventDefault();
-            navigateTo(target.path);
-            return;
-          }
+  const handleDialogKeyDown = (event: ReactKeyboardEvent<HTMLDivElement>) => {
+    const focusInsideManualInput = document.activeElement === manualInputRef.current;
+    if (event.key === "ArrowDown" && !focusInsideManualInput) {
+      event.preventDefault();
+      moveSelection(1);
+      return;
+    }
+    if (event.key === "ArrowUp" && !focusInsideManualInput) {
+      event.preventDefault();
+      moveSelection(-1);
+      return;
+    }
+    if (event.key === "Enter" && !focusInsideManualInput) {
+      if (selectedName) {
+        const target = directoryEntries.find((entry) => entry.name === selectedName);
+        if (target) {
+          event.preventDefault();
+          navigateTo(target.path);
+          return;
         }
-        event.preventDefault();
-        handleConfirm();
-        return;
       }
-      if (event.key !== "Tab") return;
-
-      const focusable = Array.from(
-        modalRef.current?.querySelectorAll<HTMLElement>(
-          'button:not(:disabled), input:not(:disabled), [href], [tabindex]:not([tabindex="-1"])',
-        ) ?? [],
-      ).filter((element) => element.offsetParent !== null);
-      if (!focusable.length) return;
-
-      const first = focusable[0];
-      const last = focusable[focusable.length - 1];
-      if (event.shiftKey && document.activeElement === first) {
-        event.preventDefault();
-        last.focus();
-      } else if (!event.shiftKey && document.activeElement === last) {
-        event.preventDefault();
-        first.focus();
-      }
-    };
-
-    window.addEventListener("keydown", handleKeyDown);
-    return () => {
-      window.cancelAnimationFrame(focusTimer);
-      window.removeEventListener("keydown", handleKeyDown);
-      document.body.style.overflow = previousOverflow;
-      previousActiveElement?.focus();
-    };
-  }, [
-    open,
-    onCancel,
-    moveSelection,
-    selectedName,
-    directoryEntries,
-    navigateTo,
-    handleConfirm,
-  ]);
+      event.preventDefault();
+      handleConfirm();
+    }
+  };
 
   if (!open || typeof document === "undefined") return null;
 
   const errorText = query.isError ? prettyFsError(query.error) : null;
   const isInitialLoad = query.isPending;
 
-  return createPortal(
-    <div
-      className={s.wpBackdrop}
-      onMouseDown={(event) => {
-        if (event.target === event.currentTarget) onCancel();
-      }}
-    >
-      <div
-        ref={modalRef}
+  return (
+    <Dialog.Root open={open} onOpenChange={(nextOpen) => { if (!nextOpen) onCancel(); }}>
+      <Dialog.Portal>
+        <Dialog.Overlay className={s.wpBackdrop} />
+        <Dialog.Content
         className={s.wpModal}
-        role="dialog"
-        aria-modal="true"
-        aria-labelledby={titleId}
-        onMouseDown={(event) => event.stopPropagation()}
+        aria-describedby={undefined}
+        onKeyDown={handleDialogKeyDown}
+        onOpenAutoFocus={(event) => {
+          event.preventDefault();
+          manualInputRef.current?.focus();
+        }}
       >
         <div className={s.wpTitleBar}>
-          <h2 id={titleId}>选择工作区目录</h2>
-          <button
-            type="button"
-            className={s.wpClose}
-            onClick={onCancel}
-            aria-label="关闭目录选择"
-          >
-            <X aria-hidden="true" />
-          </button>
+          <Dialog.Title asChild>
+            <h2>选择工作区目录</h2>
+          </Dialog.Title>
+          <Dialog.Close asChild>
+            <button
+              type="button"
+              className={s.wpClose}
+              aria-label="关闭目录选择"
+            >
+              <X aria-hidden="true" />
+            </button>
+          </Dialog.Close>
         </div>
 
         <div className={s.wpManualRow}>
@@ -346,9 +290,9 @@ export function WorkspacePickerModal({
             {resolvedPath || "—"}
           </div>
           <div className={s.wpFooterButtons}>
-            <button type="button" className={s.wpButtonGhost} onClick={onCancel}>
-              取消
-            </button>
+            <Dialog.Close asChild>
+              <button type="button" className={s.wpButtonGhost}>取消</button>
+            </Dialog.Close>
             <button
               type="button"
               className={s.wpButtonPrimary}
@@ -359,8 +303,8 @@ export function WorkspacePickerModal({
             </button>
           </div>
         </div>
-      </div>
-    </div>,
-    document.body,
+        </Dialog.Content>
+      </Dialog.Portal>
+    </Dialog.Root>
   );
 }

--- a/web/src/components/profiles/profile-actions-menu.tsx
+++ b/web/src/components/profiles/profile-actions-menu.tsx
@@ -1,5 +1,5 @@
 import { useRef, useState } from "react";
-import { Popover } from "@hermes/shared-ui";
+import { DropdownMenu } from "@hermes/shared-ui";
 import {
   AlignLeft,
   Check,
@@ -29,7 +29,7 @@ export interface ProfileActionsMenuProps {
 }
 
 /**
- * 单个档案的 ⋯ 动作菜单（自带 Popover 触发器）。对齐官方桌面端 ProfileActionsMenu：
+ * 单个档案的 ⋯ 动作菜单（自带 DropdownMenu 触发器）。对齐官方桌面端 ProfileActionsMenu：
  * 设为默认 / 改模型 / 改描述 / 编辑 SOUL / 复制 CLI 命令 / 重命名 / 删除。
  * default 档案不可重命名/删除；当前档案不可「设为默认」、且要切走后才能删。
  */
@@ -61,12 +61,12 @@ export function ProfileActionsMenu({
   };
 
   return (
-    <Popover.Root
+    <DropdownMenu.Root
       onOpenChange={(open) => {
         if (!open) setCopyState("idle");
       }}
     >
-      <Popover.Trigger asChild>
+      <DropdownMenu.Trigger asChild>
         <button
           type="button"
           className={s.menuTrigger}
@@ -74,87 +74,87 @@ export function ProfileActionsMenu({
         >
           <MoreVertical size={15} />
         </button>
-      </Popover.Trigger>
-      <Popover.Portal>
-        <Popover.Content
+      </DropdownMenu.Trigger>
+      <DropdownMenu.Portal>
+        <DropdownMenu.Content
           className={s.menu}
           align="end"
           side="bottom"
           sideOffset={4}
-          role="menu"
         >
-          <Popover.Close asChild>
+          <DropdownMenu.Item asChild onSelect={onSetActive} disabled={isActive}>
             <button
               type="button"
-              role="menuitem"
-              onClick={onSetActive}
               disabled={isActive}
             >
               <Check size={13} /> 设为默认
             </button>
-          </Popover.Close>
+          </DropdownMenu.Item>
 
-          <div className={s.menuSep} />
+          <DropdownMenu.Separator className={s.menuSep} />
 
-          <Popover.Close asChild>
-            <button type="button" role="menuitem" onClick={onEditModel}>
+          <DropdownMenu.Item asChild onSelect={onEditModel}>
+            <button type="button">
               <Cpu size={13} /> 改模型
             </button>
-          </Popover.Close>
-          <Popover.Close asChild>
-            <button type="button" role="menuitem" onClick={onEditDescription}>
+          </DropdownMenu.Item>
+          <DropdownMenu.Item asChild onSelect={onEditDescription}>
+            <button type="button">
               <AlignLeft size={13} /> 改描述
             </button>
-          </Popover.Close>
-          <Popover.Close asChild>
-            <button type="button" role="menuitem" onClick={onEditSoul}>
+          </DropdownMenu.Item>
+          <DropdownMenu.Item asChild onSelect={onEditSoul}>
+            <button type="button">
               <ScrollText size={13} /> 编辑 SOUL.md
             </button>
-          </Popover.Close>
-          <Popover.Close asChild>
-            <button type="button" role="menuitem" onClick={onManageSkills}>
+          </DropdownMenu.Item>
+          <DropdownMenu.Item asChild onSelect={onManageSkills}>
+            <button type="button">
               <Package size={13} /> 管理技能
             </button>
-          </Popover.Close>
-          {/* 不包 Popover.Close：保持菜单打开以便就地显示「已复制」反馈。 */}
-          <button
-            type="button"
-            role="menuitem"
-            onClick={handleCopyCommand}
-            className={copyState === "copied" ? s.menuItemCopied : undefined}
+          </DropdownMenu.Item>
+          <DropdownMenu.Item
+            asChild
+            onSelect={(event) => {
+              event.preventDefault();
+              void handleCopyCommand();
+            }}
           >
-            <Terminal size={13} />
-            {copyState === "copied"
-              ? "已复制"
-              : copyState === "error"
-                ? "复制失败"
-                : "复制 CLI 命令"}
-          </button>
+            <button
+              type="button"
+              className={copyState === "copied" ? s.menuItemCopied : undefined}
+            >
+              <Terminal size={13} />
+              {copyState === "copied"
+                ? "已复制"
+                : copyState === "error"
+                  ? "复制失败"
+                  : "复制 CLI 命令"}
+            </button>
+          </DropdownMenu.Item>
 
           {!profile.is_default && (
             <>
-              <div className={s.menuSep} />
-              <Popover.Close asChild>
-                <button type="button" role="menuitem" onClick={onRename}>
+              <DropdownMenu.Separator className={s.menuSep} />
+              <DropdownMenu.Item asChild onSelect={onRename}>
+                <button type="button">
                   <Pencil size={13} /> 重命名
                 </button>
-              </Popover.Close>
-              <Popover.Close asChild>
+              </DropdownMenu.Item>
+              <DropdownMenu.Item asChild onSelect={onDelete} disabled={isActive}>
                 <button
                   type="button"
-                  role="menuitem"
                   data-tone="danger"
-                  onClick={onDelete}
                   disabled={isActive}
                   title={isActive ? "切到别的档案后才能删" : undefined}
                 >
                   <Trash2 size={13} /> 删除
                 </button>
-              </Popover.Close>
+              </DropdownMenu.Item>
             </>
           )}
-        </Popover.Content>
-      </Popover.Portal>
-    </Popover.Root>
+        </DropdownMenu.Content>
+      </DropdownMenu.Portal>
+    </DropdownMenu.Root>
   );
 }

--- a/web/src/components/profiles/profiles.module.css
+++ b/web/src/components/profiles/profiles.module.css
@@ -162,9 +162,11 @@
   cursor: pointer;
 }
 
-.menu button:hover:not(:disabled) {
+.menu button:hover:not(:disabled),
+.menu button[data-highlighted]:not(:disabled) {
   background: var(--h-bg-soft);
   color: var(--h-text);
+  outline: none;
 }
 
 .menu button:disabled {
@@ -176,7 +178,8 @@
   color: var(--h-err);
 }
 
-.menu button[data-tone="danger"]:hover:not(:disabled) {
+.menu button[data-tone="danger"]:hover:not(:disabled),
+.menu button[data-tone="danger"][data-highlighted]:not(:disabled) {
   background: color-mix(in srgb, var(--h-err) 10%, transparent);
 }
 

--- a/web/src/components/session-actions/session-actions.module.css
+++ b/web/src/components/session-actions/session-actions.module.css
@@ -27,8 +27,10 @@
   font-family: var(--h-font-cn);
 }
 
-.rowMenu button:hover {
+.rowMenu button:hover,
+.rowMenu button[data-highlighted] {
   background: var(--h-bg-soft);
+  outline: none;
 }
 
 .rowMenu button:disabled {
@@ -40,7 +42,8 @@
   color: var(--h-err);
 }
 
-.rowMenu button[data-tone="danger"]:hover {
+.rowMenu button[data-tone="danger"]:hover,
+.rowMenu button[data-tone="danger"][data-highlighted] {
   background: color-mix(in srgb, var(--h-err) 12%, transparent);
 }
 

--- a/web/src/components/session-actions/session-row-menu.tsx
+++ b/web/src/components/session-actions/session-row-menu.tsx
@@ -1,4 +1,4 @@
-import { Popover } from "@hermes/shared-ui";
+import { DropdownMenu } from "@hermes/shared-ui";
 import { Archive, ArchiveRestore, Edit3, Pin, PinOff, Trash2 } from "lucide-react";
 import s from "./session-actions.module.css";
 
@@ -17,7 +17,7 @@ export interface SessionRowMenuProps {
 
 /**
  * Dropdown body for a single session's actions (pin / rename / archive /
- * delete). Render it inside a `Popover.Root` whose `Popover.Trigger` is the
+ * delete). Render it inside a `DropdownMenu.Root` whose `DropdownMenu.Trigger` is the
  * "⋯" button — shared by the history list and the workbench sidebar. In the
  * history page's archived scope the archive item flips to "取消归档".
  */
@@ -32,49 +32,50 @@ export function SessionRowMenu({
   onDelete,
 }: SessionRowMenuProps) {
   return (
-    <Popover.Portal>
-      <Popover.Content
+    <DropdownMenu.Portal>
+      <DropdownMenu.Content
         className={s.rowMenu}
         align="end"
         side="bottom"
         sideOffset={4}
-        role="menu"
         onClick={(event) => event.stopPropagation()}
       >
-        <Popover.Close asChild>
-          <button type="button" onClick={onTogglePin} role="menuitem" disabled={disabled}>
+        <DropdownMenu.Item asChild onSelect={onTogglePin} disabled={disabled}>
+          <button type="button" disabled={disabled}>
             {pinned ? <PinOff size={13} /> : <Pin size={13} />}
             {pinned ? "取消置顶" : "置顶"}
           </button>
-        </Popover.Close>
-        <Popover.Close asChild>
-          <button type="button" onClick={onRename} role="menuitem" disabled={disabled}>
+        </DropdownMenu.Item>
+        <DropdownMenu.Item asChild onSelect={onRename} disabled={disabled}>
+          <button type="button" disabled={disabled}>
             <Edit3 size={13} /> 重命名
           </button>
-        </Popover.Close>
-        <Popover.Close asChild>
+        </DropdownMenu.Item>
+        <DropdownMenu.Item
+          asChild
+          onSelect={archived ? onUnarchive : onArchive}
+          disabled={disabled}
+        >
           {archived ? (
-            <button type="button" onClick={onUnarchive} role="menuitem" disabled={disabled}>
+            <button type="button" disabled={disabled}>
               <ArchiveRestore size={13} /> 取消归档
             </button>
           ) : (
-            <button type="button" onClick={onArchive} role="menuitem" disabled={disabled}>
+            <button type="button" disabled={disabled}>
               <Archive size={13} /> 归档
             </button>
           )}
-        </Popover.Close>
-        <Popover.Close asChild>
+        </DropdownMenu.Item>
+        <DropdownMenu.Item asChild onSelect={onDelete} disabled={disabled}>
           <button
             type="button"
-            onClick={onDelete}
-            role="menuitem"
             data-tone="danger"
             disabled={disabled}
           >
             <Trash2 size={13} /> 删除
           </button>
-        </Popover.Close>
-      </Popover.Content>
-    </Popover.Portal>
+        </DropdownMenu.Item>
+      </DropdownMenu.Content>
+    </DropdownMenu.Portal>
   );
 }

--- a/web/src/routes/history.tsx
+++ b/web/src/routes/history.tsx
@@ -2,7 +2,7 @@ import { useCallback, useEffect, useMemo, useState } from "react";
 import { useAtomValue, useSetAtom } from "jotai";
 import { useQueryClient } from "@tanstack/react-query";
 import { useNavigate } from "react-router-dom";
-import { Popover } from "@hermes/shared-ui";
+import { DropdownMenu, Popover } from "@hermes/shared-ui";
 import {
   Archive,
   ArchiveRestore,
@@ -841,13 +841,13 @@ export function HistoryRoute() {
                         {workspaceName || "—"}
                       </span>
                       <span className={s.cellTimestamp}>{updatedDisplay}</span>
-                      <Popover.Root
+                      <DropdownMenu.Root
                         open={!menuDisabled && openMenuId === session.id}
                         onOpenChange={(open) => {
                           setOpenMenuId(open && !menuDisabled ? session.id : null);
                         }}
                       >
-                        <Popover.Trigger asChild>
+                        <DropdownMenu.Trigger asChild>
                           <button
                             type="button"
                             className={s.cellMore}
@@ -858,7 +858,7 @@ export function HistoryRoute() {
                           >
                             <MoreHorizontal size={14} />
                           </button>
-                        </Popover.Trigger>
+                        </DropdownMenu.Trigger>
                         <SessionRowMenu
                           pinned={pinned}
                           disabled={menuDisabled}
@@ -869,7 +869,7 @@ export function HistoryRoute() {
                           onUnarchive={() => handleUnarchive(session)}
                           onDelete={() => openDeleteDialog([session])}
                         />
-                      </Popover.Root>
+                      </DropdownMenu.Root>
                     </div>
                   );
                 })}

--- a/web/src/routes/project-detail.module.css
+++ b/web/src/routes/project-detail.module.css
@@ -62,15 +62,18 @@
   font-family: var(--h-font-cn);
 }
 
-.menu button:hover {
+.menu button:hover,
+.menu button[data-highlighted] {
   background: var(--h-bg-soft);
+  outline: none;
 }
 
 .menu button[data-tone="danger"] {
   color: var(--h-err);
 }
 
-.menu button[data-tone="danger"]:hover {
+.menu button[data-tone="danger"]:hover,
+.menu button[data-tone="danger"][data-highlighted] {
   background: color-mix(in srgb, var(--h-err) 12%, transparent);
 }
 

--- a/web/src/routes/project-detail.tsx
+++ b/web/src/routes/project-detail.tsx
@@ -1,6 +1,6 @@
 import { useCallback, useEffect, useMemo, useState } from "react";
 import { useNavigate, useParams } from "react-router-dom";
-import { Popover } from "@hermes/shared-ui";
+import { DropdownMenu } from "@hermes/shared-ui";
 import {
   ChevronLeft,
   ExternalLink,
@@ -54,29 +54,28 @@ interface MenuProps {
 
 function ProjectMenu({ desktopAvailable, onOpenInFinder, onDelete }: MenuProps) {
   return (
-    <Popover.Portal>
-      <Popover.Content
+    <DropdownMenu.Portal>
+      <DropdownMenu.Content
         className={s.menu}
         align="end"
         side="bottom"
         sideOffset={4}
-        role="menu"
         onClick={(event) => event.stopPropagation()}
       >
         {desktopAvailable ? (
-          <Popover.Close asChild>
-            <button type="button" onClick={onOpenInFinder} role="menuitem">
+          <DropdownMenu.Item asChild onSelect={onOpenInFinder}>
+            <button type="button">
               <ExternalLink size={13} /> 在 Finder 打开
             </button>
-          </Popover.Close>
+          </DropdownMenu.Item>
         ) : null}
-        <Popover.Close asChild>
-          <button type="button" onClick={onDelete} role="menuitem" data-tone="danger">
+        <DropdownMenu.Item asChild onSelect={onDelete}>
+          <button type="button" data-tone="danger">
             <Trash2 size={13} /> 删除项目
           </button>
-        </Popover.Close>
-      </Popover.Content>
-    </Popover.Portal>
+        </DropdownMenu.Item>
+      </DropdownMenu.Content>
+    </DropdownMenu.Portal>
   );
 }
 
@@ -228,18 +227,18 @@ export function ProjectDetailRoute() {
               <Plus size={13} />
               新对话
             </TopBarActionButton>
-            <Popover.Root open={menuOpen} onOpenChange={setMenuOpen}>
-              <Popover.Trigger asChild>
+            <DropdownMenu.Root open={menuOpen} onOpenChange={setMenuOpen}>
+              <DropdownMenu.Trigger asChild>
                 <TopBarActionButton aria-label="项目操作">
                   <MoreHorizontal size={14} />
                 </TopBarActionButton>
-              </Popover.Trigger>
+              </DropdownMenu.Trigger>
               <ProjectMenu
                 desktopAvailable={desktopAvailable}
                 onOpenInFinder={handleOpenInFinder}
                 onDelete={handleDelete}
               />
-            </Popover.Root>
+            </DropdownMenu.Root>
           </>
         }
       />

--- a/web/src/routes/projects.module.css
+++ b/web/src/routes/projects.module.css
@@ -260,15 +260,18 @@
   font-family: var(--h-font-cn);
 }
 
-.rowMenu button:hover {
+.rowMenu button:hover,
+.rowMenu button[data-highlighted] {
   background: var(--h-bg-soft);
+  outline: none;
 }
 
 .rowMenu button[data-tone="danger"] {
   color: var(--h-err);
 }
 
-.rowMenu button[data-tone="danger"]:hover {
+.rowMenu button[data-tone="danger"]:hover,
+.rowMenu button[data-tone="danger"][data-highlighted] {
   background: color-mix(in srgb, var(--h-err) 12%, transparent);
 }
 

--- a/web/src/routes/projects.tsx
+++ b/web/src/routes/projects.tsx
@@ -1,6 +1,6 @@
 import { useCallback, useEffect, useMemo, useState } from "react";
 import { useNavigate } from "react-router-dom";
-import { Popover } from "@hermes/shared-ui";
+import { DropdownMenu } from "@hermes/shared-ui";
 import {
   ExternalLink,
   FolderPlus,
@@ -75,35 +75,34 @@ interface RowMenuProps {
 
 function RowMenu({ pinned, desktopAvailable, onTogglePin, onOpenInFinder, onDelete }: RowMenuProps) {
   return (
-    <Popover.Portal>
-      <Popover.Content
+    <DropdownMenu.Portal>
+      <DropdownMenu.Content
         className={s.rowMenu}
         align="end"
         side="bottom"
         sideOffset={4}
-        role="menu"
         onClick={(event) => event.stopPropagation()}
       >
-        <Popover.Close asChild>
-          <button type="button" onClick={onTogglePin} role="menuitem">
+        <DropdownMenu.Item asChild onSelect={onTogglePin}>
+          <button type="button">
             {pinned ? <PinOff size={13} /> : <Pin size={13} />}
             {pinned ? "取消置顶" : "置顶项目"}
           </button>
-        </Popover.Close>
+        </DropdownMenu.Item>
         {desktopAvailable ? (
-          <Popover.Close asChild>
-            <button type="button" onClick={onOpenInFinder} role="menuitem">
+          <DropdownMenu.Item asChild onSelect={onOpenInFinder}>
+            <button type="button">
               <ExternalLink size={13} /> 在 Finder 打开
             </button>
-          </Popover.Close>
+          </DropdownMenu.Item>
         ) : null}
-        <Popover.Close asChild>
-          <button type="button" onClick={onDelete} role="menuitem" data-tone="danger">
+        <DropdownMenu.Item asChild onSelect={onDelete}>
+          <button type="button" data-tone="danger">
             <Trash2 size={13} /> 删除项目
           </button>
-        </Popover.Close>
-      </Popover.Content>
-    </Popover.Portal>
+        </DropdownMenu.Item>
+      </DropdownMenu.Content>
+    </DropdownMenu.Portal>
   );
 }
 
@@ -327,13 +326,13 @@ export function ProjectsRoute() {
                         {formatTokens(item.totalTokens)}
                       </td>
                       <td className={s.menuCell} onClick={(event) => event.stopPropagation()}>
-                        <Popover.Root
+                        <DropdownMenu.Root
                           open={openMenuPath === project.path}
                           onOpenChange={(open) =>
                             setOpenMenuPath(open ? project.path : null)
                           }
                         >
-                          <Popover.Trigger asChild>
+                          <DropdownMenu.Trigger asChild>
                             <button
                               type="button"
                               className={s.menuTrigger}
@@ -341,7 +340,7 @@ export function ProjectsRoute() {
                             >
                               <MoreHorizontal size={14} />
                             </button>
-                          </Popover.Trigger>
+                          </DropdownMenu.Trigger>
                           <RowMenu
                             pinned={pinned}
                             desktopAvailable={desktopAvailable}
@@ -349,7 +348,7 @@ export function ProjectsRoute() {
                             onOpenInFinder={() => handleOpenInFinder(project)}
                             onDelete={() => handleDelete(project)}
                           />
-                        </Popover.Root>
+                        </DropdownMenu.Root>
                       </td>
                     </tr>
                   );

--- a/web/src/routes/settings-models-section.tsx
+++ b/web/src/routes/settings-models-section.tsx
@@ -1,6 +1,5 @@
-import { useCallback, useEffect, useId, useMemo, useRef, useState } from "react";
+import { useCallback, useEffect, useMemo, useRef, useState } from "react";
 import type { Dispatch, KeyboardEvent as ReactKeyboardEvent, SetStateAction } from "react";
-import { createPortal } from "react-dom";
 import { useNavigate } from "react-router-dom";
 import {
   closestCenter,
@@ -63,7 +62,7 @@ import {
 } from "@/lib/local-provider-context";
 import type { EnvVarInfo } from "@hermes/protocol";
 import { CopyButton } from "@/components/ui/copy-button";
-import { Alert, Button, Field, Input, Select, Textarea } from "@hermes/shared-ui";
+import { Alert, Button, Dialog, Field, Input, Select, Textarea } from "@hermes/shared-ui";
 import { OAuthProvidersSection } from "./settings-oauth-section";
 import { MoaPanel } from "./settings-moa-panel";
 import { useMoaConfig } from "@/hooks/use-moa-config";
@@ -676,7 +675,6 @@ export function ModelsSection() {
   const [auxSavingTask, setAuxSavingTask] = useState<AuxiliaryTaskId | "__all__" | "image_mode" | null>(null);
   const [auxSavedTask, setAuxSavedTask] = useState<AuxiliaryTaskId | "__all__" | "image_mode" | null>(null);
   const [auxError, setAuxError] = useState("");
-  const customDialogTitleId = useId();
   const selectProvider = useCallback((providerId: string) => {
     if (!providerId || selectedProviderIdRef.current === providerId) return;
     selectedProviderIdRef.current = providerId;
@@ -718,15 +716,6 @@ export function ModelsSection() {
       contextWindow: String(RECOMMENDED_LOCAL_CONTEXT_LENGTH),
     }));
   }, []);
-  useEffect(() => {
-    if (!showCustomForm) return;
-    const handler = (e: KeyboardEvent) => {
-      if (e.key === "Escape") closeCustomForm();
-    };
-    window.addEventListener("keydown", handler);
-    return () => window.removeEventListener("keydown", handler);
-  }, [showCustomForm, closeCustomForm]);
-
   const currentProviderId = modelInfo?.provider ||
     (config?.model && typeof config.model === "object" && !Array.isArray(config.model)
       ? String((config.model as Record<string, unknown>).provider ?? "")
@@ -1939,25 +1928,29 @@ export function ModelsSection() {
         <MoaPanel />
       )}
 
-      {showCustomForm && createPortal(
-        <div className={s.customProviderBackdrop} onClick={closeCustomForm}>
-          <div
+      <Dialog.Root
+        open={showCustomForm}
+        onOpenChange={(open) => { if (!open) closeCustomForm(); }}
+      >
+        <Dialog.Portal>
+          <Dialog.Overlay className={s.customProviderBackdrop} />
+          <Dialog.Content
             className={s.customProviderModal}
-            role="dialog"
-            aria-modal="true"
-            aria-labelledby={customDialogTitleId}
-            onClick={(e) => e.stopPropagation()}
+            aria-describedby={undefined}
           >
             <div className={s.customProviderTitleBar}>
-              <h2 id={customDialogTitleId}>{customProviderTitle}</h2>
-              <button
-                type="button"
-                className={s.customProviderClose}
-                onClick={closeCustomForm}
-                aria-label="关闭"
-              >
-                ×
-              </button>
+              <Dialog.Title asChild>
+                <h2>{customProviderTitle}</h2>
+              </Dialog.Title>
+              <Dialog.Close asChild>
+                <button
+                  type="button"
+                  className={s.customProviderClose}
+                  aria-label="关闭"
+                >
+                  ×
+                </button>
+              </Dialog.Close>
             </div>
             <div className={s.customProviderBody}>
               <p className={s.customProviderHint}>
@@ -2093,7 +2086,9 @@ export function ModelsSection() {
               </Field>
             </div>
             <div className={s.customProviderActions}>
-              <Button type="button" variant="outline" onClick={closeCustomForm}>取消</Button>
+              <Dialog.Close asChild>
+                <Button type="button" variant="outline">取消</Button>
+              </Dialog.Close>
               <Button
                 type="button"
                 variant="solid"
@@ -2110,10 +2105,9 @@ export function ModelsSection() {
                 {saveConfig.isPending ? "保存中…" : "添加并选中"}
               </Button>
             </div>
-          </div>
-        </div>,
-        document.body,
-      )}
+          </Dialog.Content>
+        </Dialog.Portal>
+      </Dialog.Root>
     </div>
   );
 }

--- a/web/src/routes/settings-oauth-section.module.css
+++ b/web/src/routes/settings-oauth-section.module.css
@@ -70,7 +70,7 @@
 .modalBackdrop {
   position: fixed;
   inset: 0;
-  z-index: 200;
+  z-index: var(--h-z-dialog-overlay);
   display: flex;
   align-items: center;
   justify-content: center;

--- a/web/src/routes/settings-oauth-section.tsx
+++ b/web/src/routes/settings-oauth-section.tsx
@@ -1,5 +1,4 @@
 import { useCallback, useEffect, useMemo, useRef, useState } from "react";
-import { createPortal } from "react-dom";
 import type { OAuthProvider } from "@hermes/protocol";
 import {
   useOAuthProviders,
@@ -11,7 +10,7 @@ import {
 } from "@/hooks/use-oauth-providers";
 import { CopyButton } from "@/components/ui/copy-button";
 import { openExternalUrl } from "@/lib/external-links";
-import { Badge, Button, Input } from "@hermes/shared-ui";
+import { Badge, Button, Dialog, Input } from "@hermes/shared-ui";
 import settings from "./settings.module.css";
 import s from "./settings-oauth-section.module.css";
 
@@ -310,24 +309,24 @@ function OAuthLoginModal({ provider, onClose }: { provider: OAuthProvider; onClo
     onClose();
   }, [cancelSession, onClose, phase]);
 
-  useEffect(() => {
-    const onKey = (e: KeyboardEvent) => { if (e.key === "Escape") handleClose(); };
-    document.addEventListener("keydown", onKey);
-    return () => document.removeEventListener("keydown", onKey);
-  }, [handleClose]);
-
   const formatCountdown = (secs: number) => {
     const m = Math.floor(secs / 60);
     const sec = secs % 60;
     return `${m}:${sec.toString().padStart(2, "0")}`;
   };
 
-  return createPortal(
-    <div className={s.modalBackdrop} onClick={handleClose}>
-      <div className={s.modal} onClick={(e) => e.stopPropagation()}>
+  return (
+    <Dialog.Root open onOpenChange={(open) => { if (!open) handleClose(); }}>
+      <Dialog.Portal>
+        <Dialog.Overlay className={s.modalBackdrop} />
+        <Dialog.Content className={s.modal} aria-describedby={undefined}>
         <div className={s.modalHeader}>
-          <div className={s.modalTitle}>登录 {provider.name}</div>
-          <Button variant="plain" size="inherit" className={s.modalClose} onClick={handleClose} aria-label="关闭">✕</Button>
+          <Dialog.Title asChild>
+            <div className={s.modalTitle}>登录 {provider.name}</div>
+          </Dialog.Title>
+          <Dialog.Close asChild>
+            <Button variant="plain" size="inherit" className={s.modalClose} aria-label="关闭">✕</Button>
+          </Dialog.Close>
         </div>
 
         {phase === "starting" && (
@@ -418,12 +417,14 @@ function OAuthLoginModal({ provider, onClose }: { provider: OAuthProvider; onClo
           <>
             <div className={s.statusMessage} data-type="error">{errorMsg}</div>
             <div className={s.modalActions}>
-              <Button variant="outline" onClick={handleClose}>关闭</Button>
+              <Dialog.Close asChild>
+                <Button variant="outline">关闭</Button>
+              </Dialog.Close>
             </div>
           </>
         )}
-      </div>
-    </div>,
-    document.body,
+        </Dialog.Content>
+      </Dialog.Portal>
+    </Dialog.Root>
   );
 }

--- a/web/src/routes/settings.module.css
+++ b/web/src/routes/settings.module.css
@@ -1742,7 +1742,7 @@
 .customProviderBackdrop {
   position: fixed;
   inset: 0;
-  z-index: 100;
+  z-index: var(--h-z-dialog-overlay);
   display: flex;
   align-items: center;
   justify-content: center;


### PR DESCRIPTION
## 变更内容

- 在 shared-ui 中新增基于 Radix Dropdown Menu 的统一操作菜单封装与样式。
- 将项目、配置档案、会话和推理强度等操作菜单迁移到统一组件。
- 将 OAuth、自定义模型服务商、URL、工作区和模型选择弹窗迁移到 shared-ui 的 Radix Dialog。
- 删除各业务组件内重复的 Portal、焦点管理、Escape 关闭、滚动锁定和菜单键盘交互代码。

## 变更原因

现有多个弹窗和操作菜单分别实现了相同的可访问性与交互逻辑，维护成本较高，行为也容易不一致。统一基于 shared-ui 和 Radix 后，可复用成熟的焦点管理、键盘导航、Portal 与可访问性语义。

## 用户影响

界面视觉与业务流程保持不变，弹窗和菜单的键盘操作、焦点恢复及屏幕阅读器体验更加一致。

## 验证

- pnpm typecheck
- pnpm test:unit（protocol 66 + web 963，共 1027 项通过）
- cargo check
- pnpm web:build:desktop
- git diff --check origin/main...HEAD