### PR TITLE
chore: 发布桌面端 0.7.0

### DIFF
--- a/.codex/skills/desktop-release-preflight/SKILL.md
+++ b/.codex/skills/desktop-release-preflight/SKILL.md
@@ -30,7 +30,7 @@ description: Use BEFORE preparing or publishing any Hermes Agent CN Desktop rele
 1. ☑️ **identifier 没改**：`grep identifier tauri.conf.json` 仍是 `cn.org.hermesagent.desktop`。永不更改。
 2. ☑️ **`bundled_runtime_tag` 锁到 ≥ 线上 stable 最高 runtime，且是明确版本（不是 `latest`）**。这是**防内核静默降级**的关键（见下"坑 1"）。
    - 查线上 stable 最高 runtime：`gh release list -R Eynzof/Hermes-CN-Core | head` 或看 stable manifest。
-   - 触发 `release-desktop.yml` 时用 `workflow_dispatch` 输入 `bundled_runtime_tag=<该版本>`（输入定义在 `.github/workflows/release-desktop.yml:31`），或先把默认值 `:33,89,147`（当前 `runtime-v0.16.0-cn.6`）更新到该版本。
+   - 触发 `release-desktop.yml` 时用 `workflow_dispatch` 输入 `bundled_runtime_tag=<该版本>`（输入定义在 `.github/workflows/release-desktop.yml:35`），或先把默认值 `:37,118,176`（当前 `runtime-v0.19.0-cn.3`）更新到该版本。
 3. ☑️ **本次不 bump `MANIFEST_SCHEMA_VERSION`**（保持 `runtime.rs:29` 的 `2`）。schema→3（强升门改造）单独排期（见"坑 2"）。
 4. ☑️ **macOS 走完公证/装订**（`release-desktop.yml:153-293`）。未公证会被 Gatekeeper 拦。
 5. ☑️ **Windows 现状未签名**（无 Authenticode）→ 覆盖装会触发 SmartScreen。发版说明里明确告知用户点"仍要运行"，或本次补 Authenticode（见 `docs/hot-update-impl-plan.md` §5）。
@@ -45,7 +45,7 @@ description: Use BEFORE preparing or publishing any Hermes Agent CN Desktop rele
 
 reconcile 只判**相等**（`runtime.rs:1574` 仅 `current.runtime_version == manifest.runtime_version`），**没有"当前已是更新版本则跳过"的保护**。若某 0.3.2 用户已通过热更把内核更新到**高于本次内置版本**的 runtime，覆盖新外壳后启动会把内核**降级回内置版本**（可一键回滚，但用户无感、属意外）。
 
-- **触发条件**：`bundled_runtime_tag`（默认锁死在 `runtime-v0.16.0-cn.6`）落后于线上 stable 渠道已发布的 runtime。
+- **触发条件**：`bundled_runtime_tag`（默认锁死在 release workflow 中的明确 runtime tag）落后于线上 stable 渠道已发布的 runtime。
 - **规避**：checklist #2 —— 发版时把 `bundled_runtime_tag` 设为 ≥ 当前 stable 最高 runtime。
 - **根因修复（排期项，非本次）**：给 bundled 安装路径加 semver 守卫"当前 ≥ 内置则不降级"，与 `docs/hot-update-impl-plan.md` §3.4 的防降级配套（注意 §3.4 改的是自动更新路径，bundled 路径需单独加）。
 

--- a/.github/workflows/release-desktop.yml
+++ b/.github/workflows/release-desktop.yml
@@ -1,5 +1,5 @@
 # Build hermes-agent-cn-desktop installers and attach them to a GitHub
-# Release. Triggers on tags matching `v*` (e.g. `v0.6.3`).
+# Release. Triggers on tags matching `v*` (e.g. `v0.7.0`).
 #
 # Desktop release build runs in parallel for Windows, macOS, and Linux. Each job:
 #   1. Installs Node + pnpm + Rust toolchain
@@ -30,11 +30,11 @@ on:
   workflow_dispatch:
     inputs:
       tag:
-        description: "Tag name to associate the build with (e.g. v0.6.3)"
+        description: "Tag name to associate the build with (e.g. v0.7.0)"
         required: true
       bundled_runtime_tag:
         description: "Hermes-CN-Core runtime release tag to embed in desktop installers, or latest"
-        default: "runtime-v0.18.2-cn.2"
+        default: "runtime-v0.19.0-cn.3"
         required: false
 
 permissions:
@@ -115,7 +115,7 @@ jobs:
         shell: bash
         env:
           BUNDLED_RUNTIME_REPO: Eynzof/Hermes-CN-Core
-          BUNDLED_RUNTIME_TAG: ${{ github.event.inputs.bundled_runtime_tag || 'runtime-v0.18.2-cn.2' }}
+          BUNDLED_RUNTIME_TAG: ${{ github.event.inputs.bundled_runtime_tag || 'runtime-v0.19.0-cn.3' }}
           RUNTIME_PLATFORM: ${{ matrix.runtime_platform }}
           RUNTIME_ARCH: ${{ matrix.runtime_arch }}
         run: |
@@ -173,7 +173,7 @@ jobs:
           args=(
             scripts/stage-bundled-runtime.mjs
             --repo "Eynzof/Hermes-CN-Core"
-            --tag "${{ github.event.inputs.bundled_runtime_tag || 'runtime-v0.18.2-cn.2' }}"
+            --tag "${{ github.event.inputs.bundled_runtime_tag || 'runtime-v0.19.0-cn.3' }}"
             --platform "${{ matrix.runtime_platform }}"
             --arch "${{ matrix.runtime_arch }}"
           )
@@ -246,6 +246,11 @@ jobs:
             Windows 系统安装名称、安装目录和卸载注册表项使用英文名
             Hermes Agent CN Desktop，避免中文路径造成兼容性问题。
 
+            覆盖安装前，请先完全退出正在运行的 Hermes Agent CN Desktop。
+
+            Windows 安装包暂未做 Authenticode 签名。如遇 SmartScreen 拦截，请选择
+            “更多信息” → “仍要运行”。
+
             安装包已内置来自 ${{ steps.runtime_manifest.outputs.source_repo }}
             ${{ steps.runtime_manifest.outputs.source_commit }} 的 Dashboard 前端、内置技能和内置插件。
 
@@ -256,6 +261,10 @@ jobs:
 
             Windows 和 macOS 另附免安装（portable）压缩包：解压即用，全部数据保存在
             解压目录的 data 文件夹内，详见压缩包内 README-portable.txt。
+
+            已知限制：本版本保持 runtime manifest schema 2，不包含 schema 2/3 双读能力。
+            后续发布 schema 3 runtime manifest 前，必须先发布支持双读的桌面端，或将
+            minAppVersion 提升到对应的桌面端版本，避免 0.7.0 用户停留在旧内核。
 
             如需覆盖 runtime 更新源，可设置 HERMES_RUNTIME_UPDATE_* 环境变量。
           releaseDraft: false

--- a/Cargo.lock
+++ b/Cargo.lock
@@ -1981,7 +1981,7 @@ checksum = "2304e00983f87ffb38b55b444b5e3b60a884b5d30c0fca7d82fe33449bbe55ea"
 
 [[package]]
 name = "hermes-agent-cn-desktop"
-version = "0.6.3"
+version = "0.7.0"
 dependencies = [
  "base64 0.22.1",
  "cookie",

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -1,6 +1,6 @@
 [package]
 name = "hermes-agent-cn-desktop"
-version = "0.6.3"
+version = "0.7.0"
 edition = "2021"
 description = "Hermes Agent CN Desktop (Tauri)"
 authors = ["Hermes Agent CN Contributors"]

--- a/README.en-US.md
+++ b/README.en-US.md
@@ -12,7 +12,7 @@ Hermes Agent CN Desktop is a desktop client from the Hermes Agent Chinese commun
 
 Official site and downloads: [desktop.hermesagent.org.cn](https://desktop.hermesagent.org.cn). The desktop app is part of the [Hermes Agent Chinese Community](https://hermesagent.org.cn) ecosystem, where the main site links to Chinese docs, practice guides, community entry points, and more ecosystem projects.
 
-> Current release: `v0.6.3`. The project is still moving quickly. APIs, packaging, runtime distribution, and UI details may continue to change.
+> Current release: `v0.7.0`. The project is still moving quickly. APIs, packaging, runtime distribution, and UI details may continue to change.
 
 ## Hermes Agent Chinese Community
 
@@ -95,9 +95,9 @@ Installers are available from the [desktop website](https://desktop.hermesagent.
 
 The current release includes:
 
-- macOS Apple Silicon DMG: `Hermes.Agent.CN.Desktop_0.6.3_aarch64.dmg`
-- macOS Intel DMG: `Hermes.Agent.CN.Desktop_0.6.3_x64.dmg`
-- Windows x64 installer: `Hermes.Agent.CN.Desktop_0.6.3_x64-setup.exe`
+- macOS Apple Silicon DMG: `Hermes.Agent.CN.Desktop_0.7.0_aarch64.dmg`
+- macOS Intel DMG: `Hermes.Agent.CN.Desktop_0.7.0_x64.dmg`
+- Windows x64 installer: `Hermes.Agent.CN.Desktop_0.7.0_x64-setup.exe`
 
 Both the Windows and macOS installers include a bundled `Hermes-CN-Core` runtime. On first launch, the app initializes the local core from the bundled runtime first; managed runtime download/update is only used for upgrades or fallback repair.
 

--- a/README.md
+++ b/README.md
@@ -12,7 +12,7 @@ Hermes Agent CN Desktop 是 Hermes Agent 中文社区推出的桌面客户端，
 
 官网与下载页见 [desktop.hermesagent.org.cn](https://desktop.hermesagent.org.cn)。桌面端隶属于 [Hermes Agent 中文社区](https://hermesagent.org.cn) 生态，社区主站提供中文文档、实践指南、社群入口和更多生态项目。
 
-> 当前版本是 `v0.6.3`。项目仍在快速迭代，API、打包流程、运行时分发策略和界面细节都可能继续调整。
+> 当前版本是 `v0.7.0`。项目仍在快速迭代，API、打包流程、运行时分发策略和界面细节都可能继续调整。
 
 ## Hermes Agent 中文社区
 
@@ -96,9 +96,9 @@ Hermes Agent 已经提供本地 Dashboard。本仓库专注于 Dashboard 之外�
 
 当前版本包含：
 
-- macOS Apple Silicon DMG：`Hermes.Agent.CN.Desktop_0.6.3_aarch64.dmg`
-- macOS Intel DMG：`Hermes.Agent.CN.Desktop_0.6.3_x64.dmg`
-- Windows x64 安装器：`Hermes.Agent.CN.Desktop_0.6.3_x64-setup.exe`
+- macOS Apple Silicon DMG：`Hermes.Agent.CN.Desktop_0.7.0_aarch64.dmg`
+- macOS Intel DMG：`Hermes.Agent.CN.Desktop_0.7.0_x64.dmg`
+- Windows x64 安装器：`Hermes.Agent.CN.Desktop_0.7.0_x64-setup.exe`
 
 当前 Windows 与 macOS 安装包都会预置 `Hermes-CN-Core` runtime，安装后优先从包内 runtime 完成本地内核初始化；托管 runtime 下载与更新流程只作为升级或兜底路径使用。
 

--- a/docs/macos-signing-and-notarization.md
+++ b/docs/macos-signing-and-notarization.md
@@ -117,7 +117,7 @@ target/aarch64-apple-darwin/release/bundle/dmg/*.dmg
 如果需要手动公证和 staple，可以对最终 DMG 执行：
 
 ```bash
-DMG="target/aarch64-apple-darwin/release/bundle/dmg/Hermes Agent CN Desktop_0.6.3_aarch64.dmg"
+DMG="target/aarch64-apple-darwin/release/bundle/dmg/Hermes Agent CN Desktop_0.7.0_aarch64.dmg"
 
 xcrun notarytool submit "$DMG" \
   --key "$APPLE_API_KEY_PATH" \

--- a/docs/managed-runtime.md
+++ b/docs/managed-runtime.md
@@ -276,7 +276,7 @@ fork CI release-runtime.yml 触发：
 ## 六、桌面端升级
 
 ```
-你 git tag v0.6.3; git push origin v0.6.3
+你 git tag v0.7.0; git push origin v0.7.0
   ↓
 desktop CI release-desktop.yml 触发：
   matrix: windows-latest / macos-14 (arm64)
@@ -289,7 +289,7 @@ desktop CI release-desktop.yml 触发：
     5. tauri-apps/tauri-action@v0 → 打 .exe / .dmg
        runtime URL + 公钥仍是 baked-in 兜底，不需要 env wire 进 CI
   ↓
-新装包发到 releases/v0.6.3 → 用户下载装新版
+新装包发到 releases/v0.7.0 → 用户下载装新版
   ↓
 新版起来后，看到 current.json 已经有 runtime → 不下载 → 直接用。
 全新安装则先使用安装包内置 runtime；除非内置资源缺失或用户主动升级，

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "hermes-agent-cn-desktop",
-  "version": "0.6.3",
+  "version": "0.7.0",
   "private": true,
   "author": "Hermes Agent CN Contributors",
   "homepage": "https://hermesagent.org.cn",

--- a/packages/protocol/package.json
+++ b/packages/protocol/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@hermes/protocol",
-  "version": "0.6.3",
+  "version": "0.7.0",
   "private": true,
   "type": "module",
   "main": "./src/index.ts",

--- a/packages/shared-ui/package.json
+++ b/packages/shared-ui/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@hermes/shared-ui",
-  "version": "0.6.3",
+  "version": "0.7.0",
   "private": true,
   "type": "module",
   "main": "./src/index.ts",

--- a/tauri.conf.json
+++ b/tauri.conf.json
@@ -1,7 +1,7 @@
 {
   "$schema": "https://raw.githubusercontent.com/nicegoodthings/tauri-schema/main/tauri.conf.schema.json",
   "productName": "Hermes Agent CN Desktop",
-  "version": "0.6.3",
+  "version": "0.7.0",
   "identifier": "cn.org.hermesagent.desktop",
   "build": {
     "beforeDevCommand": "pnpm --filter @hermes/web dev",

--- a/web/package.json
+++ b/web/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@hermes/web",
-  "version": "0.6.3",
+  "version": "0.7.0",
   "private": true,
   "type": "module",
   "scripts": {


### PR DESCRIPTION
## 变更

- 将桌面端版本同步到 0.7.0。
- 将 release workflow 的 bundled_runtime_tag 三处默认值抬到 runtime-v0.19.0-cn.3。
- 在 release body 中补充覆盖安装前退出桌面端、Windows SmartScreen 提示。
- 记录 0.7.0 暂不支持 runtime manifest schema 2/3 双读的已知限制。
- 修正 desktop-release-preflight 技能中 runtime tag 和 workflow 行号的过期引用。

## 已知限制

本次不包含 Desktop PR #452 的 manifest schema 2/3 双读能力。Core #102 合入并发布 schema 3 runtime manifest 前，必须先发布支持双读的桌面端，或把 minAppVersion 提升到实际支持双读的桌面端版本。

## 验证

- pnpm typecheck
- pnpm test:unit
- cargo check
- cargo fmt --check
- cargo clippy --all-features -- -D warnings
- cargo test --all-features