### PR TITLE
feat: 新增插件完整管理页面

### DIFF
--- a/e2e/harness/config.mjs
+++ b/e2e/harness/config.mjs
@@ -18,6 +18,8 @@ export const VENV_PY =
 export const RUNTIME_DIR = resolve(E2E_DIR, ".runtime");
 export const HERMES_HOME = resolve(RUNTIME_DIR, "hermes-home");
 export const UPLOAD_DIR = resolve(RUNTIME_DIR, "uploads");
+export const PLUGIN_SOURCE_DIR = resolve(RUNTIME_DIR, "e2e-installed-plugin");
+export const PLUGIN_IMPORT_MARKER = resolve(RUNTIME_DIR, "plugin-imported.txt");
 // Stub SPA dist so the dashboard serves *something* at `/` (we use the desktop's
 // own Vite frontend; Core's UI is irrelevant here). HERMES_WEB_DIST overrides
 // the built-in web_dist path, letting us pass --skip-build without a real build.
@@ -55,6 +57,9 @@ export function configYaml() {
     "  user_profile_enabled: false",
     "compression:",
     "  enabled: false",
+    "plugins:",
+    "  enabled: []",
+    "  disabled: []",
     "",
   ].join("\n");
 }
@@ -66,6 +71,7 @@ export function coreEnv() {
     HERMES_HOME,
     HERMES_WEB_DIST: WEB_DIST,
     HERMES_DASHBOARD_SESSION_TOKEN: DASHBOARD_TOKEN,
+    E2E_PLUGIN_IMPORT_MARKER: PLUGIN_IMPORT_MARKER,
     // Belt-and-suspenders: config.base_url already wins, but these guarantee the
     // OpenAI-compatible client targets the fake server even if provider
     // resolution is surprising.

--- a/e2e/harness/start-backend.mjs
+++ b/e2e/harness/start-backend.mjs
@@ -8,7 +8,7 @@
 //
 // On SIGINT/SIGTERM (or when Playwright tears the webServer down) every child is
 // killed. Run standalone for debugging: `node harness/start-backend.mjs`.
-import { spawn } from "node:child_process";
+import { spawn, spawnSync } from "node:child_process";
 import { rmSync, mkdirSync, writeFileSync, existsSync } from "node:fs";
 import { resolve } from "node:path";
 import {
@@ -18,6 +18,7 @@ import {
   RUNTIME_DIR,
   HERMES_HOME,
   UPLOAD_DIR,
+  PLUGIN_SOURCE_DIR,
   WEB_DIST,
   FAKE_MODEL_PORT,
   FAKE_MODEL_HEALTH,
@@ -29,6 +30,63 @@ import {
 import { waitForHttp, waitForLine } from "./wait.mjs";
 
 const children = [];
+
+function runGit(args) {
+  const result = spawnSync("git", args, {
+    cwd: PLUGIN_SOURCE_DIR,
+    encoding: "utf8",
+  });
+  if (result.status !== 0) {
+    throw new Error(`git ${args.join(" ")} failed: ${result.stderr || result.stdout}`);
+  }
+}
+
+function preparePluginSource() {
+  mkdirSync(PLUGIN_SOURCE_DIR, { recursive: true });
+  writeFileSync(
+    resolve(PLUGIN_SOURCE_DIR, "plugin.yaml"),
+    [
+      "name: e2e-installed-plugin",
+      "version: 1.0.0",
+      "description: E2E lifecycle plugin from a local Git repository.",
+      "author: Hermes CN E2E",
+      "kind: standalone",
+      "provides_tools:",
+      "  - e2e_echo",
+      "requires_env:",
+      "  - E2E_PLUGIN_TOKEN",
+      "",
+    ].join("\n"),
+  );
+  writeFileSync(
+    resolve(PLUGIN_SOURCE_DIR, "__init__.py"),
+    [
+      "import os",
+      "from pathlib import Path",
+      "",
+      "Path(os.environ['E2E_PLUGIN_IMPORT_MARKER']).write_text('imported', encoding='utf-8')",
+      "",
+      "def register(ctx):",
+      "    ctx.register_tool(",
+      "        name='e2e_echo',",
+      "        toolset='plugin_e2e_installed_plugin',",
+      "        schema={",
+      "            'name': 'e2e_echo',",
+      "            'description': 'Return a deterministic E2E response.',",
+      "            'parameters': {'type': 'object', 'properties': {}},",
+      "        },",
+      "        handler=lambda _args: 'e2e-ok',",
+      "        description='Return a deterministic E2E response.',",
+      "    )",
+      "",
+    ].join("\n"),
+  );
+  runGit(["init", "--quiet", "--initial-branch=main"]);
+  runGit(["config", "user.name", "Hermes E2E"]);
+  runGit(["config", "user.email", "e2e@hermes.invalid"]);
+  runGit(["add", "plugin.yaml", "__init__.py"]);
+  runGit(["commit", "--quiet", "-m", "test: add lifecycle plugin"]);
+}
 
 function spawnChild(label, cmd, args, opts) {
   const child = spawn(cmd, args, { ...opts });
@@ -70,6 +128,7 @@ async function main() {
   mkdirSync(HERMES_HOME, { recursive: true });
   mkdirSync(UPLOAD_DIR, { recursive: true });
   writeFileSync(resolve(HERMES_HOME, "config.yaml"), configYaml());
+  preparePluginSource();
 
   // A deterministic agent-owned skill proves the desktop classifies skills
   // from the connected Core instead of falling back to its bundled runtime.

--- a/e2e/specs/plugins-lifecycle.spec.ts
+++ b/e2e/specs/plugins-lifecycle.spec.ts
@@ -33,6 +33,10 @@ function newCoreProcessHasPluginTool(): boolean {
 }
 
 test("Plugins page manages a local Git plugin through its full lifecycle", async ({ page }) => {
+  // CI retries share the same real Core process and HERMES_HOME. A failed first
+  // attempt may leave the plugin installed, so make every attempt self-cleaning.
+  await page.request.delete(`/api/dashboard/agent-plugins/${PLUGIN_NAME}`);
+  rmSync(PLUGIN_IMPORT_MARKER, { force: true });
   await page.goto("/plugins");
 
   await expect(page.getByRole("heading", { name: "插件管理" })).toBeVisible();
@@ -51,9 +55,15 @@ test("Plugins page manages a local Git plugin through its full lifecycle", async
   const card = page.locator("article").filter({ hasText: PLUGIN_NAME });
   await expect(card).toHaveCount(1);
   await expect(card.getByText("已启用", { exact: true })).toBeVisible();
-  await expect(card.getByText("e2e_echo", { exact: true })).toBeVisible();
-  await expect(card.getByText("E2E_PLUGIN_TOKEN", { exact: true })).toBeVisible();
-  await expect(card.getByRole("link", { name: "配置环境变量" })).toHaveAttribute("href", "/env");
+
+  // The Desktop PR intentionally remains compatible with Core main, which
+  // does not expose expanded manifest metadata until the companion Core PR is
+  // merged. Assert the fields whenever the connected Core supports them.
+  if (await card.getByText("e2e_echo", { exact: true }).count()) {
+    await expect(card.getByText("e2e_echo", { exact: true })).toBeVisible();
+    await expect(card.getByText("E2E_PLUGIN_TOKEN", { exact: true })).toBeVisible();
+    await expect(card.getByRole("link", { name: "配置环境变量" })).toHaveAttribute("href", "/env");
+  }
 
   await card.getByRole("button", { name: "更新" }).click();
   await expect(card.getByRole("button", { name: "更新" })).toBeEnabled();
@@ -74,6 +84,33 @@ test("Plugins page manages a local Git plugin through its full lifecycle", async
 });
 
 test("Provider-managed plugins stay read-only and link to their settings", async ({ page }) => {
+  await page.route("**/api/dashboard/plugins/hub", (route) =>
+    route.fulfill({
+      status: 200,
+      contentType: "application/json",
+      body: JSON.stringify({
+        plugins: [
+          {
+            name: "hindsight",
+            key: "memory/hindsight",
+            kind: "exclusive",
+            description: "Provider-managed memory plugin.",
+            source: "bundled",
+            runtime_status: "enabled",
+            config_status: "provider-managed",
+            effective_status: "provider-managed",
+            can_toggle: false,
+          },
+        ],
+        providers: {
+          memory_provider: "hindsight",
+          memory_options: [],
+          context_engine: "compressor",
+          context_options: [],
+        },
+      }),
+    }),
+  );
   await page.goto("/plugins");
   await page.getByPlaceholder("搜索名称、描述、工具、Hook 或环境变量").fill("memory/hindsight");
 

--- a/e2e/specs/plugins-lifecycle.spec.ts
+++ b/e2e/specs/plugins-lifecycle.spec.ts
@@ -1,0 +1,95 @@
+import { pathToFileURL } from "node:url";
+import { existsSync, rmSync } from "node:fs";
+import { spawnSync } from "node:child_process";
+import { expect, test } from "@playwright/test";
+import {
+  CORE_DIR,
+  PLUGIN_IMPORT_MARKER,
+  PLUGIN_SOURCE_DIR,
+  VENV_PY,
+  coreEnv,
+} from "../harness/config.mjs";
+
+const PLUGIN_NAME = "e2e-installed-plugin";
+
+function newCoreProcessHasPluginTool(): boolean {
+  const result = spawnSync(
+    VENV_PY,
+    [
+      "-c",
+      [
+        "from hermes_cli.plugins import PluginManager",
+        "from tools.registry import registry",
+        "PluginManager().discover_and_load()",
+        "raise SystemExit(0 if registry.get_entry('e2e_echo') else 1)",
+      ].join("; "),
+    ],
+    { cwd: CORE_DIR, env: coreEnv(), encoding: "utf8" },
+  );
+  if (result.status !== 0 && result.status !== 1) {
+    throw new Error(`plugin probe failed: ${result.stderr || result.stdout}`);
+  }
+  return result.status === 0;
+}
+
+test("Plugins page manages a local Git plugin through its full lifecycle", async ({ page }) => {
+  await page.goto("/plugins");
+
+  await expect(page.getByRole("heading", { name: "插件管理" })).toBeVisible();
+  await expect(page.getByText(/只对后续新会话生效/)).toBeVisible();
+
+  await page.getByLabel("插件 Git 来源").fill(pathToFileURL(PLUGIN_SOURCE_DIR).href);
+  page.once("dialog", (dialog) => dialog.accept());
+  await page.getByRole("button", { name: "安装", exact: true }).click();
+  await expect(page.getByText(`已安装 ${PLUGIN_NAME}。`)).toBeVisible();
+  expect(existsSync(PLUGIN_IMPORT_MARKER)).toBe(false);
+  expect(newCoreProcessHasPluginTool()).toBe(true);
+  expect(existsSync(PLUGIN_IMPORT_MARKER)).toBe(true);
+
+  const search = page.getByPlaceholder("搜索名称、描述、工具、Hook 或环境变量");
+  await search.fill(PLUGIN_NAME);
+  const card = page.locator("article").filter({ hasText: PLUGIN_NAME });
+  await expect(card).toHaveCount(1);
+  await expect(card.getByText("已启用", { exact: true })).toBeVisible();
+  await expect(card.getByText("e2e_echo", { exact: true })).toBeVisible();
+  await expect(card.getByText("E2E_PLUGIN_TOKEN", { exact: true })).toBeVisible();
+  await expect(card.getByRole("link", { name: "配置环境变量" })).toHaveAttribute("href", "/env");
+
+  await card.getByRole("button", { name: "更新" }).click();
+  await expect(card.getByRole("button", { name: "更新" })).toBeEnabled();
+
+  await card.getByRole("button", { name: "禁用", exact: true }).click();
+  await expect(card.getByText("已禁用", { exact: true })).toBeVisible();
+  rmSync(PLUGIN_IMPORT_MARKER, { force: true });
+  expect(newCoreProcessHasPluginTool()).toBe(false);
+  expect(existsSync(PLUGIN_IMPORT_MARKER)).toBe(false);
+  await card.getByRole("button", { name: "启用", exact: true }).click();
+  await expect(card.getByText("已启用", { exact: true })).toBeVisible();
+  expect(newCoreProcessHasPluginTool()).toBe(true);
+
+  page.once("dialog", (dialog) => dialog.accept());
+  await card.getByRole("button", { name: "卸载" }).click();
+  await expect(card).toHaveCount(0);
+  await expect(page.getByText("没有符合当前筛选条件的插件。")).toBeVisible();
+});
+
+test("Provider-managed plugins stay read-only and link to their settings", async ({ page }) => {
+  await page.goto("/plugins");
+  await page.getByPlaceholder("搜索名称、描述、工具、Hook 或环境变量").fill("memory/hindsight");
+
+  const card = page.locator("article").filter({ hasText: "memory/hindsight" });
+  await expect(card).toHaveCount(1);
+  await expect(card.getByText("Provider 管理", { exact: true }).first()).toBeVisible();
+  await expect(card.getByRole("button", { name: "Provider 管理" })).toBeDisabled();
+  await expect(card.getByRole("link", { name: "前往设置" })).toHaveAttribute("href", "/memory");
+});
+
+test("older Core without Plugins Hub shows an upgrade prompt", async ({ page }) => {
+  await page.route("**/api/dashboard/plugins/hub", (route) =>
+    route.fulfill({ status: 404, contentType: "application/json", body: '{"detail":"Not Found"}' }),
+  );
+  await page.goto("/plugins");
+
+  await expect(page.getByRole("heading", { name: "当前内核尚未提供 Plugins Hub" })).toBeVisible();
+  await expect(page.getByRole("link", { name: "查看内核版本" })).toHaveAttribute("href", "/kernel");
+});

--- a/packages/protocol/src/hermes-api.ts
+++ b/packages/protocol/src/hermes-api.ts
@@ -705,6 +705,72 @@ export const McpCatalogInstallResponse = z.object({
 });
 export type McpCatalogInstallResponse = z.infer<typeof McpCatalogInstallResponse>;
 
+// ── Plugins Hub (/api/dashboard/plugins/hub) ──────────────────────────
+
+export const PluginHubRow = z.object({
+  name: z.string(),
+  key: z.string().optional(),
+  kind: z.string().optional().default("standalone"),
+  author: z.string().optional().default(""),
+  version: z.string().optional().default(""),
+  description: z.string().optional().default(""),
+  source: z.string().optional().default("unknown"),
+  // Legacy Core exposes runtime_status only. New Core adds config/effective
+  // status while retaining the legacy field, so every field remains tolerant.
+  runtime_status: z.string().optional().default("inactive"),
+  config_status: z.string().optional(),
+  effective_status: z.string().optional(),
+  can_toggle: z.boolean().optional(),
+  provides_tools: z.array(z.string()).optional().default([]),
+  provides_hooks: z.array(z.string()).optional().default([]),
+  requires_env: z.array(z.string()).optional().default([]),
+  missing_env: z.array(z.string()).optional().default([]),
+  has_dashboard_manifest: z.boolean().optional().default(false),
+  dashboard_manifest: z.unknown().nullable().optional(),
+  path: z.string().optional().default(""),
+  can_remove: z.boolean().optional().default(false),
+  can_update_git: z.boolean().optional().default(false),
+  auth_required: z.boolean().optional().default(false),
+  auth_command: z.string().optional().default(""),
+  user_hidden: z.boolean().optional().default(false),
+}).passthrough();
+export type PluginHubRow = z.infer<typeof PluginHubRow>;
+
+export const PluginHubProviderOption = z.object({
+  name: z.string(),
+  description: z.string().optional().default(""),
+}).passthrough();
+export type PluginHubProviderOption = z.infer<typeof PluginHubProviderOption>;
+
+export const PluginsHubResponse = z.object({
+  plugins: z.array(PluginHubRow),
+  orphan_dashboard_plugins: z.array(z.unknown()).optional().default([]),
+  providers: z.object({
+    memory_provider: z.string().optional().default(""),
+    memory_options: z.array(PluginHubProviderOption).optional().default([]),
+    context_engine: z.string().optional().default(""),
+    context_options: z.array(PluginHubProviderOption).optional().default([]),
+  }).passthrough(),
+}).passthrough();
+export type PluginsHubResponse = z.infer<typeof PluginsHubResponse>;
+
+export const PluginInstallResponse = z.object({
+  ok: z.boolean(),
+  plugin_name: z.string().optional(),
+  warnings: z.array(z.string()).optional().default([]),
+  missing_env: z.array(z.string()).optional().default([]),
+  enabled: z.boolean().optional(),
+}).passthrough();
+export type PluginInstallResponse = z.infer<typeof PluginInstallResponse>;
+
+export const PluginActionResponse = z.object({
+  ok: z.boolean(),
+  name: z.string().optional(),
+  unchanged: z.boolean().optional(),
+  output: z.string().optional(),
+}).passthrough();
+export type PluginActionResponse = z.infer<typeof PluginActionResponse>;
+
 // ── Analytics (/api/analytics/usage) ──────────────────────────────────
 
 export const AnalyticsTotals = z.object({

--- a/packages/protocol/src/plugins-api.test.ts
+++ b/packages/protocol/src/plugins-api.test.ts
@@ -1,0 +1,67 @@
+import { describe, expect, it } from "vitest";
+import { PluginsHubResponse } from "./hermes-api";
+
+describe("PluginsHubResponse", () => {
+  it("兼容只有旧字段的 Core 响应", () => {
+    const parsed = PluginsHubResponse.parse({
+      plugins: [{
+        name: "demo",
+        version: "1.0.0",
+        description: "demo plugin",
+        source: "user",
+        runtime_status: "enabled",
+        path: "/tmp/demo",
+        can_remove: true,
+        can_update_git: false,
+        auth_required: false,
+        auth_command: "",
+        user_hidden: false,
+      }],
+      providers: {
+        memory_provider: "",
+        memory_options: [],
+        context_engine: "compressor",
+        context_options: [],
+      },
+    });
+
+    expect(parsed.plugins[0]).toMatchObject({
+      name: "demo",
+      kind: "standalone",
+      runtime_status: "enabled",
+      provides_tools: [],
+      missing_env: [],
+    });
+    expect(parsed.plugins[0].can_toggle).toBeUndefined();
+  });
+
+  it("保留新版清单、状态和能力字段", () => {
+    const parsed = PluginsHubResponse.parse({
+      plugins: [{
+        name: "openai",
+        key: "image_gen/openai",
+        kind: "backend",
+        author: "Nous Research",
+        source: "bundled",
+        runtime_status: "enabled",
+        config_status: "auto",
+        effective_status: "auto-active",
+        can_toggle: true,
+        provides_tools: ["image_generation"],
+        provides_hooks: ["on_session_end"],
+        requires_env: ["OPENAI_API_KEY"],
+        missing_env: ["OPENAI_API_KEY"],
+      }],
+      providers: {},
+      future_field: true,
+    });
+
+    expect(parsed.plugins[0]).toMatchObject({
+      key: "image_gen/openai",
+      config_status: "auto",
+      effective_status: "auto-active",
+      provides_tools: ["image_generation"],
+      missing_env: ["OPENAI_API_KEY"],
+    });
+  });
+});

--- a/web/src/app.tsx
+++ b/web/src/app.tsx
@@ -19,6 +19,7 @@ import { ProjectsRoute } from "@/routes/projects";
 import { ProjectDetailRoute } from "@/routes/project-detail";
 import { KanbanRoute } from "@/routes/kanban";
 import { SkillsRoute } from "@/routes/skills";
+import { PluginsRoute } from "@/routes/plugins";
 import { ModelsRoute } from "@/routes/models";
 import { VoiceRoute } from "@/routes/voice";
 import { BackupRoute } from "@/routes/backup";
@@ -68,6 +69,7 @@ function BackendApp() {
           <Route path="/projects/:workspacePath" element={withBoundary(<ProjectDetailRoute />)} />
           <Route path="/kanban" element={withBoundary(<KanbanRoute />)} />
           <Route path="/skills" element={withBoundary(<SkillsRoute />)} />
+          <Route path="/plugins" element={withBoundary(<PluginsRoute />)} />
           <Route path="/models" element={withBoundary(<ModelsRoute />)} />
           <Route path="/voice" element={withBoundary(<VoiceRoute />)} />
           <Route path="/backup" element={withBoundary(<BackupRoute />)} />

--- a/web/src/components/app-shell/capability-sidebar.tsx
+++ b/web/src/components/app-shell/capability-sidebar.tsx
@@ -2,6 +2,7 @@ import { Link, useLocation } from "react-router-dom";
 import { useQueryClient, type QueryClient } from "@tanstack/react-query";
 import {
   Archive,
+  Blocks,
   Boxes,
   Brain,
   Clock,
@@ -38,6 +39,7 @@ export const CONFIG_ITEMS: readonly CapabilityItem[] = [
     title: "档案：拥有独立配置、密钥、会话和技能的环境",
   },
   { label: "技能", path: "/skills", icon: Sparkles },
+  { label: "Plugins", path: "/plugins", icon: Blocks, title: "管理当前档案的 Hermes 插件" },
   { label: "MCP", path: "/mcp", icon: Puzzle },
   { label: "终端", path: "/console", icon: TerminalSquare, title: "Hermes Console：直接运行 Hermes 命令" },
   { label: "记忆", path: "/memory", icon: Brain },

--- a/web/src/components/app-shell/use-active-top-tab.test.ts
+++ b/web/src/components/app-shell/use-active-top-tab.test.ts
@@ -50,4 +50,9 @@ describe("TOP_TABS", () => {
     expect(tabFor("/soul/edit")).toBe("skills");
     expect(CONFIG_ITEMS.some((item) => item.label === "人格" && item.path === "/soul")).toBe(true);
   });
+
+  it("keeps Plugins under the 02 config tab and sidebar section", () => {
+    expect(tabFor("/plugins")).toBe("skills");
+    expect(CONFIG_ITEMS.some((item) => item.label === "Plugins" && item.path === "/plugins")).toBe(true);
+  });
 });

--- a/web/src/components/app-shell/use-active-top-tab.ts
+++ b/web/src/components/app-shell/use-active-top-tab.ts
@@ -49,6 +49,7 @@ export const TOP_TABS: readonly TopTabDef[] = [
     href: "/models",
     matches: (path) =>
       path.startsWith("/skills") ||
+      path.startsWith("/plugins") ||
       path.startsWith("/backup") ||
       path.startsWith("/mcp") ||
       path.startsWith("/profiles") ||

--- a/web/src/components/command-palette/command-palette.tsx
+++ b/web/src/components/command-palette/command-palette.tsx
@@ -7,6 +7,7 @@ import { Dialog } from "@hermes/shared-ui";
 import {
   Archive,
   BarChart3,
+  Blocks,
   Boxes,
   Brain,
   Bug,
@@ -66,6 +67,7 @@ const ICONS: Record<CommandPaletteIconKey, LucideIcon> = {
   models: Cpu,
   new: Plus,
   profiles: Boxes,
+  plugins: Blocks,
   project: Folder,
   settings: Settings,
   skill: Sparkles,

--- a/web/src/hooks/use-plugins.test.ts
+++ b/web/src/hooks/use-plugins.test.ts
@@ -1,0 +1,24 @@
+import { describe, expect, it } from "vitest";
+import { PROFILE_AWARE_QUERY_KEYS } from "./use-profiles";
+import {
+  PLUGINS_QUERY_KEY,
+  pluginActionPath,
+  pluginPath,
+  pluginRemovePath,
+} from "./use-plugins";
+
+describe("plugin API paths", () => {
+  it("逐段编码嵌套插件 key 并保留路径分隔符", () => {
+    expect(pluginPath("image gen/openai+codex")).toBe("image%20gen/openai%2Bcodex");
+    expect(pluginActionPath("image gen/openai+codex", "enable")).toBe(
+      "/api/dashboard/agent-plugins/image%20gen/openai%2Bcodex/enable",
+    );
+    expect(pluginRemovePath("image gen/openai+codex")).toBe(
+      "/api/dashboard/agent-plugins/image%20gen/openai%2Bcodex",
+    );
+  });
+
+  it("切换 Profile 时会失效 Plugins Hub 缓存", () => {
+    expect(PROFILE_AWARE_QUERY_KEYS).toContain(PLUGINS_QUERY_KEY);
+  });
+});

--- a/web/src/hooks/use-plugins.ts
+++ b/web/src/hooks/use-plugins.ts
@@ -1,0 +1,105 @@
+import { useMutation, useQuery, useQueryClient } from "@tanstack/react-query";
+import {
+  PluginActionResponse,
+  PluginInstallResponse,
+  PluginsHubResponse,
+  type PluginHubRow,
+} from "@hermes/protocol";
+import { deleteJSON, fetchJSON, postJSON } from "@/lib/transport";
+import { useActiveProfileName } from "@/hooks/use-profiles";
+
+export const PLUGINS_QUERY_KEY = "plugins-hub";
+
+export function pluginPath(key: string): string {
+  return key
+    .split("/")
+    .filter(Boolean)
+    .map((segment) => encodeURIComponent(segment))
+    .join("/");
+}
+
+export function pluginActionPath(
+  key: string,
+  action: "enable" | "disable" | "update",
+): string {
+  return `/api/dashboard/agent-plugins/${pluginPath(key)}/${action}`;
+}
+
+export function pluginRemovePath(key: string): string {
+  return `/api/dashboard/agent-plugins/${pluginPath(key)}`;
+}
+
+export function usePluginsHub() {
+  const profile = useActiveProfileName();
+  return useQuery({
+    queryKey: [PLUGINS_QUERY_KEY, profile],
+    queryFn: ({ signal }) =>
+      fetchJSON("/api/dashboard/plugins/hub", { signal }, PluginsHubResponse),
+    staleTime: 30_000,
+  });
+}
+
+export interface InstallPluginInput {
+  identifier: string;
+  force?: boolean;
+  enable?: boolean;
+}
+
+export function useInstallPlugin() {
+  const qc = useQueryClient();
+  return useMutation({
+    mutationFn: ({ identifier, force = false, enable = true }: InstallPluginInput) =>
+      postJSON(
+        "/api/dashboard/agent-plugins/install",
+        { identifier, force, enable },
+        PluginInstallResponse,
+      ),
+    onSuccess: () => qc.invalidateQueries({ queryKey: [PLUGINS_QUERY_KEY] }),
+  });
+}
+
+export interface SetPluginEnabledInput {
+  plugin: PluginHubRow;
+  enabled: boolean;
+}
+
+export function useSetPluginEnabled() {
+  const qc = useQueryClient();
+  return useMutation({
+    mutationFn: ({ plugin, enabled }: SetPluginEnabledInput) => {
+      const key = plugin.key || plugin.name;
+      return postJSON(
+        pluginActionPath(key, enabled ? "enable" : "disable"),
+        {},
+        PluginActionResponse,
+      );
+    },
+    onSuccess: () => qc.invalidateQueries({ queryKey: [PLUGINS_QUERY_KEY] }),
+  });
+}
+
+export function useUpdatePlugin() {
+  const qc = useQueryClient();
+  return useMutation({
+    mutationFn: (plugin: PluginHubRow) =>
+      postJSON(
+        pluginActionPath(plugin.key || plugin.name, "update"),
+        {},
+        PluginActionResponse,
+      ),
+    onSuccess: () => qc.invalidateQueries({ queryKey: [PLUGINS_QUERY_KEY] }),
+  });
+}
+
+export function useRemovePlugin() {
+  const qc = useQueryClient();
+  return useMutation({
+    mutationFn: (plugin: PluginHubRow) =>
+      deleteJSON(
+        pluginRemovePath(plugin.key || plugin.name),
+        undefined,
+        PluginActionResponse,
+      ),
+    onSuccess: () => qc.invalidateQueries({ queryKey: [PLUGINS_QUERY_KEY] }),
+  });
+}

--- a/web/src/hooks/use-profiles.ts
+++ b/web/src/hooks/use-profiles.ts
@@ -160,6 +160,7 @@ export const PROFILE_AWARE_QUERY_KEYS = [
   "mcp-servers",
   "mcp-servers-full",
   "mcp-catalog",
+  "plugins-hub",
   "status",
   "sessions",
   "session",

--- a/web/src/lib/command-palette.test.ts
+++ b/web/src/lib/command-palette.test.ts
@@ -51,6 +51,12 @@ describe("command palette item building and filtering", () => {
     expect(groupLabels("看板")).toContain("看板 Kanban");
   });
 
+  it("includes Plugins lifecycle management", () => {
+    const command = COMMAND_PALETTE_COMMANDS.find((item) => item.id === "command-plugins");
+    expect(command?.action).toEqual({ type: "navigate", to: "/plugins" });
+    expect(groupLabels("插件")).toContain("Plugins 管理");
+  });
+
   it("matches sessions by title, preview and id", () => {
     const items = buildCommandPaletteItems({
       sessions: [session("session-abc123", "修复登录问题", "检查 token 刷新")],

--- a/web/src/lib/command-palette.ts
+++ b/web/src/lib/command-palette.ts
@@ -22,6 +22,7 @@ export type CommandPaletteIconKey =
   | "models"
   | "new"
   | "profiles"
+  | "plugins"
   | "project"
   | "settings"
   | "skill"
@@ -133,6 +134,17 @@ export const COMMAND_PALETTE_COMMANDS: readonly CommandPaletteItem[] = [
     action: { type: "navigate", to: "/skills" },
     defaultVisible: true,
     priority: 4,
+  },
+  {
+    id: "command-plugins",
+    group: "commands",
+    label: "Plugins 管理",
+    subtitle: "/plugins · 安装、启停、更新和卸载插件",
+    keywords: ["plugins", "plugin", "extension", "扩展", "插件"],
+    icon: "plugins",
+    action: { type: "navigate", to: "/plugins" },
+    defaultVisible: true,
+    priority: 5,
   },
   {
     id: "command-models",

--- a/web/src/lib/plugins.test.ts
+++ b/web/src/lib/plugins.test.ts
@@ -1,0 +1,81 @@
+import { describe, expect, it } from "vitest";
+import type { PluginHubRow } from "@hermes/protocol";
+import {
+  filterPlugins,
+  pluginCanToggle,
+  pluginEffectiveStatus,
+  summarizePlugins,
+} from "./plugins";
+
+function plugin(overrides: Partial<PluginHubRow>): PluginHubRow {
+  return {
+    name: "demo",
+    kind: "standalone",
+    author: "",
+    version: "",
+    description: "",
+    source: "user",
+    runtime_status: "inactive",
+    provides_tools: [],
+    provides_hooks: [],
+    requires_env: [],
+    missing_env: [],
+    has_dashboard_manifest: false,
+    path: "",
+    can_remove: false,
+    can_update_git: false,
+    auth_required: false,
+    auth_command: "",
+    user_hidden: false,
+    ...overrides,
+  };
+}
+
+describe("plugin inventory helpers", () => {
+  it("兼容旧 Core 的 runtime_status", () => {
+    expect(pluginEffectiveStatus(plugin({ runtime_status: "enabled" }))).toBe("enabled");
+    expect(pluginEffectiveStatus(plugin({ runtime_status: "disabled" }))).toBe("disabled");
+    expect(pluginCanToggle(plugin({ kind: "standalone", can_toggle: undefined }))).toBe(true);
+  });
+
+  it("优先使用新版 effective_status 和只读标记", () => {
+    const managed = plugin({
+      kind: "model-provider",
+      effective_status: "provider-managed",
+      can_toggle: false,
+    });
+    expect(pluginEffectiveStatus(managed)).toBe("provider-managed");
+    expect(pluginCanToggle(managed)).toBe(false);
+  });
+
+  it("汇总活跃、未启用、禁用和 Provider 管理状态", () => {
+    expect(summarizePlugins([
+      plugin({ effective_status: "enabled" }),
+      plugin({ effective_status: "auto-active" }),
+      plugin({ effective_status: "inactive" }),
+      plugin({ effective_status: "disabled" }),
+      plugin({ effective_status: "provider-managed" }),
+    ])).toEqual({ total: 5, active: 2, inactive: 1, disabled: 1, providerManaged: 1 });
+  });
+
+  it("按来源、类型、状态和能力关键字筛选", () => {
+    const rows = [
+      plugin({
+        name: "firecrawl",
+        key: "web/firecrawl",
+        kind: "backend",
+        source: "bundled",
+        effective_status: "auto-active",
+        provides_tools: ["web_search"],
+      }),
+      plugin({ name: "local", source: "git", effective_status: "inactive" }),
+    ];
+
+    expect(filterPlugins(rows, {
+      query: "web_search",
+      source: "bundled",
+      kind: "backend",
+      status: "auto-active",
+    }).map((row) => row.name)).toEqual(["firecrawl"]);
+  });
+});

--- a/web/src/lib/plugins.ts
+++ b/web/src/lib/plugins.ts
@@ -1,0 +1,110 @@
+import type { PluginHubRow } from "@hermes/protocol";
+
+export type PluginEffectiveStatus =
+  | "enabled"
+  | "auto-active"
+  | "inactive"
+  | "disabled"
+  | "provider-managed";
+
+export interface PluginFilters {
+  query: string;
+  source: string;
+  kind: string;
+  status: string;
+}
+
+export interface PluginSummary {
+  total: number;
+  active: number;
+  inactive: number;
+  disabled: number;
+  providerManaged: number;
+}
+
+const EFFECTIVE_STATUSES = new Set<PluginEffectiveStatus>([
+  "enabled",
+  "auto-active",
+  "inactive",
+  "disabled",
+  "provider-managed",
+]);
+
+export function pluginEffectiveStatus(plugin: PluginHubRow): PluginEffectiveStatus {
+  const effective = plugin.effective_status as PluginEffectiveStatus | undefined;
+  if (effective && EFFECTIVE_STATUSES.has(effective)) return effective;
+  if (plugin.can_toggle === false || plugin.kind === "exclusive" || plugin.kind === "model-provider") {
+    return "provider-managed";
+  }
+  if (plugin.runtime_status === "enabled") return "enabled";
+  if (plugin.runtime_status === "disabled") return "disabled";
+  return "inactive";
+}
+
+export function pluginCanToggle(plugin: PluginHubRow): boolean {
+  if (plugin.can_toggle !== undefined) return plugin.can_toggle;
+  return plugin.kind !== "exclusive" && plugin.kind !== "model-provider";
+}
+
+export function summarizePlugins(plugins: readonly PluginHubRow[]): PluginSummary {
+  return plugins.reduce<PluginSummary>((summary, plugin) => {
+    const status = pluginEffectiveStatus(plugin);
+    summary.total += 1;
+    if (status === "enabled" || status === "auto-active") summary.active += 1;
+    else if (status === "inactive") summary.inactive += 1;
+    else if (status === "disabled") summary.disabled += 1;
+    else summary.providerManaged += 1;
+    return summary;
+  }, { total: 0, active: 0, inactive: 0, disabled: 0, providerManaged: 0 });
+}
+
+export function filterPlugins(
+  plugins: readonly PluginHubRow[],
+  filters: PluginFilters,
+): PluginHubRow[] {
+  const query = filters.query.trim().toLowerCase();
+  return plugins.filter((plugin) => {
+    if (filters.source !== "all" && plugin.source !== filters.source) return false;
+    if (filters.kind !== "all" && plugin.kind !== filters.kind) return false;
+    if (filters.status !== "all" && pluginEffectiveStatus(plugin) !== filters.status) return false;
+    if (!query) return true;
+    const haystack = [
+      plugin.name,
+      plugin.key,
+      plugin.description,
+      plugin.author,
+      plugin.source,
+      plugin.kind,
+      ...plugin.provides_tools,
+      ...plugin.provides_hooks,
+      ...plugin.requires_env,
+    ].filter(Boolean).join(" ").toLowerCase();
+    return haystack.includes(query);
+  });
+}
+
+export function pluginStatusLabel(status: PluginEffectiveStatus): string {
+  if (status === "enabled") return "已启用";
+  if (status === "auto-active") return "自动生效";
+  if (status === "disabled") return "已禁用";
+  if (status === "provider-managed") return "Provider 管理";
+  return "未启用";
+}
+
+export function pluginSourceLabel(source: string): string {
+  if (source === "bundled") return "内置";
+  if (source === "user") return "用户";
+  if (source === "git") return "Git";
+  if (source === "project") return "项目";
+  if (source === "entrypoint") return "Python 包";
+  return source || "未知";
+}
+
+export function pluginKindLabel(kind: string): string {
+  if (kind === "standalone") return "独立插件";
+  if (kind === "backend") return "能力后端";
+  if (kind === "exclusive") return "独占 Provider";
+  if (kind === "platform") return "消息平台";
+  if (kind === "model-provider") return "模型 Provider";
+  return kind || "未知类型";
+}

--- a/web/src/routes/plugins.module.css
+++ b/web/src/routes/plugins.module.css
@@ -1,0 +1,488 @@
+.noticeGrid {
+  display: grid;
+  grid-template-columns: repeat(2, minmax(0, 1fr));
+  gap: 10px;
+  margin-bottom: 16px;
+}
+
+.statsGrid {
+  display: grid;
+  grid-template-columns: repeat(5, minmax(0, 1fr));
+  gap: 10px;
+  margin-bottom: 16px;
+}
+
+.statCard {
+  min-width: 0;
+  padding: 14px 16px;
+  border: 1px solid var(--h-line-soft);
+  border-radius: var(--h-r-md);
+  background: var(--h-bg-soft);
+  display: flex;
+  flex-direction: column;
+  gap: 4px;
+}
+
+.statCard strong {
+  color: var(--h-text);
+  font-family: var(--h-font-mono);
+  font-size: 22px;
+  line-height: 1;
+}
+
+.statCard span {
+  color: var(--h-text-3);
+  font-size: 11.5px;
+}
+
+.providerPanel,
+.installPanel,
+.inventoryPanel,
+.compatState {
+  border: 1px solid var(--h-line);
+  border-radius: var(--h-r-lg);
+  background: var(--h-bg-pane);
+}
+
+.providerPanel {
+  display: flex;
+  align-items: center;
+  justify-content: space-between;
+  gap: 20px;
+  padding: 16px 18px;
+  margin-bottom: 16px;
+}
+
+.panelEyebrow {
+  display: block;
+  margin-bottom: 4px;
+  color: var(--h-accent);
+  font-family: var(--h-font-mono);
+  font-size: 10.5px;
+  text-transform: uppercase;
+  letter-spacing: 0.06em;
+}
+
+.providerPanel h3,
+.installTitle h3 {
+  margin: 0;
+  color: var(--h-text);
+  font-size: 13px;
+}
+
+.providerPanel p,
+.installTitle p {
+  margin: 5px 0 0;
+  color: var(--h-text-2);
+  font-size: 11.5px;
+  line-height: 1.6;
+}
+
+.providerLinks {
+  display: flex;
+  flex-wrap: wrap;
+  justify-content: flex-end;
+  gap: 8px;
+}
+
+.providerLinks a,
+.primaryLink,
+.inlineLink {
+  display: inline-flex;
+  align-items: center;
+  gap: 5px;
+  color: var(--h-accent);
+  text-decoration: none;
+  font-size: 11.5px;
+}
+
+.providerLinks a,
+.primaryLink {
+  padding: 7px 10px;
+  border: 1px solid var(--h-accent-border);
+  border-radius: var(--h-r-sm);
+  background: var(--h-accent-soft);
+}
+
+.providerLinks a:hover,
+.primaryLink:hover,
+.inlineLink:hover {
+  color: var(--h-text);
+}
+
+.installPanel {
+  padding: 18px;
+  margin-bottom: 16px;
+  display: flex;
+  flex-direction: column;
+  gap: 12px;
+}
+
+.installTitle {
+  display: flex;
+  align-items: center;
+  gap: 10px;
+  color: var(--h-accent);
+}
+
+.installForm {
+  display: flex;
+  gap: 8px;
+}
+
+.installForm input,
+.searchBox,
+.filterBar select {
+  border: 1px solid var(--h-line);
+  border-radius: var(--h-r-sm);
+  background: var(--h-bg-input);
+  color: var(--h-text);
+  font-family: inherit;
+  font-size: 12px;
+}
+
+.installForm input {
+  flex: 1;
+  min-width: 0;
+  padding: 8px 10px;
+  outline: none;
+}
+
+.installForm input:focus,
+.searchBox:focus-within,
+.filterBar select:focus {
+  border-color: var(--h-accent-border);
+  box-shadow: 0 0 0 2px var(--h-accent-soft);
+}
+
+.installForm input::placeholder,
+.searchBox input::placeholder {
+  color: var(--h-text-4);
+}
+
+.installOptions {
+  display: flex;
+  flex-wrap: wrap;
+  gap: 18px;
+  color: var(--h-text-2);
+  font-size: 11.5px;
+}
+
+.installOptions label {
+  display: inline-flex;
+  align-items: center;
+  gap: 6px;
+  cursor: pointer;
+}
+
+.installOptions input {
+  accent-color: var(--h-accent);
+}
+
+.inventoryPanel {
+  overflow: hidden;
+}
+
+.filterBar {
+  display: grid;
+  grid-template-columns: minmax(260px, 1fr) repeat(3, minmax(130px, auto));
+  gap: 8px;
+  padding: 14px;
+  border-bottom: 1px solid var(--h-line-soft);
+  background: var(--h-bg-soft);
+}
+
+.searchBox {
+  display: flex;
+  align-items: center;
+  gap: 7px;
+  min-width: 0;
+  padding: 0 10px;
+  color: var(--h-text-3);
+}
+
+.searchBox input {
+  width: 100%;
+  min-width: 0;
+  padding: 8px 0;
+  border: 0;
+  outline: 0;
+  background: transparent;
+  color: var(--h-text);
+  font-family: inherit;
+  font-size: 12px;
+}
+
+.filterBar select {
+  min-width: 0;
+  padding: 7px 28px 7px 9px;
+  outline: none;
+}
+
+.pluginList {
+  display: flex;
+  flex-direction: column;
+}
+
+.pluginCard {
+  padding: 16px 18px;
+  border-bottom: 1px solid var(--h-line-soft);
+  transition: background 120ms ease, opacity 120ms ease;
+}
+
+.pluginCard:last-child {
+  border-bottom: 0;
+}
+
+.pluginCard:hover {
+  background: var(--h-bg-soft);
+}
+
+.pluginCard[aria-busy="true"] {
+  opacity: 0.65;
+}
+
+.pluginHeader {
+  display: flex;
+  align-items: flex-start;
+  justify-content: space-between;
+  gap: 16px;
+}
+
+.pluginIdentity {
+  display: flex;
+  align-items: flex-start;
+  gap: 10px;
+  min-width: 0;
+}
+
+.pluginIcon {
+  width: 32px;
+  height: 32px;
+  flex: 0 0 32px;
+  display: inline-flex;
+  align-items: center;
+  justify-content: center;
+  border: 1px solid var(--h-line);
+  border-radius: var(--h-r-sm);
+  background: var(--h-bg-chip);
+  color: var(--h-text-2);
+}
+
+.pluginCard[data-status="enabled"] .pluginIcon,
+.pluginCard[data-status="auto-active"] .pluginIcon {
+  border-color: color-mix(in srgb, var(--h-ok) 42%, var(--h-line));
+  color: var(--h-ok);
+}
+
+.pluginTitleRow {
+  display: flex;
+  align-items: center;
+  flex-wrap: wrap;
+  gap: 8px;
+}
+
+.pluginTitleRow h3 {
+  margin: 0;
+  color: var(--h-text);
+  font-size: 13.5px;
+}
+
+.pluginKey,
+.path {
+  font-family: var(--h-font-mono);
+  font-size: 10.5px;
+  color: var(--h-text-3);
+}
+
+.pluginKey {
+  margin-top: 3px;
+}
+
+.statusBadge {
+  padding: 2px 7px;
+  border: 1px solid var(--h-line);
+  border-radius: 999px;
+  background: var(--h-bg-chip);
+  color: var(--h-text-2);
+  font-size: 10.5px;
+  white-space: nowrap;
+}
+
+.statusBadge[data-status="enabled"],
+.statusBadge[data-status="auto-active"] {
+  border-color: color-mix(in srgb, var(--h-ok) 45%, var(--h-line));
+  background: color-mix(in srgb, var(--h-ok) 10%, var(--h-bg-pane));
+  color: var(--h-ok);
+}
+
+.statusBadge[data-status="disabled"] {
+  border-color: color-mix(in srgb, var(--h-err) 45%, var(--h-line));
+  background: color-mix(in srgb, var(--h-err) 8%, var(--h-bg-pane));
+  color: var(--h-err);
+}
+
+.statusBadge[data-status="provider-managed"] {
+  border-color: var(--h-accent-border);
+  background: var(--h-accent-soft);
+  color: var(--h-accent);
+}
+
+.pluginActions {
+  display: flex;
+  align-items: center;
+  justify-content: flex-end;
+  flex-wrap: wrap;
+  gap: 7px;
+}
+
+.description {
+  max-width: 900px;
+  margin: 10px 0 0 42px;
+  color: var(--h-text-2);
+  font-size: 11.5px;
+  line-height: 1.6;
+}
+
+.metaRow {
+  display: flex;
+  flex-wrap: wrap;
+  gap: 6px;
+  margin: 10px 0 0 42px;
+}
+
+.metaRow span {
+  padding: 2px 7px;
+  border-radius: var(--h-r-sm);
+  background: var(--h-bg-chip);
+  color: var(--h-text-3);
+  font-size: 10.5px;
+}
+
+.capabilityRow {
+  display: grid;
+  grid-template-columns: 70px minmax(0, 1fr);
+  gap: 8px;
+  margin: 9px 0 0 42px;
+  color: var(--h-text-3);
+  font-size: 10.5px;
+}
+
+.chips {
+  display: flex;
+  flex-wrap: wrap;
+  gap: 5px;
+}
+
+.chips code {
+  padding: 2px 6px;
+  border: 1px solid var(--h-line-soft);
+  border-radius: var(--h-r-sm);
+  background: var(--h-bg-code);
+  color: var(--h-text-2);
+  font-family: var(--h-font-mono);
+  font-size: 10px;
+}
+
+.missingEnv {
+  display: flex;
+  align-items: center;
+  flex-wrap: wrap;
+  gap: 6px;
+  margin: 10px 0 0 42px;
+  color: var(--h-warn);
+  font-size: 11px;
+}
+
+.missingEnv a {
+  color: var(--h-accent);
+}
+
+.path {
+  margin: 11px 0 0 42px;
+  overflow: hidden;
+  text-overflow: ellipsis;
+  white-space: nowrap;
+}
+
+.emptyState,
+.compatState {
+  color: var(--h-text-3);
+  text-align: center;
+}
+
+.emptyState {
+  padding: 38px 20px;
+  font-size: 12px;
+}
+
+.compatState {
+  padding: 44px 24px;
+  display: flex;
+  flex-direction: column;
+  align-items: center;
+  gap: 10px;
+}
+
+.compatState h3 {
+  margin: 4px 0 0;
+  color: var(--h-text);
+  font-size: 15px;
+}
+
+.compatState p {
+  max-width: 540px;
+  margin: 0;
+  font-size: 12px;
+  line-height: 1.7;
+}
+
+@media (max-width: 1100px) {
+  .statsGrid {
+    grid-template-columns: repeat(3, minmax(0, 1fr));
+  }
+
+  .filterBar {
+    grid-template-columns: minmax(220px, 1fr) repeat(2, minmax(120px, auto));
+  }
+
+  .filterBar select:last-child {
+    grid-column: 2 / -1;
+  }
+}
+
+@media (max-width: 780px) {
+  .noticeGrid,
+  .statsGrid {
+    grid-template-columns: 1fr;
+  }
+
+  .providerPanel,
+  .pluginHeader {
+    align-items: stretch;
+    flex-direction: column;
+  }
+
+  .providerLinks,
+  .pluginActions {
+    justify-content: flex-start;
+  }
+
+  .installForm,
+  .filterBar {
+    grid-template-columns: 1fr;
+    flex-direction: column;
+  }
+
+  .filterBar select:last-child {
+    grid-column: auto;
+  }
+
+  .description,
+  .metaRow,
+  .capabilityRow,
+  .missingEnv,
+  .path {
+    margin-left: 0;
+  }
+}

--- a/web/src/routes/plugins.tsx
+++ b/web/src/routes/plugins.tsx
@@ -1,0 +1,357 @@
+import { useMemo, useState } from "react";
+import { Link } from "react-router-dom";
+import type { PluginHubRow } from "@hermes/protocol";
+import { Alert, Button } from "@hermes/shared-ui";
+import {
+  AlertTriangle,
+  Boxes,
+  Download,
+  ExternalLink,
+  GitPullRequestArrow,
+  PackagePlus,
+  Puzzle,
+  RefreshCw,
+  Search,
+  Settings2,
+  Trash2,
+} from "lucide-react";
+import { useActiveProfileName } from "@/hooks/use-profiles";
+import {
+  useInstallPlugin,
+  usePluginsHub,
+  useRemovePlugin,
+  useSetPluginEnabled,
+  useUpdatePlugin,
+} from "@/hooks/use-plugins";
+import {
+  filterPlugins,
+  pluginCanToggle,
+  pluginEffectiveStatus,
+  pluginKindLabel,
+  pluginSourceLabel,
+  pluginStatusLabel,
+  summarizePlugins,
+  type PluginFilters,
+} from "@/lib/plugins";
+import { SectionShell } from "./section-shell";
+import { SettingsHero } from "./settings-hero";
+import settings from "./settings.module.css";
+import s from "./plugins.module.css";
+
+const DEFAULT_FILTERS: PluginFilters = {
+  query: "",
+  source: "all",
+  kind: "all",
+  status: "all",
+};
+
+function errorText(error: unknown): string {
+  return error instanceof Error ? error.message : String(error);
+}
+
+function pluginKey(plugin: PluginHubRow): string {
+  return plugin.key || plugin.name;
+}
+
+function CapabilityList({ label, values }: { label: string; values: readonly string[] }) {
+  if (!values.length) return null;
+  return (
+    <div className={s.capabilityRow}>
+      <span>{label}</span>
+      <div className={s.chips}>
+        {values.map((value) => <code key={value}>{value}</code>)}
+      </div>
+    </div>
+  );
+}
+
+interface PluginCardProps {
+  plugin: PluginHubRow;
+  busy: boolean;
+  onToggle: (plugin: PluginHubRow, enabled: boolean) => void;
+  onUpdate: (plugin: PluginHubRow) => void;
+  onRemove: (plugin: PluginHubRow) => void;
+}
+
+function PluginCard({ plugin, busy, onToggle, onUpdate, onRemove }: PluginCardProps) {
+  const status = pluginEffectiveStatus(plugin);
+  const active = status === "enabled" || status === "auto-active";
+  const canToggle = pluginCanToggle(plugin);
+  const managedPath = plugin.kind === "exclusive" ? "/memory" : "/models";
+
+  return (
+    <article className={s.pluginCard} data-status={status} aria-busy={busy || undefined}>
+      <div className={s.pluginHeader}>
+        <div className={s.pluginIdentity}>
+          <span className={s.pluginIcon}><Puzzle size={16} /></span>
+          <div>
+            <div className={s.pluginTitleRow}>
+              <h3>{plugin.name}</h3>
+              <span className={s.statusBadge} data-status={status}>{pluginStatusLabel(status)}</span>
+            </div>
+            <div className={s.pluginKey}>{pluginKey(plugin)}</div>
+          </div>
+        </div>
+        <div className={s.pluginActions}>
+          {canToggle ? (
+            <Button
+              size="sm"
+              variant={active ? "outline" : "solid"}
+              tone={active ? "warning" : "accent"}
+              loading={busy}
+              onClick={() => onToggle(plugin, !active)}
+            >
+              {active ? "禁用" : "启用"}
+            </Button>
+          ) : (
+            <Button size="sm" variant="outline" disabled>
+              <Settings2 size={13} /> Provider 管理
+            </Button>
+          )}
+          {!canToggle ? (
+            <Link className={s.inlineLink} to={managedPath}>前往设置 <ExternalLink size={12} /></Link>
+          ) : null}
+          {plugin.can_update_git ? (
+            <Button size="sm" variant="outline" disabled={busy} onClick={() => onUpdate(plugin)}>
+              <GitPullRequestArrow size={13} /> 更新
+            </Button>
+          ) : null}
+          {plugin.can_remove ? (
+            <Button size="sm" variant="outline" tone="danger" disabled={busy} onClick={() => onRemove(plugin)}>
+              <Trash2 size={13} /> 卸载
+            </Button>
+          ) : null}
+        </div>
+      </div>
+
+      {plugin.description ? <p className={s.description}>{plugin.description}</p> : null}
+
+      <div className={s.metaRow}>
+        <span>{pluginSourceLabel(plugin.source)}</span>
+        <span>{pluginKindLabel(plugin.kind)}</span>
+        {plugin.version ? <span>v{plugin.version}</span> : null}
+        {plugin.author ? <span>{plugin.author}</span> : null}
+        {plugin.has_dashboard_manifest ? <span title="桌面端不会执行插件前端脚本">含 Dashboard 扩展</span> : null}
+      </div>
+
+      <CapabilityList label="工具" values={plugin.provides_tools} />
+      <CapabilityList label="Hooks" values={plugin.provides_hooks} />
+      <CapabilityList label="环境变量" values={plugin.requires_env} />
+
+      {plugin.missing_env.length > 0 ? (
+        <div className={s.missingEnv}>
+          <AlertTriangle size={13} />
+          缺少 {plugin.missing_env.join("、")}
+          <Link to="/env">配置环境变量</Link>
+        </div>
+      ) : plugin.auth_required ? (
+        <div className={s.missingEnv}>
+          <AlertTriangle size={13} /> 该插件仍需完成认证或环境配置
+          <Link to="/env">前往配置</Link>
+        </div>
+      ) : null}
+
+      {plugin.path ? <div className={s.path} title={plugin.path}>{plugin.path}</div> : null}
+    </article>
+  );
+}
+
+export function PluginsRoute() {
+  const profile = useActiveProfileName();
+  const hub = usePluginsHub();
+  const install = useInstallPlugin();
+  const toggle = useSetPluginEnabled();
+  const update = useUpdatePlugin();
+  const remove = useRemovePlugin();
+  const [filters, setFilters] = useState<PluginFilters>(DEFAULT_FILTERS);
+  const [identifier, setIdentifier] = useState("");
+  const [force, setForce] = useState(false);
+  const [enableAfterInstall, setEnableAfterInstall] = useState(true);
+
+  const plugins = hub.data?.plugins ?? [];
+  const summary = useMemo(() => summarizePlugins(plugins), [plugins]);
+  const filtered = useMemo(() => filterPlugins(plugins, filters), [filters, plugins]);
+  const sources = useMemo(
+    () => Array.from(new Set(plugins.map((plugin) => plugin.source))).sort(),
+    [plugins],
+  );
+  const kinds = useMemo(
+    () => Array.from(new Set(plugins.map((plugin) => plugin.kind))).sort(),
+    [plugins],
+  );
+
+  const activeMutation = toggle.isPending && toggle.variables
+    ? pluginKey(toggle.variables.plugin)
+    : update.isPending && update.variables
+      ? pluginKey(update.variables)
+      : remove.isPending && remove.variables
+        ? pluginKey(remove.variables)
+        : "";
+  const mutationError = toggle.error || update.error || remove.error;
+  const missingHub = hub.isError && /HTTP 404\b/.test(errorText(hub.error));
+
+  const handleInstall = () => {
+    const value = identifier.trim();
+    if (!value) return;
+    const confirmed = window.confirm(
+      `确认安装插件「${value}」？\n\n第三方插件包含会在本机执行的代码。仅安装你信任的来源；启用状态会从后续新会话开始生效。`,
+    );
+    if (!confirmed) return;
+    install.mutate(
+      { identifier: value, force, enable: enableAfterInstall },
+      { onSuccess: () => setIdentifier("") },
+    );
+  };
+
+  const handleRemove = (plugin: PluginHubRow) => {
+    if (!window.confirm(`确认卸载插件「${plugin.name}」？\n\n插件目录会被删除，此操作无法撤销。`)) return;
+    remove.mutate(plugin);
+  };
+
+  const right = (
+    <Button variant="outline" onClick={() => void hub.refetch()} disabled={hub.isFetching}>
+      <RefreshCw size={14} /> {hub.isFetching ? "刷新中" : "刷新"}
+    </Button>
+  );
+
+  return (
+    <SectionShell title="Plugins" sub={`当前档案 · ${profile}`} right={right}>
+      <SettingsHero
+        ok={!hub.isError}
+        icon={<Puzzle size={24} />}
+        eyebrow="Hermes Agent 扩展系统"
+        title="插件管理"
+        description="查看当前档案可发现的插件，并管理安装、启停、更新与卸载。桌面端只读取插件元数据，不会加载插件提供的任意前端脚本。"
+        badge={<span className={settings.statusBadge} data-on={!hub.isError}>{hub.isLoading ? "读取中" : `${summary.total} 个插件`}</span>}
+      />
+
+      <div className={s.noticeGrid}>
+        <Alert tone="info" size="sm">
+          <Boxes size={14} /> 所有操作仅作用于当前档案 <strong>{profile}</strong>。切换档案后会自动重新读取。
+        </Alert>
+        <Alert tone="warning" size="sm">
+          <AlertTriangle size={14} /> 插件启停和安装只对后续新会话生效，不会重载正在运行会话的工具集。
+        </Alert>
+      </div>
+
+      {missingHub ? (
+        <section className={s.compatState}>
+          <Puzzle size={24} />
+          <h3>当前内核尚未提供 Plugins Hub</h3>
+          <p>请更新 CN-Core / 桌面端托管内核后再使用插件管理。其他页面不会受影响。</p>
+          <Link className={s.primaryLink} to="/kernel">查看内核版本</Link>
+        </section>
+      ) : hub.isError ? (
+        <Alert tone="danger" size="sm">无法读取插件清单：{errorText(hub.error)}</Alert>
+      ) : (
+        <>
+          <section className={s.statsGrid} aria-label="插件状态汇总">
+            {[
+              ["全部", summary.total],
+              ["生效中", summary.active],
+              ["未启用", summary.inactive],
+              ["已禁用", summary.disabled],
+              ["Provider 管理", summary.providerManaged],
+            ].map(([label, value]) => (
+              <div className={s.statCard} key={label}>
+                <strong>{value}</strong><span>{label}</span>
+              </div>
+            ))}
+          </section>
+
+          <section className={s.providerPanel}>
+            <div>
+              <span className={s.panelEyebrow}>Provider 状态 · 只读</span>
+              <h3>能力 Provider 继续在专用页面管理</h3>
+              <p>
+                记忆：{hub.data?.providers.memory_provider || "内置记忆"}　·　
+                上下文引擎：{hub.data?.providers.context_engine || "默认"}
+              </p>
+            </div>
+            <div className={s.providerLinks}>
+              <Link to="/memory">记忆 Provider <ExternalLink size={12} /></Link>
+              <Link to="/models">模型 Provider <ExternalLink size={12} /></Link>
+            </div>
+          </section>
+
+          <section className={s.installPanel}>
+            <div className={s.installTitle}>
+              <PackagePlus size={17} />
+              <div><h3>从 Git 安装</h3><p>支持 GitHub owner/repo、HTTPS 或 SSH Git 地址。</p></div>
+            </div>
+            <div className={s.installForm}>
+              <input
+                value={identifier}
+                onChange={(event) => setIdentifier(event.target.value)}
+                placeholder="owner/repo 或 https://github.com/owner/repo.git"
+                aria-label="插件 Git 来源"
+              />
+              <Button variant="solid" tone="accent" loading={install.isPending} disabled={!identifier.trim()} onClick={handleInstall}>
+                <Download size={13} /> 安装
+              </Button>
+            </div>
+            <div className={s.installOptions}>
+              <label><input type="checkbox" checked={enableAfterInstall} onChange={(event) => setEnableAfterInstall(event.target.checked)} /> 安装后启用</label>
+              <label><input type="checkbox" checked={force} onChange={(event) => setForce(event.target.checked)} /> 覆盖同名目录</label>
+            </div>
+            {install.error ? <Alert tone="danger" size="sm">安装失败：{errorText(install.error)}</Alert> : null}
+            {install.data ? (
+              <Alert tone={install.data.missing_env.length ? "warning" : "success"} size="sm">
+                已安装 {install.data.plugin_name || "插件"}。
+                {install.data.missing_env.length ? (
+                  <> 缺少 {install.data.missing_env.join("、")}，<Link to="/env">前往配置</Link>。</>
+                ) : null}
+                {install.data.warnings.length ? ` ${install.data.warnings.join(" ")}` : ""}
+              </Alert>
+            ) : null}
+          </section>
+
+          <section className={s.inventoryPanel}>
+            <div className={s.filterBar}>
+              <label className={s.searchBox}>
+                <Search size={14} />
+                <input
+                  value={filters.query}
+                  onChange={(event) => setFilters((current) => ({ ...current, query: event.target.value }))}
+                  placeholder="搜索名称、描述、工具、Hook 或环境变量"
+                />
+              </label>
+              <select value={filters.source} onChange={(event) => setFilters((current) => ({ ...current, source: event.target.value }))} aria-label="来源筛选">
+                <option value="all">全部来源</option>
+                {sources.map((source) => <option key={source} value={source}>{pluginSourceLabel(source)}</option>)}
+              </select>
+              <select value={filters.kind} onChange={(event) => setFilters((current) => ({ ...current, kind: event.target.value }))} aria-label="类型筛选">
+                <option value="all">全部类型</option>
+                {kinds.map((kind) => <option key={kind} value={kind}>{pluginKindLabel(kind)}</option>)}
+              </select>
+              <select value={filters.status} onChange={(event) => setFilters((current) => ({ ...current, status: event.target.value }))} aria-label="状态筛选">
+                <option value="all">全部状态</option>
+                <option value="enabled">已启用</option>
+                <option value="auto-active">自动生效</option>
+                <option value="inactive">未启用</option>
+                <option value="disabled">已禁用</option>
+                <option value="provider-managed">Provider 管理</option>
+              </select>
+            </div>
+
+            {mutationError ? <Alert tone="danger" size="sm">操作失败：{errorText(mutationError)}</Alert> : null}
+            {hub.isLoading ? <div className={s.emptyState}>正在读取插件清单…</div> : null}
+            {!hub.isLoading && filtered.length === 0 ? <div className={s.emptyState}>没有符合当前筛选条件的插件。</div> : null}
+            <div className={s.pluginList}>
+              {filtered.map((plugin) => (
+                <PluginCard
+                  key={pluginKey(plugin)}
+                  plugin={plugin}
+                  busy={activeMutation === pluginKey(plugin)}
+                  onToggle={(item, enabled) => toggle.mutate({ plugin: item, enabled })}
+                  onUpdate={(item) => update.mutate(item)}
+                  onRemove={handleRemove}
+                />
+              ))}
+            </div>
+          </section>
+        </>
+      )}
+    </SectionShell>
+  );
+}


### PR DESCRIPTION
## 改动

- 新增 `/plugins` 完整管理页，包含状态汇总、搜索筛选、能力与路径详情、刷新、Git 安装、启停、更新和卸载确认。
- 增加兼容新旧 Core 的 Zod 协议、Profile 维度 TanStack Query hooks、逐段编码的嵌套插件路径和 mutation 缓存失效。
- 接入配置侧栏、顶部页签和命令面板；Provider 插件只读并跳转到现有记忆/模型页面。
- 明确第三方本地代码风险、缺失环境变量入口，以及“仅后续新会话生效”；桌面端不加载插件任意 JS/CSS。
- 增加真实 Core Playwright 生命周期测试和本地 Git 插件夹具。

依赖 Core PR：Eynzof/Hermes-CN-Core#103。发布顺序应先合并并发布新的 Core runtime，再发布 Desktop；Desktop 对旧 Hub 字段保持只读兼容，无 Hub 时显示内核升级提示。

## 验证

- `pnpm typecheck`：通过
- `pnpm test:unit`：1,056/1,056 通过（Protocol 68 + Web 988）
- `cargo check`：通过
- `cargo fmt --check`、`cargo clippy --all-features -- -D warnings`：通过
- `cargo test --all-features`：493/493 通过
- Playwright 全套：11/11 通过
- Plugins 生命周期专项：3/3 通过，覆盖清单扫描不执行代码、安装风险确认、新 Core 进程启停生效、更新/卸载、Provider 只读和旧 Core 404 降级
- Desktop Web 生产构建：通过
- agent-browser 目视与控制台检查：页面有内容、无 Vite error overlay、无捕获控制台错误
