### PR TITLE
feat: 新增 UI 热更通道（轨道 B），签名前端 bundle 免整包更新

### DIFF
--- a/.github/workflows/release-ui.yml
+++ b/.github/workflows/release-ui.yml
@@ -1,0 +1,155 @@
+# UI hot-update channel release (Track B).
+#
+# Builds the Tauri webview frontend (web/dist), packages it per platform, signs
+# a manifest with the SAME Ed25519 trust key as the runtime channel, and
+# publishes zip + manifest to a GitHub prerelease. The desktop client's UI
+# update channel fetches `{channel}-{platform}-{arch}.json` and installs the
+# signed bundle into its writable ui/ tree without touching the kernel or the
+# shell binary.
+#
+# The UI bundle content is platform-independent (it's web assets); we still key
+# manifests by platform/arch so the file-name scheme matches the runtime
+# channel and a future platform-specific split needs no client change.
+#
+# NOTE: the Desktop repo's `releases/latest` is claimed by the shell release
+# (release-desktop.yml), so UI manifests must NOT rely on a `latest` alias.
+# The artifactUrl is signed to a per-TAG release download URL, and the client's
+# fallback base URL points at the landing mirror's /ui path, not GitHub latest.
+
+name: release-ui
+
+on:
+  push:
+    tags:
+      - "ui-v*"
+  workflow_dispatch:
+    inputs:
+      ui_version:
+        description: "UI bundle version, e.g. 0.7.1"
+        required: true
+      channel:
+        description: "Release channel"
+        default: stable
+        type: choice
+        options: [stable, beta, canary]
+      app_version_floor:
+        description: "Minimum compatible desktop shell version (signed gate)"
+        required: true
+        default: "0.7.0"
+
+permissions:
+  contents: write
+
+jobs:
+  build:
+    runs-on: ubuntu-latest
+    env:
+      RUNTIME_SIGN_PRIVATE_KEY_PEM: ${{ secrets.RUNTIME_SIGN_PRIVATE_KEY_PEM }}
+    steps:
+      - uses: actions/checkout@v4
+
+      - name: Resolve UI version + channel + floor
+        id: meta
+        shell: bash
+        run: |
+          if [[ -n "${{ github.event.inputs.ui_version }}" ]]; then
+            UI_VERSION="${{ github.event.inputs.ui_version }}"
+            CHANNEL="${{ github.event.inputs.channel }}"
+            FLOOR="${{ github.event.inputs.app_version_floor }}"
+          else
+            # Tag is `ui-v<version>` (optionally `-<channel>` suffix); strip prefix.
+            RAW="${GITHUB_REF_NAME#ui-v}"
+            if [[ "$RAW" == *-canary* ]]; then CHANNEL="canary";
+            elif [[ "$RAW" == *-beta* ]]; then CHANNEL="beta";
+            else CHANNEL="stable"; fi
+            UI_VERSION="${RAW%%-*}"
+            # Tag-triggered releases fall back to the repo-tracked floor default.
+            FLOOR="0.7.0"
+          fi
+
+          if [[ ! "$UI_VERSION" =~ ^[0-9]+\.[0-9]+\.[0-9]+([.-][0-9A-Za-z.-]+)?$ ]]; then
+            echo "Invalid UI version: $UI_VERSION" >&2
+            exit 1
+          fi
+          if [[ ! "$FLOOR" =~ ^[0-9]+\.[0-9]+\.[0-9]+([.-][0-9A-Za-z.-]+)?$ ]]; then
+            echo "Invalid app version floor: $FLOOR" >&2
+            exit 1
+          fi
+
+          echo "ui_version=$UI_VERSION" >> "$GITHUB_OUTPUT"
+          echo "channel=$CHANNEL" >> "$GITHUB_OUTPUT"
+          echo "app_version_floor=$FLOOR" >> "$GITHUB_OUTPUT"
+
+      - uses: pnpm/action-setup@v4
+        with:
+          version: 9.15.0
+
+      - uses: actions/setup-node@v4
+        with:
+          node-version: 20
+          cache: pnpm
+
+      - uses: actions/setup-python@v5
+        with:
+          python-version: "3.11"
+
+      - name: Install deps
+        run: |
+          pnpm install --frozen-lockfile
+          python -m pip install --upgrade pip cryptography
+
+      - name: Version sync check
+        run: pnpm version:check
+
+      - name: Build web bundle
+        run: pnpm --filter @hermes/web build:desktop
+
+      - name: Package + sign per platform
+        shell: bash
+        run: |
+          set -euo pipefail
+          mkdir -p out
+          CHANNEL="${{ steps.meta.outputs.channel }}"
+          UI_VERSION="${{ steps.meta.outputs.ui_version }}"
+          FLOOR="${{ steps.meta.outputs.app_version_floor }}"
+          # Content is identical across platforms; name per platform/arch so the
+          # client's {channel}-{platform}-{arch}.json scheme resolves.
+          for pa in win32-x64 darwin-arm64 darwin-x64 linux-x64; do
+            PLATFORM="${pa%-*}"
+            ARCH="${pa##*-}"
+            NAME="ui-${pa}"
+            (cd web/dist && zip -r -q "../../out/${NAME}.zip" .)
+
+            # artifactUrl is inside the signed payload; it must equal the exact
+            # per-tag Release download URL the assets will publish at. NOT the
+            # `latest` alias (claimed by the shell release).
+            URL="https://github.com/${GITHUB_REPOSITORY}/releases/download/${GITHUB_REF_NAME}/${NAME}.zip"
+
+            if [[ -n "${RUNTIME_SIGN_PRIVATE_KEY_PEM:-}" ]]; then
+              python scripts/sign_ui_manifest.py \
+                --channel "$CHANNEL" \
+                --ui-version "$UI_VERSION" \
+                --app-version-floor "$FLOOR" \
+                --platform "$PLATFORM" \
+                --arch "$ARCH" \
+                --artifact-url "$URL" \
+                --artifact-path "out/${NAME}.zip" \
+                --source-repo "${GITHUB_REPOSITORY}" \
+                --source-commit "${GITHUB_SHA}" \
+                --output "out/${CHANNEL}-${pa}.json"
+            else
+              echo "RUNTIME_SIGN_PRIVATE_KEY_PEM absent — skipping signing (fork / secret-less run)" >&2
+            fi
+          done
+          ls -la out
+
+      - name: Publish prerelease
+        if: startsWith(github.ref, 'refs/tags/')
+        uses: softprops/action-gh-release@v2
+        with:
+          # UI channel releases are marked prerelease so they never become the
+          # repo's `latest` (which the shell installer release owns).
+          prerelease: true
+          files: |
+            out/*.zip
+            out/*.json

--- a/packages/protocol/src/channels.ts
+++ b/packages/protocol/src/channels.ts
@@ -307,6 +307,59 @@ export type RuntimeUpdateStage =
 
 export const RUNTIME_UPDATE_STAGE_EVENT = "runtime-update-stage";
 
+/** UI 热更通道（轨道 B）：签名的前端 bundle 清单，镜像 Rust 侧 process/ui_update.rs。 */
+export interface UiUpdateManifest {
+  schemaVersion: number;
+  channel: string;
+  uiVersion: string;
+  /** 该 UI 包要求的最低桌面端版本，签名保护（防 UI↔壳 IPC 契约错位的核心闸门）。 */
+  appVersionFloor: string;
+  platform: string;
+  arch: string;
+  artifactUrl: string;
+  sha256: string;
+  signature: string;
+  sourceRepo: string;
+  sourceCommit: string;
+  createdAt?: string;
+}
+
+export interface UiInstallRecord {
+  schemaVersion: number;
+  uiVersion: string;
+  appVersionFloor: string;
+  channel: string;
+  platform: string;
+  arch: string;
+  path: string;
+  sha256: string;
+  source: string;
+  installedAt: string;
+  previousUiVersion?: string;
+}
+
+export interface UiUpdateCheckResult {
+  ok: boolean;
+  updateAvailable: boolean;
+  downgradeBlocked?: boolean;
+  /** 清单签名的 appVersionFloor 高于当前桌面端版本，安装被阻断。 */
+  floorBlocked?: boolean;
+  requiredAppVersion?: string;
+  currentUiVersion?: string;
+  manifest?: UiUpdateManifest;
+  error?: string;
+}
+
+export interface UiInstallUpdateResult {
+  ok: boolean;
+  installed?: UiInstallRecord;
+  previous?: UiInstallRecord;
+  error?: string;
+}
+
+/** UI 安装/回滚生效后触发（payload 为新的 uiVersion），Rust 侧会随即导航主窗口。 */
+export const UI_UPDATE_READY_EVENT = "ui-update-ready";
+
 export interface RuntimeInstallUpdateResult {
   ok: boolean;
   installed?: RuntimeInstallRecord;

--- a/scripts/sign_ui_manifest.py
+++ b/scripts/sign_ui_manifest.py
@@ -1,0 +1,176 @@
+#!/usr/bin/env python3
+r"""Sign a Hermes CN Desktop UI hot-update manifest with Ed25519.
+
+Ported from Hermes-CN-Core/scripts/sign_runtime_manifest.py for the UI channel
+(Track B). The desktop client verifies against the same trust key it uses for
+runtime updates (`HERMES_RUNTIME_UPDATE_PUBLIC_KEY_PEM(_DEFAULT)` cascade).
+
+The canonical payload concatenated with ``\n`` matches what the Rust side
+reconstructs in ``src/process/ui_update.rs::ui_signature_payload()`` — keep the
+field order in sync (both sides carry order-lock tests).
+
+``appVersionFloor`` is the safety core of the channel: the minimum desktop
+shell version the bundle is compatible with. It is REQUIRED and signed — a UI
+bundle that calls invoke commands an older shell doesn't have must carry a
+floor above that shell, and the client refuses to serve it.
+
+Usage:
+    python scripts/sign_ui_manifest.py \
+        --channel stable \
+        --ui-version 0.7.1 \
+        --app-version-floor 0.7.0 \
+        --platform win32 \
+        --arch x64 \
+        --artifact-url https://github.com/.../ui-win32-x64.zip \
+        --artifact-path out/ui-win32-x64.zip \
+        --source-repo Eynzof/Hermes-CN-Desktop \
+        --source-commit "$GITHUB_SHA" \
+        --output out/stable-win32-x64.json
+"""
+
+from __future__ import annotations
+
+import argparse
+import base64
+import datetime as _dt
+import hashlib
+import json
+import os
+import re
+import sys
+from pathlib import Path
+
+try:
+    from cryptography.hazmat.primitives.asymmetric.ed25519 import Ed25519PrivateKey
+    from cryptography.hazmat.primitives.serialization import load_pem_private_key
+except ImportError:
+    raise SystemExit(
+        "scripts/sign_ui_manifest.py needs `cryptography` (pip install cryptography)."
+    )
+
+
+SCHEMA_VERSION = 1
+
+# Field order MUST match `ui_signature_payload()` in src/process/ui_update.rs.
+# Any reorder here is a silent verification failure on every UI install —
+# change both sides together or not at all.
+PAYLOAD_FIELDS = (
+    "schemaVersion",
+    "channel",
+    "uiVersion",
+    "appVersionFloor",
+    "platform",
+    "arch",
+    "artifactUrl",
+    "sha256",
+    "sourceRepo",
+    "sourceCommit",
+)
+
+_SEMVER_RE = re.compile(r"^\d+\.\d+\.\d+(?:-[0-9A-Za-z.-]+)?$")
+
+
+def _sha256_hex(path: Path) -> str:
+    h = hashlib.sha256()
+    with path.open("rb") as f:
+        for chunk in iter(lambda: f.read(1 << 20), b""):
+            h.update(chunk)
+    return h.hexdigest()
+
+
+def _load_private_key() -> Ed25519PrivateKey:
+    pem = os.environ.get("RUNTIME_SIGN_PRIVATE_KEY_PEM")
+    if not pem:
+        raise SystemExit(
+            "RUNTIME_SIGN_PRIVATE_KEY_PEM is not set. The UI channel signs "
+            "with the same Ed25519 trust key as the runtime channel. Never "
+            "put the key on argv (it'd leak via process listings)."
+        )
+    pem = pem.replace("\\n", "\n").encode()
+    key = load_pem_private_key(pem, password=None)
+    if not isinstance(key, Ed25519PrivateKey):
+        raise SystemExit("RUNTIME_SIGN_PRIVATE_KEY_PEM is not an Ed25519 key.")
+    return key
+
+
+def main() -> int:
+    p = argparse.ArgumentParser(
+        description=__doc__,
+        formatter_class=argparse.RawDescriptionHelpFormatter,
+    )
+    p.add_argument("--channel", required=True, help="stable | beta | canary | ...")
+    p.add_argument("--ui-version", required=True, help="UI bundle version, e.g. 0.7.1")
+    p.add_argument(
+        "--app-version-floor",
+        required=True,
+        help="minimum compatible desktop shell version (signed gate)",
+    )
+    p.add_argument("--platform", required=True, choices=("win32", "darwin", "linux"))
+    p.add_argument("--arch", required=True, choices=("x64", "arm64"))
+    p.add_argument("--artifact-url", required=True, help="HTTPS URL clients fetch")
+    p.add_argument(
+        "--artifact-path",
+        required=True,
+        type=Path,
+        help="Local path to the zip — used to compute sha256",
+    )
+    p.add_argument("--source-repo", required=True, help="org/name slug")
+    p.add_argument("--source-commit", required=True, help="commit SHA")
+    p.add_argument("--output", required=True, type=Path)
+    args = p.parse_args()
+
+    for label, value in (
+        ("--ui-version", args.ui_version),
+        ("--app-version-floor", args.app_version_floor),
+    ):
+        if not _SEMVER_RE.match(value):
+            # The Rust floor gate REFUSES unparseable floors (fails closed),
+            # which would brick the bundle; fail fast at signing time.
+            raise SystemExit(f"{label} must be semver (X.Y.Z), got {value!r}")
+
+    if not args.artifact_path.is_file():
+        raise SystemExit(f"artifact zip not found: {args.artifact_path}")
+
+    if not args.artifact_url.startswith("https://"):
+        # Rust side rejects non-https; fail fast so CI can't ship a manifest
+        # the client will refuse.
+        raise SystemExit(f"artifact_url must be https:, got {args.artifact_url!r}")
+
+    sha256 = _sha256_hex(args.artifact_path)
+    print(f"sha256({args.artifact_path.name}) = {sha256}", file=sys.stderr)
+
+    manifest = {
+        "schemaVersion": SCHEMA_VERSION,
+        "channel": args.channel,
+        "uiVersion": args.ui_version,
+        "appVersionFloor": args.app_version_floor,
+        "platform": args.platform,
+        "arch": args.arch,
+        "artifactUrl": args.artifact_url,
+        "sha256": sha256,
+        "sourceRepo": args.source_repo,
+        "sourceCommit": args.source_commit,
+    }
+    payload = "\n".join(str(manifest[f]) for f in PAYLOAD_FIELDS).encode()
+    manifest["createdAt"] = _dt.datetime.now(_dt.timezone.utc).strftime(
+        "%Y-%m-%dT%H:%M:%SZ"
+    )
+
+    key = _load_private_key()
+    signature = key.sign(payload)
+    manifest["signature"] = base64.standard_b64encode(signature).decode()
+
+    # Self-check: verify with the derived public key before writing, so a
+    # payload-construction bug can never ship a manifest clients reject.
+    key.public_key().verify(signature, payload)
+
+    args.output.parent.mkdir(parents=True, exist_ok=True)
+    args.output.write_text(
+        json.dumps(manifest, indent=2, ensure_ascii=False) + "\n", encoding="utf-8"
+    )
+    print(f"wrote {args.output}", file=sys.stderr)
+    return 0
+
+
+if __name__ == "__main__":
+    raise SystemExit(main())

--- a/src/commands/mod.rs
+++ b/src/commands/mod.rs
@@ -21,5 +21,6 @@ pub mod restart;
 pub mod runtime_manager;
 pub mod terminal;
 pub mod ui_store;
+pub mod ui_update;
 pub mod ws_proxy;
 pub mod yolo;

--- a/src/commands/ui_update.rs
+++ b/src/commands/ui_update.rs
@@ -1,0 +1,117 @@
+// UI hot-update commands (Track B).
+//
+// Thin wrappers around process/ui_update.rs. Unlike the runtime channel these
+// never touch the dashboard subprocess — a UI swap only needs the webview to
+// load the new bundle, which `apply_active_ui` does by navigating the main
+// window (Rust-side navigate, so the tauri://-to-hermesui cross-scheme hop is
+// not subject to webview navigation policy).
+
+use tauri::Manager;
+
+use crate::error::AppError;
+use crate::process::ui_update::{self, UiInstallUpdateResult, UiUpdateCheckResult};
+use crate::update_stage::UpdateStage;
+
+/// Event fired after a UI install/rollback has been activated.
+pub const UI_UPDATE_READY_EVENT: &str = "ui-update-ready";
+
+pub const UI_PROTOCOL_ENTRY_URL: &str = "hermesui://localhost/index.html";
+
+/// Point the main window at the active UI source: the hermesui override when
+/// one passes every gate, else the embedded bundle. Reload semantics come for
+/// free — navigate always re-requests index.html, and the protocol handler
+/// serves it with no-cache.
+fn apply_active_ui(app: &tauri::AppHandle) {
+    let Some(window) = app.get_webview_window(crate::tray::MAIN_WINDOW_LABEL) else {
+        return;
+    };
+    let target = if ui_update::active_ui_dir().is_some() {
+        UI_PROTOCOL_ENTRY_URL.parse()
+    } else {
+        "tauri://localhost/index.html".parse()
+    };
+    match target {
+        Ok(url) => {
+            if let Err(e) = window.navigate(url) {
+                log::warn!("failed to navigate main window to updated UI: {e}");
+            }
+        }
+        Err(e) => log::warn!("invalid UI navigation URL: {e}"),
+    }
+}
+
+#[tauri::command]
+pub async fn ui_check_update() -> Result<UiUpdateCheckResult, AppError> {
+    Ok(ui_update::check_ui_update().await)
+}
+
+/// Install a UI update and reload the webview onto it. The dashboard/kernel
+/// is untouched.
+#[tauri::command]
+pub async fn ui_install_update(app: tauri::AppHandle) -> Result<UiInstallUpdateResult, AppError> {
+    let stage_app = app.clone();
+    let sink = move |stage: UpdateStage| stage.emit(&stage_app);
+    let result = ui_update::install_ui_update(None, Some(&sink)).await;
+    if !result.ok {
+        UpdateStage::Failed {
+            error: result
+                .error
+                .clone()
+                .unwrap_or_else(|| "UI update failed".to_string()),
+            new_version: None,
+        }
+        .emit(&app);
+        return Ok(result);
+    }
+
+    let new_version = result
+        .installed
+        .as_ref()
+        .map(|r| r.ui_version.clone())
+        .unwrap_or_default();
+    use tauri::Emitter;
+    let _ = app.emit(UI_UPDATE_READY_EVENT, &new_version);
+    apply_active_ui(&app);
+    UpdateStage::Complete {
+        new_version,
+        previous_version: result.previous.as_ref().map(|p| p.ui_version.clone()),
+    }
+    .emit(&app);
+    Ok(result)
+}
+
+/// Roll the UI back to the previous installed bundle (pure disk repoint).
+#[tauri::command]
+pub async fn ui_rollback(app: tauri::AppHandle) -> Result<UiInstallUpdateResult, AppError> {
+    UpdateStage::RollingBack.emit(&app);
+    let result = ui_update::rollback_ui_update();
+    if !result.ok {
+        UpdateStage::Failed {
+            error: result
+                .error
+                .clone()
+                .unwrap_or_else(|| "UI rollback failed".to_string()),
+            new_version: None,
+        }
+        .emit(&app);
+        return Ok(result);
+    }
+    let restored_version = result
+        .installed
+        .as_ref()
+        .map(|r| r.ui_version.clone())
+        .unwrap_or_default();
+    use tauri::Emitter;
+    let _ = app.emit(UI_UPDATE_READY_EVENT, &restored_version);
+    apply_active_ui(&app);
+    UpdateStage::RolledBack { restored_version }.emit(&app);
+    Ok(result)
+}
+
+/// Escape hatch: drop the installed override and return to the embedded UI.
+#[tauri::command]
+pub async fn ui_reset_to_embedded(app: tauri::AppHandle) -> Result<(), AppError> {
+    ui_update::reset_ui_to_embedded().map_err(AppError::FileError)?;
+    apply_active_ui(&app);
+    Ok(())
+}

--- a/src/main.rs
+++ b/src/main.rs
@@ -19,7 +19,7 @@ use hermes_agent_cn::commands;
 use hermes_agent_cn::commands::profiles::read_active_profile_sticky;
 use hermes_agent_cn::connection::{self, ConnectionBackend, ConnectionMode};
 use hermes_agent_cn::desktop_control;
-use hermes_agent_cn::process::{dashboard, instance, runtime};
+use hermes_agent_cn::process::{dashboard, instance, runtime, ui_update};
 use hermes_agent_cn::state::{AppState, DashboardHandle};
 use hermes_agent_cn::tray;
 
@@ -153,11 +153,54 @@ fn main() {
         .plugin(tauri_plugin_dialog::init())
         .plugin(tauri_plugin_notification::init())
         .plugin(tauri_plugin_clipboard_manager::init())
+        // UI hot-update channel (Track B): `hermesui://` serves the signed,
+        // gated UI override from the writable tree, falling back per-file to
+        // the embedded bundle (process/ui_update.rs::serve_ui_request). The
+        // window only loads via this scheme when an override is installed, so
+        // default installs behave exactly like the static embedded window.
+        .register_asynchronous_uri_scheme_protocol("hermesui", |ctx, request, responder| {
+            let app = ctx.app_handle().clone();
+            let path = request.uri().path().to_string();
+            tauri::async_runtime::spawn_blocking(move || {
+                let response = ui_update::serve_ui_request(&app, &path);
+                let http_response = tauri::http::Response::builder()
+                    .status(response.status)
+                    .header("content-type", response.mime)
+                    .header("cache-control", response.cache_control)
+                    .body(response.body)
+                    .unwrap_or_else(|_| tauri::http::Response::new(Vec::new()));
+                responder.respond(http_response);
+            });
+        })
         .manage(app_state)
         .setup(move |app| {
             use tauri::Manager;
             let state = app.state::<AppState>();
             let bundled_resource_dir = app.path().resource_dir().ok();
+
+            // The main window is built in code (not tauri.conf.json) so the
+            // startup URL can select the installed UI override. In dev, and
+            // whenever no override passes the gates, WebviewUrl::App keeps
+            // today's behavior exactly (devUrl in dev, embedded dist packed).
+            let window_url = if !cfg!(dev) && ui_update::active_ui_dir().is_some() {
+                commands::ui_update::UI_PROTOCOL_ENTRY_URL
+                    .parse()
+                    .map(tauri::WebviewUrl::CustomProtocol)
+                    .unwrap_or_else(|_| tauri::WebviewUrl::App("index.html".into()))
+            } else {
+                tauri::WebviewUrl::App("index.html".into())
+            };
+            let window_builder = tauri::WebviewWindowBuilder::new(
+                app,
+                crate::tray::MAIN_WINDOW_LABEL,
+                window_url,
+            )
+            .title("Hermes Agent 中文社区桌面版")
+            .inner_size(1240.0, 820.0)
+            .min_inner_size(960.0, 680.0);
+            #[cfg(target_os = "macos")]
+            let window_builder = window_builder.title_bar_style(tauri::TitleBarStyle::Transparent);
+            window_builder.build()?;
 
             // Focus channel for the single-instance guard: consume any stale
             // request from a previous run, then watch for new ones. Armed
@@ -536,6 +579,10 @@ fn main() {
             commands::runtime_manager::runtime_check_update,
             commands::runtime_manager::runtime_install_update,
             commands::runtime_manager::runtime_rollback,
+            commands::ui_update::ui_check_update,
+            commands::ui_update::ui_install_update,
+            commands::ui_update::ui_rollback,
+            commands::ui_update::ui_reset_to_embedded,
             commands::runtime_manager::get_desktop_control_state,
             commands::runtime_manager::set_guide_state,
             commands::runtime_manager::managed_runtime_install,

--- a/src/process/mod.rs
+++ b/src/process/mod.rs
@@ -3,3 +3,4 @@ pub mod gateway;
 pub mod instance;
 pub mod port_lock;
 pub mod runtime;
+pub mod ui_update;

--- a/src/process/runtime.rs
+++ b/src/process/runtime.rs
@@ -23,7 +23,7 @@ use crate::update_stage::UpdateStage;
 /// (bundled bootstrap at startup) free of UI events.
 pub type StageSink<'a> = &'a (dyn Fn(UpdateStage) + Send + Sync);
 
-fn emit_stage(sink: Option<StageSink<'_>>, stage: UpdateStage) {
+pub(crate) fn emit_stage(sink: Option<StageSink<'_>>, stage: UpdateStage) {
     if let Some(sink) = sink {
         sink(stage);
     }
@@ -66,8 +66,8 @@ const BUNDLED_SKILLS_DIR: &str = "skills";
 const BUNDLED_PLUGINS_RESOURCE_DIR: &str = "bundled-plugins";
 const BUNDLED_PLUGINS_DIR: &str = "plugins";
 const RUNTIME_HTTP_CONNECT_TIMEOUT: Duration = Duration::from_secs(15);
-const RUNTIME_MANIFEST_HTTP_TIMEOUT: Duration = Duration::from_secs(30);
-const RUNTIME_ARTIFACT_HTTP_TIMEOUT: Duration = Duration::from_secs(15 * 60);
+pub(crate) const RUNTIME_MANIFEST_HTTP_TIMEOUT: Duration = Duration::from_secs(30);
+pub(crate) const RUNTIME_ARTIFACT_HTTP_TIMEOUT: Duration = Duration::from_secs(15 * 60);
 // The release runtime is a PyInstaller-style onefile binary. On a cold macOS
 // launch it has to unpack its embedded Python payload before argparse can even
 // print `dashboard --help`; current arm64 artifacts routinely take ~18s on the
@@ -81,7 +81,7 @@ const SMOKE_TIMEOUT: Duration = Duration::from_secs(60);
 // exits). This hardens both the real post-install path and the smoke-check test
 // under cargo's multi-threaded runner.
 const SMOKE_SPAWN_RETRIES: u32 = 5;
-static RUNTIME_HTTP_CLIENT: LazyLock<reqwest::Client> = LazyLock::new(|| {
+pub(crate) static RUNTIME_HTTP_CLIENT: LazyLock<reqwest::Client> = LazyLock::new(|| {
     reqwest::Client::builder()
         .connect_timeout(RUNTIME_HTTP_CONNECT_TIMEOUT)
         .build()
@@ -293,7 +293,7 @@ pub struct RuntimeInstallUpdateResult {
     pub error: Option<String>,
 }
 
-fn current_platform() -> &'static str {
+pub(crate) fn current_platform() -> &'static str {
     if cfg!(target_os = "windows") {
         "win32"
     } else if cfg!(target_os = "macos") {
@@ -303,7 +303,7 @@ fn current_platform() -> &'static str {
     }
 }
 
-fn current_arch() -> &'static str {
+pub(crate) fn current_arch() -> &'static str {
     if cfg!(target_arch = "x86_64") {
         "x64"
     } else if cfg!(target_arch = "aarch64") {
@@ -316,7 +316,7 @@ fn current_arch() -> &'static str {
 /// Desktop shell version, taken from the crate itself (kept in sync with
 /// `package.json`/`tauri.conf.json` by `pnpm version:sync`). Never accept this
 /// from the webview — the min-app-version gate must not be spoofable.
-fn desktop_app_version() -> &'static str {
+pub(crate) fn desktop_app_version() -> &'static str {
     env!("CARGO_PKG_VERSION")
 }
 
@@ -326,7 +326,7 @@ fn desktop_app_version() -> &'static str {
 /// ever added: `0.18.2-cn.2-canary.3` makes the pre-release `cn.2-canary` an
 /// *alphanumeric* identifier that sorts ABOVE the numeric `cn.2` — canary
 /// version grammar must be designed together with these gates.
-fn parse_runtime_semver(version: &str) -> Option<semver::Version> {
+pub(crate) fn parse_runtime_semver(version: &str) -> Option<semver::Version> {
     semver::Version::parse(version.trim().trim_start_matches('v')).ok()
 }
 
@@ -334,7 +334,7 @@ fn parse_runtime_semver(version: &str) -> Option<semver::Version> {
 /// Only ever true when BOTH sides parse as semver — unparseable versions fall
 /// back to the legacy "any difference is installable" behavior rather than
 /// bricking updates over a formatting quirk.
-fn is_version_downgrade(candidate: &str, current: &str) -> bool {
+pub(crate) fn is_version_downgrade(candidate: &str, current: &str) -> bool {
     match (
         parse_runtime_semver(candidate),
         parse_runtime_semver(current),
@@ -898,7 +898,7 @@ fn configured_manifest_url() -> Option<String> {
     ))
 }
 
-fn configured_public_key() -> Option<String> {
+pub(crate) fn configured_public_key() -> Option<String> {
     // 1. PEM via runtime env (highest precedence)
     if let Ok(direct) = std::env::var("HERMES_RUNTIME_UPDATE_PUBLIC_KEY_PEM") {
         let pem = direct.trim().replace("\\n", "\n");
@@ -968,7 +968,7 @@ pub fn get_runtime_info(last_error: Option<String>) -> RuntimeInfo {
     }
 }
 
-fn file_sha256(path: &Path) -> Option<String> {
+pub(crate) fn file_sha256(path: &Path) -> Option<String> {
     let mut file = fs::File::open(path).ok()?;
     let mut hasher = Sha256::new();
     let mut buf = [0u8; 64 * 1024];
@@ -1530,7 +1530,7 @@ fn verify_signature_with_key(
         .map_err(|_| "Signature verification failed".to_string())
 }
 
-fn safe_version_segment(version: &str) -> Result<String, String> {
+pub(crate) fn safe_version_segment(version: &str) -> Result<String, String> {
     const MAX_VERSION_SEGMENT_LEN: usize = 120;
 
     if version.is_empty() {
@@ -2549,7 +2549,7 @@ fn symlink_target_within(dest: &Path, link_parent: &Path, target: &Path) -> bool
     resolved.starts_with(dest)
 }
 
-fn extract_zip(zip_path: &Path, dest: &Path) -> Result<(), String> {
+pub(crate) fn extract_zip(zip_path: &Path, dest: &Path) -> Result<(), String> {
     let file = fs::File::open(zip_path).map_err(|e| e.to_string())?;
     let mut archive = zip::ZipArchive::new(file).map_err(|e| e.to_string())?;
 
@@ -2814,7 +2814,7 @@ fn validate_bundled_plugins_tree(dir: &Path) -> Result<(), String> {
     Ok(())
 }
 
-fn copy_dir_all(src: &Path, dst: &Path) -> Result<(), String> {
+pub(crate) fn copy_dir_all(src: &Path, dst: &Path) -> Result<(), String> {
     fs::create_dir_all(dst).map_err(|e| e.to_string())?;
     for entry in fs::read_dir(src).map_err(|e| e.to_string())? {
         let entry = entry.map_err(|e| e.to_string())?;
@@ -2835,7 +2835,7 @@ fn copy_dir_all(src: &Path, dst: &Path) -> Result<(), String> {
     Ok(())
 }
 
-fn chrono_now() -> String {
+pub(crate) fn chrono_now() -> String {
     let secs = std::time::SystemTime::now()
         .duration_since(std::time::UNIX_EPOCH)
         .unwrap_or_default()

--- a/src/process/ui_update.rs
+++ b/src/process/ui_update.rs
@@ -1,0 +1,1095 @@
+// UI hot-update channel (Track B of the hot-update plan).
+//
+// Delivers signed zips of the Tauri webview frontend (`web/dist`) into a
+// writable versions tree under `runtime_root()/ui/`, served to the window by
+// the `hermesui` custom URI scheme registered in main.rs. The embedded
+// `frontendDist` stays in the binary as the never-brick fallback: the window
+// only loads from the writable tree when an installed override passes every
+// gate (schema, platform, signed appVersionFloor, index.html present).
+//
+// The engine deliberately mirrors process/runtime.rs — same Ed25519 trust key,
+// same sha256 + signature double check, same extract_zip guardrails, same
+// `versions/<v>/ + current.json` pointer layout, same single-step rollback.
+
+use std::fs;
+use std::path::{Path, PathBuf};
+
+use serde::{Deserialize, Serialize};
+
+use crate::process::runtime::{
+    self, chrono_now, configured_public_key, current_arch, current_platform, desktop_app_version,
+    emit_stage, extract_zip, file_sha256, is_version_downgrade, parse_runtime_semver,
+    safe_version_segment, StageSink, RUNTIME_ARTIFACT_HTTP_TIMEOUT, RUNTIME_HTTP_CLIENT,
+    RUNTIME_MANIFEST_HTTP_TIMEOUT,
+};
+use crate::update_stage::UpdateStage;
+
+const UI_SUBDIR: &str = "ui";
+const UI_CURRENT_FILE: &str = "current.json";
+const UI_MANIFEST_FILE: &str = "manifest.json";
+/// Install-record schema for `ui/current.json`.
+const UI_RECORD_SCHEMA_VERSION: u32 = 1;
+/// UI update-manifest schemas this client accepts.
+const SUPPORTED_UI_MANIFEST_SCHEMA_VERSIONS: [u32; 1] = [1];
+const DEFAULT_UI_CHANNEL: &str = "stable";
+
+// Compile-time defaults, mirroring the runtime channel's cascade
+// (HERMES_RUNTIME_UPDATE_*). Trust key is shared with the runtime channel.
+const BAKED_UI_MANIFEST_BASE_URL: Option<&str> = option_env!("HERMES_UI_UPDATE_BASE_URL_DEFAULT");
+const BAKED_UI_MANIFEST_CHANNEL: Option<&str> = option_env!("HERMES_UI_UPDATE_CHANNEL_DEFAULT");
+const FALLBACK_UI_MANIFEST_BASE_URL: &str = "https://desktop.hermesagent.org.cn/ui";
+
+#[derive(Debug, Clone, Serialize, Deserialize)]
+#[serde(rename_all = "camelCase")]
+pub struct UiUpdateManifest {
+    pub schema_version: u32,
+    pub channel: String,
+    pub ui_version: String,
+    /// Minimum desktop shell version this UI bundle is compatible with.
+    /// Signed (payload field #4) — the safety core of the whole channel: a UI
+    /// that calls invoke commands the installed shell doesn't have is refused
+    /// here and the window keeps serving the embedded bundle.
+    pub app_version_floor: String,
+    pub platform: String,
+    pub arch: String,
+    pub artifact_url: String,
+    pub sha256: String,
+    pub signature: String,
+    pub source_repo: String,
+    pub source_commit: String,
+    #[serde(skip_serializing_if = "Option::is_none")]
+    pub created_at: Option<String>,
+}
+
+#[derive(Debug, Clone, Serialize, Deserialize)]
+#[serde(rename_all = "camelCase")]
+pub struct UiInstallRecord {
+    pub schema_version: u32,
+    pub ui_version: String,
+    pub app_version_floor: String,
+    pub channel: String,
+    pub platform: String,
+    pub arch: String,
+    pub path: String,
+    pub sha256: String,
+    pub source: String,
+    pub installed_at: String,
+    #[serde(skip_serializing_if = "Option::is_none")]
+    pub previous_ui_version: Option<String>,
+}
+
+#[derive(Debug, Serialize, Deserialize)]
+#[serde(rename_all = "camelCase")]
+pub struct UiUpdateCheckResult {
+    pub ok: bool,
+    pub update_available: bool,
+    #[serde(default)]
+    pub downgrade_blocked: bool,
+    /// The manifest's signed appVersionFloor is above this desktop build.
+    #[serde(default)]
+    pub floor_blocked: bool,
+    #[serde(skip_serializing_if = "Option::is_none")]
+    pub required_app_version: Option<String>,
+    #[serde(skip_serializing_if = "Option::is_none")]
+    pub current_ui_version: Option<String>,
+    #[serde(skip_serializing_if = "Option::is_none")]
+    pub manifest: Option<UiUpdateManifest>,
+    #[serde(skip_serializing_if = "Option::is_none")]
+    pub error: Option<String>,
+}
+
+impl UiUpdateCheckResult {
+    fn failure(error: String) -> Self {
+        UiUpdateCheckResult {
+            ok: false,
+            update_available: false,
+            downgrade_blocked: false,
+            floor_blocked: false,
+            required_app_version: None,
+            current_ui_version: None,
+            manifest: None,
+            error: Some(error),
+        }
+    }
+}
+
+#[derive(Debug, Serialize, Deserialize)]
+#[serde(rename_all = "camelCase")]
+pub struct UiInstallUpdateResult {
+    pub ok: bool,
+    #[serde(skip_serializing_if = "Option::is_none")]
+    pub installed: Option<UiInstallRecord>,
+    #[serde(skip_serializing_if = "Option::is_none")]
+    pub previous: Option<UiInstallRecord>,
+    #[serde(skip_serializing_if = "Option::is_none")]
+    pub error: Option<String>,
+}
+
+impl UiInstallUpdateResult {
+    fn failure(error: String) -> Self {
+        UiInstallUpdateResult {
+            ok: false,
+            installed: None,
+            previous: None,
+            error: Some(error),
+        }
+    }
+}
+
+// ---------------------------------------------------------------------------
+// Disk layout
+// ---------------------------------------------------------------------------
+
+pub fn ui_root() -> PathBuf {
+    runtime::runtime_root().join(UI_SUBDIR)
+}
+
+fn ui_versions_root() -> PathBuf {
+    ui_root().join("versions")
+}
+
+fn ui_downloads_root() -> PathBuf {
+    ui_root().join("downloads")
+}
+
+fn ui_current_record_path() -> PathBuf {
+    ui_root().join(UI_CURRENT_FILE)
+}
+
+fn read_json_file<T: serde::de::DeserializeOwned>(path: &Path) -> Option<T> {
+    let text = fs::read_to_string(path).ok()?;
+    serde_json::from_str(&text).ok()
+}
+
+fn write_json_file<T: Serialize>(path: &Path, value: &T) -> Result<(), String> {
+    if let Some(parent) = path.parent() {
+        fs::create_dir_all(parent)
+            .map_err(|e| format!("Failed to create {}: {}", parent.display(), e))?;
+    }
+    let json = serde_json::to_string_pretty(value)
+        .map_err(|e| format!("Failed to serialize {}: {}", path.display(), e))?;
+    fs::write(path, json + "\n").map_err(|e| format!("Failed to write {}: {}", path.display(), e))
+}
+
+pub fn read_ui_current_record() -> Option<UiInstallRecord> {
+    let record: UiInstallRecord = read_json_file(&ui_current_record_path())?;
+    if record.schema_version != UI_RECORD_SCHEMA_VERSION {
+        return None;
+    }
+    if record.platform != current_platform() || record.arch != current_arch() {
+        return None;
+    }
+    if !Path::new(&record.path).join("index.html").is_file() {
+        return None;
+    }
+    Some(record)
+}
+
+/// True when `floor` allows this desktop build. Unparseable floors REFUSE the
+/// bundle — unlike the kernel's minAppVersion (where a bad value only skips a
+/// gate on an otherwise-verified artifact), a UI bundle whose floor cannot be
+/// evaluated could call invoke commands this shell doesn't have.
+fn floor_allows_current_app(floor: &str) -> bool {
+    match (
+        parse_runtime_semver(floor),
+        parse_runtime_semver(desktop_app_version()),
+    ) {
+        (Some(floor), Some(app)) => floor <= app,
+        _ => false,
+    }
+}
+
+/// The directory the `hermesui` protocol should serve, or None to fall back
+/// to the embedded bundle. Every gate is re-checked on read so a bad override
+/// can never outlive its welcome: record schema/platform, signed floor vs the
+/// CURRENT shell version (an app downgrade re-locks newer UI bundles), and
+/// index.html presence.
+pub fn active_ui_dir() -> Option<PathBuf> {
+    let record = read_ui_current_record()?;
+    if !floor_allows_current_app(&record.app_version_floor) {
+        log::warn!(
+            "installed UI {} requires desktop >= {} (current {}); serving embedded bundle",
+            record.ui_version,
+            record.app_version_floor,
+            desktop_app_version()
+        );
+        return None;
+    }
+    Some(PathBuf::from(record.path))
+}
+
+// ---------------------------------------------------------------------------
+// Request-path sanitizing for the hermesui protocol handler
+// ---------------------------------------------------------------------------
+
+/// Normalize a hermesui request path into a safe relative path. Returns None
+/// for anything that could escape the served directory: absolute paths,
+/// `..`/`.` segments, backslashes, NUL, or empty segments after decoding.
+/// An empty path resolves to `index.html` (SPA entry).
+pub fn sanitize_ui_request_path(raw_path: &str) -> Option<String> {
+    let path = raw_path.split(['?', '#']).next().unwrap_or("");
+    let decoded = urlencoding::decode(path).ok()?;
+    let decoded = decoded.trim_start_matches('/');
+    if decoded.is_empty() {
+        return Some("index.html".to_string());
+    }
+    if decoded.contains('\0') || decoded.contains('\\') {
+        return None;
+    }
+    let mut segments = Vec::new();
+    for segment in decoded.split('/') {
+        if segment.is_empty() || segment == "." || segment == ".." {
+            return None;
+        }
+        segments.push(segment);
+    }
+    Some(segments.join("/"))
+}
+
+// ---------------------------------------------------------------------------
+// Manifest URL + signature
+// ---------------------------------------------------------------------------
+
+fn configured_ui_manifest_url() -> Option<String> {
+    if let Ok(explicit) = std::env::var("HERMES_UI_UPDATE_MANIFEST_URL") {
+        let trimmed = explicit.trim().to_string();
+        if !trimmed.is_empty() {
+            return Some(trimmed);
+        }
+    }
+    let base = std::env::var("HERMES_UI_UPDATE_BASE_URL")
+        .ok()
+        .filter(|s| !s.trim().is_empty())
+        .or_else(|| BAKED_UI_MANIFEST_BASE_URL.map(|s| s.to_string()))
+        .unwrap_or_else(|| FALLBACK_UI_MANIFEST_BASE_URL.to_string());
+    let base = base.trim().trim_end_matches('/').to_string();
+    if base.is_empty() {
+        return None;
+    }
+    let channel = std::env::var("HERMES_UI_UPDATE_CHANNEL")
+        .ok()
+        .filter(|s| !s.trim().is_empty())
+        .or_else(|| BAKED_UI_MANIFEST_CHANNEL.map(|s| s.to_string()))
+        .unwrap_or_else(|| DEFAULT_UI_CHANNEL.to_string());
+    Some(format!(
+        "{}/{}-{}-{}.json",
+        base,
+        channel,
+        current_platform(),
+        current_arch()
+    ))
+}
+
+// Signed payload, one field per line. Field ORDER is a cross-language
+// contract with scripts/sign_ui_manifest.py — change both together, guarded
+// by the order-lock tests below.
+fn ui_signature_payload(manifest: &UiUpdateManifest) -> Vec<u8> {
+    format!(
+        "{}\n{}\n{}\n{}\n{}\n{}\n{}\n{}\n{}\n{}",
+        manifest.schema_version,
+        manifest.channel,
+        manifest.ui_version,
+        manifest.app_version_floor,
+        manifest.platform,
+        manifest.arch,
+        manifest.artifact_url,
+        manifest.sha256,
+        manifest.source_repo,
+        manifest.source_commit,
+    )
+    .into_bytes()
+}
+
+fn validate_ui_manifest(manifest: &UiUpdateManifest) -> Result<String, String> {
+    if !SUPPORTED_UI_MANIFEST_SCHEMA_VERSIONS.contains(&manifest.schema_version) {
+        return Err(format!(
+            "UI manifest schemaVersion is {}, expected one of {:?}",
+            manifest.schema_version, SUPPORTED_UI_MANIFEST_SCHEMA_VERSIONS
+        ));
+    }
+    if manifest.app_version_floor.trim().is_empty() {
+        return Err("UI manifest requires a non-empty appVersionFloor".to_string());
+    }
+    if manifest.platform != current_platform() || manifest.arch != current_arch() {
+        return Err(format!(
+            "UI manifest is for {}-{}, not {}-{}",
+            manifest.platform,
+            manifest.arch,
+            current_platform(),
+            current_arch()
+        ));
+    }
+    safe_version_segment(&manifest.ui_version)
+}
+
+fn verify_ui_signature(manifest: &UiUpdateManifest) -> Result<(), String> {
+    use base64::Engine;
+    use ed25519_dalek::pkcs8::DecodePublicKey;
+    use ed25519_dalek::{Signature, VerifyingKey};
+
+    let public_key_pem = configured_public_key().ok_or("UI update public key is not configured")?;
+    let key = VerifyingKey::from_public_key_pem(public_key_pem.trim())
+        .map_err(|e| format!("Invalid public key PEM: {}", e))?;
+    let sig_bytes = base64::engine::general_purpose::STANDARD
+        .decode(&manifest.signature)
+        .map_err(|e| format!("Invalid signature base64: {}", e))?;
+    let signature =
+        Signature::from_slice(&sig_bytes).map_err(|e| format!("Invalid signature: {}", e))?;
+    let payload = ui_signature_payload(manifest);
+    key.verify_strict(&payload, &signature)
+        .map_err(|_| "UI manifest signature verification failed".to_string())
+}
+
+// ---------------------------------------------------------------------------
+// check / install / rollback
+// ---------------------------------------------------------------------------
+
+pub async fn check_ui_update() -> UiUpdateCheckResult {
+    let url = match configured_ui_manifest_url() {
+        Some(u) => u,
+        None => {
+            return UiUpdateCheckResult::failure(
+                "UI update manifest URL is not configured".to_string(),
+            )
+        }
+    };
+
+    let manifest: UiUpdateManifest = match RUNTIME_HTTP_CLIENT
+        .get(&url)
+        .timeout(RUNTIME_MANIFEST_HTTP_TIMEOUT)
+        .send()
+        .await
+    {
+        Ok(res) if res.status().is_success() => match res.json().await {
+            Ok(m) => m,
+            Err(e) => {
+                return UiUpdateCheckResult::failure(format!("Failed to parse UI manifest: {}", e))
+            }
+        },
+        Ok(res) => return UiUpdateCheckResult::failure(format!("HTTP {}", res.status())),
+        Err(e) => return UiUpdateCheckResult::failure(e.to_string()),
+    };
+
+    if let Err(e) = validate_ui_manifest(&manifest) {
+        return UiUpdateCheckResult::failure(e);
+    }
+
+    let current = read_ui_current_record();
+    let (update_available, downgrade_blocked) = match current.as_ref() {
+        None => (true, false),
+        Some(c) if c.ui_version == manifest.ui_version => (false, false),
+        Some(c) if is_version_downgrade(&manifest.ui_version, &c.ui_version) => (false, true),
+        Some(_) => (true, false),
+    };
+    let floor_blocked = !floor_allows_current_app(&manifest.app_version_floor);
+    UiUpdateCheckResult {
+        ok: true,
+        update_available,
+        downgrade_blocked,
+        floor_blocked,
+        required_app_version: floor_blocked.then(|| manifest.app_version_floor.clone()),
+        current_ui_version: current.map(|c| c.ui_version),
+        manifest: Some(manifest),
+        error: None,
+    }
+}
+
+/// UI-specific smoke check: index.html parses as UTF-8 and at least one asset
+/// it references exists on disk. Catches truncated/mispacked bundles before
+/// they are activated (the runtime channel's `dashboard --help` equivalent).
+fn smoke_check_ui_dir(dir: &Path) -> Result<(), String> {
+    let index_path = dir.join("index.html");
+    let bytes =
+        fs::read(&index_path).map_err(|e| format!("UI bundle has no readable index.html: {e}"))?;
+    let html = String::from_utf8(bytes)
+        .map_err(|_| "UI bundle index.html is not valid UTF-8".to_string())?;
+
+    let mut referenced_any = false;
+    for capture in html.split(['"', '\'']) {
+        let reference = capture.trim_start_matches("./").trim_start_matches('/');
+        if !(reference.starts_with("assets/") || reference.starts_with("static/")) {
+            continue;
+        }
+        referenced_any = true;
+        if let Some(safe) = sanitize_ui_request_path(reference) {
+            if dir.join(safe).is_file() {
+                return Ok(());
+            }
+        }
+    }
+    if referenced_any {
+        return Err("UI bundle index.html references assets that are missing on disk".to_string());
+    }
+    // An index.html with no asset references at all is suspicious for a Vite
+    // build, but not provably broken — allow it (inline-everything builds).
+    Ok(())
+}
+
+pub async fn install_ui_update(
+    manifest: Option<UiUpdateManifest>,
+    stage_sink: Option<StageSink<'_>>,
+) -> UiInstallUpdateResult {
+    let resolved = match manifest {
+        Some(m) => m,
+        None => {
+            let check = check_ui_update().await;
+            match check.manifest {
+                Some(m) => m,
+                None => {
+                    return UiInstallUpdateResult::failure(
+                        check
+                            .error
+                            .unwrap_or_else(|| "No UI manifest available".into()),
+                    )
+                }
+            }
+        }
+    };
+
+    if let Err(e) = verify_ui_signature(&resolved) {
+        return UiInstallUpdateResult::failure(e);
+    }
+    let version_segment = match validate_ui_manifest(&resolved) {
+        Ok(segment) => segment,
+        Err(e) => return UiInstallUpdateResult::failure(e),
+    };
+
+    // Signed floor gate: refuse bundles demanding a newer shell. check
+    // surfaces this as a flag; install re-enforces for direct callers.
+    if !floor_allows_current_app(&resolved.app_version_floor) {
+        return UiInstallUpdateResult::failure(format!(
+            "此界面更新要求桌面端版本 ≥ {}（当前 {}），请先升级桌面应用",
+            resolved.app_version_floor,
+            desktop_app_version()
+        ));
+    }
+    if let Some(current) = read_ui_current_record() {
+        if is_version_downgrade(&resolved.ui_version, &current.ui_version) {
+            return UiInstallUpdateResult::failure(format!(
+                "已拒绝降级安装：更新源提供的界面 {} 低于当前已安装的 {}",
+                resolved.ui_version, current.ui_version
+            ));
+        }
+    }
+
+    match url::Url::parse(&resolved.artifact_url) {
+        Ok(u) if u.scheme() == "https" => {}
+        Ok(u) => {
+            return UiInstallUpdateResult::failure(format!(
+                "artifact_url must be https, got {}",
+                u.scheme()
+            ))
+        }
+        Err(e) => return UiInstallUpdateResult::failure(format!("Invalid artifact_url: {}", e)),
+    }
+
+    emit_stage(
+        stage_sink,
+        UpdateStage::Downloading {
+            new_version: resolved.ui_version.clone(),
+        },
+    );
+    let artifact = match RUNTIME_HTTP_CLIENT
+        .get(&resolved.artifact_url)
+        .timeout(RUNTIME_ARTIFACT_HTTP_TIMEOUT)
+        .send()
+        .await
+    {
+        Ok(res) if res.status().is_success() => match res.bytes().await {
+            Ok(b) => b.to_vec(),
+            Err(e) => return UiInstallUpdateResult::failure(format!("Download failed: {}", e)),
+        },
+        Ok(res) => {
+            return UiInstallUpdateResult::failure(format!("Download HTTP {}", res.status()))
+        }
+        Err(e) => return UiInstallUpdateResult::failure(format!("Download failed: {}", e)),
+    };
+
+    let zip_path = ui_downloads_root().join(format!("{version_segment}.zip"));
+    if let Some(parent) = zip_path.parent() {
+        if let Err(e) = fs::create_dir_all(parent) {
+            return UiInstallUpdateResult::failure(format!("Failed to create downloads dir: {e}"));
+        }
+    }
+    if let Err(e) = fs::write(&zip_path, &artifact) {
+        return UiInstallUpdateResult::failure(format!("Failed to write zip: {}", e));
+    }
+
+    install_ui_zip(resolved, &zip_path, "update", stage_sink).await
+}
+
+pub(crate) async fn install_ui_zip(
+    resolved: UiUpdateManifest,
+    zip_path: &Path,
+    source: &str,
+    stage_sink: Option<StageSink<'_>>,
+) -> UiInstallUpdateResult {
+    let version_segment = match validate_ui_manifest(&resolved) {
+        Ok(segment) => segment,
+        Err(e) => return UiInstallUpdateResult::failure(e),
+    };
+
+    emit_stage(
+        stage_sink,
+        UpdateStage::Verifying {
+            new_version: resolved.ui_version.clone(),
+        },
+    );
+    let digest = match file_sha256(zip_path) {
+        Some(d) => d,
+        None => {
+            return UiInstallUpdateResult::failure(format!(
+                "UI artifact not readable: {}",
+                zip_path.display()
+            ))
+        }
+    };
+    if digest != resolved.sha256.to_lowercase() {
+        return UiInstallUpdateResult::failure(format!(
+            "SHA-256 mismatch: expected {}, got {}",
+            resolved.sha256, digest
+        ));
+    }
+
+    emit_stage(
+        stage_sink,
+        UpdateStage::Extracting {
+            new_version: resolved.ui_version.clone(),
+        },
+    );
+    let versions_root = ui_versions_root();
+    if let Err(e) = fs::create_dir_all(&versions_root) {
+        return UiInstallUpdateResult::failure(format!("Failed to create UI versions dir: {e}"));
+    }
+    let staging = match tempfile::Builder::new()
+        .prefix(".staging-")
+        .tempdir_in(&versions_root)
+    {
+        Ok(d) => d,
+        Err(e) => {
+            return UiInstallUpdateResult::failure(format!("Failed to create staging dir: {e}"))
+        }
+    };
+    if let Err(e) = extract_zip(zip_path, staging.path()) {
+        return UiInstallUpdateResult::failure(format!("Failed to extract: {}", e));
+    }
+
+    // Zips may wrap everything in a single top-level dir; serve its contents.
+    let content_root =
+        single_child_dir(staging.path()).unwrap_or_else(|| staging.path().to_path_buf());
+
+    emit_stage(
+        stage_sink,
+        UpdateStage::SmokeChecking {
+            new_version: resolved.ui_version.clone(),
+        },
+    );
+    if let Err(e) = smoke_check_ui_dir(&content_root) {
+        return UiInstallUpdateResult::failure(format!("UI smoke check failed: {}", e));
+    }
+
+    emit_stage(
+        stage_sink,
+        UpdateStage::Installing {
+            new_version: resolved.ui_version.clone(),
+        },
+    );
+    let target = versions_root.join(&version_segment);
+    if target.exists() {
+        if let Err(e) = fs::remove_dir_all(&target) {
+            return UiInstallUpdateResult::failure(format!(
+                "Failed to clear existing UI version dir: {e}"
+            ));
+        }
+    }
+    if let Err(e) = fs::rename(&content_root, &target) {
+        if let Err(e2) = runtime::copy_dir_all(&content_root, &target) {
+            return UiInstallUpdateResult::failure(format!(
+                "Failed to install UI bundle: rename={}, copy={}",
+                e, e2
+            ));
+        }
+    }
+    if !target.join("index.html").is_file() {
+        return UiInstallUpdateResult::failure("index.html disappeared after install".to_string());
+    }
+
+    let previous = read_ui_current_record();
+    let installed = UiInstallRecord {
+        schema_version: UI_RECORD_SCHEMA_VERSION,
+        ui_version: resolved.ui_version.clone(),
+        app_version_floor: resolved.app_version_floor.clone(),
+        channel: resolved.channel.clone(),
+        platform: current_platform().to_string(),
+        arch: current_arch().to_string(),
+        path: target.to_string_lossy().to_string(),
+        sha256: resolved.sha256.clone(),
+        source: source.to_string(),
+        installed_at: chrono_now(),
+        previous_ui_version: previous.as_ref().map(|p| p.ui_version.clone()),
+    };
+
+    let _ = write_json_file(&target.join(UI_MANIFEST_FILE), &resolved);
+    // current.json is written LAST: a crash anywhere above leaves the active
+    // pointer untouched and the window keeps serving the previous bundle.
+    if let Err(e) = write_json_file(&ui_current_record_path(), &installed) {
+        return UiInstallUpdateResult::failure(e);
+    }
+
+    UiInstallUpdateResult {
+        ok: true,
+        installed: Some(installed),
+        previous,
+        error: None,
+    }
+}
+
+fn single_child_dir(dir: &Path) -> Option<PathBuf> {
+    let mut entries = fs::read_dir(dir).ok()?.filter_map(|e| e.ok());
+    let first = entries.next()?;
+    if entries.next().is_some() {
+        return None;
+    }
+    let path = first.path();
+    path.is_dir().then_some(path)
+}
+
+/// Repoint `ui/current.json` at the previous UI version. Pure disk operation
+/// (no network); the previous tree is integrity-gated on index.html presence.
+pub fn rollback_ui_update() -> UiInstallUpdateResult {
+    let current = match read_ui_current_record() {
+        Some(c) => c,
+        None => return UiInstallUpdateResult::failure("No current UI record".to_string()),
+    };
+    let prev_version = match &current.previous_ui_version {
+        Some(v) => v.clone(),
+        None => {
+            return UiInstallUpdateResult::failure("No previous UI version recorded".to_string())
+        }
+    };
+    let prev_segment = match safe_version_segment(&prev_version) {
+        Ok(s) => s,
+        Err(e) => {
+            return UiInstallUpdateResult::failure(format!("Invalid previous UI version: {e}"))
+        }
+    };
+    let prev_path = ui_versions_root().join(prev_segment);
+    if !prev_path.join("index.html").is_file() {
+        return UiInstallUpdateResult::failure(format!(
+            "Previous UI bundle is missing or incomplete: {}",
+            prev_path.display()
+        ));
+    }
+    let prev_manifest: Option<UiUpdateManifest> = read_json_file(&prev_path.join(UI_MANIFEST_FILE));
+
+    let installed = UiInstallRecord {
+        schema_version: UI_RECORD_SCHEMA_VERSION,
+        ui_version: prev_version.clone(),
+        app_version_floor: prev_manifest
+            .as_ref()
+            .map(|m| m.app_version_floor.clone())
+            .unwrap_or_else(|| current.app_version_floor.clone()),
+        channel: current.channel.clone(),
+        platform: current_platform().to_string(),
+        arch: current_arch().to_string(),
+        path: prev_path.to_string_lossy().to_string(),
+        sha256: prev_manifest
+            .as_ref()
+            .map(|m| m.sha256.clone())
+            .unwrap_or_default(),
+        source: "rollback".to_string(),
+        installed_at: chrono_now(),
+        previous_ui_version: Some(current.ui_version.clone()),
+    };
+    if let Err(e) = write_json_file(&ui_current_record_path(), &installed) {
+        return UiInstallUpdateResult::failure(e);
+    }
+    UiInstallUpdateResult {
+        ok: true,
+        installed: Some(installed),
+        previous: Some(current),
+        error: None,
+    }
+}
+
+/// Remove the installed override entirely, returning the window to the
+/// embedded bundle on next load. Used as the escape hatch when both installed
+/// versions misbehave.
+pub fn reset_ui_to_embedded() -> Result<(), String> {
+    let path = ui_current_record_path();
+    if path.exists() {
+        fs::remove_file(&path)
+            .map_err(|e| format!("Failed to remove {}: {}", path.display(), e))?;
+    }
+    Ok(())
+}
+
+// ---------------------------------------------------------------------------
+// hermesui protocol serving
+// ---------------------------------------------------------------------------
+
+pub struct UiResponse {
+    pub status: u16,
+    pub mime: &'static str,
+    pub cache_control: &'static str,
+    pub body: Vec<u8>,
+}
+
+fn mime_for_path(path: &str) -> &'static str {
+    match path.rsplit('.').next().unwrap_or("") {
+        "html" => "text/html",
+        "js" | "mjs" => "text/javascript",
+        "css" => "text/css",
+        "json" | "map" => "application/json",
+        "svg" => "image/svg+xml",
+        "png" => "image/png",
+        "jpg" | "jpeg" => "image/jpeg",
+        "webp" => "image/webp",
+        "gif" => "image/gif",
+        "ico" => "image/x-icon",
+        "woff" => "font/woff",
+        "woff2" => "font/woff2",
+        "ttf" => "font/ttf",
+        "otf" => "font/otf",
+        "wasm" => "application/wasm",
+        "txt" => "text/plain",
+        _ => "application/octet-stream",
+    }
+}
+
+fn cache_control_for(path: &str) -> &'static str {
+    // index.html must revalidate every load or the webview would keep serving
+    // a stale entry after a version switch; Vite assets are content-hashed
+    // and safely immutable.
+    if path == "index.html" {
+        "no-cache"
+    } else {
+        "public, max-age=31536000, immutable"
+    }
+}
+
+fn ui_response(path: &str, body: Vec<u8>) -> UiResponse {
+    UiResponse {
+        status: 200,
+        mime: mime_for_path(path),
+        cache_control: cache_control_for(path),
+        body,
+    }
+}
+
+/// Read `safe_path` from the override dir with canonical-containment
+/// enforcement — a symlink pointing outside the bundle serves nothing.
+fn read_override_file(dir: &Path, safe_path: &str) -> Option<Vec<u8>> {
+    let candidate = dir.join(safe_path);
+    let canonical_dir = dir.canonicalize().ok()?;
+    let canonical = candidate.canonicalize().ok()?;
+    if !canonical.starts_with(&canonical_dir) {
+        log::warn!(
+            "hermesui request escaped the UI bundle via symlink: {}",
+            candidate.display()
+        );
+        return None;
+    }
+    fs::read(&canonical).ok()
+}
+
+fn embedded_asset(app: &tauri::AppHandle, safe_path: &str) -> Option<Vec<u8>> {
+    app.asset_resolver()
+        .get(format!("/{safe_path}"))
+        .map(|asset| asset.bytes().to_vec())
+}
+
+/// Resolve a hermesui request. Precedence per file: gated override dir →
+/// embedded bundle → SPA index fallback (either source) → 404. The embedded
+/// bundle is always reachable, so a broken override degrades per-file instead
+/// of white-screening the window.
+pub fn serve_ui_request(app: &tauri::AppHandle, uri_path: &str) -> UiResponse {
+    let Some(safe_path) = sanitize_ui_request_path(uri_path) else {
+        return UiResponse {
+            status: 404,
+            mime: "text/plain",
+            cache_control: "no-cache",
+            body: b"not found".to_vec(),
+        };
+    };
+
+    let override_dir = active_ui_dir();
+    if let Some(dir) = override_dir.as_deref() {
+        if let Some(body) = read_override_file(dir, &safe_path) {
+            return ui_response(&safe_path, body);
+        }
+    }
+    if let Some(body) = embedded_asset(app, &safe_path) {
+        return ui_response(&safe_path, body);
+    }
+
+    // SPA route fallback: extension-less paths (e.g. /settings on reload)
+    // resolve to the entry point of whichever source is active.
+    let last_segment = safe_path.rsplit('/').next().unwrap_or("");
+    if !last_segment.contains('.') {
+        if let Some(dir) = override_dir.as_deref() {
+            if let Some(body) = read_override_file(dir, "index.html") {
+                return ui_response("index.html", body);
+            }
+        }
+        if let Some(body) = embedded_asset(app, "index.html") {
+            return ui_response("index.html", body);
+        }
+    }
+
+    UiResponse {
+        status: 404,
+        mime: "text/plain",
+        cache_control: "no-cache",
+        body: b"not found".to_vec(),
+    }
+}
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+    use base64::Engine;
+    use ed25519_dalek::{Signer, SigningKey};
+    use pretty_assertions::assert_eq;
+    use serial_test::serial;
+    use tempfile::TempDir;
+
+    fn test_keypair() -> (SigningKey, String) {
+        use ed25519_dalek::pkcs8::EncodePublicKey;
+        let signing_key = SigningKey::from_bytes(&[11u8; 32]);
+        let pem = signing_key
+            .verifying_key()
+            .to_public_key_pem(ed25519_dalek::pkcs8::spki::der::pem::LineEnding::LF)
+            .unwrap();
+        (signing_key, pem)
+    }
+
+    fn fixture_manifest() -> UiUpdateManifest {
+        UiUpdateManifest {
+            schema_version: 1,
+            channel: "stable".to_string(),
+            ui_version: "0.7.1".to_string(),
+            app_version_floor: "0.7.0".to_string(),
+            platform: current_platform().to_string(),
+            arch: current_arch().to_string(),
+            artifact_url: "https://example.com/ui.zip".to_string(),
+            sha256: "deadbeef".to_string(),
+            signature: String::new(),
+            source_repo: "owner/repo".to_string(),
+            source_commit: "abc123".to_string(),
+            created_at: None,
+        }
+    }
+
+    fn sign(key: &SigningKey, m: &mut UiUpdateManifest) {
+        let sig = key.sign(&ui_signature_payload(m));
+        m.signature = base64::engine::general_purpose::STANDARD.encode(sig.to_bytes());
+    }
+
+    #[test]
+    fn ui_signature_payload_field_order_is_locked() {
+        // Cross-language contract with scripts/sign_ui_manifest.py.
+        let mut m = fixture_manifest();
+        m.platform = "linux".to_string();
+        m.arch = "x64".to_string();
+        let payload = String::from_utf8(ui_signature_payload(&m)).unwrap();
+        assert_eq!(
+            payload.split('\n').collect::<Vec<_>>(),
+            vec![
+                "1",                          // schema_version
+                "stable",                     // channel
+                "0.7.1",                      // ui_version
+                "0.7.0",                      // app_version_floor
+                "linux",                      // platform
+                "x64",                        // arch
+                "https://example.com/ui.zip", // artifact_url
+                "deadbeef",                   // sha256
+                "owner/repo",                 // source_repo
+                "abc123",                     // source_commit
+            ]
+        );
+    }
+
+    #[test]
+    #[serial]
+    fn ui_signature_roundtrip_and_floor_tampering_detection() {
+        let (key, pem) = test_keypair();
+        std::env::set_var("HERMES_RUNTIME_UPDATE_PUBLIC_KEY_PEM", pem);
+        let mut m = fixture_manifest();
+        sign(&key, &mut m);
+        verify_ui_signature(&m).expect("should verify");
+
+        // appVersionFloor is signed — lowering it (to sneak an incompatible
+        // bundle past an old shell) must break the signature.
+        let mut tampered = m.clone();
+        tampered.app_version_floor = "0.0.1".to_string();
+        assert!(verify_ui_signature(&tampered).is_err());
+        std::env::remove_var("HERMES_RUNTIME_UPDATE_PUBLIC_KEY_PEM");
+    }
+
+    #[test]
+    fn floor_gate_blocks_newer_requirements_and_unparseable_floors() {
+        assert!(floor_allows_current_app("0.0.1"));
+        assert!(floor_allows_current_app(desktop_app_version()));
+        assert!(!floor_allows_current_app("999.0.0"));
+        // Unlike the kernel gate, an unevaluable floor REFUSES the bundle.
+        assert!(!floor_allows_current_app("not-a-version"));
+        assert!(!floor_allows_current_app(""));
+    }
+
+    #[test]
+    fn validate_ui_manifest_gates_schema_floor_and_platform() {
+        assert!(validate_ui_manifest(&fixture_manifest()).is_ok());
+
+        let mut wrong_schema = fixture_manifest();
+        wrong_schema.schema_version = 2;
+        assert!(validate_ui_manifest(&wrong_schema).is_err());
+
+        let mut empty_floor = fixture_manifest();
+        empty_floor.app_version_floor = "  ".to_string();
+        assert!(validate_ui_manifest(&empty_floor).is_err());
+
+        let mut wrong_platform = fixture_manifest();
+        wrong_platform.platform = "some-other-os".to_string();
+        assert!(validate_ui_manifest(&wrong_platform).is_err());
+
+        let mut bad_version = fixture_manifest();
+        bad_version.ui_version = "../escape".to_string();
+        assert!(validate_ui_manifest(&bad_version).is_err());
+    }
+
+    #[test]
+    fn sanitize_rejects_traversal_and_normalizes_entry() {
+        assert_eq!(sanitize_ui_request_path("").as_deref(), Some("index.html"));
+        assert_eq!(sanitize_ui_request_path("/").as_deref(), Some("index.html"));
+        assert_eq!(
+            sanitize_ui_request_path("/assets/app.js").as_deref(),
+            Some("assets/app.js")
+        );
+        assert_eq!(
+            sanitize_ui_request_path("/assets/app.js?v=1#frag").as_deref(),
+            Some("assets/app.js")
+        );
+        assert_eq!(sanitize_ui_request_path("/../secret"), None);
+        assert_eq!(sanitize_ui_request_path("/a/../../b"), None);
+        assert_eq!(sanitize_ui_request_path("/a//b"), None);
+        assert_eq!(sanitize_ui_request_path("/./a"), None);
+        assert_eq!(sanitize_ui_request_path("/a\\b"), None);
+        // URL-encoded traversal must not survive decoding.
+        assert_eq!(sanitize_ui_request_path("/%2e%2e/secret"), None);
+        assert_eq!(sanitize_ui_request_path("/a%2f..%2fb"), None);
+    }
+
+    #[test]
+    fn smoke_check_requires_utf8_index_with_existing_assets() {
+        let tmp = TempDir::new().unwrap();
+        // Missing index.html
+        assert!(smoke_check_ui_dir(tmp.path()).is_err());
+
+        // Non-UTF-8 index
+        fs::write(tmp.path().join("index.html"), [0xff, 0xfe, 0x00]).unwrap();
+        assert!(smoke_check_ui_dir(tmp.path()).is_err());
+
+        // References an asset that is missing
+        fs::write(
+            tmp.path().join("index.html"),
+            r#"<script src="/assets/app.js"></script>"#,
+        )
+        .unwrap();
+        assert!(smoke_check_ui_dir(tmp.path()).is_err());
+
+        // Asset exists → passes
+        fs::create_dir_all(tmp.path().join("assets")).unwrap();
+        fs::write(tmp.path().join("assets").join("app.js"), "console.log(1)").unwrap();
+        assert!(smoke_check_ui_dir(tmp.path()).is_ok());
+    }
+
+    #[test]
+    #[serial]
+    fn active_ui_dir_enforces_floor_and_index_presence() {
+        let tmp = TempDir::new().unwrap();
+        std::env::set_var("HERMES_DESKTOP_RUNTIME_ROOT", tmp.path());
+
+        let bundle = ui_versions_root().join("0.7.1");
+        fs::create_dir_all(&bundle).unwrap();
+        fs::write(bundle.join("index.html"), "<html></html>").unwrap();
+
+        let mut record = UiInstallRecord {
+            schema_version: UI_RECORD_SCHEMA_VERSION,
+            ui_version: "0.7.1".to_string(),
+            app_version_floor: "0.0.1".to_string(),
+            channel: "stable".to_string(),
+            platform: current_platform().to_string(),
+            arch: current_arch().to_string(),
+            path: bundle.to_string_lossy().to_string(),
+            sha256: "deadbeef".to_string(),
+            source: "update".to_string(),
+            installed_at: "2026-07-18T00:00:00.000Z".to_string(),
+            previous_ui_version: None,
+        };
+        write_json_file(&ui_current_record_path(), &record).unwrap();
+        assert_eq!(active_ui_dir(), Some(bundle.clone()));
+
+        // Floor above the current shell → override is ignored (embedded).
+        record.app_version_floor = "999.0.0".to_string();
+        write_json_file(&ui_current_record_path(), &record).unwrap();
+        assert_eq!(active_ui_dir(), None);
+
+        // index.html vanished → override is ignored.
+        record.app_version_floor = "0.0.1".to_string();
+        write_json_file(&ui_current_record_path(), &record).unwrap();
+        fs::remove_file(bundle.join("index.html")).unwrap();
+        assert_eq!(active_ui_dir(), None);
+
+        std::env::remove_var("HERMES_DESKTOP_RUNTIME_ROOT");
+    }
+
+    #[test]
+    #[serial]
+    fn rollback_repoints_to_previous_bundle_and_back() {
+        let tmp = TempDir::new().unwrap();
+        std::env::set_var("HERMES_DESKTOP_RUNTIME_ROOT", tmp.path());
+
+        for (version, floor) in [("0.7.1", "0.0.1"), ("0.7.2", "0.0.1")] {
+            let dir = ui_versions_root().join(version);
+            fs::create_dir_all(&dir).unwrap();
+            fs::write(dir.join("index.html"), "<html></html>").unwrap();
+            let mut manifest = fixture_manifest();
+            manifest.ui_version = version.to_string();
+            manifest.app_version_floor = floor.to_string();
+            write_json_file(&dir.join(UI_MANIFEST_FILE), &manifest).unwrap();
+        }
+        let current = UiInstallRecord {
+            schema_version: UI_RECORD_SCHEMA_VERSION,
+            ui_version: "0.7.2".to_string(),
+            app_version_floor: "0.0.1".to_string(),
+            channel: "stable".to_string(),
+            platform: current_platform().to_string(),
+            arch: current_arch().to_string(),
+            path: ui_versions_root()
+                .join("0.7.2")
+                .to_string_lossy()
+                .to_string(),
+            sha256: "deadbeef".to_string(),
+            source: "update".to_string(),
+            installed_at: "2026-07-18T00:00:00.000Z".to_string(),
+            previous_ui_version: Some("0.7.1".to_string()),
+        };
+        write_json_file(&ui_current_record_path(), &current).unwrap();
+
+        let result = rollback_ui_update();
+        assert!(result.ok, "unexpected error: {:?}", result.error);
+        let restored = result.installed.unwrap();
+        assert_eq!(restored.ui_version, "0.7.1");
+        assert_eq!(restored.source, "rollback");
+        // Single-step back-and-forth: the rollback records the rolled-away
+        // version as its own previous.
+        assert_eq!(restored.previous_ui_version.as_deref(), Some("0.7.2"));
+
+        // Reset escape hatch removes the pointer entirely.
+        reset_ui_to_embedded().unwrap();
+        assert!(read_ui_current_record().is_none());
+
+        std::env::remove_var("HERMES_DESKTOP_RUNTIME_ROOT");
+    }
+}

--- a/tauri.conf.json
+++ b/tauri.conf.json
@@ -10,18 +10,9 @@
     "frontendDist": "./web/dist"
   },
   "app": {
-    "windows": [
-      {
-        "title": "Hermes Agent 中文社区桌面版",
-        "width": 1240,
-        "height": 820,
-        "minWidth": 960,
-        "minHeight": 680,
-        "titleBarStyle": "Transparent"
-      }
-    ],
+    "windows": [],
     "security": {
-      "csp": "default-src 'self'; script-src 'self' 'unsafe-inline'; style-src 'self' 'unsafe-inline'; connect-src 'self' http://127.0.0.1:* ws://127.0.0.1:* wss://127.0.0.1:*; img-src 'self' data: blob:; media-src 'self' data: blob:; frame-src 'self' http://localhost:* http://127.0.0.1:*"
+      "csp": "default-src 'self' hermesui: http://hermesui.localhost; script-src 'self' 'unsafe-inline' hermesui: http://hermesui.localhost; style-src 'self' 'unsafe-inline' hermesui: http://hermesui.localhost; connect-src 'self' http://127.0.0.1:* ws://127.0.0.1:* wss://127.0.0.1:*; img-src 'self' data: blob: hermesui: http://hermesui.localhost; media-src 'self' data: blob: hermesui: http://hermesui.localhost; frame-src 'self' http://localhost:* http://127.0.0.1:*"
     }
   },
   "bundle": {

--- a/tests/ui_update.rs
+++ b/tests/ui_update.rs
@@ -1,0 +1,169 @@
+// HTTP-boundary tests for the UI hot-update channel (Track B).
+//
+// check_ui_update fetches and parses a remote UI manifest and applies the
+// schema / platform / downgrade / floor gates. Signature verification and disk
+// install are covered by the in-module unit tests (they need a signing key and
+// a zip); here we exercise the fetch + gate path against wiremock.
+//
+// All tests are #[serial] because they mutate HERMES_UI_UPDATE_* /
+// HERMES_DESKTOP_RUNTIME_ROOT process-global env vars.
+
+use hermes_agent_cn::process::ui_update::check_ui_update;
+use serial_test::serial;
+use wiremock::matchers::{method, path};
+use wiremock::{Mock, MockServer, ResponseTemplate};
+
+fn host_platform() -> &'static str {
+    if cfg!(target_os = "windows") {
+        "win32"
+    } else if cfg!(target_os = "macos") {
+        "darwin"
+    } else {
+        "linux"
+    }
+}
+
+fn host_arch() -> &'static str {
+    if cfg!(target_arch = "x86_64") {
+        "x64"
+    } else if cfg!(target_arch = "aarch64") {
+        "arm64"
+    } else {
+        std::env::consts::ARCH
+    }
+}
+
+fn manifest_json(ui_version: &str, app_version_floor: &str) -> serde_json::Value {
+    serde_json::json!({
+        "schemaVersion": 1,
+        "channel": "stable",
+        "uiVersion": ui_version,
+        "appVersionFloor": app_version_floor,
+        "platform": host_platform(),
+        "arch": host_arch(),
+        "artifactUrl": "https://example.com/ui.zip",
+        "sha256": "0".repeat(64),
+        "signature": "stub-signature",
+        "sourceRepo": "owner/repo",
+        "sourceCommit": "abc123",
+    })
+}
+
+fn clear_env() {
+    for var in [
+        "HERMES_UI_UPDATE_MANIFEST_URL",
+        "HERMES_UI_UPDATE_BASE_URL",
+        "HERMES_UI_UPDATE_CHANNEL",
+        "HERMES_DESKTOP_RUNTIME_ROOT",
+    ] {
+        std::env::remove_var(var);
+    }
+}
+
+async fn mount(server: &MockServer, body: serde_json::Value) {
+    Mock::given(method("GET"))
+        .and(path("/manifest.json"))
+        .respond_with(ResponseTemplate::new(200).set_body_json(body))
+        .mount(server)
+        .await;
+}
+
+fn point_at(server: &MockServer) {
+    std::env::set_var(
+        "HERMES_UI_UPDATE_MANIFEST_URL",
+        format!("{}/manifest.json", server.uri()),
+    );
+}
+
+#[tokio::test]
+#[serial]
+async fn fresh_install_reports_update_available() {
+    clear_env();
+    let tmp = tempfile::TempDir::new().unwrap();
+    std::env::set_var("HERMES_DESKTOP_RUNTIME_ROOT", tmp.path());
+    let server = MockServer::start().await;
+    mount(&server, manifest_json("9.9.9", "0.0.1")).await;
+    point_at(&server);
+
+    let result = check_ui_update().await;
+
+    assert!(result.ok, "unexpected error: {:?}", result.error);
+    assert!(result.update_available);
+    assert!(!result.floor_blocked);
+    assert!(!result.downgrade_blocked);
+    assert_eq!(result.manifest.unwrap().ui_version, "9.9.9");
+
+    clear_env();
+}
+
+#[tokio::test]
+#[serial]
+async fn floor_above_shell_sets_floor_blocked() {
+    clear_env();
+    let tmp = tempfile::TempDir::new().unwrap();
+    std::env::set_var("HERMES_DESKTOP_RUNTIME_ROOT", tmp.path());
+    let server = MockServer::start().await;
+    mount(&server, manifest_json("9.9.9", "999.0.0")).await;
+    point_at(&server);
+
+    let result = check_ui_update().await;
+
+    assert!(result.ok, "unexpected error: {:?}", result.error);
+    assert!(result.floor_blocked);
+    assert_eq!(result.required_app_version.as_deref(), Some("999.0.0"));
+
+    clear_env();
+}
+
+#[tokio::test]
+#[serial]
+async fn wrong_schema_is_rejected() {
+    clear_env();
+    let mut body = manifest_json("9.9.9", "0.0.1");
+    body["schemaVersion"] = serde_json::json!(2);
+    let server = MockServer::start().await;
+    mount(&server, body).await;
+    point_at(&server);
+
+    let result = check_ui_update().await;
+
+    assert!(!result.ok);
+    assert!(result.error.unwrap().contains("schemaVersion"));
+
+    clear_env();
+}
+
+#[tokio::test]
+#[serial]
+async fn empty_floor_is_rejected() {
+    clear_env();
+    let server = MockServer::start().await;
+    mount(&server, manifest_json("9.9.9", "")).await;
+    point_at(&server);
+
+    let result = check_ui_update().await;
+
+    assert!(!result.ok);
+    assert!(result.error.unwrap().contains("appVersionFloor"));
+
+    clear_env();
+}
+
+#[tokio::test]
+#[serial]
+async fn wrong_platform_is_rejected() {
+    clear_env();
+    let mut body = manifest_json("9.9.9", "0.0.1");
+    body["platform"] = serde_json::json!("some-other-os");
+    body["arch"] = serde_json::json!("some-other-arch");
+    let server = MockServer::start().await;
+    mount(&server, body).await;
+    point_at(&server);
+
+    let result = check_ui_update().await;
+
+    assert!(!result.ok);
+    assert!(result.error.unwrap().contains("UI manifest is for"));
+
+    clear_env();
+}

--- a/web/src/hooks/use-ui-update.ts
+++ b/web/src/hooks/use-ui-update.ts
@@ -1,0 +1,29 @@
+import { useMutation } from "@tanstack/react-query";
+import type { UiInstallUpdateResult, UiUpdateCheckResult } from "@hermes/protocol";
+
+// UI 热更通道（轨道 B）。与内核更新不同：安装/回滚只换 webview 加载的
+// 前端 bundle，不碰 dashboard 子进程 —— Rust 侧成功后会直接把主窗口导航到
+// 新 bundle（hermesui:// 协议），所以这里不需要遮罩/断连处理。注意：导航
+// 发生时当前页面即被替换，mutation 的 onSuccess 可能来不及展示。
+
+export function useCheckUiUpdate() {
+  return useMutation<UiUpdateCheckResult>({
+    mutationFn: () => window.hermesDesktop!.checkUiUpdate!(),
+  });
+}
+
+export function useInstallUiUpdate() {
+  return useMutation<UiInstallUpdateResult>({
+    mutationFn: () => window.hermesDesktop!.installUiUpdate!(),
+  });
+}
+
+export function useRollbackUiUpdate() {
+  return useMutation<UiInstallUpdateResult>({
+    mutationFn: () => window.hermesDesktop!.rollbackUiUpdate!(),
+  });
+}
+
+export function hasUiUpdateBridge(): boolean {
+  return typeof window !== "undefined" && Boolean(window.hermesDesktop?.checkUiUpdate);
+}

--- a/web/src/lib/runtime.ts
+++ b/web/src/lib/runtime.ts
@@ -460,6 +460,10 @@ declare global {
       checkRuntimeUpdate?(): Promise<RuntimeUpdateCheckResult>;
       installRuntimeUpdate?(): Promise<RuntimeInstallUpdateResult>;
       rollbackRuntime?(): Promise<RuntimeInstallUpdateResult>;
+      checkUiUpdate?(): Promise<import("@hermes/protocol").UiUpdateCheckResult>;
+      installUiUpdate?(): Promise<import("@hermes/protocol").UiInstallUpdateResult>;
+      rollbackUiUpdate?(): Promise<import("@hermes/protocol").UiInstallUpdateResult>;
+      resetUiToEmbedded?(): Promise<void>;
       exportProfileBackup?(): Promise<BackupExportResult>;
       importProfileBackup?(): Promise<BackupImportResult>;
       switchProfile?(input: SwitchProfileInput): Promise<SwitchProfileResult>;

--- a/web/src/lib/tauri-bridge.ts
+++ b/web/src/lib/tauri-bridge.ts
@@ -39,6 +39,8 @@ import type {
   GuideState,
   RuntimeInstallUpdateResult,
   RuntimeUpdateCheckResult,
+  UiInstallUpdateResult,
+  UiUpdateCheckResult,
   SetYoloModeInput,
   SetYoloModeResult,
   SwitchProfileInput,
@@ -351,6 +353,22 @@ const tauriBridge = {
 
   async rollbackRuntime(): Promise<RuntimeInstallUpdateResult> {
     return invokeCommand("runtime_rollback");
+  },
+
+  async checkUiUpdate(): Promise<UiUpdateCheckResult> {
+    return invokeCommand("ui_check_update");
+  },
+
+  async installUiUpdate(): Promise<UiInstallUpdateResult> {
+    return invokeCommand("ui_install_update");
+  },
+
+  async rollbackUiUpdate(): Promise<UiInstallUpdateResult> {
+    return invokeCommand("ui_rollback");
+  },
+
+  async resetUiToEmbedded(): Promise<void> {
+    return invokeCommand("ui_reset_to_embedded");
   },
 
   async exportProfileBackup(): Promise<BackupExportResult> {

--- a/web/src/routes/settings.tsx
+++ b/web/src/routes/settings.tsx
@@ -43,6 +43,12 @@ import {
   useRuntimeInfo,
 } from "@/hooks/use-runtime-update";
 import {
+  hasUiUpdateBridge,
+  useCheckUiUpdate,
+  useInstallUiUpdate,
+  useRollbackUiUpdate,
+} from "@/hooks/use-ui-update";
+import {
   CONVERSATION_FONT_SIZE_OPTIONS,
   DEFAULT_ASSISTANT_DISPLAY_NAME,
   assistantAvatarDataUrlAtom,
@@ -76,7 +82,7 @@ import { buildNestedConfigUpdate, mergeConfigUpdate } from "@/lib/config-update"
 import { translateConfigField, translateConfigOption } from "@/lib/config-translations";
 import { gatewayRestartButtonLabel, gatewayRestartTitle } from "@/lib/gateway-restart";
 import type { ComposerSubmitShortcut } from "@/lib/composer-submit-shortcut";
-import type { ConfigSchemaField, CronJob, DesktopUpdateCheckResult, RuntimeInfo, RuntimeUpdateCheckResult } from "@hermes/protocol";
+import type { ConfigSchemaField, CronJob, DesktopUpdateCheckResult, RuntimeInfo, RuntimeUpdateCheckResult, UiUpdateCheckResult } from "@hermes/protocol";
 import { CopyButton } from "@/components/ui/copy-button";
 import wechatCommunityQr from "@/assets/wechat-community-qr.png";
 import feishuCommunityQr from "@/assets/feishu-community-qr.png";
@@ -1197,9 +1203,37 @@ export function KernelSection({ showHeading = true }: SettingsSectionProps) {
   const checkRuntimeUpdate = useCheckRuntimeUpdate();
   const installRuntimeUpdate = useInstallRuntimeUpdate();
   const rollbackRuntime = useRollbackRuntime();
+  const checkUiUpdate = useCheckUiUpdate();
+  const installUiUpdate = useInstallUiUpdate();
+  const rollbackUiUpdate = useRollbackUiUpdate();
   const gatewayRestart = useGatewayRestartAction();
   const [runtimeMessage, setRuntimeMessage] = useState("");
+  const [uiMessage, setUiMessage] = useState("");
   const [aboutMessage, setAboutMessage] = useState("");
+
+  const handleCheckUi = async () => {
+    setUiMessage("");
+    const result = await checkUiUpdate.mutateAsync();
+    setUiMessage(formatUiUpdateResult(result));
+  };
+
+  const handleInstallUi = async () => {
+    setUiMessage("");
+    const result = await installUiUpdate.mutateAsync();
+    // 成功时 Rust 侧会立即把窗口导航到新 bundle，这条消息通常来不及展示；
+    // 失败时留在原界面，把原因说清楚。
+    setUiMessage(result.ok
+      ? `界面已更新到 ${result.installed?.uiVersion ?? ""}`.trim()
+      : result.error ?? "界面更新失败");
+  };
+
+  const handleRollbackUi = async () => {
+    setUiMessage("");
+    const result = await rollbackUiUpdate.mutateAsync();
+    setUiMessage(result.ok
+      ? `已回滚界面到 ${result.installed?.uiVersion ?? ""}`.trim()
+      : result.error ?? "界面回滚失败");
+  };
 
   const handleCheckRuntime = async () => {
     setRuntimeMessage("");
@@ -1479,6 +1513,53 @@ export function KernelSection({ showHeading = true }: SettingsSectionProps) {
             </>
           ) : (
             <p className={s.desc}>当前环境没有桌面 runtime bridge，无法读取独立内核信息。</p>
+          )}
+        </DebugCard>
+
+        <DebugCard icon={<RefreshCw size={15} />} title="界面热更新" sub="仅更新桌面界面（UI bundle），不重启内核，秒级生效">
+          {hasUiUpdateBridge() ? (
+            <>
+              <p className={s.desc}>
+                纯前端修复（文案、样式、界面逻辑）通过此通道下发，签名校验后立即生效；
+                涉及桌面壳/内核能力的更新仍需整包升级。安装后窗口会自动重载。
+              </p>
+              <div className={s.providerActions}>
+                <Button
+                  variant="outline"
+                  type="button"
+                  onClick={handleCheckUi}
+                  disabled={checkUiUpdate.isPending}
+                >
+                  <RefreshCw size={13} />
+                  {checkUiUpdate.isPending ? "检查中" : "检查界面更新"}
+                </Button>
+                <Button
+                  variant="solid"
+                  tone="accent"
+                  type="button"
+                  onClick={handleInstallUi}
+                  disabled={
+                    !checkUiUpdate.data?.ok ||
+                    !checkUiUpdate.data.updateAvailable ||
+                    Boolean(checkUiUpdate.data.floorBlocked) ||
+                    installUiUpdate.isPending
+                  }
+                >
+                  {installUiUpdate.isPending ? "安装中…" : "安装界面更新"}
+                </Button>
+                <Button
+                  variant="outline"
+                  type="button"
+                  onClick={handleRollbackUi}
+                  disabled={rollbackUiUpdate.isPending}
+                >
+                  {rollbackUiUpdate.isPending ? "回滚中…" : "回滚界面"}
+                </Button>
+              </div>
+              {uiMessage && <p className={s.desc}>{uiMessage}</p>}
+            </>
+          ) : (
+            <p className={s.desc}>当前环境没有桌面 UI 更新 bridge。</p>
           )}
         </DebugCard>
 
@@ -1902,6 +1983,20 @@ function formatDateTime(value: string | undefined): string {
   const date = new Date(value);
   if (Number.isNaN(date.getTime())) return value;
   return date.toLocaleString("zh-CN", { hour12: false });
+}
+
+function formatUiUpdateResult(result: UiUpdateCheckResult): string {
+  if (!result.ok) return result.error ?? "界面更新检查失败";
+  if (result.floorBlocked) {
+    return `发现新界面 ${result.manifest?.uiVersion ?? ""}，但需要桌面端 ≥ ${result.requiredAppVersion ?? ""}，请先升级桌面应用`.trim();
+  }
+  if (result.downgradeBlocked) {
+    return `更新源提供的界面 ${result.manifest?.uiVersion ?? ""} 低于当前版本，已忽略（防降级保护）`.trim();
+  }
+  if (!result.updateAvailable) {
+    return `界面已是最新${result.currentUiVersion ? `（${result.currentUiVersion}）` : "（内置版本）"}`;
+  }
+  return `发现新界面 ${result.manifest?.uiVersion ?? ""}，点击"安装界面更新"立即生效`.trim();
 }
 
 function formatRuntimeUpdateResult(result: RuntimeUpdateCheckResult): string {


### PR DESCRIPTION
## 背景

热更新三轨道·**轨道 B（UI 热更，新建）**。上游 hermes-studio 没有此能力，属超越项：纯前端修复（文案/样式/界面逻辑）以签名 zip 秒级下发，无需重装外壳、不重启内核。设计依据 `docs/hot-update-impl-plan.md` §4，约 90% 复用轨道 A（`runtime.rs`）的 OTA 引擎。

> ⚠️ **本 PR base 为 `feat/runtime-update-v3-gate`（#452），因为它复用了轨道 A 收口时放开的 `runtime.rs` 原语。请先合 #452 再合本 PR**，或合并时确认 base 已随之更新为 main。

## 机制

- **`src/process/ui_update.rs`**：签名 UI 清单（Ed25519，复用 runtime 同一信任公钥）+ sha256 双校验 + `extract_zip` 护栏 + UI 专属冒烟检查（index.html UTF-8 可解析且引用的 assets 在盘上）+ `runtime_root()/ui/versions/<v>/ + current.json` 指针 + 单步回滚 + 复位到内嵌包
- **安全核心 = 签名的 `appVersionFloor` 闸门**：UI 包要求的最低外壳版本高于当前外壳则拒绝，窗口回退内嵌 `web/dist` —— 一个误发的、需要新 invoke 命令的 UI 包永远不会白屏。防降级同 runtime；**不可解析的 floor 一律拒绝（fail closed）**，与内核 minAppVersion 的 fail-open 语义相反（内核那边是已验签产物上的额外闸门，UI 这边坏 floor 可能意味着调用了不存在的命令）
- **`hermesui://` 自定义协议**（`src/main.rs`）：按文件优先级"覆盖目录→内嵌 bundle→SPA index 兜底"，index.html `no-cache`、Vite 哈希资产 `immutable`，符号链接出界防护；主窗口改为代码建窗（`WebviewWindowBuilder`），**dev 模式与未安装覆盖时行为与原来完全一致**
- 新增 4 个命令，安装/回滚成功后直接导航主窗口到新 bundle（不碰 dashboard）
- CSP 加 `hermesui:` 与 `http://hermesui.localhost`；下载走 Rust 侧 reqwest，`connect-src` 不变
- 前端：类型 + invoke + `use-ui-update` hook + 设置页"界面热更新"区块（含 floor 阻断提示）
- CI：`scripts/sign_ui_manifest.py`（从 Core signer 移植）+ `release-ui.yml`（`ui-v*` tag，artifactUrl 签名前定死为 per-tag Release URL，prerelease 避免占用被外壳 release 认领的 `latest`）

## 测试

- 单测：载荷顺序锁 / floor 三态 / schema+平台校验 / 路径穿越（含 URL 编码）/ 冒烟 / `active_ui_dir` 门控 / 回滚往返
- 集成 `tests/ui_update.rs`：wiremock check 全路径（fresh/floor-blocked/schema/floor-empty/platform）
- `cargo test --all-features` 462 lib + 5 集成、clippy/fmt 干净、`pnpm typecheck` + 980 vitest 通过
- UI 签名脚本端到端冒烟 + 与 Rust 侧同 fixture 的跨语言字段序核对

## 前置依赖（P0，非本 PR 代码范围）

- `RUNTIME_SIGN_PRIVATE_KEY_PEM` 需提升为 org-level secret 供 Desktop 仓 `release-ui.yml` 使用
- landing 仓需新增 `ui/` 路径同步（客户端 fallback base 指向 `desktop.hermesagent.org.cn/ui`）

🤖 Generated with [Claude Code](https://claude.com/claude-code)