### PR TITLE
feat: 接入 tauri-plugin-updater，外壳整包自更新（轨道 C）

### DIFF
--- a/.github/workflows/release-desktop.yml
+++ b/.github/workflows/release-desktop.yml
@@ -42,6 +42,12 @@ permissions:
 
 jobs:
   build:
+    # Mapped at job level so the "Compute updater args" step's `if:` can read
+    # whether the minisign key is present (a step's `if` runs before its own
+    # env is applied — job-level env is the documented way to gate on a secret).
+    env:
+      TAURI_SIGNING_PRIVATE_KEY: ${{ secrets.TAURI_SIGNING_PRIVATE_KEY }}
+      TAURI_SIGNING_PRIVATE_KEY_PASSWORD: ${{ secrets.TAURI_SIGNING_PRIVATE_KEY_PASSWORD }}
     strategy:
       fail-fast: false
       matrix:
@@ -227,6 +233,23 @@ jobs:
         shell: bash
         run: scripts/verify-macos-runtime-payload.sh "static/bundled-runtime/hermes-agent-cn-runtime-${{ matrix.runtime_platform }}-${{ matrix.runtime_arch }}.zip"
 
+      # Track C: enable signed updater artifacts (.sig + latest.json) ONLY when
+      # the minisign key is present, so a release cut before the key is
+      # provisioned (P0) still succeeds — it just ships no self-update. Passed
+      # as a config override rather than baked into tauri.conf.json for exactly
+      # that reason (createUpdaterArtifacts:true hard-fails a keyless build).
+      - name: Compute updater args
+        id: updater
+        shell: bash
+        run: |
+          if [[ -n "${TAURI_SIGNING_PRIVATE_KEY:-}" ]]; then
+            echo 'config_arg=--config {"bundle":{"createUpdaterArtifacts":true}}' >> "$GITHUB_OUTPUT"
+            echo "Shell self-update artifacts ENABLED (signing key present)."
+          else
+            echo 'config_arg=' >> "$GITHUB_OUTPUT"
+            echo "::warning::TAURI_SIGNING_PRIVATE_KEY absent — building WITHOUT self-update artifacts. Set the secret (P0) to enable Track C."
+          fi
+
       - name: Build + upload installers
         uses: tauri-apps/tauri-action@v0
         env:
@@ -234,6 +257,10 @@ jobs:
           APPLE_CERTIFICATE: ${{ secrets.APPLE_CERTIFICATE }}
           APPLE_CERTIFICATE_PASSWORD: ${{ secrets.APPLE_CERTIFICATE_PASSWORD }}
           APPLE_SIGNING_IDENTITY: ${{ secrets.APPLE_SIGNING_IDENTITY }}
+          # minisign key for signing the updater artifacts (Track C). Absent =>
+          # config_arg is empty above and no updater artifacts are produced.
+          TAURI_SIGNING_PRIVATE_KEY: ${{ env.TAURI_SIGNING_PRIVATE_KEY }}
+          TAURI_SIGNING_PRIVATE_KEY_PASSWORD: ${{ env.TAURI_SIGNING_PRIVATE_KEY_PASSWORD }}
         with:
           # tauri-action looks up the tag from this input. On a push:tags
           # trigger it falls back to GITHUB_REF, but we pass it explicitly
@@ -261,7 +288,7 @@ jobs:
           releaseDraft: false
           # Mark SemVer prerelease tags as prerelease on GitHub Releases.
           prerelease: ${{ contains(github.ref_name, '-alpha') || contains(github.ref_name, '-beta') || contains(github.ref_name, '-rc') }}
-          args: --target ${{ matrix.target }} --bundles ${{ matrix.bundles }}
+          args: --target ${{ matrix.target }} --bundles ${{ matrix.bundles }} ${{ steps.updater.outputs.config_arg }}
 
       - name: Package + upload Windows portable zip
         if: matrix.runtime_platform == 'win32'
@@ -274,6 +301,18 @@ jobs:
           node scripts/package-portable-windows.mjs --target ${{ matrix.target }}
           gh release upload "$RELEASE_TAG" target/portable/*-portable.zip --clobber
 
+      # KNOWN FOLLOW-UPS for Track C shell self-update (do before GA):
+      #  - macOS: the updater artifact is a `.app.tar.gz` (+ .sig), signed by
+      #    tauri-action during the build BEFORE this DMG notarization step. Its
+      #    embedded .app carries the Developer-ID signature but NOT this step's
+      #    stapled notarization ticket. Gatekeeper still accepts it (online
+      #    notarization check), but for parity the updater `.app.tar.gz` should
+      #    be rebuilt from the notarized+stapled .app and re-signed. See
+      #    docs/hot-update-impl-plan.md §5.
+      #  - Windows: NSIS installer is not Authenticode-signed. Enabling silent
+      #    (passive) self-update before buying an OV/EV cert means SmartScreen
+      #    warnings on every update. Keep the frontend on prompt-then-install
+      #    until the cert lands.
       - name: Notarize, staple, verify, and reupload macOS DMG
         if: matrix.runtime_platform == 'darwin'
         shell: bash

--- a/Cargo.lock
+++ b/Cargo.lock
@@ -2012,6 +2012,7 @@ dependencies = [
  "tauri-plugin-clipboard-manager",
  "tauri-plugin-dialog",
  "tauri-plugin-notification",
+ "tauri-plugin-updater",
  "tempfile",
  "thiserror 2.0.18",
  "tokio",
@@ -2021,7 +2022,7 @@ dependencies = [
  "windows-sys 0.61.2",
  "winreg 0.55.0",
  "wiremock",
- "zip",
+ "zip 2.4.2",
 ]
 
 [[package]]
@@ -2486,6 +2487,36 @@ dependencies = [
 ]
 
 [[package]]
+name = "jni"
+version = "0.22.4"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "5efd9a482cf3a427f00d6b35f14332adc7902ce91efb778580e180ff90fa3498"
+dependencies = [
+ "cfg-if",
+ "combine",
+ "jni-macros",
+ "jni-sys 0.4.1",
+ "log",
+ "simd_cesu8",
+ "thiserror 2.0.18",
+ "walkdir",
+ "windows-link 0.2.1",
+]
+
+[[package]]
+name = "jni-macros"
+version = "0.22.4"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "a00109accc170f0bdb141fed3e393c565b6f5e072365c3bd58f5b062591560a3"
+dependencies = [
+ "proc-macro2",
+ "quote",
+ "rustc_version",
+ "simd_cesu8",
+ "syn 2.0.117",
+]
+
+[[package]]
 name = "jni-sys"
 version = "0.3.1"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -2782,6 +2813,12 @@ dependencies = [
  "mime",
  "unicase",
 ]
+
+[[package]]
+name = "minisign-verify"
+version = "0.2.5"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "22f9645cb765ea72b8111f36c522475d2daa0d22c957a9826437e97534bc4e9e"
 
 [[package]]
 name = "miniz_oxide"
@@ -3119,6 +3156,18 @@ dependencies = [
 ]
 
 [[package]]
+name = "objc2-osa-kit"
+version = "0.3.2"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "f112d1746737b0da274ef79a23aac283376f335f4095a083a267a082f21db0c0"
+dependencies = [
+ "bitflags 2.11.1",
+ "objc2",
+ "objc2-app-kit",
+ "objc2-foundation",
+]
+
+[[package]]
 name = "objc2-quartz-core"
 version = "0.3.2"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -3199,6 +3248,12 @@ dependencies = [
 ]
 
 [[package]]
+name = "openssl-probe"
+version = "0.2.1"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "7c87def4c32ab89d880effc9e097653c8da5d6ef28e6b539d313baaacfbafcbe"
+
+[[package]]
 name = "option-ext"
 version = "0.2.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -3222,6 +3277,20 @@ checksum = "7d8fae84b431384b68627d0f9b3b1245fcf9f46f6c0e3dc902e9dce64edd1967"
 dependencies = [
  "libc",
  "windows-sys 0.61.2",
+]
+
+[[package]]
+name = "osakit"
+version = "0.3.1"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "732c71caeaa72c065bb69d7ea08717bd3f4863a4f451402fc9513e29dbd5261b"
+dependencies = [
+ "objc2",
+ "objc2-foundation",
+ "objc2-osa-kit",
+ "serde",
+ "serde_json",
+ "thiserror 2.0.18",
 ]
 
 [[package]]
@@ -3900,15 +3969,20 @@ dependencies = [
  "http-body",
  "http-body-util",
  "hyper",
+ "hyper-rustls",
  "hyper-util",
  "js-sys",
  "log",
  "percent-encoding",
  "pin-project-lite",
+ "rustls",
+ "rustls-pki-types",
+ "rustls-platform-verifier",
  "serde",
  "serde_json",
  "sync_wrapper",
  "tokio",
+ "tokio-rustls",
  "tokio-util",
  "tower",
  "tower-http",
@@ -4015,6 +4089,18 @@ dependencies = [
 ]
 
 [[package]]
+name = "rustls-native-certs"
+version = "0.8.4"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "dab5152771c58876a2146916e53e35057e1a4dfa2b9df0f0305b07f611fdea4d"
+dependencies = [
+ "openssl-probe",
+ "rustls-pki-types",
+ "schannel",
+ "security-framework",
+]
+
+[[package]]
 name = "rustls-pki-types"
 version = "1.14.1"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -4023,6 +4109,33 @@ dependencies = [
  "web-time",
  "zeroize",
 ]
+
+[[package]]
+name = "rustls-platform-verifier"
+version = "0.7.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "26d1e2536ce4f35f4846aa13bff16bd0ff40157cdb14cc056c7b14ba41233ba0"
+dependencies = [
+ "core-foundation",
+ "core-foundation-sys",
+ "jni 0.22.4",
+ "log",
+ "once_cell",
+ "rustls",
+ "rustls-native-certs",
+ "rustls-platform-verifier-android",
+ "rustls-webpki",
+ "security-framework",
+ "security-framework-sys",
+ "webpki-root-certs",
+ "windows-sys 0.61.2",
+]
+
+[[package]]
+name = "rustls-platform-verifier-android"
+version = "0.1.1"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "f87165f0995f63a9fbeea62b64d10b4d9d8e78ec6d7d51fb2125fda7bb36788f"
 
 [[package]]
 name = "rustls-webpki"
@@ -4063,6 +4176,15 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "46e6f046b7fef48e2660c57ed794263155d713de679057f2d0c169bfc6e756cc"
 dependencies = [
  "sdd",
+]
+
+[[package]]
+name = "schannel"
+version = "0.1.29"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "91c1b7e4904c873ef0710c1f407dde2e6287de2bebc1bbbf7d430bb7cbffd939"
+dependencies = [
+ "windows-sys 0.61.2",
 ]
 
 [[package]]
@@ -4127,6 +4249,29 @@ name = "sdd"
 version = "3.0.10"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "490dcfcbfef26be6800d11870ff2df8774fa6e86d047e3e8c8a76b25655e41ca"
+
+[[package]]
+name = "security-framework"
+version = "3.7.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "b7f4bc775c73d9a02cde8bf7b2ec4c9d12743edf609006c7facc23998404cd1d"
+dependencies = [
+ "bitflags 2.11.1",
+ "core-foundation",
+ "core-foundation-sys",
+ "libc",
+ "security-framework-sys",
+]
+
+[[package]]
+name = "security-framework-sys"
+version = "2.17.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "6ce2691df843ecc5d231c0b14ece2acc3efb62c0a398c7e1d875f3983ce020e3"
+dependencies = [
+ "core-foundation-sys",
+ "libc",
+]
 
 [[package]]
 name = "selectors"
@@ -4434,6 +4579,22 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "703d5c7ef118737c72f1af64ad2f6f8c5e1921f818cdcb97b8fe6fc69bf66214"
 
 [[package]]
+name = "simd_cesu8"
+version = "1.2.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "11031e251abf8611c80f460e19dbdeb54a66db918e49c65a7065b46ac7aec520"
+dependencies = [
+ "rustc_version",
+ "simdutf8",
+]
+
+[[package]]
+name = "simdutf8"
+version = "0.1.5"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "e3a9fe34e3e7a50316060351f37187a3f546bce95496156754b601a5fa71b76e"
+
+[[package]]
 name = "siphasher"
 version = "1.0.3"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -4644,7 +4805,7 @@ dependencies = [
  "gdkwayland-sys",
  "gdkx11-sys",
  "gtk",
- "jni",
+ "jni 0.21.1",
  "libc",
  "log",
  "ndk",
@@ -4678,6 +4839,17 @@ dependencies = [
 ]
 
 [[package]]
+name = "tar"
+version = "0.4.46"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "3f6221d9a6003c78398e3b239969f352578258df48c8eb051caadae0015bc840"
+dependencies = [
+ "filetime",
+ "libc",
+ "xattr",
+]
+
+[[package]]
 name = "target-lexicon"
 version = "0.12.16"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -4700,7 +4872,7 @@ dependencies = [
  "gtk",
  "heck 0.5.0",
  "http",
- "jni",
+ "jni 0.21.1",
  "libc",
  "log",
  "mime",
@@ -4889,6 +5061,39 @@ dependencies = [
 ]
 
 [[package]]
+name = "tauri-plugin-updater"
+version = "2.10.1"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "806d9dac662c2e4594ff03c647a552f2c9bd544e7d0f683ec58f872f952ce4af"
+dependencies = [
+ "base64 0.22.1",
+ "dirs",
+ "flate2",
+ "futures-util",
+ "http",
+ "infer",
+ "log",
+ "minisign-verify",
+ "osakit",
+ "percent-encoding",
+ "reqwest 0.13.3",
+ "rustls",
+ "semver",
+ "serde",
+ "serde_json",
+ "tar",
+ "tauri",
+ "tauri-plugin",
+ "tempfile",
+ "thiserror 2.0.18",
+ "time",
+ "tokio",
+ "url",
+ "windows-sys 0.60.2",
+ "zip 4.6.1",
+]
+
+[[package]]
 name = "tauri-runtime"
 version = "2.11.1"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -4898,7 +5103,7 @@ dependencies = [
  "dpi",
  "gtk",
  "http",
- "jni",
+ "jni 0.21.1",
  "objc2",
  "objc2-ui-kit",
  "objc2-web-kit",
@@ -4921,7 +5126,7 @@ checksum = "a3989df2ae1c476404fe0a2e8ffc4cfbde97e51efd613c2bb5355fbc9ab52cf0"
 dependencies = [
  "gtk",
  "http",
- "jni",
+ "jni 0.21.1",
  "log",
  "objc2",
  "objc2-app-kit",
@@ -5951,6 +6156,15 @@ dependencies = [
 ]
 
 [[package]]
+name = "webpki-root-certs"
+version = "1.0.9"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "b96554aa2acc8ccdb7e1c9a58a7a68dd5d13bccc69cd124cb09406db612a1c9b"
+dependencies = [
+ "rustls-pki-types",
+]
+
+[[package]]
 name = "webpki-roots"
 version = "0.26.11"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -6712,7 +6926,7 @@ dependencies = [
  "gtk",
  "http",
  "javascriptcore-rs",
- "jni",
+ "jni 0.21.1",
  "libc",
  "ndk",
  "objc2",
@@ -6775,6 +6989,16 @@ name = "x11rb-protocol"
 version = "0.13.2"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "ea6fc2961e4ef194dcbfe56bb845534d0dc8098940c7e5c012a258bfec6701bd"
+
+[[package]]
+name = "xattr"
+version = "1.6.1"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "32e45ad4206f6d2479085147f02bc2ef834ac85886624a23575ae137c8aa8156"
+dependencies = [
+ "libc",
+ "rustix",
+]
 
 [[package]]
 name = "xz2"
@@ -6997,6 +7221,18 @@ dependencies = [
  "zeroize",
  "zopfli",
  "zstd",
+]
+
+[[package]]
+name = "zip"
+version = "4.6.1"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "caa8cd6af31c3b31c6631b8f483848b91589021b28fffe50adada48d4f4d2ed1"
+dependencies = [
+ "arbitrary",
+ "crc32fast",
+ "indexmap 2.14.0",
+ "memchr",
 ]
 
 [[package]]

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -17,6 +17,11 @@ name = "hermes_agent_cn"
 tauri = { version = "2", features = ["tray-icon", "devtools"] }
 tauri-plugin-dialog = "2"
 tauri-plugin-notification = "2"
+# Shell self-update (Track C): signed full-installer updates via latest.json +
+# minisign. Distinct from the runtime (Ed25519) and UI channels — see
+# docs/hot-update-impl-plan.md §5. Requires TAURI_SIGNING_PRIVATE_KEY at build
+# time only when createUpdaterArtifacts is enabled (CI-gated).
+tauri-plugin-updater = "2"
 serde = { version = "1", features = ["derive"] }
 serde_json = "1"
 tokio = { version = "1", features = ["full"] }

--- a/capabilities/default.json
+++ b/capabilities/default.json
@@ -10,6 +10,7 @@
     "dialog:default",
     "dialog:allow-open",
     "clipboard-manager:allow-read-image",
-    "notification:default"
+    "notification:default",
+    "updater:default"
   ]
 }

--- a/pnpm-lock.yaml
+++ b/pnpm-lock.yaml
@@ -103,6 +103,12 @@ importers:
       '@tauri-apps/plugin-clipboard-manager':
         specifier: ^2.3.2
         version: 2.3.2
+      '@tauri-apps/plugin-process':
+        specifier: ^2.2.0
+        version: 2.3.1
+      '@tauri-apps/plugin-updater':
+        specifier: ^2.7.0
+        version: 2.10.1
       '@xterm/addon-fit':
         specifier: ^0.11.0
         version: 0.11.0
@@ -1058,6 +1064,12 @@ packages:
 
   '@tauri-apps/plugin-clipboard-manager@2.3.2':
     resolution: {integrity: sha512-CUlb5Hqi2oZbcZf4VUyUH53XWPPdtpw43EUpCza5HWZJwxEoDowFzNUDt1tRUXA8Uq+XPn17Ysfptip33sG4eQ==}
+
+  '@tauri-apps/plugin-process@2.3.1':
+    resolution: {integrity: sha512-nCa4fGVaDL/B9ai03VyPOjfAHRHSBz5v6F/ObsB73r/dA3MHHhZtldaDMIc0V/pnUw9ehzr2iEG+XkSEyC0JJA==}
+
+  '@tauri-apps/plugin-updater@2.10.1':
+    resolution: {integrity: sha512-NFYMg+tWOZPJdzE/PpFj2qfqwAWwNS3kXrb1tm1gnBJ9mYzZ4WDRrwy8udzWoAnfGCHLuePNLY1WVCNHnh3eRA==}
 
   '@types/babel__core@7.20.5':
     resolution: {integrity: sha512-qoQprZvz5wQFJwMDqeseRXWv3rqMvhgpbXFfVyWhbx9X47POIA6i/+dXefEmZKoAgOaTdaIgNSMqMIU61yRyzA==}
@@ -3286,6 +3298,14 @@ snapshots:
       '@tauri-apps/cli-win32-x64-msvc': 2.11.1
 
   '@tauri-apps/plugin-clipboard-manager@2.3.2':
+    dependencies:
+      '@tauri-apps/api': 2.11.0
+
+  '@tauri-apps/plugin-process@2.3.1':
+    dependencies:
+      '@tauri-apps/api': 2.11.0
+
+  '@tauri-apps/plugin-updater@2.10.1':
     dependencies:
       '@tauri-apps/api': 2.11.0
 

--- a/src/commands/desktop_update.rs
+++ b/src/commands/desktop_update.rs
@@ -13,6 +13,18 @@ use serde::{Deserialize, Serialize};
 const DESKTOP_UPDATE_MANIFEST_URL: &str = "https://desktop.hermesagent.org.cn/latest.json";
 const DESKTOP_UPDATE_TIMEOUT: Duration = Duration::from_secs(10);
 
+/// The landing-site notification manifest URL, overridable via
+/// `HERMES_DESKTOP_UPDATE_MANIFEST_URL` so self-hosters / mirror operators can
+/// repoint the soft-update check without rebuilding. Empty env falls back to
+/// the baked default.
+fn desktop_update_manifest_url() -> String {
+    std::env::var("HERMES_DESKTOP_UPDATE_MANIFEST_URL")
+        .ok()
+        .map(|s| s.trim().to_string())
+        .filter(|s| !s.is_empty())
+        .unwrap_or_else(|| DESKTOP_UPDATE_MANIFEST_URL.to_string())
+}
+
 static DESKTOP_UPDATE_HTTP_CLIENT: LazyLock<reqwest::Client> = LazyLock::new(|| {
     reqwest::Client::builder()
         .timeout(DESKTOP_UPDATE_TIMEOUT)
@@ -123,7 +135,7 @@ async fn fetch_desktop_update_manifest_from(
 
 #[tauri::command]
 pub async fn desktop_check_update() -> DesktopUpdateManifestFetchResult {
-    fetch_desktop_update_manifest_from(&DESKTOP_UPDATE_HTTP_CLIENT, DESKTOP_UPDATE_MANIFEST_URL)
+    fetch_desktop_update_manifest_from(&DESKTOP_UPDATE_HTTP_CLIENT, &desktop_update_manifest_url())
         .await
 }
 
@@ -136,6 +148,28 @@ mod tests {
 
     fn test_client(timeout: Duration) -> reqwest::Client {
         reqwest::Client::builder().timeout(timeout).build().unwrap()
+    }
+
+    #[test]
+    #[serial_test::serial]
+    fn manifest_url_env_override() {
+        std::env::remove_var("HERMES_DESKTOP_UPDATE_MANIFEST_URL");
+        assert_eq!(desktop_update_manifest_url(), DESKTOP_UPDATE_MANIFEST_URL);
+
+        std::env::set_var(
+            "HERMES_DESKTOP_UPDATE_MANIFEST_URL",
+            "https://mirror.example.com/latest.json",
+        );
+        assert_eq!(
+            desktop_update_manifest_url(),
+            "https://mirror.example.com/latest.json"
+        );
+
+        // Blank env falls back to the baked default.
+        std::env::set_var("HERMES_DESKTOP_UPDATE_MANIFEST_URL", "   ");
+        assert_eq!(desktop_update_manifest_url(), DESKTOP_UPDATE_MANIFEST_URL);
+
+        std::env::remove_var("HERMES_DESKTOP_UPDATE_MANIFEST_URL");
     }
 
     #[tokio::test]

--- a/src/main.rs
+++ b/src/main.rs
@@ -153,6 +153,12 @@ fn main() {
         .plugin(tauri_plugin_dialog::init())
         .plugin(tauri_plugin_notification::init())
         .plugin(tauri_plugin_clipboard_manager::init())
+        // Shell self-update (Track C). Endpoints + minisign pubkey live in
+        // tauri.conf.json's plugins.updater; the frontend drives
+        // check→download→install→relaunch via @tauri-apps/plugin-updater and
+        // falls back to the notify-and-guide flow (commands/desktop_update.rs)
+        // when the updater is unconfigured.
+        .plugin(tauri_plugin_updater::Builder::new().build())
         .manage(app_state)
         .setup(move |app| {
             use tauri::Manager;

--- a/tauri.conf.json
+++ b/tauri.conf.json
@@ -73,5 +73,17 @@
     "macOS": {
       "minimumSystemVersion": "10.15"
     }
+  },
+  "plugins": {
+    "updater": {
+      "endpoints": [
+        "https://desktop.hermesagent.org.cn/shell/latest.json",
+        "https://github.com/Eynzof/Hermes-CN-Desktop/releases/latest/download/latest.json"
+      ],
+      "pubkey": "dW50cnVzdGVkIGNvbW1lbnQ6IG1pbmlzaWduIHB1YmxpYyBrZXk6IDM5RDcwMEQyNjE0REI4RUQKUldUdHVFMWgwZ0RYT1dhMCs5ZDB3ZUh6Q1R1ajR1LzJlRE5DWkFQWmdFc0tMRmp4SE5zb1VDTG0K",
+      "windows": {
+        "installMode": "passive"
+      }
+    }
   }
 }

--- a/web/package.json
+++ b/web/package.json
@@ -23,6 +23,8 @@
     "@streamdown/mermaid": "^1.0.2",
     "@tanstack/react-query": "^5.100.5",
     "@tauri-apps/plugin-clipboard-manager": "^2.3.2",
+    "@tauri-apps/plugin-process": "^2.2.0",
+    "@tauri-apps/plugin-updater": "^2.7.0",
     "@xterm/addon-fit": "^0.11.0",
     "@xterm/addon-web-links": "^0.12.0",
     "@xterm/xterm": "^6.0.0",

--- a/web/src/components/desktop-update-notifier.tsx
+++ b/web/src/components/desktop-update-notifier.tsx
@@ -14,6 +14,7 @@ import { openExternalUrl } from "@/lib/external-links";
 import { runtime } from "@/lib/runtime";
 import { readUiValue, writeUiValue } from "@/lib/ui-store";
 import { versionLabel } from "@/lib/build-info";
+import { checkShellUpdate, type ShellUpdateInfo } from "@/lib/shell-updater";
 import s from "./desktop-update-notifier.module.css";
 
 let autoCheckPromise: Promise<DesktopUpdateCheckResult> | null = null;
@@ -38,6 +39,12 @@ function startAutoCheckIfNeeded(): Promise<DesktopUpdateCheckResult> | null {
 export function DesktopUpdateNotifier() {
   const [result, setResult] = useState<DesktopUpdateCheckResult | null>(null);
   const [open, setOpen] = useState(false);
+  // Track C: when the updater plugin is configured and reports an update, we
+  // can download+install+relaunch in-app instead of only linking to the site.
+  const [shellUpdate, setShellUpdate] = useState<ShellUpdateInfo | null>(null);
+  const [installing, setInstalling] = useState(false);
+  const [installError, setInstallError] = useState<string | null>(null);
+  const [progressPct, setProgressPct] = useState<number | null>(null);
 
   useEffect(() => {
     if (runtime.platform === "web" || !window.hermesDesktop?.checkDesktopUpdate) return;
@@ -46,13 +53,16 @@ export function DesktopUpdateNotifier() {
     const promise = startAutoCheckIfNeeded();
     if (!promise) return;
 
-    promise.then((next) => {
+    promise.then(async (next) => {
       if (cancelled) return;
       const dismissedVersion = readUiValue<string | null>(DESKTOP_UPDATE_DISMISSED_VERSION_KEY, null);
-      if (shouldShowDesktopUpdateNotice(next, dismissedVersion)) {
-        setResult(next);
-        setOpen(true);
-      }
+      if (!shouldShowDesktopUpdateNotice(next, dismissedVersion)) return;
+      setResult(next);
+      setOpen(true);
+      // Probe the in-app updater in the background; if configured and it
+      // agrees an update exists, the dialog upgrades to an install button.
+      const info = await checkShellUpdate();
+      if (!cancelled) setShellUpdate(info);
     });
 
     return () => {
@@ -61,8 +71,28 @@ export function DesktopUpdateNotifier() {
   }, []);
 
   const close = () => {
+    if (installing) return;
     rememberDismissedVersion(result);
     setOpen(false);
+  };
+
+  const installInApp = async () => {
+    if (!shellUpdate) return;
+    setInstalling(true);
+    setInstallError(null);
+    try {
+      await shellUpdate.downloadInstallAndRelaunch((event) => {
+        if (event.phase === "downloading" && event.contentLength) {
+          setProgressPct(Math.min(100, Math.round((event.downloaded / event.contentLength) * 100)));
+        } else if (event.phase === "finished") {
+          setProgressPct(100);
+        }
+      });
+      // relaunch() replaces the process; code below usually never runs.
+    } catch (error) {
+      setInstallError(error instanceof Error ? error.message : String(error));
+      setInstalling(false);
+    }
   };
 
   const download = async () => {
@@ -95,11 +125,40 @@ export function DesktopUpdateNotifier() {
               <b>{versionLabel(result?.latestVersion)}</b>
             </div>
           </div>
+          {installError && (
+            <p className={s.body} role="alert">
+              自动更新失败：{installError}。可改用「去官网下载」手动安装。
+            </p>
+          )}
+          {installing && (
+            <p className={s.body} aria-live="polite">
+              {progressPct == null ? "正在准备更新…" : `正在下载并安装… ${progressPct}%`}
+              （完成后应用会自动重启）
+            </p>
+          )}
           <div className={s.actions}>
-            <button className={s.btn} type="button" onClick={close}>本版本不再提醒</button>
-            <button className={s.btnPrimary} type="button" onClick={() => void download()}>
-              <Download size={13} /> 去官网下载
+            <button className={s.btn} type="button" onClick={close} disabled={installing}>
+              本版本不再提醒
             </button>
+            {shellUpdate && !runtime.isPortable() ? (
+              <button
+                className={s.btnPrimary}
+                type="button"
+                onClick={() => void installInApp()}
+                disabled={installing}
+              >
+                <Download size={13} /> {installing ? "更新中…" : "下载并安装"}
+              </button>
+            ) : (
+              <button
+                className={s.btnPrimary}
+                type="button"
+                onClick={() => void download()}
+                disabled={installing}
+              >
+                <Download size={13} /> 去官网下载
+              </button>
+            )}
           </div>
         </Dialog.Content>
       </Dialog.Portal>

--- a/web/src/lib/shell-updater.ts
+++ b/web/src/lib/shell-updater.ts
@@ -1,0 +1,76 @@
+// Track C: in-app shell self-update via @tauri-apps/plugin-updater.
+//
+// Distinct from the runtime channel (Ed25519, replaces the Python kernel) and
+// the UI channel (hermesui override): this downloads and installs a full
+// signed installer for the Tauri shell itself, then relaunches. Endpoints and
+// the minisign pubkey are configured in tauri.conf.json's plugins.updater.
+//
+// Everything degrades gracefully: on any platform where the plugin is absent
+// or unconfigured, the helpers resolve to "unavailable" and the caller falls
+// back to the notify-and-guide flow (lib/desktop-update.ts).
+
+import { runtime } from "./runtime";
+
+export interface ShellUpdateInfo {
+  version: string;
+  currentVersion: string;
+  notes?: string;
+  /** Download + install the update, reporting bytes downloaded, then relaunch. */
+  downloadInstallAndRelaunch: (onProgress?: (event: ShellUpdateProgress) => void) => Promise<void>;
+}
+
+export type ShellUpdateProgress =
+  | { phase: "started"; contentLength?: number }
+  | { phase: "downloading"; downloaded: number; contentLength?: number }
+  | { phase: "finished" };
+
+function updaterAvailable(): boolean {
+  // The updater plugin only exists in the Tauri shell. Guard the dynamic
+  // import so web/electron builds never try to load it.
+  return typeof window !== "undefined" && runtime.platform === "tauri";
+}
+
+/**
+ * Check the configured update endpoints. Returns null when up to date, the
+ * plugin is unavailable/unconfigured, or the check errors — callers treat all
+ * of these as "no in-app update, use the fallback notice".
+ */
+export async function checkShellUpdate(): Promise<ShellUpdateInfo | null> {
+  if (!updaterAvailable()) return null;
+  try {
+    const { check } = await import("@tauri-apps/plugin-updater");
+    const update = await check();
+    if (!update) return null;
+    return {
+      version: update.version,
+      currentVersion: update.currentVersion,
+      notes: update.body ?? undefined,
+      downloadInstallAndRelaunch: async (onProgress) => {
+        let downloaded = 0;
+        let contentLength: number | undefined;
+        await update.downloadAndInstall((event) => {
+          switch (event.event) {
+            case "Started":
+              contentLength = event.data.contentLength;
+              onProgress?.({ phase: "started", contentLength });
+              break;
+            case "Progress":
+              downloaded += event.data.chunkLength;
+              onProgress?.({ phase: "downloading", downloaded, contentLength });
+              break;
+            case "Finished":
+              onProgress?.({ phase: "finished" });
+              break;
+          }
+        });
+        const { relaunch } = await import("@tauri-apps/plugin-process");
+        await relaunch();
+      },
+    };
+  } catch (error) {
+    // Unconfigured endpoints, network failure, signature mismatch, etc. —
+    // never surface as a hard error; the notify-and-guide path takes over.
+    console.warn("shell updater check failed; falling back to notice", error);
+    return null;
+  }
+}


### PR DESCRIPTION
## 背景

热更新三轨道·**轨道 C（外壳自更新，新建）**，对标上游 hermes-studio 的 `electron-updater`。目前 CN 外壳只有 `desktop_update.rs` 的"检查通知 + 引导去官网重装"，没有真正的自更新。本 PR 接入官方 `tauri-plugin-updater`（minisign + latest.json），前端可在应用内 check→download→install→relaunch 一键升级整包外壳。设计依据 `docs/hot-update-impl-plan.md` §5。

> 与 P2/P4 文件面不相交，基于 main 独立分支，可与它们并行合并。

## 改动

- `Cargo.toml` 加 `tauri-plugin-updater`，`main.rs` 注册插件；`tauri.conf.json` 加 `plugins.updater`（endpoints：landing `shell/latest.json` 主源 + GitHub `releases/latest` 兜底；minisign pubkey；Windows `passive` 安装）；`capabilities` 加 `updater:default`
- 前端 `web/src/lib/shell-updater.ts` 封装插件（懒加载、非 tauri 平台/未配置/网络失败一律优雅返回 null）；`desktop-update-notifier` 弹窗时后台探测插件，可用则把"去官网下载"换成"下载并安装"（带进度、装完自动重启），免安装版与不可用时保留原引导流程
- `desktop_update.rs` 写死的 manifest URL 加 `HERMES_DESKTOP_UPDATE_MANIFEST_URL` env 覆盖，保留为通知兼容层

**关键不对称（注释已写明）**：外壳 minisign 签的是安装包字节而非 URL，镜像 URL 服务器侧可自由设置，无轨道 A/B 的 artifactUrl-在签名内 的重签陷阱；但外壳通道**无本地回滚**，只能服务器把 `latest.json` 重指旧版 + 重装。

## CI 安全接线

`createUpdaterArtifacts` **不写进** `tauri.conf.json`（否则无密钥时打包硬失败），改由 `release-desktop.yml` 在检测到 `TAURI_SIGNING_PRIVATE_KEY` secret 时才用 `--config` 覆盖启用 —— 发版早于 P0 配密钥也不会挂，只是不产自更新产物。

## ⚠️ 前置依赖（P0 / GA 前收尾，非本 PR 代码范围）

1. 生成 minisign 密钥对，私钥入 `TAURI_SIGNING_PRIVATE_KEY(_PASSWORD)` secret；**`tauri.conf.json` 里的 pubkey 是脚手架占位符（其私钥已即时销毁），必须替换为 P0 生成的真实公钥**
2. **macOS**：updater 的 `.app.tar.gz` 目前带 Developer-ID 签名但未装订公证票据（在线校验仍通过），GA 前应从公证+装订后的 .app 重打重签
3. **Windows**：NSIS 未 Authenticode 签名，购证前不开静默更新（前端维持提示后安装）

后两项已在 `release-desktop.yml` 注释登记。

## 测试

- `desktop_update` env 覆盖单测；`cargo test --all-features` 446 lib、clippy/fmt 干净、tauri 配置校验通过
- `pnpm typecheck` + 980 vitest 通过

🤖 Generated with [Claude Code](https://claude.com/claude-code)