### PR TITLE
ci: 发版后自动同步产物到 R2 下载镜像(mirror-sync job)

### DIFF
--- a/.github/workflows/release-desktop.yml
+++ b/.github/workflows/release-desktop.yml
@@ -372,3 +372,52 @@ jobs:
 
           node scripts/package-portable-macos.mjs --target ${{ matrix.target }}
           gh release upload "$RELEASE_TAG" target/portable/*-portable.zip --clobber
+
+  # Mirror all release assets to Cloudflare R2 so the dl-desktop download
+  # mirror (landing repo workers/release-mirror) serves from R2 instead of
+  # proxying GitHub. Runs after every build leg finishes, i.e. after the
+  # notarized DMG --clobber re-uploads and portable zips are final.
+  #
+  # Failure here never blocks the release: the mirror Worker falls back to
+  # GitHub for any object missing from R2. Re-run this job from the Actions
+  # UI after a failure — every step is idempotent.
+  #
+  # Required repo secrets (R2 API token scoped to the bucket, created in
+  # Cloudflare Dashboard → R2 → Manage API Tokens):
+  #   R2_ACCESS_KEY_ID / R2_SECRET_ACCESS_KEY / R2_ACCOUNT_ID
+  mirror-sync:
+    needs: build
+    runs-on: ubuntu-latest
+    env:
+      RELEASE_TAG: ${{ github.event.inputs.tag || github.ref_name }}
+      GH_TOKEN: ${{ secrets.RELEASE_TOKEN || github.token }}
+      BUCKET: hermes-desktop-releases
+      AWS_ACCESS_KEY_ID: ${{ secrets.R2_ACCESS_KEY_ID }}
+      AWS_SECRET_ACCESS_KEY: ${{ secrets.R2_SECRET_ACCESS_KEY }}
+      AWS_DEFAULT_REGION: auto
+      AWS_ENDPOINT_URL: https://${{ secrets.R2_ACCOUNT_ID }}.r2.cloudflarestorage.com
+      # aws cli v2.23+ 默认的数据完整性校验头与 R2 不兼容,必须降级
+      AWS_REQUEST_CHECKSUM_CALCULATION: WHEN_REQUIRED
+      AWS_RESPONSE_CHECKSUM_VALIDATION: WHEN_REQUIRED
+    steps:
+      - name: Download all release assets
+        run: |
+          mkdir -p assets && cd assets
+          gh release download "$RELEASE_TAG" -R "$GITHUB_REPOSITORY"
+
+      - name: Generate and upload checksums.txt
+        run: |
+          cd assets
+          rm -f checksums.txt
+          sha256sum * | sort -k2 > checksums.txt
+          gh release upload "$RELEASE_TAG" checksums.txt -R "$GITHUB_REPOSITORY" --clobber
+
+      - name: Sync assets to R2
+        run: aws s3 sync assets/ "s3://$BUCKET/$RELEASE_TAG/"
+
+      - name: Prune old versions from R2 (keep newest 5 tags)
+        run: |
+          aws s3 ls "s3://$BUCKET/" | awk '{print $2}' | tr -d '/' \
+            | sort -V | head -n -5 | while read -r old; do
+              [ -n "$old" ] && aws s3 rm "s3://$BUCKET/$old/" --recursive
+            done


### PR DESCRIPTION
## 概要

给 `release-desktop.yml` 追加独立的 **mirror-sync** job(`needs: build`,4 个平台 leg 全部完成后运行):

1. `gh release download` 拉取该 tag 全部资产(此时公证 DMG 与 portable zip 已定稿)
2. 生成 `checksums.txt` 并 `--clobber` 上传回 release(landing 仓库的 `sync-release.mjs` 依赖它取 sha256)
3. `aws s3 sync` 同步到 R2 桶 `hermes-desktop-releases`(dl-desktop 镜像 Worker 的主源,key 结构 `<tag>/<asset>` 与 GitHub 路径同构)
4. prune 只保留最新 5 个 tag(~6.5GB,R2 免费额度内;被清掉的旧版本镜像 Worker 自动兜底 GitHub,旧链接不 404)

## 失败语义

- 本 job 失败**不影响 release 发布**(资产在 build job 里已上传;镜像 Worker 对 R2 miss 自动回源 GitHub)
- 不加 `continue-on-error`,失败在 Actions 里可见;每步幂等,直接 Re-run 即可

## ⚠️ 合并前需配置 secrets

Cloudflare Dashboard → R2 → Manage API Tokens → 创建 **Object Read & Write** token(限定 `hermes-desktop-releases` 桶),然后在本仓库 Settings → Secrets 添加:

- `R2_ACCESS_KEY_ID`
- `R2_SECRET_ACCESS_KEY`
- `R2_ACCOUNT_ID`

背景与整体方案见 landing 仓库 `docs/release-mirror-plan.md`(Eynzof/hermes-agent-cn-desktop-landing#36)。

🤖 Generated with [Claude Code](https://claude.com/claude-code)