### PR TITLE
fix: 修复桌面壳启动时丢失内核地址

### DIFF
--- a/web/src/lib/tauri-bridge.test.ts
+++ b/web/src/lib/tauri-bridge.test.ts
@@ -4,6 +4,7 @@ import {
   installTauriBridge,
   isTauriDevMode,
   normalizeTauriInvokeError,
+  shouldWaitForManagedRuntimeConfig,
 } from "./tauri-bridge";
 
 const mockInvoke = vi.fn();
@@ -244,6 +245,27 @@ describe("isTauriDevMode", () => {
       managedRuntimeLifecycleState: "stopped",
     });
     expect(mockInvoke).not.toHaveBeenCalledWith("runtime_info", undefined);
+  });
+
+  it("waits for apiBaseUrl when managed runtime is still starting", () => {
+    expect(shouldWaitForManagedRuntimeConfig({
+      apiBaseUrl: "",
+      connectionMode: "managed",
+      backendReady: false,
+      managedRuntimeDesiredState: "running",
+    })).toBe(true);
+    expect(shouldWaitForManagedRuntimeConfig({
+      apiBaseUrl: "",
+      connectionMode: "managed",
+      backendReady: false,
+      managedRuntimeDesiredState: "stopped",
+    })).toBe(false);
+    expect(shouldWaitForManagedRuntimeConfig({
+      apiBaseUrl: "http://127.0.0.1:9120",
+      connectionMode: "managed",
+      backendReady: true,
+      managedRuntimeDesiredState: "running",
+    })).toBe(false);
   });
 
   it("exposes persisted guide and managed runtime lifecycle commands", async () => {

--- a/web/src/lib/tauri-bridge.ts
+++ b/web/src/lib/tauri-bridge.ts
@@ -965,6 +965,20 @@ function registerDevtoolsShortcut(): void {
   );
 }
 
+export function shouldWaitForManagedRuntimeConfig(config: {
+  apiBaseUrl?: string;
+  backendReady?: boolean;
+  connectionMode?: "managed" | "local" | "remote";
+  managedRuntimeDesiredState?: import("@hermes/protocol").ManagedRuntimeDesiredState;
+}): boolean {
+  if (config.apiBaseUrl) return false;
+  const connectionMode = config.connectionMode ?? "managed";
+  const managedRuntimeShouldRun =
+    connectionMode === "managed" &&
+    (config.managedRuntimeDesiredState ?? "running") === "running";
+  return config.backendReady !== false || managedRuntimeShouldRun;
+}
+
 export async function installTauriBridge(): Promise<void> {
   // Install before any React component mounts a Tauri event listener, so the
   // StrictMode mount→unmount teardown race can't leak an unhandled rejection.
@@ -1002,7 +1016,7 @@ export async function installTauriBridge(): Promise<void> {
   // the populated apiBaseUrl/sessionToken. In Vite dev we still avoid writing
   // apiBaseUrl into window.__HERMES_RUNTIME__ later, but waiting here prevents
   // the React app from racing the managed dashboard startup.
-  if (!config.apiBaseUrl && config.backendReady !== false) {
+  if (shouldWaitForManagedRuntimeConfig(config)) {
     const result = await waitForBootstrap(
       "正在唤醒Hermes...",
       () => invokeCommand("get_runtime_config"),

--- a/web/src/lib/transport.test.ts
+++ b/web/src/lib/transport.test.ts
@@ -159,6 +159,33 @@ describe("transport · debug-bus integration", () => {
     expect(globalThis.fetch).not.toHaveBeenCalled();
   });
 
+  it("fetchJSON uses Tauri IPC when backend is ready even if renderer missed apiBaseUrl", async () => {
+    const request = vi.fn(async () => ({
+      ok: true,
+      status: 200,
+      statusText: "OK",
+      headers: {},
+      body: JSON.stringify({ version: "0.19.0" }),
+    }));
+    globalThis.fetch = vi.fn(async () => makeResponse(500, "should not fetch")) as unknown as typeof globalThis.fetch;
+    window.__HERMES_RUNTIME__ = { platform: "tauri", backendReady: true };
+    window.hermesDesktop = {
+      windowType: "tauri",
+      request,
+    };
+
+    const out = await fetchJSON<{ version: string }>("/api/status");
+
+    expect(out).toEqual({ version: "0.19.0" });
+    expect(request).toHaveBeenCalledWith({
+      path: "/api/status",
+      method: undefined,
+      headers: { "Content-Type": "application/json" },
+      body: null,
+    });
+    expect(globalThis.fetch).not.toHaveBeenCalled();
+  });
+
   it("fetchExternalJSON uses desktop externalRequest capability on Tauri", async () => {
     const externalRequest = vi.fn(async () => ({
       ok: true,

--- a/web/src/lib/transport.ts
+++ b/web/src/lib/transport.ts
@@ -84,8 +84,11 @@ function shouldUseNativeIpc(path: string): boolean {
     path.startsWith("/__hermes_session_log/") || path.startsWith("/__hermes_cron_runs/");
 
   if (runtime.platform === "tauri") {
-    if (isLocalDesktopRoute && window.hermesDesktop?.request) return true;
-    if (!window.__HERMES_RUNTIME__?.apiBaseUrl) return false;
+    if (!window.hermesDesktop?.request) return false;
+    if (isLocalDesktopRoute) return true;
+    if (!window.__HERMES_RUNTIME__?.apiBaseUrl && window.__HERMES_RUNTIME__?.backendReady !== true) {
+      return false;
+    }
     return true;
   }
   if (runtime.platform !== "electron") return false;


### PR DESCRIPTION
## 修改内容

- managed runtime 目标为 running 时，即使初始 `backendReady=false` 也等待 runtime ready 后重新读取完整配置
- renderer 已标记后端就绪但遗漏 `apiBaseUrl` 时，通过 Rust IPC 代理 REST 请求
- 增加启动等待条件与 IPC 兜底回归测试

## 根因

异步启动期间首轮 `get_runtime_config` 可能返回空 `apiBaseUrl` 和 `backendReady=false`。旧逻辑因此跳过等待并挂载 React；后续状态只更新 `backendReady`，没有补回地址，使 REST 请求退化为 `tauri://localhost/api/...`，WebKit 抛出 `The string did not match the expected pattern.`。

## 用户影响

修复覆盖安装后内核已经正常运行，但桌面壳的 Dashboard、Hermes Home、Skills、Profiles 等状态仍读取失败的问题。

## 验证

- `pnpm typecheck`
- `pnpm test:unit`
- `pnpm --filter @hermes/web build`
- `cargo check`
- `git diff --check`