### PR TITLE
feat: 内核更新加防降级与强升闸门，接活升级进度状态机（轨道 A 收口）

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -2003,6 +2003,7 @@ dependencies = [
  "regex",
  "reqwest 0.12.28",
  "rusqlite",
+ "semver",
  "serde",
  "serde_json",
  "serial_test",

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -37,6 +37,9 @@ log = "0.4"
 env_logger = "0.11"
 tempfile = "3"
 base64 = "0.22"
+# Runtime-update version ordering (process/runtime.rs): upgrade/downgrade
+# gates parse `0.18.2-cn.N` as semver with a `cn.N` pre-release.
+semver = "1"
 url = "2"
 urlencoding = "2"
 open = "5"

--- a/packages/protocol/src/channels.ts
+++ b/packages/protocol/src/channels.ts
@@ -263,6 +263,7 @@ export interface RuntimeUpdateManifest {
   signature: string;
   sourceRepo: string;
   sourceCommit: string;
+  /** schema v3 起为必填且纳入签名载荷（强制升级闸门）；v2 为可选未签名字段。 */
   minAppVersion?: string;
   createdAt?: string;
 }
@@ -270,10 +271,41 @@ export interface RuntimeUpdateManifest {
 export interface RuntimeUpdateCheckResult {
   ok: boolean;
   updateAvailable: boolean;
+  /** 更新源提供的 runtime 低于当前已装版本，防降级门已忽略它。 */
+  downgradeBlocked?: boolean;
+  /** manifest 签名的 minAppVersion 高于当前桌面端版本，安装被阻断。 */
+  forceAppUpdateRequired?: boolean;
+  /** 与 forceAppUpdateRequired 配套：manifest 要求的最低桌面端版本。 */
+  requiredAppVersion?: string;
   currentRuntimeVersion?: string;
   manifest?: RuntimeUpdateManifest;
   error?: string;
 }
+
+/**
+ * 内核更新/回滚过程的阶段事件（Tauri 事件 "runtime-update-stage"）。
+ * 镜像 Rust 侧 src/update_stage.rs 的 UpdateStage：serde tag = "stage"、
+ * 变体名 camelCase、字段名保持 snake_case（由 Rust 侧序列化测试锁定）。
+ */
+export type RuntimeUpdateStage =
+  | { stage: "idle" }
+  | { stage: "checking" }
+  | { stage: "noUpdateAvailable" }
+  | { stage: "updateAvailable"; current_version?: string | null; new_version: string }
+  | { stage: "downloading"; new_version: string }
+  | { stage: "verifying"; new_version: string }
+  | { stage: "extracting"; new_version: string }
+  | { stage: "smokeChecking"; new_version: string }
+  | { stage: "installing"; new_version: string }
+  | { stage: "restartingDashboard"; new_version: string }
+  /** 半更新态：runtime 已换好，仅内核自动重启失败——提示"请重启应用"，不是失败。 */
+  | { stage: "restartRequired"; new_version: string }
+  | { stage: "complete"; new_version: string; previous_version?: string | null }
+  | { stage: "failed"; error: string; new_version?: string | null }
+  | { stage: "rollingBack" }
+  | { stage: "rolledBack"; restored_version: string };
+
+export const RUNTIME_UPDATE_STAGE_EVENT = "runtime-update-stage";
 
 export interface RuntimeInstallUpdateResult {
   ok: boolean;

--- a/src/bootstrap.rs
+++ b/src/bootstrap.rs
@@ -143,7 +143,7 @@ pub async fn acquire_managed_dashboard(
     if info.current.is_none() && info.updates_configured {
         emit_runtime_status(app, "installing", "正在下载 hermes-agent-cn runtime...");
         log::info!("Bootstrap: install_runtime_update");
-        let install = runtime::install_runtime_update(None).await;
+        let install = runtime::install_runtime_update(None, None).await;
         if !install.ok {
             let msg = install
                 .error

--- a/src/commands/api_proxy.rs
+++ b/src/commands/api_proxy.rs
@@ -498,7 +498,7 @@ async fn api_request_impl_inner(
 
     // 4. Runtime update intercept
     if url_p == "/api/hermes/update" && method.to_uppercase() == "POST" {
-        let result = crate::process::runtime::install_runtime_update(None).await;
+        let result = crate::process::runtime::install_runtime_update(None, None).await;
         let status = if result.ok { 200 } else { 503 };
         let status_text = if result.ok {
             "OK"

--- a/src/commands/runtime_manager.rs
+++ b/src/commands/runtime_manager.rs
@@ -14,6 +14,7 @@ use crate::error::AppError;
 use crate::process::dashboard;
 use crate::process::runtime;
 use crate::state::AppState;
+use crate::update_stage::UpdateStage;
 use std::path::{Path, PathBuf};
 use std::sync::atomic::Ordering;
 use std::time::{SystemTime, UNIX_EPOCH};
@@ -173,23 +174,55 @@ pub async fn runtime_check_update() -> Result<runtime::RuntimeUpdateCheckResult,
 }
 
 /// Install a runtime update and restart the dashboard.
+///
+/// Progress is pushed to the webview as `runtime-update-stage` events
+/// (src/update_stage.rs) so the update overlay can render real stages instead
+/// of an indeterminate spinner.
 #[tauri::command]
 pub async fn runtime_install_update(
+    app: tauri::AppHandle,
     state: State<'_, AppState>,
 ) -> Result<runtime::RuntimeInstallUpdateResult, AppError> {
     {
         let inner = state.inner.lock()?;
         crate::connection::require_managed_mode(inner.connection_mode, "Runtime 更新")?;
     }
-    let result = runtime::install_runtime_update(None).await;
+    let stage_app = app.clone();
+    let sink = move |stage: UpdateStage| stage.emit(&stage_app);
+    let result = runtime::install_runtime_update(None, Some(&sink)).await;
     if !result.ok {
+        UpdateStage::Failed {
+            error: result
+                .error
+                .clone()
+                .unwrap_or_else(|| "runtime update failed".to_string()),
+            new_version: result.installed.as_ref().map(|r| r.runtime_version.clone()),
+        }
+        .emit(&app);
         let mut inner = state.inner.lock()?;
         inner.last_runtime_error = result.error.clone();
         return Ok(result);
     }
 
+    let new_version = result
+        .installed
+        .as_ref()
+        .map(|r| r.runtime_version.clone())
+        .unwrap_or_default();
+
     // Restart dashboard after successful install
+    UpdateStage::RestartingDashboard {
+        new_version: new_version.clone(),
+    }
+    .emit(&app);
     if let Err(e) = restart_dashboard(&state).await {
+        // Half-updated state: the new runtime is already active on disk — only
+        // the dashboard restart failed. Message and stage must both read as
+        // "restart the app", never as a failed update the user should retry.
+        UpdateStage::RestartRequired {
+            new_version: new_version.clone(),
+        }
+        .emit(&app);
         let mut inner = state.inner.lock()?;
         inner.last_runtime_error = Some(e.to_string());
         return Ok(runtime::RuntimeInstallUpdateResult {
@@ -197,12 +230,16 @@ pub async fn runtime_install_update(
             installed: result.installed,
             previous: result.previous,
             error: Some(format!(
-                "Runtime installed, but dashboard restart failed: {}",
-                e
+                "内核已更新到 {new_version}，但自动重启失败：{e}。更新已生效，请手动重启应用。"
             )),
         });
     }
 
+    UpdateStage::Complete {
+        new_version,
+        previous_version: result.previous.as_ref().map(|p| p.runtime_version.clone()),
+    }
+    .emit(&app);
     {
         let mut inner = state.inner.lock()?;
         inner.last_runtime_error = None;
@@ -355,7 +392,7 @@ async fn install_runtime_payload(app: &tauri::AppHandle) -> runtime::RuntimeInst
     {
         runtime::install_bundled_runtime_if_needed(resource_dir.as_deref()).await
     } else {
-        runtime::install_runtime_update(None).await
+        runtime::install_runtime_update(None, None).await
     }
 }
 
@@ -799,20 +836,46 @@ mod tests {
 /// Rollback runtime and restart the dashboard.
 #[tauri::command]
 pub async fn runtime_rollback(
+    app: tauri::AppHandle,
     state: State<'_, AppState>,
 ) -> Result<runtime::RuntimeInstallUpdateResult, AppError> {
     {
         let inner = state.inner.lock()?;
         crate::connection::require_managed_mode(inner.connection_mode, "Runtime 回滚")?;
     }
+    UpdateStage::RollingBack.emit(&app);
     let result = runtime::rollback_runtime();
     if !result.ok {
+        UpdateStage::Failed {
+            error: result
+                .error
+                .clone()
+                .unwrap_or_else(|| "runtime rollback failed".to_string()),
+            new_version: None,
+        }
+        .emit(&app);
         let mut inner = state.inner.lock()?;
         inner.last_runtime_error = result.error.clone();
         return Ok(result);
     }
 
+    let restored_version = result
+        .installed
+        .as_ref()
+        .map(|r| r.runtime_version.clone())
+        .unwrap_or_default();
+    UpdateStage::RestartingDashboard {
+        new_version: restored_version.clone(),
+    }
+    .emit(&app);
     if let Err(e) = restart_dashboard(&state).await {
+        // Half-rolled-back: current.json already points at the previous
+        // version — only the dashboard restart failed. Same "restart the app"
+        // messaging as the install path.
+        UpdateStage::RestartRequired {
+            new_version: restored_version.clone(),
+        }
+        .emit(&app);
         let mut inner = state.inner.lock()?;
         inner.last_runtime_error = Some(e.to_string());
         return Ok(runtime::RuntimeInstallUpdateResult {
@@ -820,12 +883,12 @@ pub async fn runtime_rollback(
             installed: result.installed,
             previous: result.previous,
             error: Some(format!(
-                "Runtime rolled back, but dashboard restart failed: {}",
-                e
+                "已回滚到内核 {restored_version}，但自动重启失败：{e}。回滚已生效，请手动重启应用。"
             )),
         });
     }
 
+    UpdateStage::RolledBack { restored_version }.emit(&app);
     {
         let mut inner = state.inner.lock()?;
         inner.last_runtime_error = None;

--- a/src/process/runtime.rs
+++ b/src/process/runtime.rs
@@ -1435,13 +1435,12 @@ pub async fn check_runtime_update() -> RuntimeUpdateCheckResult {
                 let (update_available, downgrade_blocked) = match current.as_ref() {
                     None => (true, false),
                     Some(c) if c.runtime_version == manifest.runtime_version => (false, false),
-                    Some(c) => {
-                        if is_version_downgrade(&manifest.runtime_version, &c.runtime_version) {
-                            (false, true)
-                        } else {
-                            (true, false)
-                        }
+                    Some(c)
+                        if is_version_downgrade(&manifest.runtime_version, &c.runtime_version) =>
+                    {
+                        (false, true)
                     }
+                    Some(_) => (true, false),
                 };
                 let required_app_version = blocking_min_app_version(&manifest);
                 RuntimeUpdateCheckResult {

--- a/src/process/runtime.rs
+++ b/src/process/runtime.rs
@@ -16,6 +16,19 @@ use serde::{Deserialize, Serialize};
 use sha2::{Digest, Sha256};
 use tokio::process::Command;
 
+use crate::update_stage::UpdateStage;
+
+/// Progress sink threaded through the install path so the command layer can
+/// forward [`UpdateStage`]s to the webview. `None` keeps silent installs
+/// (bundled bootstrap at startup) free of UI events.
+pub type StageSink<'a> = &'a (dyn Fn(UpdateStage) + Send + Sync);
+
+fn emit_stage(sink: Option<StageSink<'_>>, stage: UpdateStage) {
+    if let Some(sink) = sink {
+        sink(stage);
+    }
+}
+
 const RUNTIME_BASENAME: &str = "hermes-agent-cn-runtime";
 /// Managed runtime tree used by release / packaged installs.
 const RUNTIME_SUBDIR_RELEASE: &str = "runtime";
@@ -31,7 +44,21 @@ const PORTABLE_MARKER_FILE: &str = "portable.marker";
 const CURRENT_FILE: &str = "current.json";
 const MANIFEST_FILE: &str = "manifest.json";
 const DEFAULT_CHANNEL: &str = "stable";
-const MANIFEST_SCHEMA_VERSION: u32 = 2;
+/// Schema written into `current.json` install records. The record shape did
+/// NOT change when the update manifest gained v3 (minAppVersion lives only in
+/// the signed manifest payload), so this stays at 2 — bumping it would orphan
+/// every existing install: `read_current_record` treats unknown schemas as
+/// "nothing installed" and forces a full re-bootstrap.
+const RECORD_SCHEMA_VERSION: u32 = 2;
+/// Install records this client accepts. 3 is reserved forward-compat so a
+/// future record bump can roll out reader-first, mirroring the manifest plan.
+const SUPPORTED_RECORD_SCHEMA_VERSIONS: [u32; 2] = [2, 3];
+/// Update-manifest schemas this client can verify.
+/// v2 = original 12-field signature payload; v3 appends `minAppVersion` as
+/// field #13 (see `signature_payload`) and requires it to be present.
+/// Keep accepting v2 until the Core signing pipeline has fully moved to v3
+/// (client-first rollout: readers must ship before signers switch).
+const SUPPORTED_MANIFEST_SCHEMA_VERSIONS: [u32; 2] = [2, 3];
 const DASHBOARD_RESOURCE_DIR: &str = "dashboard";
 const DASHBOARD_WEB_DIST_DIR: &str = "web_dist";
 const BUNDLED_SKILLS_RESOURCE_DIR: &str = "bundled-skills";
@@ -218,12 +245,40 @@ pub struct RuntimeProcessInfo {
 pub struct RuntimeUpdateCheckResult {
     pub ok: bool,
     pub update_available: bool,
+    /// The channel offered an older runtime than the installed one and the
+    /// downgrade gate suppressed it (`update_available` stays false).
+    #[serde(default)]
+    pub downgrade_blocked: bool,
+    /// The manifest's signed `minAppVersion` is newer than this desktop build:
+    /// installing is blocked until the shell itself is upgraded.
+    #[serde(default)]
+    pub force_app_update_required: bool,
+    /// Set alongside `force_app_update_required`: the minimum shell version
+    /// the manifest demands, for UI messaging.
+    #[serde(skip_serializing_if = "Option::is_none")]
+    pub required_app_version: Option<String>,
     #[serde(skip_serializing_if = "Option::is_none")]
     pub current_runtime_version: Option<String>,
     #[serde(skip_serializing_if = "Option::is_none")]
     pub manifest: Option<RuntimeUpdateManifest>,
     #[serde(skip_serializing_if = "Option::is_none")]
     pub error: Option<String>,
+}
+
+impl RuntimeUpdateCheckResult {
+    /// Failed check with every gate flag cleared.
+    fn failure(error: String) -> Self {
+        RuntimeUpdateCheckResult {
+            ok: false,
+            update_available: false,
+            downgrade_blocked: false,
+            force_app_update_required: false,
+            required_app_version: None,
+            current_runtime_version: None,
+            manifest: None,
+            error: Some(error),
+        }
+    }
 }
 
 #[derive(Debug, Serialize, Deserialize)]
@@ -256,6 +311,84 @@ fn current_arch() -> &'static str {
     } else {
         std::env::consts::ARCH
     }
+}
+
+/// Desktop shell version, taken from the crate itself (kept in sync with
+/// `package.json`/`tauri.conf.json` by `pnpm version:sync`). Never accept this
+/// from the webview — the min-app-version gate must not be spoofable.
+fn desktop_app_version() -> &'static str {
+    env!("CARGO_PKG_VERSION")
+}
+
+/// Runtime versions are `<kernel>-cn.<rev>` (e.g. `0.18.2-cn.7`), which is
+/// valid semver with a `cn.<rev>` pre-release: `cn.2 < cn.10` compares
+/// numerically, and `0.18.2-cn.* < 0.18.3-cn.*`. Beware if a canary suffix is
+/// ever added: `0.18.2-cn.2-canary.3` makes the pre-release `cn.2-canary` an
+/// *alphanumeric* identifier that sorts ABOVE the numeric `cn.2` — canary
+/// version grammar must be designed together with these gates.
+fn parse_runtime_semver(version: &str) -> Option<semver::Version> {
+    semver::Version::parse(version.trim().trim_start_matches('v')).ok()
+}
+
+/// True when installing `candidate` over `current` would be a downgrade.
+/// Only ever true when BOTH sides parse as semver — unparseable versions fall
+/// back to the legacy "any difference is installable" behavior rather than
+/// bricking updates over a formatting quirk.
+fn is_version_downgrade(candidate: &str, current: &str) -> bool {
+    match (
+        parse_runtime_semver(candidate),
+        parse_runtime_semver(current),
+    ) {
+        (Some(candidate), Some(current)) => candidate < current,
+        _ => {
+            log::warn!(
+                "runtime version compare fell back to string equality: {candidate:?} vs {current:?}"
+            );
+            false
+        }
+    }
+}
+
+/// Returns the manifest's `minAppVersion` when it demands a newer desktop
+/// shell than this build. Unparseable values never block: the field is
+/// signature-protected, so a bad value is an authoring bug, not an attack.
+fn blocking_min_app_version(manifest: &RuntimeUpdateManifest) -> Option<String> {
+    let min = manifest.min_app_version.as_deref()?.trim();
+    if min.is_empty() {
+        return None;
+    }
+    let (Some(min_version), Some(app_version)) = (
+        parse_runtime_semver(min),
+        parse_runtime_semver(desktop_app_version()),
+    ) else {
+        log::warn!("ignoring unparseable minAppVersion {min:?} in runtime update manifest");
+        return None;
+    };
+    (min_version > app_version).then(|| min.to_string())
+}
+
+/// Schema acceptance shared by every manifest consumer (update check, install,
+/// bundled bootstrap). v3 additionally requires `minAppVersion`: the field is
+/// part of the v3 signature payload, and Python's signer must never have to
+/// serialize a missing value (`str(None)` vs `""` ambiguity).
+fn validate_manifest_schema(manifest: &RuntimeUpdateManifest) -> Result<(), String> {
+    if !SUPPORTED_MANIFEST_SCHEMA_VERSIONS.contains(&manifest.schema_version) {
+        return Err(format!(
+            "Manifest schemaVersion is {}, expected one of {:?}",
+            manifest.schema_version, SUPPORTED_MANIFEST_SCHEMA_VERSIONS
+        ));
+    }
+    if manifest.schema_version >= 3
+        && manifest
+            .min_app_version
+            .as_deref()
+            .map(str::trim)
+            .unwrap_or("")
+            .is_empty()
+    {
+        return Err("Manifest schemaVersion 3 requires a non-empty minAppVersion".to_string());
+    }
+    Ok(())
 }
 
 fn executable_extension() -> &'static str {
@@ -654,7 +787,7 @@ fn read_legacy_current_record(path: &Path) -> Option<RuntimeInstallRecord> {
     let runtime_dir = PathBuf::from(&legacy.path);
     let kernel_version = infer_kernel_version_from_local_manifest(&runtime_dir, &legacy.version);
     Some(RuntimeInstallRecord {
-        schema_version: MANIFEST_SCHEMA_VERSION,
+        schema_version: RECORD_SCHEMA_VERSION,
         runtime_version: legacy.version,
         kernel_version,
         runtime_flavor: if legacy.source == "local-source" {
@@ -684,7 +817,7 @@ pub fn read_current_record() -> Option<RuntimeInstallRecord> {
     } else {
         (read_legacy_current_record(&path)?, true)
     };
-    if record.schema_version != MANIFEST_SCHEMA_VERSION {
+    if !SUPPORTED_RECORD_SCHEMA_VERSIONS.contains(&record.schema_version) {
         return None;
     }
     if record.platform != current_platform() || record.arch != current_arch() {
@@ -1177,12 +1310,7 @@ pub fn bundled_runtime_available(resource_dir: Option<&Path>) -> bool {
 fn validate_manifest_for_current_platform(
     manifest: &RuntimeUpdateManifest,
 ) -> Result<String, String> {
-    if manifest.schema_version != MANIFEST_SCHEMA_VERSION {
-        return Err(format!(
-            "Manifest schemaVersion is {}, expected {}",
-            manifest.schema_version, MANIFEST_SCHEMA_VERSION
-        ));
-    }
+    validate_manifest_schema(manifest)?;
     if manifest.platform != current_platform() || manifest.arch != current_arch() {
         return Err(format!(
             "Manifest is for {}-{}, not {}-{}",
@@ -1274,13 +1402,9 @@ pub async fn check_runtime_update() -> RuntimeUpdateCheckResult {
     let url = match configured_manifest_url() {
         Some(u) => u,
         None => {
-            return RuntimeUpdateCheckResult {
-                ok: false,
-                update_available: false,
-                current_runtime_version: None,
-                manifest: None,
-                error: Some("Runtime update manifest URL is not configured".to_string()),
-            };
+            return RuntimeUpdateCheckResult::failure(
+                "Runtime update manifest URL is not configured".to_string(),
+            );
         }
     };
 
@@ -1292,68 +1416,49 @@ pub async fn check_runtime_update() -> RuntimeUpdateCheckResult {
     {
         Ok(res) if res.status().is_success() => match res.json::<RuntimeUpdateManifest>().await {
             Ok(manifest) => {
-                if manifest.schema_version != MANIFEST_SCHEMA_VERSION {
-                    return RuntimeUpdateCheckResult {
-                        ok: false,
-                        update_available: false,
-                        current_runtime_version: None,
-                        manifest: None,
-                        error: Some(format!(
-                            "Manifest schemaVersion is {}, expected {}",
-                            manifest.schema_version, MANIFEST_SCHEMA_VERSION
-                        )),
-                    };
+                if let Err(e) = validate_manifest_schema(&manifest) {
+                    return RuntimeUpdateCheckResult::failure(e);
                 }
                 if manifest.platform != current_platform() || manifest.arch != current_arch() {
-                    return RuntimeUpdateCheckResult {
-                        ok: false,
-                        update_available: false,
-                        current_runtime_version: None,
-                        manifest: None,
-                        error: Some(format!(
-                            "Manifest is for {}-{}, not {}-{}",
-                            manifest.platform,
-                            manifest.arch,
-                            current_platform(),
-                            current_arch()
-                        )),
-                    };
+                    return RuntimeUpdateCheckResult::failure(format!(
+                        "Manifest is for {}-{}, not {}-{}",
+                        manifest.platform,
+                        manifest.arch,
+                        current_platform(),
+                        current_arch()
+                    ));
                 }
                 let current = read_current_record();
-                let update_available = current
-                    .as_ref()
-                    .map(|c| c.runtime_version != manifest.runtime_version)
-                    .unwrap_or(true);
+                // Same version → up to date; older (semver) → downgrade gate
+                // suppresses it; anything else (newer or unparseable) keeps
+                // the legacy "different means installable" behavior.
+                let (update_available, downgrade_blocked) = match current.as_ref() {
+                    None => (true, false),
+                    Some(c) if c.runtime_version == manifest.runtime_version => (false, false),
+                    Some(c) => {
+                        if is_version_downgrade(&manifest.runtime_version, &c.runtime_version) {
+                            (false, true)
+                        } else {
+                            (true, false)
+                        }
+                    }
+                };
+                let required_app_version = blocking_min_app_version(&manifest);
                 RuntimeUpdateCheckResult {
                     ok: true,
                     update_available,
+                    downgrade_blocked,
+                    force_app_update_required: required_app_version.is_some(),
+                    required_app_version,
                     current_runtime_version: current.map(|c| c.runtime_version),
                     manifest: Some(manifest),
                     error: None,
                 }
             }
-            Err(e) => RuntimeUpdateCheckResult {
-                ok: false,
-                update_available: false,
-                current_runtime_version: None,
-                manifest: None,
-                error: Some(format!("Failed to parse manifest: {}", e)),
-            },
+            Err(e) => RuntimeUpdateCheckResult::failure(format!("Failed to parse manifest: {}", e)),
         },
-        Ok(res) => RuntimeUpdateCheckResult {
-            ok: false,
-            update_available: false,
-            current_runtime_version: None,
-            manifest: None,
-            error: Some(format!("HTTP {}", res.status())),
-        },
-        Err(e) => RuntimeUpdateCheckResult {
-            ok: false,
-            update_available: false,
-            current_runtime_version: None,
-            manifest: None,
-            error: Some(e.to_string()),
-        },
+        Ok(res) => RuntimeUpdateCheckResult::failure(format!("HTTP {}", res.status())),
+        Err(e) => RuntimeUpdateCheckResult::failure(e.to_string()),
     }
 }
 
@@ -1364,8 +1469,14 @@ fn sha256_hex(data: &[u8]) -> String {
     format!("{:x}", hasher.finalize())
 }
 
+// Signed payload, one field per line. Field ORDER and the exact set per
+// schema version are a cross-language contract with the Core signer
+// (Hermes-CN-Core/scripts/sign_runtime_manifest.py `_PAYLOAD_FIELDS`) — any
+// change must land in both repos in lockstep, guarded by the order-lock tests
+// below. v2 = 12 fields; v3 appends `minAppVersion` as field #13 (validated
+// non-empty before verification, so the signer never serializes a null).
 fn signature_payload(manifest: &RuntimeUpdateManifest) -> Vec<u8> {
-    format!(
+    let mut payload = format!(
         "{}\n{}\n{}\n{}\n{}\n{}\n{}\n{}\n{}\n{}\n{}\n{}",
         manifest.schema_version,
         manifest.channel,
@@ -1379,8 +1490,12 @@ fn signature_payload(manifest: &RuntimeUpdateManifest) -> Vec<u8> {
         manifest.sha256,
         manifest.source_repo,
         manifest.source_commit,
-    )
-    .into_bytes()
+    );
+    if manifest.schema_version >= 3 {
+        payload.push('\n');
+        payload.push_str(manifest.min_app_version.as_deref().unwrap_or(""));
+    }
+    payload.into_bytes()
 }
 
 fn verify_signature(manifest: &RuntimeUpdateManifest) -> Result<(), String> {
@@ -1396,6 +1511,10 @@ fn verify_signature_with_key(
     use base64::Engine;
     use ed25519_dalek::pkcs8::DecodePublicKey;
     use ed25519_dalek::{Signature, VerifyingKey};
+
+    // Reject unsupported schemas / v3-without-minAppVersion up front so the
+    // caller gets a precise error instead of an opaque signature mismatch.
+    validate_manifest_schema(manifest)?;
 
     let key = VerifyingKey::from_public_key_pem(public_key_pem.trim())
         .map_err(|e| format!("Invalid public key PEM: {}", e))?;
@@ -1627,7 +1746,7 @@ fn install_record_from_manifest(
     previous: Option<&RuntimeInstallRecord>,
 ) -> RuntimeInstallRecord {
     RuntimeInstallRecord {
-        schema_version: MANIFEST_SCHEMA_VERSION,
+        schema_version: RECORD_SCHEMA_VERSION,
         runtime_version: resolved.runtime_version.clone(),
         kernel_version: resolved.kernel_version.clone(),
         runtime_flavor: resolved.runtime_flavor.clone(),
@@ -1650,6 +1769,7 @@ async fn install_runtime_zip(
     resolved: RuntimeUpdateManifest,
     zip_path: &Path,
     source: &str,
+    stage_sink: Option<StageSink<'_>>,
 ) -> RuntimeInstallUpdateResult {
     let version_segment = match validate_manifest_for_current_platform(&resolved) {
         Ok(version_segment) => version_segment,
@@ -1663,6 +1783,12 @@ async fn install_runtime_zip(
         }
     };
 
+    emit_stage(
+        stage_sink,
+        UpdateStage::Verifying {
+            new_version: resolved.runtime_version.clone(),
+        },
+    );
     let digest = match file_sha256(zip_path) {
         Some(digest) => digest,
         None => {
@@ -1727,6 +1853,12 @@ async fn install_runtime_zip(
         }
     };
 
+    emit_stage(
+        stage_sink,
+        UpdateStage::Extracting {
+            new_version: resolved.runtime_version.clone(),
+        },
+    );
     if let Err(e) = extract_zip(&cached_zip_path, staging.path()) {
         return RuntimeInstallUpdateResult {
             ok: false,
@@ -1748,6 +1880,12 @@ async fn install_runtime_zip(
         }
     };
 
+    emit_stage(
+        stage_sink,
+        UpdateStage::SmokeChecking {
+            new_version: resolved.runtime_version.clone(),
+        },
+    );
     if let Err(e) = smoke_check_runtime(&executable).await {
         return RuntimeInstallUpdateResult {
             ok: false,
@@ -1757,6 +1895,12 @@ async fn install_runtime_zip(
         };
     }
 
+    emit_stage(
+        stage_sink,
+        UpdateStage::Installing {
+            new_version: resolved.runtime_version.clone(),
+        },
+    );
     let target = versions_root().join(&version_segment);
     if let Err(e) = remove_existing_runtime_target(&target) {
         return RuntimeInstallUpdateResult {
@@ -2057,6 +2201,23 @@ pub async fn install_bundled_runtime_if_needed(
                 previous: Some(current),
                 error: None,
             };
+        } else if is_version_downgrade(&manifest.runtime_version, &current.runtime_version) {
+            // Overwrite-install safety: a user who auto-updated the kernel past
+            // the version bundled with this (newer) shell installer must NOT be
+            // silently downgraded back to the bundled kernel. Keep the newer
+            // installed runtime and skip the resource sync too — the bundled
+            // dashboard web_dist/skills belong to the older bundled kernel.
+            log::info!(
+                "Bundled runtime {} is older than installed {}; keeping the installed runtime",
+                manifest.runtime_version,
+                current.runtime_version
+            );
+            return RuntimeInstallUpdateResult {
+                ok: true,
+                installed: None,
+                previous: Some(current),
+                error: None,
+            };
         }
     }
 
@@ -2072,7 +2233,7 @@ pub async fn install_bundled_runtime_if_needed(
     let mut result = if has_expanded_runtime {
         install_runtime_tree(manifest, &expanded_runtime_dir, "bundled").await
     } else {
-        install_runtime_zip(manifest, &artifact_path, "bundled").await
+        install_runtime_zip(manifest, &artifact_path, "bundled", None).await
     };
     if result.ok {
         if let Some(installed) = &result.installed {
@@ -2090,6 +2251,7 @@ pub async fn install_bundled_runtime_if_needed(
 /// Download, verify, and install a runtime update.
 pub async fn install_runtime_update(
     manifest: Option<RuntimeUpdateManifest>,
+    stage_sink: Option<StageSink<'_>>,
 ) -> RuntimeInstallUpdateResult {
     let resolved = match manifest {
         Some(m) => m,
@@ -2121,6 +2283,35 @@ pub async fn install_runtime_update(
             previous: None,
             error: Some(e),
         };
+    }
+
+    // Post-signature gates. Both fields are signature-protected, so at this
+    // point they carry the release pipeline's intent, not an attacker's.
+    // `check` surfaces them as flags; install must re-enforce because callers
+    // can pass a manifest directly and skip the check step.
+    if let Some(required) = blocking_min_app_version(&resolved) {
+        return RuntimeInstallUpdateResult {
+            ok: false,
+            installed: None,
+            previous: None,
+            error: Some(format!(
+                "此内核更新要求桌面端版本 ≥ {required}（当前 {}），请先升级桌面应用后再更新内核",
+                desktop_app_version()
+            )),
+        };
+    }
+    if let Some(current) = read_current_record() {
+        if is_version_downgrade(&resolved.runtime_version, &current.runtime_version) {
+            return RuntimeInstallUpdateResult {
+                ok: false,
+                installed: None,
+                previous: None,
+                error: Some(format!(
+                    "已拒绝降级安装：更新源提供的内核 {} 低于当前已安装的 {}",
+                    resolved.runtime_version, current.runtime_version
+                )),
+            };
+        }
     }
 
     let version_segment = match validate_manifest_for_current_platform(&resolved) {
@@ -2156,6 +2347,12 @@ pub async fn install_runtime_update(
         }
     }
 
+    emit_stage(
+        stage_sink,
+        UpdateStage::Downloading {
+            new_version: resolved.runtime_version.clone(),
+        },
+    );
     let artifact = match RUNTIME_HTTP_CLIENT
         .get(&resolved.artifact_url)
         .timeout(RUNTIME_ARTIFACT_HTTP_TIMEOUT)
@@ -2211,7 +2408,7 @@ pub async fn install_runtime_update(
         };
     }
 
-    install_runtime_zip(resolved, &zip_path, "update").await
+    install_runtime_zip(resolved, &zip_path, "update", stage_sink).await
 }
 
 /// Rollback to the previous runtime version.
@@ -2278,7 +2475,7 @@ pub fn rollback_runtime() -> RuntimeInstallUpdateResult {
         read_json_file(&prev_path.join(MANIFEST_FILE));
 
     let installed = RuntimeInstallRecord {
-        schema_version: MANIFEST_SCHEMA_VERSION,
+        schema_version: RECORD_SCHEMA_VERSION,
         runtime_version: prev_runtime_version.clone(),
         kernel_version: prev_manifest
             .as_ref()
@@ -2773,7 +2970,9 @@ mod tests {
 
     fn fixture_manifest() -> RuntimeUpdateManifest {
         RuntimeUpdateManifest {
-            schema_version: MANIFEST_SCHEMA_VERSION,
+            // v2 manifest fixture — the original 12-field signature payload.
+            // v3 tests clone this and bump schema + minAppVersion.
+            schema_version: 2,
             channel: "stable".to_string(),
             runtime_version: "1.2.3-cn.1".to_string(),
             kernel_version: "1.2.3".to_string(),
@@ -3083,7 +3282,7 @@ mod tests {
         sign_manifest(&key, &mut manifest);
         std::env::set_var("HERMES_RUNTIME_UPDATE_PUBLIC_KEY_PEM", pem);
 
-        let result = install_runtime_update(Some(manifest)).await;
+        let result = install_runtime_update(Some(manifest), None).await;
 
         std::env::remove_var("HERMES_RUNTIME_UPDATE_PUBLIC_KEY_PEM");
         assert!(!result.ok);
@@ -3108,7 +3307,7 @@ mod tests {
         std::env::set_var("HERMES_DESKTOP_RUNTIME_ROOT", &runtime_root);
 
         let current = RuntimeInstallRecord {
-            schema_version: MANIFEST_SCHEMA_VERSION,
+            schema_version: RECORD_SCHEMA_VERSION,
             runtime_version: "current".to_string(),
             kernel_version: "1.0.0".to_string(),
             runtime_flavor: "cn".to_string(),
@@ -3240,7 +3439,7 @@ mod tests {
         .unwrap();
 
         let record = read_current_record().expect("legacy record should migrate");
-        assert_eq!(record.schema_version, MANIFEST_SCHEMA_VERSION);
+        assert_eq!(record.schema_version, RECORD_SCHEMA_VERSION);
         assert_eq!(record.runtime_version, runtime_version);
         assert_eq!(record.kernel_version, "0.14.0");
         assert_eq!(record.runtime_flavor, "cn-local");
@@ -3252,6 +3451,59 @@ mod tests {
         assert!(rewritten.contains(r#""schemaVersion": 2"#));
         assert!(rewritten.contains(r#""runtimeVersion": "dev-local-0.14.0"#));
         assert!(!rewritten.contains(r#""upstreamRepo""#));
+
+        std::env::remove_var("HERMES_DESKTOP_RUNTIME_ROOT");
+    }
+
+    #[test]
+    #[serial]
+    fn read_current_record_accepts_forward_record_schema_but_rejects_unknown() {
+        // Records are written as schema 2 (RECORD_SCHEMA_VERSION) and the
+        // reader additionally accepts 3, so a future record bump can ship
+        // reader-first without orphaning installs. Unknown schemas still mean
+        // "nothing installed" — that fallback is exactly the re-bootstrap
+        // hazard the forward window exists to avoid.
+        let tmp = TempDir::new().unwrap();
+        std::env::set_var("HERMES_DESKTOP_RUNTIME_ROOT", tmp.path());
+
+        let runtime_dir = tmp.path().join("versions").join("0.18.2-cn.7");
+        let exe = runtime_dir.join("hermes");
+        fs::create_dir_all(&runtime_dir).unwrap();
+        fs::write(&exe, "#!/bin/sh\n").unwrap();
+
+        let write_record = |schema: u32| {
+            fs::write(
+                current_record_path(),
+                serde_json::to_string_pretty(&serde_json::json!({
+                    "schemaVersion": schema,
+                    "runtimeVersion": "0.18.2-cn.7",
+                    "kernelVersion": "0.18.2",
+                    "runtimeFlavor": "cn",
+                    "runtimeRevision": 7,
+                    "platform": current_platform(),
+                    "arch": current_arch(),
+                    "path": runtime_dir.display().to_string(),
+                    "executablePath": exe.display().to_string(),
+                    "source": "update",
+                    "installedAt": "2026-07-18T00:00:00.000Z",
+                }))
+                .unwrap(),
+            )
+            .unwrap();
+        };
+
+        write_record(2);
+        assert!(read_current_record().is_some(), "schema 2 must be accepted");
+        write_record(3);
+        assert!(
+            read_current_record().is_some(),
+            "schema 3 is the forward-compat window"
+        );
+        write_record(4);
+        assert!(
+            read_current_record().is_none(),
+            "unknown schemas must be treated as not installed"
+        );
 
         std::env::remove_var("HERMES_DESKTOP_RUNTIME_ROOT");
     }
@@ -3357,6 +3609,100 @@ mod tests {
         assert_ne!(signature_payload(&m2), baseline);
     }
 
+    fn fixture_manifest_v3() -> RuntimeUpdateManifest {
+        let mut m = fixture_manifest();
+        m.schema_version = 3;
+        m.min_app_version = Some("0.7.0".to_string());
+        m
+    }
+
+    #[test]
+    fn signature_payload_v3_appends_min_app_version_as_field_13() {
+        // Cross-language order lock with Core's sign_runtime_manifest.py:
+        // v3 = the 12 v2 fields, then minAppVersion. Any reorder or resize
+        // here must ship together with the Python signer.
+        let payload = String::from_utf8(signature_payload(&fixture_manifest_v3())).unwrap();
+        let lines: Vec<&str> = payload.split('\n').collect();
+        assert_eq!(lines.len(), 13);
+        assert_eq!(lines[0], "3");
+        assert_eq!(lines[12], "0.7.0");
+        // The first 12 fields keep the exact v2 order.
+        let v2_payload = String::from_utf8(signature_payload(&fixture_manifest())).unwrap();
+        let v2_lines: Vec<&str> = v2_payload.split('\n').collect();
+        assert_eq!(&lines[1..12], &v2_lines[1..12]);
+    }
+
+    #[test]
+    fn signature_payload_v2_ignores_min_app_version() {
+        // A v2 manifest must produce a byte-identical payload whether or not
+        // the (unsigned, optional) minAppVersion field happens to be present —
+        // otherwise old signatures would break the moment Core starts
+        // emitting the field.
+        let baseline = signature_payload(&fixture_manifest());
+        let mut m = fixture_manifest();
+        m.min_app_version = Some("9.9.9".to_string());
+        assert_eq!(signature_payload(&m), baseline);
+    }
+
+    #[test]
+    fn validate_manifest_schema_accepts_supported_versions_only() {
+        assert!(validate_manifest_schema(&fixture_manifest()).is_ok());
+        assert!(validate_manifest_schema(&fixture_manifest_v3()).is_ok());
+
+        let mut v3_missing = fixture_manifest();
+        v3_missing.schema_version = 3;
+        let err = validate_manifest_schema(&v3_missing).unwrap_err();
+        assert!(err.contains("minAppVersion"), "unexpected error: {err}");
+
+        let mut v3_blank = fixture_manifest_v3();
+        v3_blank.min_app_version = Some("   ".to_string());
+        assert!(validate_manifest_schema(&v3_blank).is_err());
+
+        let mut v4 = fixture_manifest();
+        v4.schema_version = 4;
+        assert!(validate_manifest_schema(&v4).is_err());
+        let mut v1 = fixture_manifest();
+        v1.schema_version = 1;
+        assert!(validate_manifest_schema(&v1).is_err());
+    }
+
+    // -------- version gates --------
+
+    #[test]
+    fn is_version_downgrade_orders_cn_revisions_numerically() {
+        // cn.<rev> is a numeric pre-release identifier: cn.2 < cn.10.
+        assert!(is_version_downgrade("0.18.2-cn.2", "0.18.2-cn.10"));
+        assert!(!is_version_downgrade("0.18.2-cn.10", "0.18.2-cn.2"));
+        // Kernel bump beats revision.
+        assert!(is_version_downgrade("0.18.2-cn.9", "0.18.3-cn.1"));
+        assert!(!is_version_downgrade("0.18.3-cn.1", "0.18.2-cn.9"));
+        // Equal is not a downgrade.
+        assert!(!is_version_downgrade("0.18.2-cn.7", "0.18.2-cn.7"));
+        // Unparseable falls back to "not a downgrade" (legacy behavior).
+        assert!(!is_version_downgrade("dev-local-0.14.0-abc", "0.18.2-cn.7"));
+        assert!(!is_version_downgrade("0.18.2-cn.7", "dev-local-0.14.0-abc"));
+    }
+
+    #[test]
+    fn blocking_min_app_version_gates_only_newer_requirements() {
+        let mut m = fixture_manifest_v3();
+        // Far above any real desktop version → blocked.
+        m.min_app_version = Some("999.0.0".to_string());
+        assert_eq!(blocking_min_app_version(&m).as_deref(), Some("999.0.0"));
+        // At or below the current desktop version → allowed.
+        m.min_app_version = Some(desktop_app_version().to_string());
+        assert_eq!(blocking_min_app_version(&m), None);
+        m.min_app_version = Some("0.0.1".to_string());
+        assert_eq!(blocking_min_app_version(&m), None);
+        // Absent / blank / unparseable never block.
+        m.min_app_version = None;
+        assert_eq!(blocking_min_app_version(&m), None);
+        m.min_app_version = Some("  ".to_string());
+        assert_eq!(blocking_min_app_version(&m), None);
+        m.min_app_version = Some("not-a-version".to_string());
+        assert_eq!(blocking_min_app_version(&m), None);
+    }
+
     // -------- verify_signature_with_key --------
 
     #[test]
@@ -3365,6 +3711,30 @@ mod tests {
         let mut m = fixture_manifest();
         sign_manifest(&key, &mut m);
         verify_signature_with_key(&m, &pem).expect("should verify");
+    }
+
+    #[test]
+    fn verify_accepts_valid_v3_signature_and_detects_min_app_version_tampering() {
+        let (key, pem) = test_keypair();
+        let mut m = fixture_manifest_v3();
+        sign_manifest(&key, &mut m);
+        verify_signature_with_key(&m, &pem).expect("v3 should verify");
+
+        // minAppVersion is inside the v3 payload — tampering (e.g. a MITM
+        // nulling the forced-upgrade gate) must break the signature.
+        let mut tampered = m.clone();
+        tampered.min_app_version = Some("0.0.1".to_string());
+        assert!(verify_signature_with_key(&tampered, &pem).is_err());
+    }
+
+    #[test]
+    fn verify_rejects_v3_manifest_without_min_app_version() {
+        let (key, pem) = test_keypair();
+        let mut m = fixture_manifest();
+        m.schema_version = 3;
+        sign_manifest(&key, &mut m);
+        let err = verify_signature_with_key(&m, &pem).unwrap_err();
+        assert!(err.contains("minAppVersion"), "unexpected error: {err}");
     }
 
     #[test]
@@ -4017,6 +4387,67 @@ mod tests {
 
     #[tokio::test]
     #[serial]
+    async fn install_bundled_runtime_never_downgrades_a_newer_installed_runtime() {
+        // Overwrite-install safety (impl-plan §12.3): a user who auto-updated
+        // the kernel past the version bundled with a newer shell installer
+        // must keep their newer kernel — the bundled reconcile only installs
+        // when the bundled version is genuinely different AND not older.
+        let dir = TempDir::new().unwrap();
+        let runtime_root = dir.path().join("runtime-root");
+        let resource = dir.path().join("resources");
+        let bundled = resource.join("bundled-runtime");
+        std::fs::create_dir_all(bundled_expanded_runtime_dir(&bundled)).unwrap();
+
+        let mut manifest = fixture_manifest();
+        manifest.runtime_version = "0.18.2-cn.2".to_string();
+        manifest.platform = current_platform().to_string();
+        manifest.arch = current_arch().to_string();
+        write_json_file(&bundled_manifest_path(&bundled), &manifest).unwrap();
+
+        std::env::set_var("HERMES_DESKTOP_RUNTIME_ROOT", &runtime_root);
+
+        // Installed runtime is NEWER than the bundled one.
+        let installed_dir = runtime_root.join("versions").join("0.18.2-cn.5");
+        let installed_exe = installed_dir.join(primary_runtime_name());
+        std::fs::create_dir_all(&installed_dir).unwrap();
+        std::fs::write(&installed_exe, b"#!/bin/sh\nexit 0\n").unwrap();
+        let current = RuntimeInstallRecord {
+            schema_version: RECORD_SCHEMA_VERSION,
+            runtime_version: "0.18.2-cn.5".to_string(),
+            kernel_version: "0.18.2".to_string(),
+            runtime_flavor: "cn".to_string(),
+            runtime_revision: 5,
+            platform: current_platform().to_string(),
+            arch: current_arch().to_string(),
+            path: installed_dir.display().to_string(),
+            executable_path: installed_exe.display().to_string(),
+            source: "update".to_string(),
+            installed_at: "2026-07-18T00:00:00.000Z".to_string(),
+            source_repo: None,
+            source_commit: None,
+            local_dirty_hash: None,
+            artifact_sha256: None,
+            previous_runtime_version: None,
+        };
+        write_json_file(&current_record_path(), &current).unwrap();
+
+        let result = install_bundled_runtime_if_needed(Some(&resource)).await;
+
+        std::env::remove_var("HERMES_DESKTOP_RUNTIME_ROOT");
+
+        assert!(result.ok, "unexpected error: {:?}", result.error);
+        assert!(
+            result.installed.is_none(),
+            "bundled runtime must not be installed over a newer kernel"
+        );
+        assert_eq!(
+            result.previous.map(|p| p.runtime_version),
+            Some("0.18.2-cn.5".to_string())
+        );
+    }
+
+    #[tokio::test]
+    #[serial]
     #[cfg(unix)]
     async fn install_bundled_runtime_does_not_overwrite_local_source_runtime() {
         use std::os::unix::fs::PermissionsExt;
@@ -4065,7 +4496,7 @@ mod tests {
         std::fs::create_dir_all(local_exe.parent().unwrap()).unwrap();
         std::fs::write(&local_exe, b"#!/bin/sh\nexit 0\n").unwrap();
         let local_record = RuntimeInstallRecord {
-            schema_version: MANIFEST_SCHEMA_VERSION,
+            schema_version: RECORD_SCHEMA_VERSION,
             runtime_version: local_version.to_string(),
             kernel_version: "0.15.2".to_string(),
             runtime_flavor: "cn-local".to_string(),
@@ -4156,7 +4587,7 @@ mod tests {
         std::fs::create_dir_all(local_exe.parent().unwrap()).unwrap();
         std::fs::write(&local_exe, b"#!/bin/sh\nexit 0\n").unwrap();
         let local_record = RuntimeInstallRecord {
-            schema_version: MANIFEST_SCHEMA_VERSION,
+            schema_version: RECORD_SCHEMA_VERSION,
             runtime_version: local_version.to_string(),
             kernel_version: "0.15.2".to_string(),
             runtime_flavor: "cn-local".to_string(),

--- a/src/update_stage.rs
+++ b/src/update_stage.rs
@@ -2,8 +2,15 @@
 //
 // Inspired by Warp's autoupdate/mod.rs: clear enum-based stages make the
 // update lifecycle visible to the frontend and simplify error recovery.
+//
+// Stages are pushed to the webview as `runtime-update-stage` events while a
+// runtime install/rollback is in flight (commands/runtime_manager.rs threads a
+// sink into process/runtime.rs); the update overlay renders them as progress.
 
 use serde::Serialize;
+
+/// Tauri event name carrying [`UpdateStage`] payloads to the webview.
+pub const RUNTIME_UPDATE_STAGE_EVENT: &str = "runtime-update-stage";
 
 #[derive(Debug, Clone, Serialize)]
 #[serde(tag = "stage", rename_all = "camelCase")]
@@ -33,6 +40,12 @@ pub enum UpdateStage {
     RestartingDashboard {
         new_version: String,
     },
+    /// Half-updated: the new runtime is already installed on disk, but the
+    /// dashboard restart failed. The update itself succeeded — the frontend
+    /// must ask the user to restart the app, not report a failed update.
+    RestartRequired {
+        new_version: String,
+    },
     Complete {
         new_version: String,
         previous_version: Option<String>,
@@ -48,11 +61,17 @@ pub enum UpdateStage {
 }
 
 impl UpdateStage {
+    pub fn emit(&self, app: &tauri::AppHandle) {
+        use tauri::Emitter;
+        let _ = app.emit(RUNTIME_UPDATE_STAGE_EVENT, self);
+    }
+
     pub fn is_terminal(&self) -> bool {
         matches!(
             self,
             UpdateStage::Idle
                 | UpdateStage::NoUpdateAvailable
+                | UpdateStage::RestartRequired { .. }
                 | UpdateStage::Complete { .. }
                 | UpdateStage::Failed { .. }
                 | UpdateStage::RolledBack { .. }
@@ -93,6 +112,12 @@ mod tests {
         .is_terminal());
         assert!(UpdateStage::RolledBack {
             restored_version: v("0.9")
+        }
+        .is_terminal());
+        // Half-updated is terminal: the install itself finished — only a
+        // manual app restart is pending. Never render it as "in progress".
+        assert!(UpdateStage::RestartRequired {
+            new_version: v("1")
         }
         .is_terminal());
     }

--- a/tests/runtime_manifest.rs
+++ b/tests/runtime_manifest.rs
@@ -1,13 +1,17 @@
-// HTTP-boundary tests for runtime update manifest fetching.
+// HTTP-boundary tests for runtime update manifest fetching, plus the signed
+// v3 gates (minAppVersion forced-upgrade, semver anti-downgrade).
 //
 // check_runtime_update fetches and parses a remote manifest. It does NOT
-// verify the signature (that happens in install_runtime_update). Tests
-// here cover the fetch/parse/platform-match path.
+// verify the signature (that happens in install_runtime_update). The gate
+// tests for install pass a signed manifest directly — both gates fire before
+// any artifact download, so no HTTP mock is needed there.
 //
-// All tests are #[serial] because they mutate HERMES_RUNTIME_UPDATE_*
-// process-global env vars.
+// All tests are #[serial] because they mutate HERMES_RUNTIME_UPDATE_* /
+// HERMES_DESKTOP_RUNTIME_ROOT process-global env vars.
 
-use hermes_agent_cn::process::runtime::check_runtime_update;
+use hermes_agent_cn::process::runtime::{
+    check_runtime_update, install_runtime_update, RuntimeUpdateManifest,
+};
 use serial_test::serial;
 use wiremock::matchers::{method, path};
 use wiremock::{Mock, MockServer, ResponseTemplate};
@@ -159,4 +163,227 @@ async fn returns_error_for_wrong_platform() {
     assert!(err.contains("Manifest is for"), "got: {}", err);
 
     clear_env();
+}
+
+// -------- v3 schema + signed gates --------
+
+fn clear_gate_env() {
+    clear_env();
+    for var in [
+        "HERMES_DESKTOP_RUNTIME_ROOT",
+        "HERMES_RUNTIME_UPDATE_PUBLIC_KEY_PEM",
+    ] {
+        std::env::remove_var(var);
+    }
+}
+
+fn manifest_json_v3(runtime_version: &str, min_app_version: &str) -> serde_json::Value {
+    let mut m = manifest_json(runtime_version);
+    m["schemaVersion"] = serde_json::json!(3);
+    m["minAppVersion"] = serde_json::json!(min_app_version);
+    m
+}
+
+fn test_keypair() -> (ed25519_dalek::SigningKey, String) {
+    use ed25519_dalek::pkcs8::EncodePublicKey;
+    let signing_key = ed25519_dalek::SigningKey::from_bytes(&[9u8; 32]);
+    let pem = signing_key
+        .verifying_key()
+        .to_public_key_pem(ed25519_dalek::pkcs8::spki::der::pem::LineEnding::LF)
+        .unwrap();
+    (signing_key, pem)
+}
+
+/// Mirror of the cross-language signing contract (Core
+/// sign_runtime_manifest.py): one field per line, v3 appends minAppVersion.
+fn sign_manifest(key: &ed25519_dalek::SigningKey, manifest: &mut RuntimeUpdateManifest) {
+    use base64::Engine;
+    use ed25519_dalek::Signer;
+    let mut payload = format!(
+        "{}\n{}\n{}\n{}\n{}\n{}\n{}\n{}\n{}\n{}\n{}\n{}",
+        manifest.schema_version,
+        manifest.channel,
+        manifest.runtime_version,
+        manifest.kernel_version,
+        manifest.runtime_flavor,
+        manifest.runtime_revision,
+        manifest.platform,
+        manifest.arch,
+        manifest.artifact_url,
+        manifest.sha256,
+        manifest.source_repo,
+        manifest.source_commit,
+    );
+    if manifest.schema_version >= 3 {
+        payload.push('\n');
+        payload.push_str(manifest.min_app_version.as_deref().unwrap_or(""));
+    }
+    let sig = key.sign(payload.as_bytes());
+    manifest.signature = base64::engine::general_purpose::STANDARD.encode(sig.to_bytes());
+}
+
+/// Point the managed runtime tree at a temp dir holding an installed record
+/// for `runtime_version`, so read_current_record() resolves it.
+fn seed_current_record(root: &std::path::Path, runtime_version: &str) {
+    let installed_dir = root.join("versions").join(runtime_version);
+    let exe = installed_dir.join("hermes-agent-cn-runtime");
+    std::fs::create_dir_all(&installed_dir).unwrap();
+    std::fs::write(&exe, b"#!/bin/sh\nexit 0\n").unwrap();
+    std::fs::write(
+        root.join("current.json"),
+        serde_json::to_string_pretty(&serde_json::json!({
+            "schemaVersion": 2,
+            "runtimeVersion": runtime_version,
+            "kernelVersion": runtime_version.split("-cn.").next().unwrap_or(runtime_version),
+            "runtimeFlavor": "cn",
+            "runtimeRevision": 1,
+            "platform": host_platform(),
+            "arch": host_arch(),
+            "path": installed_dir.display().to_string(),
+            "executablePath": exe.display().to_string(),
+            "source": "update",
+            "installedAt": "2026-07-18T00:00:00.000Z",
+        }))
+        .unwrap(),
+    )
+    .unwrap();
+}
+
+#[tokio::test]
+#[serial]
+async fn v3_manifest_with_high_min_app_version_sets_force_flag() {
+    clear_gate_env();
+    let tmp = tempfile::TempDir::new().unwrap();
+    std::env::set_var("HERMES_DESKTOP_RUNTIME_ROOT", tmp.path());
+
+    let server = MockServer::start().await;
+    Mock::given(method("GET"))
+        .and(path("/manifest.json"))
+        .respond_with(
+            ResponseTemplate::new(200)
+                .set_body_json(manifest_json_v3("999.999.999-cn.1", "999.0.0")),
+        )
+        .mount(&server)
+        .await;
+    std::env::set_var(
+        "HERMES_RUNTIME_UPDATE_MANIFEST_URL",
+        format!("{}/manifest.json", server.uri()),
+    );
+
+    let result = check_runtime_update().await;
+
+    assert!(result.ok, "unexpected error: {:?}", result.error);
+    assert!(result.update_available);
+    assert!(result.force_app_update_required);
+    assert_eq!(result.required_app_version.as_deref(), Some("999.0.0"));
+
+    clear_gate_env();
+}
+
+#[tokio::test]
+#[serial]
+async fn v3_manifest_missing_min_app_version_fails_schema_check() {
+    clear_gate_env();
+    let mut body = manifest_json("999.999.999-cn.1");
+    body["schemaVersion"] = serde_json::json!(3);
+
+    let server = MockServer::start().await;
+    Mock::given(method("GET"))
+        .and(path("/manifest.json"))
+        .respond_with(ResponseTemplate::new(200).set_body_json(body))
+        .mount(&server)
+        .await;
+    std::env::set_var(
+        "HERMES_RUNTIME_UPDATE_MANIFEST_URL",
+        format!("{}/manifest.json", server.uri()),
+    );
+
+    let result = check_runtime_update().await;
+
+    assert!(!result.ok);
+    let err = result.error.unwrap();
+    assert!(err.contains("minAppVersion"), "got: {}", err);
+
+    clear_gate_env();
+}
+
+#[tokio::test]
+#[serial]
+async fn check_suppresses_downgrade_from_newer_installed_runtime() {
+    clear_gate_env();
+    let tmp = tempfile::TempDir::new().unwrap();
+    std::env::set_var("HERMES_DESKTOP_RUNTIME_ROOT", tmp.path());
+    seed_current_record(tmp.path(), "0.18.5-cn.3");
+
+    let server = MockServer::start().await;
+    Mock::given(method("GET"))
+        .and(path("/manifest.json"))
+        .respond_with(ResponseTemplate::new(200).set_body_json(manifest_json("0.18.2-cn.9")))
+        .mount(&server)
+        .await;
+    std::env::set_var(
+        "HERMES_RUNTIME_UPDATE_MANIFEST_URL",
+        format!("{}/manifest.json", server.uri()),
+    );
+
+    let result = check_runtime_update().await;
+
+    assert!(result.ok, "unexpected error: {:?}", result.error);
+    assert!(!result.update_available);
+    assert!(result.downgrade_blocked);
+    assert_eq!(
+        result.current_runtime_version.as_deref(),
+        Some("0.18.5-cn.3")
+    );
+
+    clear_gate_env();
+}
+
+#[tokio::test]
+#[serial]
+async fn install_rejects_signed_manifest_requiring_newer_desktop() {
+    clear_gate_env();
+    let tmp = tempfile::TempDir::new().unwrap();
+    std::env::set_var("HERMES_DESKTOP_RUNTIME_ROOT", tmp.path());
+
+    let (key, pem) = test_keypair();
+    std::env::set_var("HERMES_RUNTIME_UPDATE_PUBLIC_KEY_PEM", pem);
+
+    let mut manifest: RuntimeUpdateManifest =
+        serde_json::from_value(manifest_json_v3("999.999.999-cn.1", "999.0.0")).unwrap();
+    sign_manifest(&key, &mut manifest);
+
+    // The gate fires after signature verification and before any download,
+    // so no artifact server is needed.
+    let result = install_runtime_update(Some(manifest), None).await;
+
+    assert!(!result.ok);
+    let err = result.error.unwrap();
+    assert!(err.contains("升级桌面应用"), "got: {}", err);
+
+    clear_gate_env();
+}
+
+#[tokio::test]
+#[serial]
+async fn install_rejects_signed_downgrade_manifest() {
+    clear_gate_env();
+    let tmp = tempfile::TempDir::new().unwrap();
+    std::env::set_var("HERMES_DESKTOP_RUNTIME_ROOT", tmp.path());
+    seed_current_record(tmp.path(), "0.18.5-cn.3");
+
+    let (key, pem) = test_keypair();
+    std::env::set_var("HERMES_RUNTIME_UPDATE_PUBLIC_KEY_PEM", pem);
+
+    let mut manifest: RuntimeUpdateManifest =
+        serde_json::from_value(manifest_json("0.18.2-cn.9")).unwrap();
+    sign_manifest(&key, &mut manifest);
+
+    let result = install_runtime_update(Some(manifest), None).await;
+
+    assert!(!result.ok);
+    let err = result.error.unwrap();
+    assert!(err.contains("降级"), "got: {}", err);
+
+    clear_gate_env();
 }

--- a/web/src/components/runtime-update-overlay.tsx
+++ b/web/src/components/runtime-update-overlay.tsx
@@ -1,5 +1,7 @@
 import { useAtomValue } from "jotai";
-import { runtimeUpdatingAtom } from "@/stores/ui";
+import type { RuntimeUpdateStage } from "@hermes/protocol";
+import { runtimeUpdateStageAtom, runtimeUpdatingAtom } from "@/stores/ui";
+import { useRuntimeUpdateStageListener } from "@/hooks/use-runtime-update";
 import s from "./profile-switch-overlay.module.css";
 
 // 仅在桌面端安装 runtime 更新 / 回滚期间显示。和切 profile 一样，主进程会
@@ -7,8 +9,46 @@ import s from "./profile-switch-overlay.module.css";
 // 都会重新随机生成（web_server.py: secrets.token_urlsafe(32)）。重启窗口里
 // 前端缓存的旧 token 打到新进程会 401。挡住 UI 直到 onSettled 刷新完 token，
 // 顺带让用户知道正在发生什么，而不是看到一堆 401 / network error。
+//
+// 主进程在更新过程中经 "runtime-update-stage" 事件推送阶段
+// （src/update_stage.rs），这里把泛化的转圈文案换成具体阶段。
+
+function stageTitle(stage: RuntimeUpdateStage | null, isRollback: boolean): string {
+  switch (stage?.stage) {
+    case "downloading":
+      return `正在下载内核 ${stage.new_version}…`;
+    case "verifying":
+      return "正在校验签名与完整性…";
+    case "extracting":
+      return "正在解压…";
+    case "smokeChecking":
+      return "正在自检新内核…";
+    case "installing":
+      return "正在安装…";
+    case "restartingDashboard":
+      return "正在重启内核…";
+    case "rollingBack":
+      return "正在恢复到上一版本…";
+    case "restartRequired":
+      return "更新已完成，等待重启";
+    default:
+      return isRollback ? "正在恢复到上一版本…" : "正在更新 Hermes…";
+  }
+}
+
+function stageBody(stage: RuntimeUpdateStage | null): string {
+  if (stage?.stage === "restartRequired") {
+    // 半更新态：runtime 已换好，只是内核自动重启失败。文案必须指向
+    // "重启应用"，绝不能让用户误以为更新失败而重试。
+    return "新内核已安装生效，但自动重启失败。请手动重启应用完成收尾。";
+  }
+  return "更新期间内核会重启，连接将短暂断开，通常只需几秒。请勿关闭应用。";
+}
+
 export function RuntimeUpdateOverlay() {
+  useRuntimeUpdateStageListener();
   const state = useAtomValue(runtimeUpdatingAtom);
+  const stage = useAtomValue(runtimeUpdateStageAtom);
   if (!state.active) return null;
   const isRollback = state.mode === "rollback";
   return (
@@ -16,11 +56,9 @@ export function RuntimeUpdateOverlay() {
       <div className={s.card}>
         <div className={s.title}>
           <span className={s.spinner} aria-hidden="true" />
-          {isRollback ? "正在恢复到上一版本…" : "正在更新 Hermes…"}
+          {stageTitle(stage, isRollback)}
         </div>
-        <div className={s.body}>
-          更新期间内核会重启，连接将短暂断开，通常只需几秒。请勿关闭应用。
-        </div>
+        <div className={s.body}>{stageBody(stage)}</div>
       </div>
     </div>
   );

--- a/web/src/hooks/use-runtime-update.ts
+++ b/web/src/hooks/use-runtime-update.ts
@@ -1,14 +1,17 @@
+import { useEffect } from "react";
 import { useMutation, useQuery, useQueryClient } from "@tanstack/react-query";
 import { useSetAtom } from "jotai";
 import type {
   RuntimeInfo,
   RuntimeInstallUpdateResult,
   RuntimeUpdateCheckResult,
+  RuntimeUpdateStage,
 } from "@hermes/protocol";
+import { RUNTIME_UPDATE_STAGE_EVENT } from "@hermes/protocol";
 import { runtime } from "@/lib/runtime";
 import { raceAbort } from "@/lib/transport";
 import { forceExistingGatewayReconnect } from "@/lib/gateway-client";
-import { runtimeUpdatingAtom } from "@/stores/ui";
+import { runtimeUpdateStageAtom, runtimeUpdatingAtom } from "@/stores/ui";
 
 const RUNTIME_INFO_KEY = ["desktop-runtime-info"] as const;
 
@@ -23,6 +26,39 @@ async function refreshDesktopGateway(): Promise<void> {
     await runtime.refreshGatewayUrl();
     forceExistingGatewayReconnect("runtime-update");
   }
+}
+
+/**
+ * Subscribe to the Rust-side runtime-update-stage events (update_stage.rs)
+ * and mirror the latest stage into runtimeUpdateStageAtom. Mount once from a
+ * window-level component (RuntimeUpdateOverlay) — only Tauri emits the event,
+ * so non-Tauri platforms register nothing.
+ */
+export function useRuntimeUpdateStageListener() {
+  const setStage = useSetAtom(runtimeUpdateStageAtom);
+  useEffect(() => {
+    if (runtime.platform !== "tauri") return;
+    let unlisten: (() => void) | null = null;
+    let disposed = false;
+    void import("@tauri-apps/api/event")
+      .then(({ listen }) =>
+        listen<RuntimeUpdateStage>(RUNTIME_UPDATE_STAGE_EVENT, (event) => {
+          setStage(event.payload);
+        }),
+      )
+      .then((fn) => {
+        if (disposed) fn();
+        else unlisten = fn;
+      })
+      .catch(() => {
+        // Event bridge unavailable (e.g. plain browser) — overlay falls back
+        // to its stage-less copy.
+      });
+    return () => {
+      disposed = true;
+      unlisten?.();
+    };
+  }, [setStage]);
 }
 
 export function useRuntimeInfo() {
@@ -44,12 +80,14 @@ export function useCheckRuntimeUpdate() {
 export function useInstallRuntimeUpdate() {
   const qc = useQueryClient();
   const setUpdating = useSetAtom(runtimeUpdatingAtom);
+  const setStage = useSetAtom(runtimeUpdateStageAtom);
   return useMutation<RuntimeInstallUpdateResult>({
     mutationFn: () => window.hermesDesktop!.installRuntimeUpdate!(),
     // Raise the blocking overlay before the IPC call so the dashboard restart
     // window (stale token → 401) never surfaces to the user. Keep it up through
     // onSettled until the token has been refreshed.
     onMutate: () => {
+      setStage(null);
       setUpdating({ active: true, mode: "install" });
     },
     onSettled: async () => {
@@ -65,9 +103,11 @@ export function useInstallRuntimeUpdate() {
 export function useRollbackRuntime() {
   const qc = useQueryClient();
   const setUpdating = useSetAtom(runtimeUpdatingAtom);
+  const setStage = useSetAtom(runtimeUpdateStageAtom);
   return useMutation<RuntimeInstallUpdateResult>({
     mutationFn: () => window.hermesDesktop!.rollbackRuntime!(),
     onMutate: () => {
+      setStage(null);
       setUpdating({ active: true, mode: "rollback" });
     },
     onSettled: async () => {

--- a/web/src/routes/settings.tsx
+++ b/web/src/routes/settings.tsx
@@ -1241,7 +1241,14 @@ export function KernelSection({ showHeading = true }: SettingsSectionProps) {
   const checking = checkRuntimeUpdate.isPending;
   const rollingBack = rollbackRuntime.isPending;
   const hasRuntimeBridge = typeof window !== "undefined" && Boolean(window.hermesDesktop?.getRuntimeInfo);
-  const canInstall = Boolean(updateResult?.ok && updateResult.updateAvailable && info?.updatesConfigured);
+  // forceAppUpdateRequired：manifest 签名的 minAppVersion 高于当前桌面端，
+  // Rust 侧 install 也会拒绝——这里同步禁用按钮并引导先升级桌面应用。
+  const canInstall = Boolean(
+    updateResult?.ok &&
+    updateResult.updateAvailable &&
+    !updateResult.forceAppUpdateRequired &&
+    info?.updatesConfigured,
+  );
   const refreshing = runtimeInfo.isFetching || statusQuery.isFetching;
   const runtimeInsideRoot = Boolean(
     info?.current?.executablePath &&
@@ -1899,6 +1906,13 @@ function formatDateTime(value: string | undefined): string {
 
 function formatRuntimeUpdateResult(result: RuntimeUpdateCheckResult): string {
   if (!result.ok) return result.error ?? "runtime 更新检查失败";
+  if (result.forceAppUpdateRequired) {
+    const required = result.requiredAppVersion ?? result.manifest?.minAppVersion ?? "";
+    return `发现新 runtime ${result.manifest?.runtimeVersion ?? ""}，但需要桌面端 ≥ ${required}，请先升级桌面应用`.trim();
+  }
+  if (result.downgradeBlocked) {
+    return `更新源提供的 runtime ${result.manifest?.runtimeVersion ?? ""} 低于当前已安装版本，已忽略（防降级保护）`.trim();
+  }
   if (!result.updateAvailable) return `已是最新版本 ${result.currentRuntimeVersion ?? ""}`.trim();
   return `发现新 runtime ${result.manifest?.runtimeVersion ?? ""}`.trim();
 }

--- a/web/src/stores/ui.ts
+++ b/web/src/stores/ui.ts
@@ -1,4 +1,5 @@
 import { atom } from "jotai";
+import type { RuntimeUpdateStage } from "@hermes/protocol";
 import type { ComposerSubmitShortcut } from "@/lib/composer-submit-shortcut";
 import { readUiValue, writeUiValue } from "@/lib/ui-store";
 import hermesDefaultAvatar from "@/assets/hermes-default-avatar.png";
@@ -289,3 +290,9 @@ export const profileSwitchingAtom = atom<{
 export const runtimeUpdatingAtom = atom<{ active: boolean; mode?: "install" | "rollback" }>({
   active: false,
 });
+
+// Latest runtime-update-stage event from the Rust side (update_stage.rs),
+// written by the listener in use-runtime-update.ts while an install/rollback
+// is in flight. The RuntimeUpdateOverlay renders it as stage-level progress;
+// null means "no stage received yet" (overlay falls back to generic copy).
+export const runtimeUpdateStageAtom = atom<RuntimeUpdateStage | null>(null);


### PR DESCRIPTION
## 背景

热更新三轨道落地的第一步（轨道 A 收口，客户端先行）。设计依据 `docs/hot-update-impl-plan.md` §3：内核 OTA 引擎已完备，但缺三根"保险栓"——`minAppVersion` 是死字段且不受签名保护、更新判定纯字符串 `!=` 可被诱导降级、`update_stage.rs` 进度状态机是死代码。

**发布顺序约束（重要）**：本 PR 是 Core 侧签名清单切 schema v3 的前置。必须先随桌面端新版本（0.7.0）铺开，Core 的 `sign_runtime_manifest.py` 才能切 v3，否则存量客户端无法验签新清单。

## 改动

### semver 防降级
- `check_runtime_update` 判定改为 semver 比较（`0.18.2-cn.N` 的 `cn.N` 按数值序），同渠道只升不降，新增 `downgradeBlocked` 字段
- `install_runtime_update` 入口独立复验（check 可被绕过）
- `install_bundled_runtime_if_needed` 加"当前更新则不降级"守卫，修复覆盖安装静默降级已自更内核的坑（impl-plan §12.3）
- 解析失败回退旧的字符串不等行为，不因版式问题卡死更新

### v2/v3 双 schema + minAppVersion 强升闸门
- 签名载荷按 schema 分派：v3 = 12 字段 + 末位 `minAppVersion`（与 Core signer 的跨语言契约，顺序锁测试锁定）；v3 缺 `minAppVersion` 直接拒绝
- 闸门：清单要求高于当前桌面版本时 `forceAppUpdateRequired=true`、install 拒绝；版本号取 `CARGO_PKG_VERSION` 防前端篡改
- **current.json 记录 schema 保持 2 不 bump**（记录结构未变），读取放宽到 {2,3} 留前向窗口——bump 会触发全员重 bootstrap

### 进度状态机接活
- install/rollback 各阶段经 `runtime-update-stage` 事件推送，前端遮罩升级为阶段进度面板
- 新增 `RestartRequired` 半更新态：install 成功但内核重启失败时，文案指向"请重启应用"（更新已生效），不再误报"更新失败"诱导重试

## 测试

- 单测：载荷 v2/v3 顺序锁、v2 对 minAppVersion 字段不敏感、schema 校验、semver 比较表、闸门表、record 前向兼容、bundled 防降级、篡改 minAppVersion 验签失败
- 集成（wiremock + 测试密钥）：v3 check、强升闸门 flag、防降级抑制、install 双闸门拒绝
- `cargo test --all-features` 454+ 通过、clippy/fmt 干净、`pnpm typecheck` + 980 vitest 通过

🤖 Generated with [Claude Code](https://claude.com/claude-code)