### PR TITLE
chore: 更新桌面端内置内核到 cn.4

### DIFF
--- a/.codex/skills/desktop-release-preflight/SKILL.md
+++ b/.codex/skills/desktop-release-preflight/SKILL.md
@@ -30,7 +30,7 @@ description: Use BEFORE preparing or publishing any Hermes Agent CN Desktop rele
 1. ☑️ **identifier 没改**：`grep identifier tauri.conf.json` 仍是 `cn.org.hermesagent.desktop`。永不更改。
 2. ☑️ **`bundled_runtime_tag` 锁到 ≥ 线上 stable 最高 runtime，且是明确版本（不是 `latest`）**。这是**防内核静默降级**的关键（见下"坑 1"）。
    - 查线上 stable 最高 runtime：`gh release list -R Eynzof/Hermes-CN-Core | head` 或看 stable manifest。
-   - 触发 `release-desktop.yml` 时用 `workflow_dispatch` 输入 `bundled_runtime_tag=<该版本>`（输入定义在 `.github/workflows/release-desktop.yml:35`），或先把默认值 `:37,118,176`（当前 `runtime-v0.19.0-cn.3`）更新到该版本。
+   - 触发 `release-desktop.yml` 时用 `workflow_dispatch` 输入 `bundled_runtime_tag=<该版本>`（输入定义在 `.github/workflows/release-desktop.yml:35`），或先把默认值 `:37,118,176`（当前 `runtime-v0.19.0-cn.4`）更新到该版本。
 3. ☑️ **本次不 bump `MANIFEST_SCHEMA_VERSION`**（保持 `runtime.rs:29` 的 `2`）。schema→3（强升门改造）单独排期（见"坑 2"）。
 4. ☑️ **macOS 走完公证/装订**（`release-desktop.yml:153-293`）。未公证会被 Gatekeeper 拦。
 5. ☑️ **Windows 现状未签名**（无 Authenticode）→ 覆盖装会触发 SmartScreen。发版说明里明确告知用户点"仍要运行"，或本次补 Authenticode（见 `docs/hot-update-impl-plan.md` §5）。

--- a/.github/workflows/release-desktop.yml
+++ b/.github/workflows/release-desktop.yml
@@ -34,7 +34,7 @@ on:
         required: true
       bundled_runtime_tag:
         description: "Hermes-CN-Core runtime release tag to embed in desktop installers, or latest"
-        default: "runtime-v0.19.0-cn.3"
+        default: "runtime-v0.19.0-cn.4"
         required: false
 
 permissions:
@@ -115,7 +115,7 @@ jobs:
         shell: bash
         env:
           BUNDLED_RUNTIME_REPO: Eynzof/Hermes-CN-Core
-          BUNDLED_RUNTIME_TAG: ${{ github.event.inputs.bundled_runtime_tag || 'runtime-v0.19.0-cn.3' }}
+          BUNDLED_RUNTIME_TAG: ${{ github.event.inputs.bundled_runtime_tag || 'runtime-v0.19.0-cn.4' }}
           RUNTIME_PLATFORM: ${{ matrix.runtime_platform }}
           RUNTIME_ARCH: ${{ matrix.runtime_arch }}
         run: |
@@ -173,7 +173,7 @@ jobs:
           args=(
             scripts/stage-bundled-runtime.mjs
             --repo "Eynzof/Hermes-CN-Core"
-            --tag "${{ github.event.inputs.bundled_runtime_tag || 'runtime-v0.19.0-cn.3' }}"
+            --tag "${{ github.event.inputs.bundled_runtime_tag || 'runtime-v0.19.0-cn.4' }}"
             --platform "${{ matrix.runtime_platform }}"
             --arch "${{ matrix.runtime_arch }}"
           )


### PR DESCRIPTION
## 变更
- 将 release-desktop.yml 的 bundled_runtime_tag 默认值更新为 runtime-v0.19.0-cn.4
- 同步 desktop-release-preflight 清单中的当前内置 runtime 版本

## 背景
- Core runtime-v0.19.0-cn.4 已发布并成为 latest
- cn.4 指向 Eynzof/Hermes-CN-Core@22e724f79136f120f7725ca98aacb7499f58aef5，包含 PR #120 的桌面首启配置文件生成修复
- Desktop v0.7.0-rc.2 需要内置 cn.4，避免继续携带 rc.1 的 cn.3 runtime

## 验证
- pnpm typecheck
- pnpm test:unit
- cargo check
- cargo fmt --check
- cargo clippy --all-features -- -D warnings
- cargo test --all-features
