### PR TITLE
fix: 合并 dev-fix 稳定性修复到主分支

### DIFF
--- a/.codex/skills/project-structure/SKILL.md
+++ b/.codex/skills/project-structure/SKILL.md
@@ -1,0 +1,385 @@
+---
+name: project-structure
+description: Use when orienting within the Hermes Agent CN Desktop codebase, locating source files, understanding the Tauri+React architecture, finding Rust commands or frontend modules, or navigating the monorepo. Triggers: project structure, 项目结构, where is, 在哪里, codebase overview, 代码概览, repository layout, how is this repo organized, 仓库结构, workspace layout.
+---
+
+# Hermes Agent CN Desktop — Project Structure
+
+## Overview
+
+**Hermes Agent CN Desktop** is a standalone desktop application built with **Tauri v2 + React**, replacing the original Electron shell. It pairs with the [Hermes-CN-Core](https://github.com/Eynzof/Hermes-CN-Core) backend runtime (the CN community runtime, originally named `hermes-agent-cn`).
+
+- **Version**: 0.6.3
+- **Bundle identifier**: `cn.org.hermesagent.desktop` (DO NOT CHANGE — used for upgrade path)
+- **Rust crate name**: `hermes_agent_cn` (lib), `hermes-agent-cn-desktop` (package)
+- **Package manager**: pnpm 9.15.0 (monorepo)
+
+The desktop-managed runtime defaults to port **9120**, avoiding port 9119 used by the user's global Hermes Agent.
+
+---
+
+## Top-Level Directory Layout
+
+```
+Hermes-CN-Desktop/
+├── src/                          Rust Tauri backend (~24,000 lines)
+├── web/                          React frontend (Vite + TanStack Query + Jotai)
+├── packages/
+│   ├── protocol/                 Shared Zod schemas, IPC types, session log parsing
+│   └── shared-ui/                Design tokens, shared React components, hooks
+├── e2e/                          Playwright E2E (real web → real Core backend → fake model)
+├── tests/                        Rust integration tests (crate: hermes_agent_cn)
+├── scripts/                      Build & dev automation scripts (.mjs)
+├── static/                       Stage targets for bundled builds
+│   ├── bundled-runtime/          Managed runtime binaries
+│   ├── bundled-skills/           Bundled skill packs
+│   ├── bundled-plugins/          Bundled plugins
+│   └── dashboard/                Dashboard web dist
+├── docs/                         Project documentation & PRD specs
+├── icons/                        App icons (Windows/macOS/Linux)
+├── installer/                    NSIS installer customization
+├── legal/                        EULA & license files
+├── gen/schemas/                  Generated JSON schemas
+├── capabilities/                 Tauri capability definitions
+├── .github/workflows/            CI/CD pipelines
+├── Cargo.toml                    Rust dependencies & build config
+├── tauri.conf.json               Tauri window/bundle/CSP configuration
+├── pnpm-workspace.yaml           pnpm monorepo (web + packages/* + e2e)
+└── package.json                  Workspace root scripts
+```
+
+---
+
+## Rust Backend (`src/`)
+
+The Rust crate `hermes_agent_cn` is the Tauri backend. All source lives under `src/`.
+
+### Entry Points & Core Modules
+
+| File | Purpose |
+|------|---------|
+| `main.rs` | Entry point: resolves `HERMES_HOME`, starts dashboard, registers **60 commands** (`generate_handler!`), system tray |
+| `lib.rs` | Library root: declares **18 public modules** |
+| `state.rs` | `AppState` (`Mutex<AppStateInner>`) — shared state injected into every Tauri command |
+| `error.rs` | `AppError` unified domain error type (thiserror + Serialize) |
+| `tray.rs` | System tray menu |
+
+### Bootstrap & Environment
+
+| File | Purpose |
+|------|---------|
+| `bootstrap.rs` | Startup sequence: probe/spawn dashboard, connect backend, fetch token |
+| `environment.rs` | Environment resolution and validation |
+| `connection.rs` | Connection backend + mode (local/remote), remote-mode WS connection |
+| `path_resolver.rs` | PATH/PATHEXT resolution for child processes |
+| `env_file.rs` | Parse `$HERMES_HOME/.env` for per-spawn child env injection |
+
+### Runtime & Process Management
+
+| File | Purpose |
+|------|---------|
+| `supervisor.rs` | Child process supervision |
+| `prevent_sleep.rs` | Keep-awake during long-running tasks |
+| `cron_runs.rs` | Scheduled task orchestration |
+| `update_stage.rs` | Update staging logic |
+| `process/` | Subprocess management |
+| `process/dashboard.rs` | Dashboard subprocess: probe/spawn/port fallback |
+| `process/gateway.rs` | Gateway subprocess + conflict detection |
+| `process/runtime.rs` | Managed runtime install/signature verification |
+| `process/instance.rs` | Single-instance guard per runtime root |
+| `process/port_lock.rs` | Port lock management |
+
+### Session & Logging
+
+| File | Purpose |
+|------|---------|
+| `session_archive.rs` | Session archiving |
+| `session_log.rs` | Session log reading |
+| `oauth_session.rs` | OAuth session handling |
+
+### Other Core Modules
+
+| File | Purpose |
+|------|---------|
+| `coding_agents.rs` | Coding agent management |
+| `desktop_control.rs` | Desktop-level controls |
+| `ui_store.rs` | UI state persistence |
+| `util.rs` | Shared utilities |
+
+### Commands (`src/commands/`) — 60 Tauri IPC Commands
+
+| Module | Purpose |
+|--------|---------|
+| `api_proxy.rs` | HTTP proxy: `api_request`, `external_request`, `upload_file` |
+| `ws_proxy.rs` | /api/ws WebSocket relay (fallback when webview native WS blocked) |
+| `gateway.rs` | Runtime config + gateway URL refresh |
+| `runtime_manager.rs` | Managed runtime download/update/rollback |
+| `desktop_update.rs` | Desktop self-update |
+| `profiles.rs` | Profile switching (incl. fault recovery) |
+| `config_migration.rs` | Configuration migration |
+| `im_onboarding.rs` | Feishu/DingTalk/WeCom/WeChat onboarding |
+| `connection.rs` | Connection management commands |
+| `connection_auth.rs` | OAuth-based connection authentication |
+| `backup.rs` | Backup operations |
+| `memory.rs` | Memory management |
+| `skills.rs` | Skill management (hidden from mod.rs) |
+| `terminal.rs` | Embedded terminal (portable-pty) |
+| `log_export.rs` | Log export |
+| `debug_bundle.rs` | Debug bundle generation |
+| `notify.rs` | Desktop notifications |
+| `preview.rs` | File preview with native filesystem watch |
+| `environment.rs` | Environment variables |
+| `file_dialogs.rs` | Native file dialogs |
+| `restart.rs` | App restart |
+| `ui_store.rs` | UI state persistence commands |
+| `yolo.rs` | YOLO mode |
+| `devtools.rs` | WebView devtools toggle |
+| `coding_agents.rs` | Coding agent management commands |
+| `git.rs` | Git operations |
+
+---
+
+## React Frontend (`web/`)
+
+Built with **Vite + React 19 + TanStack Query + Jotai**. CSS Modules (no Tailwind).
+
+### Key Files & Directories
+
+```
+web/src/
+├── main.tsx                    App entry
+├── App.tsx                     Root component
+├── lib/                        Core library (~156 files, most with co-located tests)
+│   ├── tauri-bridge.ts         Tauri invoke wrapper + hermesDesktop shim
+│   ├── runtime.ts              Platform detection (web / electron / tauri)
+│   ├── transport.ts            HTTP routing (native IPC vs fetch) + auth header injection
+│   ├── gateway-client.ts       Gateway WS client (JSON-RPC over /api/ws, backoff/reconnect)
+│   ├── gateway-socket-path.ts  Native WS vs Rust relay socket path selection
+│   └── ...                     ~150 other lib modules (models, skills, sessions, etc.)
+├── hooks/                      React hooks (~42 files)
+│   ├── use-gateway.ts          Gateway WebSocket connection hook
+│   ├── use-config.ts           Configuration hook
+│   ├── use-sessions.ts         Sessions management
+│   ├── use-skills.ts           Skills management
+│   └── ...                     Many more domain hooks
+├── stores/                     Jotai atoms (~13 files)
+│   ├── chat.ts                 Chat state
+│   ├── panel.ts                Panel state
+│   ├── ui.ts                   UI state
+│   └── ...
+├── routes/                     Page components (~39 files)
+│   ├── guide.tsx               Onboarding guide
+│   ├── health.tsx              Health dashboard
+│   ├── settings.tsx            Settings page
+│   ├── chat.tsx                Chat interface
+│   └── ...                     Many more page routes
+├── components/                 UI components
+│   ├── app-shell/              App shell layout
+│   ├── chat/                   Chat components (incl. preview-rail)
+│   ├── composer/               Message composer (incl. workspace-picker)
+│   ├── console/                Console/terminal
+│   ├── settings/               Settings panels
+│   ├── sidebar/                Sidebar navigation
+│   ├── top-bar/                Top navigation bar
+│   ├── command-palette/        Command palette (⌘K)
+│   ├── mcp/                    MCP server management
+│   ├── profiles/               Profile management
+│   ├── projects/               Project/workspace management
+│   ├── session-actions/        Session actions
+│   ├── panel/                  Panel components
+│   ├── brand/                  Branding components
+│   └── ui/                     Generic UI primitives
+├── styles/                     Global styles
+├── types/                      TypeScript type definitions
+└── assets/                     Static assets (incl. provider-icons)
+```
+
+### State Management Strategy
+
+| Layer | Technology |
+|-------|-----------|
+| Server state (REST API data) | TanStack Query |
+| Local / real-time stream state | Jotai atoms |
+| Rust-side state | `AppState` (`Mutex<AppStateInner>`) via `tauri::State` |
+
+### Key Architecture Patterns
+
+- **Transport**: All HTTP requests go through `transport.ts` (auth header injection, native IPC vs fetch routing). NEVER hand-write fetch elsewhere.
+- **Gateway**: JSON-RPC over WebSocket at `/api/ws`. Use `use-gateway.ts` hook, never call `gateway-client.ts` raw socket directly.
+- **Tauri Bridge**: `tauri-bridge.ts` mounts Tauri invoke wrappers onto `window.hermesDesktop` at startup. Existing code checking `window.hermesDesktop?.someMethod` works unchanged.
+- **CSS**: CSS Modules only — no Tailwind, no styled-components. Design tokens in `packages/shared-ui/src/tokens/`.
+
+---
+
+## Packages (`packages/`)
+
+### `@hermes/protocol`
+Shared type definitions and validation:
+- Zod schemas for the Hermes API (`hermes-api.ts`)
+- IPC types
+- Session log parsing (`session-log.ts`)
+- MCP API schemas
+- Channel types
+
+### `@hermes/shared-ui`
+Shared UI primitives:
+- Design tokens (`tokens/`): colors, typography, spacing, motion, z-index, component tokens, semantic tokens, primitives
+- Components: alert, badge, button, card, copy-button, empty-state, field, input
+- Composites: dialog, popover
+- Hooks
+- Utilities
+
+---
+
+## Testing
+
+### Unit Tests (Vitest)
+- **~93 test files** across the monorepo
+- `web/src/lib/` — most modules have co-located `.test.ts` files
+- `packages/protocol/` — Zod schema tests
+- Run: `pnpm test:unit` (serial per workspace)
+
+### Rust Integration Tests (`tests/`)
+- Crate name: `hermes_agent_cn`
+- Mock-based: `wiremock` for HTTP, `tempfile::TempDir` for FS
+- Tests: `api_proxy.rs`, `connection_config.rs`, `connection_ws_e2e.rs`, `dashboard_probe.rs`, `dashboard_spawn_retry.rs`, `dashboard_token.rs`, `runtime_manifest.rs`
+- Run: `cargo test --all-features`
+
+### E2E Tests (`e2e/`)
+- Playwright (real web → real Core backend → local fake model)
+- Specs: chat-loop, guide-layout, image-paste, models-cli-custom-provider, skills-provenance
+- Fake model server: `e2e/fake-model/server.py`
+- Harness: config, global-warmup, protocol-smoke, start-backend, wait
+- Run: `pnpm test:e2e`
+
+---
+
+## Scripts (`scripts/`)
+
+| Script | Purpose |
+|--------|---------|
+| `tauri-dev-managed.mjs` | Install backend into dev-runtime, launch Tauri dev |
+| `tauri-dev-external.mjs` | Tauri dev with external backend |
+| `install-local-runtime.mjs` | Copy Hermes-CN-Core into dev-runtime |
+| `install-release-dmg.mjs` | Download & install release DMG |
+| `stage-bundled-runtime.mjs` | Stage runtime for bundled build |
+| `stage-dashboard-web-dist.mjs` | Stage dashboard web dist |
+| `stage-bundled-skills.mjs` | Stage bundled skills |
+| `stage-bundled-plugins.mjs` | Stage bundled plugins |
+| `sync-desktop-version.mjs` | Sync version across packages |
+| `generate-license-rtf.mjs` | Generate license RTF |
+| `migrate-runtime-trees.mjs` | Migrate polluted runtime trees |
+| `package-portable-windows.mjs` | Create Windows portable package |
+| `package-portable-macos.mjs` | Create macOS portable package |
+| `only-pnpm.mjs` | Enforce pnpm as package manager |
+| `cdp-eval.mjs` | Chrome DevTools Protocol evaluation |
+
+---
+
+## Configuration Files
+
+| File | Purpose |
+|------|---------|
+| `Cargo.toml` | Rust dependencies (tauri 2, tokio, reqwest, rusqlite, etc.) |
+| `tauri.conf.json` | Tauri window config, CSP, bundle targets (NSIS/DMG/deb/AppImage) |
+| `package.json` | Root workspace scripts (version sync, build, test) |
+| `pnpm-workspace.yaml` | Workspace members: web, packages/*, e2e |
+| `web/vite.config.ts` | Vite config (dev server on port 9545, strictPort) |
+
+---
+
+## CI/CD (`.github/workflows/`)
+
+| Workflow | Trigger | Purpose |
+|----------|---------|---------|
+| `rust-test.yml` | PR / push to main | `cargo fmt --check`, `cargo clippy -D warnings`, `cargo test` |
+| `web-test.yml` | PR / push to main | TypeScript typecheck + vitest unit tests |
+| `web-e2e.yml` | PR / push to main | Playwright E2E (checkout Hermes-CN-Core + fake model) |
+| `release-desktop.yml` | Tag push | Release build & publish |
+
+---
+
+## Documentation (`docs/`)
+
+| File | Content |
+|------|---------|
+| `desktop-prd/` | Product Requirements Document (6 docs: feature inventory, PRD, IA, specs, backend contract, parity gap) |
+| `gateway-connection-overhaul.md` | Gateway connection architecture |
+| `managed-runtime.md` | Managed runtime design |
+| `hot-update-plan.md` / `hot-update-impl-plan.md` | Hot update design |
+| `macos-signing-and-notarization.md` | macOS code signing |
+| `portable-mode.md` | Portable mode |
+| `yolo-mode.md` | YOLO mode |
+| `custom-model-context-window.md` | Custom model context window |
+
+---
+
+## Port Conventions
+
+| Port | Purpose |
+|------|---------|
+| **9120** | Hermes Dashboard (desktop managed runtime) |
+| **9119** | User global Hermes Agent (AVOID — managed runtime only) |
+| **9545** | Vite dev server (strictPort) |
+
+---
+
+## Dev vs Production Mode
+
+| Aspect | Dev | Production |
+|--------|-----|------------|
+| WebView loads | `http://localhost:9545` (Vite) | Bundled `web/dist/` |
+| REST API | Vite proxy → dashboard (same-origin) | Rust IPC proxy (`api_request` command) |
+| Gateway events | WebSocket → Vite proxy `/api/ws` | Official `/api/ws`, fallback to Rust WS relay (`ws_proxy.rs`) |
+| Session token | Vite `/__hermes_token` endpoint | Rust `get_runtime_config` command |
+| `apiBaseUrl` | Not set (relative path) | Set to dashboard URL |
+
+---
+
+## Rust Testing Conventions
+
+- **Unit tests**: `#[cfg(test)] mod tests { ... }` inline in source files; can access private functions
+- **Integration tests**: In `tests/` directory, only use `pub` API via `hermes_agent_cn` crate
+- **Env-dependent tests**: Must use `#[serial_test::serial]`
+- **Filesystem tests**: Use `tempfile::TempDir`; never write to `/tmp`, cwd, or fixed paths
+- **HTTP tests**: Use `wiremock::MockServer`; never real network
+- **Assertions**: Prefer `pretty_assertions::assert_eq`
+- **Pre-commit**: `cargo test --all-features`
+
+---
+
+## Key Dependencies
+
+### Rust
+- **Tauri v2** with `tray-icon` and `devtools` features
+- **tokio** (full), **reqwest** (rustls-tls), **tokio-tungstenite**
+- **tauri-plugin-dialog**, **tauri-plugin-notification**, **tauri-plugin-clipboard-manager**
+- **rusqlite** (bundled), **zip**, **sha2**, **ed25519-dalek**
+- **thiserror**, **serde/serde_json**, **portable-pty**, **notify**
+- Platform: **windows-sys** + **winreg** (Windows), **objc2** (macOS)
+
+### Frontend
+- **React 19**, **react-router 7**, **TanStack Query 5**, **Jotai 2**
+- **@tauri-apps/api**, **@tauri-apps/plugin-clipboard-manager**
+- **streamdown** (Markdown renderer with CJK/math/mermaid extensions)
+- **Radix UI** (dialog, dropdown-menu, popover)
+- **xterm** (terminal), **cmdk** (command palette), **recharts**, **lucide-react**
+
+---
+
+## Architecture Rules (DO NOT Violate)
+
+- ❌ Don't hand-write `fetch` outside `web/src/lib/transport.ts` — auth header injection lives there
+- ❌ Don't call `gateway-client.ts` raw socket directly — use `hooks/use-gateway.ts`
+- ❌ Don't put business logic in `web/src/routes/` — extract to `hooks/` or `lib/`
+- ❌ Don't hardcode colors in components — use CSS variables from `packages/shared-ui/src/tokens/`
+- ❌ Don't change the bundle identifier `cn.org.hermesagent.desktop`
+- ❌ Don't use port 9119 (reserved for user's global Hermes Agent)
+
+---
+
+## Commit Convention
+
+- Conventional Commits: `feat` / `fix` / `style` / `docs` / `refactor` / `chore`
+- English subject line, imperative mood ("add ...", "fix ...", "rework ...")
+- Description can mix Chinese/English; explain "why" not "what"

--- a/.codex/skills/project-structure/agents/openai.yaml
+++ b/.codex/skills/project-structure/agents/openai.yaml
@@ -1,0 +1,4 @@
+interface:
+  display_name: "项目结构导航"
+  short_description: "理解 Hermes Agent CN Desktop 代码库结构，定位源文件，了解 Tauri+React 架构，查找 Rust 命令或前端模块，导航 monorepo。"
+  default_prompt: "根据项目结构技能，帮助用户在 Hermes Agent CN Desktop 代码库中定位文件、理解模块职责、导航 monorepo 结构、查找特定 Tauri 命令或 React 组件位置。"

--- a/.github/workflows/web-e2e.yml
+++ b/.github/workflows/web-e2e.yml
@@ -47,7 +47,7 @@ jobs:
 
       - uses: actions/setup-python@v5
         with:
-          python-version: "3.12"
+          python-version: "3.14"
 
       - name: Install Core (Python) into .venv
         working-directory: Hermes-CN-Core

--- a/AGENTS.md
+++ b/AGENTS.md
@@ -80,6 +80,8 @@ Hermes CN 的需求与 bug 修复通常**同时横跨 Desktop 与 Core 两个仓
 
 ### 仓库技能
 
+开始任何工作前，必须先阅读项目结构技能：`.codex/skills/project-structure/SKILL.md`。
+
 双仓库（Desktop + Core）最新分支启动、dev 冒烟或打包态补验，必须使用：
 `.codex/skills/desktop-dual-repo-test/SKILL.md`。
 

--- a/src/process/dashboard.rs
+++ b/src/process/dashboard.rs
@@ -21,8 +21,7 @@ use serde::{Deserialize, Serialize};
 
 use crate::error::AppError;
 use crate::process::port_lock::{
-    claim_port_set, pid_is_running, release_orphaned_port_locks, reset_local_claims,
-    PortLock,
+    claim_port_set, pid_is_running, release_orphaned_port_locks, reset_local_claims, PortLock,
 };
 use crate::state::{DashboardHandle, DashboardJobHandle};
 

--- a/src/process/dashboard.rs
+++ b/src/process/dashboard.rs
@@ -20,7 +20,10 @@ use regex::Regex;
 use serde::{Deserialize, Serialize};
 
 use crate::error::AppError;
-use crate::process::port_lock::{claim_port_set, release_orphaned_port_locks, PortLock};
+use crate::process::port_lock::{
+    claim_port_set, pid_is_running, release_orphaned_port_locks, reset_local_claims,
+    PortLock,
+};
 use crate::state::{DashboardHandle, DashboardJobHandle};
 
 // A freshly installed onefile runtime can spend tens of seconds on macOS
@@ -116,16 +119,28 @@ fn fallback_ports(start: u16) -> Vec<u16> {
     ports
 }
 
-/// The well-known satellite ports that a desktop-managed dashboard tree may
-/// bind (webhook, proxy). These are reserved alongside the dashboard API port.
-const WELL_KNOWN_DASHBOARD_PORTS: &[u16] = &[8644, 8645];
+/// The base satellite ports that a desktop-managed dashboard tree may bind
+/// (webhook, proxy).  These are offset from ``DEFAULT_DESKTOP_DASHBOARD_PORT``
+/// so that multiple Hermes instances can coexist without colliding:
+///
+/// ```text
+///     dashboard=9120 → [9120, 8644, 8645]
+///     dashboard=9121 → [9121, 8646, 8647]
+///     dashboard=9122 → [9122, 8648, 8649]
+///     ...
+/// ```
+///
+/// Must be kept in sync with the Python ``_compute_well_known_ports`` in
+/// ``hermes_cli/main.py``.
+const SATELLITE_PORT_BASE_WEBHOOK: u16 = 8644;
+const SATELLITE_PORT_BASE_PROXY: u16 = 8645;
 
 /// Build the full set of ports to claim for a dashboard at ``dashboard_port``.
 fn ports_to_claim(dashboard_port: u16) -> Vec<u16> {
-    let mut ports = Vec::with_capacity(WELL_KNOWN_DASHBOARD_PORTS.len() + 1);
-    ports.push(dashboard_port);
-    ports.extend_from_slice(WELL_KNOWN_DASHBOARD_PORTS);
-    ports
+    let offset = (dashboard_port.saturating_sub(DEFAULT_DESKTOP_DASHBOARD_PORT)) * 2;
+    let webhook_port = SATELLITE_PORT_BASE_WEBHOOK.saturating_add(offset);
+    let proxy_port = SATELLITE_PORT_BASE_PROXY.saturating_add(offset);
+    vec![dashboard_port, webhook_port, proxy_port]
 }
 
 /// Try to claim the full port set for a candidate dashboard port.
@@ -217,34 +232,8 @@ fn marker_owner_state(
     }
 }
 
-#[cfg(unix)]
-fn pid_is_running(pid: u32) -> bool {
-    if pid == 0 {
-        return false;
-    }
-    let rc = unsafe { libc::kill(pid as libc::pid_t, 0) };
-    rc == 0 || std::io::Error::last_os_error().raw_os_error() == Some(libc::EPERM)
-}
-
-#[cfg(windows)]
-fn pid_is_running(pid: u32) -> bool {
-    if pid == 0 {
-        return false;
-    }
-    let filter = format!("PID eq {}", pid);
-    let Ok(output) = Command::new("tasklist")
-        .args(["/FI", &filter, "/FO", "CSV", "/NH"])
-        .output()
-    else {
-        return false;
-    };
-    String::from_utf8_lossy(&output.stdout).contains(&pid.to_string())
-}
-
-#[cfg(not(any(unix, windows)))]
-fn pid_is_running(_pid: u32) -> bool {
-    false
-}
+// pid_is_running is imported from port_lock.rs (the single canonical
+// implementation, using OpenProcess on Windows and libc::kill on Unix).
 
 fn wait_for_child_exit(child: &mut Child, timeout: Duration) -> bool {
     let start = Instant::now();
@@ -1570,6 +1559,9 @@ pub async fn ensure_hermes_dashboard(
             // scan. Release the old claim first — the new candidate (possibly
             // the same port) gets a fresh atomic claim of its full port set.
             drop(std::mem::take(&mut port_locks));
+            // Ensure no stale local claims remain from the dropped locks so
+            // the re-claim below gets real OS locks (not no-op handles).
+            reset_local_claims();
             let next = std::iter::once(options.port)
                 .chain(fallback_ports(options.port))
                 .filter(|port| {
@@ -2167,5 +2159,40 @@ mod tests {
             "live-foreign marker must collapse to stale adoption, not live attach"
         );
         std::env::remove_var("HERMES_DESKTOP_RUNTIME_ROOT");
+    }
+
+    // ── Bug 2: Satellite port offset ─────────────────────────────────
+
+    #[test]
+    fn ports_to_claim_offsets_satellite_ports() {
+        // dashboard=9120 → [9120, 8644, 8645]
+        let ports = ports_to_claim(9120);
+        assert_eq!(ports, vec![9120, 8644, 8645]);
+
+        // dashboard=9121 → [9121, 8646, 8647]
+        let ports = ports_to_claim(9121);
+        assert_eq!(ports, vec![9121, 8646, 8647]);
+
+        // dashboard=9130 → [9130, 8664, 8665]
+        let ports = ports_to_claim(9130);
+        assert_eq!(ports, vec![9130, 8664, 8665]);
+    }
+
+    #[test]
+    fn fallback_ports_each_have_unique_satellite_ports() {
+        use std::collections::HashSet;
+
+        let mut all_ports: HashSet<u16> = HashSet::new();
+        for offset in 0..=20 {
+            let dashboard_port = DEFAULT_DESKTOP_DASHBOARD_PORT + offset;
+            for p in ports_to_claim(dashboard_port) {
+                assert!(
+                    all_ports.insert(p),
+                    "port {} collides between offset {} and another",
+                    p,
+                    offset
+                );
+            }
+        }
     }
 }

--- a/src/process/port_lock.rs
+++ b/src/process/port_lock.rs
@@ -36,7 +36,7 @@ fn local_claims_remove(port: u16) {
 /// Check whether *port* is in the local claims set (used by tests).
 pub fn local_claims_contains(port: u16) -> bool {
     let guard = LOCAL_CLAIMS.lock().unwrap_or_else(|e| e.into_inner());
-    guard.as_ref().map_or(false, |set| set.contains(&port))
+    guard.as_ref().is_some_and(|set| set.contains(&port))
 }
 
 /// Clear all local port claims (used before retry-loops that re-acquire
@@ -591,7 +591,7 @@ mod tests {
         // Write a lock with our PID but a deliberately *wrong* start_time
         // (simulating PID reuse).
         let our_pid = std::process::id();
-        let fake_start = (now_millis() as u64).saturating_sub(3600_000); // 1h ago
+        let fake_start = (now_millis() as u64).saturating_sub(3_600_000); // 1h ago
         fs::write(&path, format!("{}:{}\n", our_pid, fake_start)).unwrap();
 
         // stale_lock_owner should detect the mismatch

--- a/src/process/port_lock.rs
+++ b/src/process/port_lock.rs
@@ -208,11 +208,7 @@ fn get_process_start_time(pid: u32) -> Option<u64> {
     const PROCESS_QUERY_LIMITED_INFORMATION: u32 = 0x1000;
 
     extern "system" {
-        fn OpenProcess(
-            dwDesiredAccess: u32,
-            bInheritHandle: i32,
-            dwProcessId: u32,
-        ) -> *mut c_void;
+        fn OpenProcess(dwDesiredAccess: u32, bInheritHandle: i32, dwProcessId: u32) -> *mut c_void;
         fn CloseHandle(hObject: *mut c_void) -> i32;
         fn GetProcessTimes(
             hProcess: *mut c_void,
@@ -232,7 +228,13 @@ fn get_process_start_time(pid: u32) -> Option<u64> {
         let mut exit_t: u64 = 0;
         let mut kernel_t: u64 = 0;
         let mut user_t: u64 = 0;
-        let result = GetProcessTimes(handle, &mut creation, &mut exit_t, &mut kernel_t, &mut user_t);
+        let result = GetProcessTimes(
+            handle,
+            &mut creation,
+            &mut exit_t,
+            &mut kernel_t,
+            &mut user_t,
+        );
         CloseHandle(handle);
         if result == 0 {
             return None;
@@ -568,8 +570,11 @@ mod tests {
         // Re-claim same ports — should get real OS locks, not no-op handles
         let locks2 = claim_port_set(&[50010, 50011, 50012], home).unwrap();
         for lock in &locks2 {
-            assert!(lock.file.is_some(),
-                "port {} should have real OS lock after re-claim", lock.port());
+            assert!(
+                lock.file.is_some(),
+                "port {} should have real OS lock after re-claim",
+                lock.port()
+            );
         }
         drop(locks2);
     }
@@ -590,8 +595,10 @@ mod tests {
         fs::write(&path, format!("{}:{}\n", our_pid, fake_start)).unwrap();
 
         // stale_lock_owner should detect the mismatch
-        assert!(stale_lock_owner(&path),
-            "should detect stale lock via start_time mismatch");
+        assert!(
+            stale_lock_owner(&path),
+            "should detect stale lock via start_time mismatch"
+        );
 
         // And try_claim_port should break it
         let lock = try_claim_port(50020, home).expect("should break stale lock and claim");
@@ -610,18 +617,20 @@ mod tests {
         write_lock_owner(&path, our_pid);
 
         // stale_lock_owner should return false (we're alive, times match)
-        assert!(!stale_lock_owner(&path),
-            "live owner with matching start_time should not be stale");
+        assert!(
+            !stale_lock_owner(&path),
+            "live owner with matching start_time should not be stale"
+        );
     }
 
     // ── Bug 7: PID consistency matrix ────────────────────────────────
 
     #[test]
     fn pid_is_running_consistency_matrix() {
-        assert!(!pid_is_running(0));                    // PID 0
-        assert!(pid_is_running(std::process::id()));    // ourselves
-        assert!(!pid_is_running(99999999));              // nonexistent
-        // SYSTEM PID (4) — should not crash
+        assert!(!pid_is_running(0)); // PID 0
+        assert!(pid_is_running(std::process::id())); // ourselves
+        assert!(!pid_is_running(99999999)); // nonexistent
+                                            // SYSTEM PID (4) — should not crash
         let _system = pid_is_running(4);
     }
 
@@ -650,9 +659,11 @@ mod tests {
         for (content, expected) in cases {
             fs::write(&path, content).unwrap();
             let result = read_lock_owner(&path);
-            assert_eq!(result, expected,
+            assert_eq!(
+                result, expected,
                 "Mismatch for content {:?}: got {:?}, expected {:?}",
-                content, result, expected);
+                content, result, expected
+            );
         }
     }
 

--- a/src/process/port_lock.rs
+++ b/src/process/port_lock.rs
@@ -33,6 +33,20 @@ fn local_claims_remove(port: u16) {
     }
 }
 
+/// Check whether *port* is in the local claims set (used by tests).
+pub fn local_claims_contains(port: u16) -> bool {
+    let guard = LOCAL_CLAIMS.lock().unwrap_or_else(|e| e.into_inner());
+    guard.as_ref().map_or(false, |set| set.contains(&port))
+}
+
+/// Clear all local port claims (used before retry-loops that re-acquire
+/// locks on potentially different ports).
+pub fn reset_local_claims() {
+    if let Ok(mut guard) = LOCAL_CLAIMS.lock() {
+        *guard = None;
+    }
+}
+
 /// Opaque handle representing a held port lock.
 pub struct PortLock {
     port: u16,
@@ -83,20 +97,54 @@ fn lock_file_path(port: u16, hermes_home: impl AsRef<Path>) -> PathBuf {
 }
 
 /// Read the owner PID stored in a lock file, if any.
+///
+/// The lock file format is ``PID:START_TIME_EPOCH_MS`` on one line.
+/// Old-format files (just ``PID`` alone) are also parsed for backward
+/// compatibility.
 fn read_lock_owner(path: &Path) -> Option<u32> {
     let mut content = String::new();
     File::open(path).ok()?.read_to_string(&mut content).ok()?;
-    content.lines().next()?.trim().parse().ok()
+    let first = content.lines().next()?.trim();
+    let pid_str = first.split(':').next()?.trim();
+    pid_str.parse().ok()
 }
 
-/// Write the current owner PID into the lock file.
+/// Read ``(PID, start_time_epoch_ms)`` from the lock file.
+/// Old-format files (no ``:``) return ``(pid, 0)``.
+fn read_lock_owner_with_start_time(path: &Path) -> Option<(u32, u64)> {
+    let mut content = String::new();
+    File::open(path).ok()?.read_to_string(&mut content).ok()?;
+    let first = content.lines().next()?.trim();
+    if first.is_empty() {
+        return None;
+    }
+    if let Some((pid_str, time_str)) = first.split_once(':') {
+        let pid = pid_str.trim().parse().ok()?;
+        let start_time = time_str.trim().parse().unwrap_or(0);
+        Some((pid, start_time))
+    } else {
+        // Old format: just PID.
+        let pid = first.parse().ok()?;
+        Some((pid, 0))
+    }
+}
+
+/// Write the current owner PID and start time into the lock file.
+/// Format: ``PID:START_TIME_EPOCH_MS`` where START_TIME is the process
+/// creation time (used to detect PID reuse — see Bug 5).
 fn write_lock_owner(path: &Path, pid: u32) {
-    let _ = fs::write(path, format!("{}\n", pid));
+    let start_time = get_my_start_time().unwrap_or_else(|| now_millis() as u64);
+    let _ = fs::write(path, format!("{}:{}\n", pid, start_time));
+}
+
+/// Return the current process's creation time as epoch ms, or ``None``.
+pub fn get_my_start_time() -> Option<u64> {
+    get_process_start_time(std::process::id())
 }
 
 /// Best-effort PID liveness check.
 #[cfg(unix)]
-fn pid_is_running(pid: u32) -> bool {
+pub fn pid_is_running(pid: u32) -> bool {
     if pid == 0 {
         return false;
     }
@@ -105,7 +153,7 @@ fn pid_is_running(pid: u32) -> bool {
 }
 
 #[cfg(windows)]
-fn pid_is_running(pid: u32) -> bool {
+pub fn pid_is_running(pid: u32) -> bool {
     if pid == 0 {
         return false;
     }
@@ -143,7 +191,119 @@ fn pid_is_running(pid: u32) -> bool {
 }
 
 #[cfg(not(any(unix, windows)))]
-fn pid_is_running(_pid: u32) -> bool {
+pub fn pid_is_running(_pid: u32) -> bool {
+    false
+}
+
+/// Return the creation time of *pid* as epoch milliseconds, or ``None``.
+///
+/// Used to detect PID reuse.
+#[cfg(windows)]
+fn get_process_start_time(pid: u32) -> Option<u64> {
+    if pid == 0 {
+        return None;
+    }
+    use std::os::raw::c_void;
+
+    const PROCESS_QUERY_LIMITED_INFORMATION: u32 = 0x1000;
+
+    extern "system" {
+        fn OpenProcess(
+            dwDesiredAccess: u32,
+            bInheritHandle: i32,
+            dwProcessId: u32,
+        ) -> *mut c_void;
+        fn CloseHandle(hObject: *mut c_void) -> i32;
+        fn GetProcessTimes(
+            hProcess: *mut c_void,
+            lpCreationTime: *mut u64,
+            lpExitTime: *mut u64,
+            lpKernelTime: *mut u64,
+            lpUserTime: *mut u64,
+        ) -> i32;
+    }
+
+    unsafe {
+        let handle = OpenProcess(PROCESS_QUERY_LIMITED_INFORMATION, 0, pid);
+        if handle.is_null() {
+            return None;
+        }
+        let mut creation: u64 = 0;
+        let mut exit_t: u64 = 0;
+        let mut kernel_t: u64 = 0;
+        let mut user_t: u64 = 0;
+        let result = GetProcessTimes(handle, &mut creation, &mut exit_t, &mut kernel_t, &mut user_t);
+        CloseHandle(handle);
+        if result == 0 {
+            return None;
+        }
+        // FILETIME is 100-ns intervals since 1601-01-01.
+        // 11644473600 = seconds from 1601-01-01 to 1970-01-01.
+        let epoch_ms = (creation / 10_000).saturating_sub(11644473600_000);
+        Some(epoch_ms)
+    }
+}
+
+#[cfg(unix)]
+fn get_process_start_time(pid: u32) -> Option<u64> {
+    if pid == 0 {
+        return None;
+    }
+    // Read /proc/<pid>/stat field 22 (start_time in jiffies since boot).
+    let stat_path = format!("/proc/{pid}/stat");
+    let stat_content = fs::read_to_string(&stat_path).ok()?;
+    let fields: Vec<&str> = stat_content.split_whitespace().collect();
+    if fields.len() < 22 {
+        return None;
+    }
+    let start_jiffies: u64 = fields.get(21)?.parse().ok()?;
+    // Read boot time from /proc/stat.
+    let proc_stat = fs::read_to_string("/proc/stat").ok()?;
+    let btime_secs: u64 = proc_stat
+        .lines()
+        .find(|line| line.starts_with("btime "))?
+        .split_whitespace()
+        .nth(1)?
+        .parse()
+        .ok()?;
+    let clk_tck: u64 = unsafe { libc::sysconf(libc::_SC_CLK_TCK) } as u64;
+    let start_secs = btime_secs + (start_jiffies / clk_tck);
+    Some(start_secs * 1000)
+}
+
+#[cfg(not(any(unix, windows)))]
+fn get_process_start_time(_pid: u32) -> Option<u64> {
+    None
+}
+
+/// Check if the lock at *path* is held by a stale (dead or PID-reused) owner.
+///
+/// Returns ``true`` when the lock should be broken.
+fn stale_lock_owner(path: &Path) -> bool {
+    let Some((pid, stored_start_time)) = read_lock_owner_with_start_time(path) else {
+        return false;
+    };
+
+    // PID 0 is never valid.
+    if pid == 0 {
+        return true;
+    }
+
+    // If PID is not running, the lock is definitely stale.
+    if !pid_is_running(pid) {
+        return true;
+    }
+
+    // PID is running.  Check if the start time matches (PID reuse guard).
+    if stored_start_time > 0 {
+        if let Some(actual_start_time) = get_process_start_time(pid) {
+            if actual_start_time != stored_start_time {
+                // The process with this PID today is a *different* process.
+                return true;
+            }
+        }
+    }
+
     false
 }
 
@@ -223,30 +383,29 @@ pub fn try_claim_port(port: u16, hermes_home: impl AsRef<Path>) -> Option<PortLo
         });
     }
 
-    // Lock is held. Check whether the owner is still alive.
-    if let Some(owner) = read_lock_owner(&path) {
-        if !pid_is_running(owner) {
-            // Break stale lock. Close our failed handle first to avoid holding
-            // a conflicting view, then reopen and claim.
-            drop(file);
-            // Small, deterministic backoff to reduce thundering herd when many
-            // instances race to break a stale lock.
-            std::thread::sleep(std::time::Duration::from_millis(10));
-            let fresh = OpenOptions::new()
-                .create(true)
-                .truncate(false)
-                .read(true)
-                .write(true)
-                .open(&path)
-                .ok()?;
-            if fresh.try_lock_exclusive().is_ok() {
-                write_lock_owner(&path, std::process::id());
-                return Some(PortLock {
-                    port,
-                    file: Some(fresh),
-                    owns_local_claim: true,
-                });
-            }
+    // Lock is held. Check whether the owner is still alive (stale lock,
+    // including PID reuse detection via start_time mismatch).
+    if stale_lock_owner(&path) {
+        // Break stale lock. Close our failed handle first to avoid holding
+        // a conflicting view, then reopen and claim.
+        drop(file);
+        // Small, deterministic backoff to reduce thundering herd when many
+        // instances race to break a stale lock.
+        std::thread::sleep(std::time::Duration::from_millis(10));
+        let fresh = OpenOptions::new()
+            .create(true)
+            .truncate(false)
+            .read(true)
+            .write(true)
+            .open(&path)
+            .ok()?;
+        if fresh.try_lock_exclusive().is_ok() {
+            write_lock_owner(&path, std::process::id());
+            return Some(PortLock {
+                port,
+                file: Some(fresh),
+                owns_local_claim: true,
+            });
         }
     }
 
@@ -383,5 +542,143 @@ mod tests {
 
         let lock = try_claim_port(50006, home).expect("should recover stale lock");
         lock.release();
+    }
+
+    // ── Bug 4: local_claims cleanup ─────────────────────────────────
+
+    #[test]
+    fn local_claims_cleared_after_drop_all_locks() {
+        let dir = TempDir::new().unwrap();
+        let home = dir.path();
+
+        // First claim
+        let locks = claim_port_set(&[50010, 50011, 50012], home).unwrap();
+        assert!(local_claims_contains(50010));
+        assert!(local_claims_contains(50011));
+        assert!(local_claims_contains(50012));
+
+        // Release all
+        drop(locks);
+
+        // Local claims cleared
+        assert!(!local_claims_contains(50010));
+        assert!(!local_claims_contains(50011));
+        assert!(!local_claims_contains(50012));
+
+        // Re-claim same ports — should get real OS locks, not no-op handles
+        let locks2 = claim_port_set(&[50010, 50011, 50012], home).unwrap();
+        for lock in &locks2 {
+            assert!(lock.file.is_some(),
+                "port {} should have real OS lock after re-claim", lock.port());
+        }
+        drop(locks2);
+    }
+
+    // ── Bug 5: PID reuse detection ───────────────────────────────────
+
+    #[test]
+    fn stale_lock_with_start_time_detected() {
+        let dir = TempDir::new().unwrap();
+        let home = dir.path();
+        let path = lock_file_path(50020, home);
+        fs::create_dir_all(path.parent().unwrap()).unwrap();
+
+        // Write a lock with our PID but a deliberately *wrong* start_time
+        // (simulating PID reuse).
+        let our_pid = std::process::id();
+        let fake_start = (now_millis() as u64).saturating_sub(3600_000); // 1h ago
+        fs::write(&path, format!("{}:{}\n", our_pid, fake_start)).unwrap();
+
+        // stale_lock_owner should detect the mismatch
+        assert!(stale_lock_owner(&path),
+            "should detect stale lock via start_time mismatch");
+
+        // And try_claim_port should break it
+        let lock = try_claim_port(50020, home).expect("should break stale lock and claim");
+        lock.release();
+    }
+
+    #[test]
+    fn stale_lock_not_broken_when_owner_alive() {
+        let dir = TempDir::new().unwrap();
+        let home = dir.path();
+        let path = lock_file_path(50021, home);
+        fs::create_dir_all(path.parent().unwrap()).unwrap();
+
+        // Write a lock with our PID and our actual start_time.
+        let our_pid = std::process::id();
+        write_lock_owner(&path, our_pid);
+
+        // stale_lock_owner should return false (we're alive, times match)
+        assert!(!stale_lock_owner(&path),
+            "live owner with matching start_time should not be stale");
+    }
+
+    // ── Bug 7: PID consistency matrix ────────────────────────────────
+
+    #[test]
+    fn pid_is_running_consistency_matrix() {
+        assert!(!pid_is_running(0));                    // PID 0
+        assert!(pid_is_running(std::process::id()));    // ourselves
+        assert!(!pid_is_running(99999999));              // nonexistent
+        // SYSTEM PID (4) — should not crash
+        let _system = pid_is_running(4);
+    }
+
+    // ── Bug 8: Lock file format compatibility ────────────────────────
+
+    #[test]
+    fn read_lock_owner_edge_cases() {
+        let dir = TempDir::new().unwrap();
+        let path = dir.path().join("test.lock");
+
+        let cases: Vec<(&str, Option<u32>)> = vec![
+            ("12345\n", Some(12345)),
+            ("12345", Some(12345)),
+            ("  12345  \n", Some(12345)),
+            ("12345\n99999\n", Some(12345)),
+            ("", None),
+            ("\n", None),
+            ("abc", None),
+            ("12abc", None),
+            ("0\n", Some(0)),
+            // New format (pid:start_time): read_lock_owner returns just the pid
+            ("12345:67890\n", Some(12345)),
+            ("  12345  :  67890  \n", Some(12345)),
+        ];
+
+        for (content, expected) in cases {
+            fs::write(&path, content).unwrap();
+            let result = read_lock_owner(&path);
+            assert_eq!(result, expected,
+                "Mismatch for content {:?}: got {:?}, expected {:?}",
+                content, result, expected);
+        }
+    }
+
+    #[test]
+    fn read_lock_owner_with_start_time_parses() {
+        let dir = TempDir::new().unwrap();
+        let path = dir.path().join("test2.lock");
+
+        // Old format (no colon)
+        fs::write(&path, "42\n").unwrap();
+        let r = read_lock_owner_with_start_time(&path);
+        assert_eq!(r, Some((42, 0)));
+
+        // New format
+        fs::write(&path, "42:1234567890\n").unwrap();
+        let r = read_lock_owner_with_start_time(&path);
+        assert_eq!(r, Some((42, 1234567890)));
+
+        // Empty file
+        fs::write(&path, "").unwrap();
+        let r = read_lock_owner_with_start_time(&path);
+        assert_eq!(r, None);
+
+        // Garbage
+        fs::write(&path, "abc\n").unwrap();
+        let r = read_lock_owner_with_start_time(&path);
+        assert_eq!(r, None);
     }
 }


### PR DESCRIPTION
## 摘要
- 合并 `dev-fix` 到 `main`
- 覆盖端口锁修复与 project-structure skill 更新

## 预检
- 已刷新 `origin/main` 和 `origin/dev-fix`
- `origin/main...origin/dev-fix`: main 落后 0，dev-fix ahead 2