### PR TITLE
feat: 更新模型目录

### DIFF
--- a/web/src/lib/provider-catalog.test.ts
+++ b/web/src/lib/provider-catalog.test.ts
@@ -2,6 +2,7 @@ import { beforeEach, describe, expect, it, vi } from "vitest";
 import { fetchExternalJSON } from "./transport";
 import {
   BUILTIN_PROVIDER_CATALOG,
+  BUILTIN_PROVIDER_CATALOG_VERSION,
   buildCurrentModelConfigUpdate,
   buildCustomProviderDeleteUpdate,
   buildProviderConfigUpdate,
@@ -36,6 +37,45 @@ const mockedFetchExternalJSON = vi.mocked(fetchExternalJSON);
 
 beforeEach(() => {
   mockedFetchExternalJSON.mockReset();
+});
+
+describe("builtin provider catalog", () => {
+  it("ships the current Kimi and SiliconFlow coding models", () => {
+    expect(BUILTIN_PROVIDER_CATALOG_VERSION).toBe("2026.07.26.1");
+
+    const kimi = BUILTIN_PROVIDER_CATALOG.providers.find((provider) => provider.id === "kimi-for-coding");
+    expect(kimi).toMatchObject({
+      defaultModel: "kimi-k3",
+      models: expect.arrayContaining([
+        expect.objectContaining({
+          id: "kimi-k3",
+          contextWindow: 1_000_000,
+          supportsTools: true,
+          supportsReasoning: true,
+          supportsVision: true,
+        }),
+        expect.objectContaining({
+          id: "kimi-k2.7-code-highspeed",
+          contextWindow: 262_144,
+          supportsTools: true,
+          supportsReasoning: true,
+          supportsVision: true,
+        }),
+      ]),
+    });
+
+    const siliconflow = BUILTIN_PROVIDER_CATALOG.providers.find((provider) => provider.id === "siliconflow");
+    expect(siliconflow?.models).toEqual(
+      expect.arrayContaining([
+        expect.objectContaining({
+          id: "deepseek-ai/DeepSeek-V4-Flash",
+          contextWindow: 1_049_000,
+          supportsTools: true,
+          supportsReasoning: true,
+        }),
+      ]),
+    );
+  });
 });
 
 describe("provider catalog config updates", () => {

--- a/web/src/lib/provider-catalog.ts
+++ b/web/src/lib/provider-catalog.ts
@@ -320,7 +320,7 @@ export function parseContextWindowInput(raw: string | undefined): number {
   return Math.floor(parsed);
 }
 
-export const BUILTIN_PROVIDER_CATALOG_VERSION = "2026.07.18.4";
+export const BUILTIN_PROVIDER_CATALOG_VERSION = "2026.07.26.1";
 
 export const BUILTIN_PROVIDER_CATALOG: ProviderCatalog = {
   version: BUILTIN_PROVIDER_CATALOG_VERSION,
@@ -511,10 +511,12 @@ export const BUILTIN_PROVIDER_CATALOG: ProviderCatalog = {
       icon: "kimi",
       websiteUrl: "https://www.kimi.com/code",
       docsUrl: "https://platform.moonshot.cn/docs",
-      defaultModel: "kimi-k2.6",
+      defaultModel: "kimi-k3",
       models: [
-        { id: "kimi-k2.7-code", supportsTools: true, supportsReasoning: true },
-        { id: "kimi-k2.6", supportsTools: true },
+        { id: "kimi-k3", contextWindow: 1_000_000, supportsTools: true, supportsReasoning: true, supportsVision: true },
+        { id: "kimi-k2.7-code-highspeed", contextWindow: 262_144, supportsTools: true, supportsReasoning: true, supportsVision: true },
+        { id: "kimi-k2.7-code", contextWindow: 262_144, supportsTools: true, supportsReasoning: true, supportsVision: true },
+        { id: "kimi-k2.6", contextWindow: 262_144, supportsTools: true, supportsReasoning: true, supportsVision: true },
         { id: "kimi-k2-0905-preview", supportsTools: true },
         { id: "kimi-latest", supportsTools: true },
         { id: "moonshot-v1-128k" },
@@ -731,7 +733,8 @@ export const BUILTIN_PROVIDER_CATALOG: ProviderCatalog = {
       models: [
         { id: "Qwen/Qwen3-Coder-480B-A35B-Instruct", supportsTools: true },
         { id: "zai-org/GLM-5.2", supportsTools: true, supportsReasoning: true },
-        { id: "deepseek-ai/DeepSeek-V4-Pro", supportsTools: true, supportsReasoning: true },
+        { id: "deepseek-ai/DeepSeek-V4-Pro", contextWindow: 1_049_000, supportsTools: true, supportsReasoning: true },
+        { id: "deepseek-ai/DeepSeek-V4-Flash", contextWindow: 1_049_000, supportsTools: true, supportsReasoning: true },
         { id: "deepseek-ai/DeepSeek-V3.2", supportsTools: true },
         { id: "deepseek-ai/DeepSeek-R1", supportsReasoning: true },
       ],
@@ -1058,7 +1061,7 @@ export const BUILTIN_PROVIDER_CATALOG: ProviderCatalog = {
       icon: "rightcode",
       websiteUrl: "https://www.right.codes",
       promotion: {
-        url: "https://www.right.codes/register?aff=d7899e4a",
+        url: "https://right.codes/register?aff=e4158139",
         badge: "partner",
       },
       defaultModel: "claude-opus-4-8",


### PR DESCRIPTION
## 变更
- 将内置 provider catalog 版本更新到 2026.07.26.1
- 将 Kimi / Moonshot 默认模型切到 kimi-k3，并加入 kimi-k2.7-code-highspeed
- 为 Kimi 新模型补充 context window、vision、reasoning、tools 标记
- 吸收 PR #470 的 SiliconFlow DeepSeek-V4-Flash，并补充 DeepSeek-V4 系列 context window
- 同步 RightCode 已在 Landing 生效的新推广链接，避免导出回滚
- 增加 provider catalog 单测覆盖新模型清单

## 验证
- pnpm --filter @hermes/web exec vitest run src/lib/provider-catalog.test.ts
- pnpm --filter @hermes/web exec vitest run src/lib/provider-id.test.ts
- pnpm typecheck
- pnpm test:unit
- cargo check
