### PR TITLE
fix: 修复编码代理委派面板状态

### DIFF
--- a/packages/protocol/src/hermes-api.ts
+++ b/packages/protocol/src/hermes-api.ts
@@ -1518,7 +1518,7 @@ export const GatewayKnownEvent = z.discriminatedUnion("type", [
       flags: z.record(z.unknown()).optional(),
     }).passthrough().optional(),
   }).passthrough(),
-  // 仅后台委派：≤2Hz 合并的实时输出（chunk 已脱敏/去 ANSI），events 是后端
+  // 前后台委派：≤2Hz 合并的实时输出（chunk 已脱敏/去 ANSI），events 是后端
   // 归一化出的子事件（init/text/tool_use/result，snake_case 字段）。
   z.object({
     type: z.literal("delegation.cli.output"),

--- a/web/src/components/chat/message-adapter.test.ts
+++ b/web/src/components/chat/message-adapter.test.ts
@@ -181,6 +181,22 @@ describe("message adapter", () => {
     expect(message?.text).toBe("阅读这张图片的内容\n\n附件：ga.png");
   });
 
+  it("normalizes injected Skill instructions from user to system messages", () => {
+    const message = hermesUIMessageToChatMessage(uiMessage({
+      id: "skill-invocation",
+      role: "user",
+      parts: [{
+        type: "text",
+        text: '[IMPORTANT: The user has invoked the "codex" skill, indicating they want you to follow its instructions.]',
+      }],
+    }));
+
+    expect(message).toMatchObject({
+      id: "skill-invocation",
+      role: "system",
+    });
+  });
+
   it("deduplicates stored image transport prompts against live display prompts", () => {
     const stored = [
       uiMessage({

--- a/web/src/components/chat/message-adapter.ts
+++ b/web/src/components/chat/message-adapter.ts
@@ -17,6 +17,7 @@ import {
   imagePartFromSource,
 } from "@/lib/message-images";
 import { stableTextHash, type UiTurnStats } from "@/lib/ui-store";
+import { isSkillInvocationText } from "@/lib/skill-invocation";
 import type { AssistantTurnBlock } from "@/stores/chat";
 import type { AssistantMessageStats, ChatImageItem, ChatMessage, ChatToolItem } from "./chat-types";
 
@@ -799,6 +800,11 @@ export function hermesUIMessageToChatMessage(msg: HermesUIMessage): ChatMessage 
   const text = msg.role === "system"
     ? noticeTextFromParts(msg.parts) ?? textFromParts(msg.parts)
     : textFromParts(msg.parts);
+  // Core 把 Skill 指令作为 user 上下文注入模型，但它不是用户在聊天框发送的
+  // 内容。进入展示模型时归一为 system，避免污染用户气泡、轮次导航和动作栏。
+  const displayRole = msg.role === "user" && isSkillInvocationText(text)
+    ? "system"
+    : msg.role;
   const reasoning = reasoningFromParts(msg.parts);
   const images = imagesFromParts(msg.parts);
   const blocks = msg.role === "assistant"
@@ -812,7 +818,7 @@ export function hermesUIMessageToChatMessage(msg: HermesUIMessage): ChatMessage 
 
   return {
     id: msg.id,
-    role: msg.role,
+    role: displayRole,
     createdAt: msg.createdAt,
     text,
     reasoning,

--- a/web/src/components/chat/message-timeline.module.css
+++ b/web/src/components/chat/message-timeline.module.css
@@ -157,6 +157,10 @@
   font-family: var(--h-font-cn);
 }
 
+.systemNotice[data-kind="skill-invocation"] {
+  max-width: none;
+}
+
 .systemNotice[data-error="true"] {
   background: color-mix(in srgb, #c5462b 6%, var(--h-bg-pane));
   border-color: color-mix(in srgb, #c5462b 26%, var(--h-line));
@@ -276,7 +280,7 @@
 }
 
 .skillInvocation {
-  width: min(640px, 72vw);
+  width: 100%;
   max-width: 100%;
 }
 
@@ -288,6 +292,9 @@
   line-clamp: 2;
   overflow-wrap: anywhere;
   white-space: normal;
+  color: var(--h-text-2);
+  font-size: var(--conversation-font-size, 12.5px);
+  line-height: var(--conversation-line-height, 1.6);
 }
 
 .skillInvocationBody {
@@ -328,6 +335,7 @@
 :global(#root) .messageText *,
 :global(#root) .systemNoticeText,
 :global(#root) .systemNoticeText *,
+:global(#root) .skillInvocationPreview,
 :global(#root) .reasoningBody,
 :global(#root) .reasoningBody *,
 :global(#root) .toolBody pre,

--- a/web/src/components/chat/message-timeline.module.css
+++ b/web/src/components/chat/message-timeline.module.css
@@ -275,6 +275,50 @@
   font-variant-east-asian: normal;
 }
 
+.skillInvocation {
+  width: min(640px, 72vw);
+  max-width: 100%;
+}
+
+.skillInvocationPreview {
+  display: -webkit-box;
+  overflow: hidden;
+  -webkit-box-orient: vertical;
+  -webkit-line-clamp: 2;
+  line-clamp: 2;
+  overflow-wrap: anywhere;
+  white-space: normal;
+}
+
+.skillInvocationBody {
+  min-width: 0;
+}
+
+.skillInvocationToggle {
+  display: inline-flex;
+  align-items: center;
+  gap: 4px;
+  margin-top: 8px;
+  padding: 2px 0;
+  border: 0;
+  background: transparent;
+  color: var(--h-text-2);
+  cursor: pointer;
+  font: inherit;
+  font-size: 12px;
+  line-height: 1.4;
+}
+
+.skillInvocationToggle:hover {
+  color: var(--h-text);
+}
+
+.skillInvocationToggle:focus-visible {
+  border-radius: 4px;
+  outline: 2px solid var(--h-accent);
+  outline-offset: 2px;
+}
+
 /* global.css disables selection across the app to keep desktop chrome from
    feeling like a web page. Conversation content is the important exception:
    users need to drag-select assistant/user text, code, reasoning, and visible

--- a/web/src/components/chat/message-timeline.test.tsx
+++ b/web/src/components/chat/message-timeline.test.tsx
@@ -11,6 +11,14 @@ import type { ChatMessage } from "./chat-types";
 const renderTimeline = (node: ReactElement) =>
   ReactDOMServer.renderToStaticMarkup(<MemoryRouter>{node}</MemoryRouter>);
 
+const skillInvocationText = [
+  '[IMPORTANT: The user has invoked the "codex" skill, indicating they want you to follow its instructions. The full skill content is loaded below.]',
+  "",
+  "# Codex",
+  "",
+  "Always use a PTY.",
+].join("\n");
+
 describe("MessageTimeline", () => {
   it("keeps bottom auto-follow disabled after an explicit upward scroll", () => {
     expect(resolveBottomFollowState(40, true)).toEqual({
@@ -240,6 +248,7 @@ describe("MessageTimeline", () => {
     const messages: ChatMessage[] = [
       { id: "user-1", role: "user", createdAt: 1, text: "第一轮问题" },
       { id: "assistant-1", role: "assistant", createdAt: 2, text: "第一轮回答" },
+      { id: "skill-1", role: "user", createdAt: 2.5, text: skillInvocationText },
       { id: "user-2", role: "user", createdAt: 3, text: "第二轮追问" },
       { id: "assistant-2", role: "assistant", createdAt: 4, text: "第二轮回答" },
     ];
@@ -251,6 +260,31 @@ describe("MessageTimeline", () => {
     expect(html).toContain("aria-label=\"对话轮次定位\"");
     expect(html).toContain("aria-label=\"定位到第 1 轮对话\"");
     expect(html).toContain("aria-label=\"定位到第 2 轮对话\"");
+    expect(html).not.toContain("aria-label=\"定位到第 3 轮对话\"");
+    expect(html.match(/data-turn-anchor=\"true\"/g)).toHaveLength(2);
+  });
+
+  it("renders injected Skill content as a full-width system notice without user actions", () => {
+    const html = renderTimeline(
+      <MessageTimeline
+        messages={[{
+          id: "skill-1",
+          role: "user",
+          createdAt: 1,
+          text: skillInvocationText,
+        }]}
+      />,
+    );
+
+    expect(html).toContain('data-role="system"');
+    expect(html).toContain('data-system-kind="skill-invocation"');
+    expect(html).toContain('data-kind="skill-invocation"');
+    expect(html).toContain('role="status"');
+    expect(html).toContain("Skill 指令已加载");
+    expect(html).toContain('data-skill-invocation="true"');
+    expect(html).not.toContain('data-role="user"');
+    expect(html).not.toContain('data-turn-anchor="true"');
+    expect(html).not.toContain("复制");
   });
 
   it("does not show turn navigation for a single user turn", () => {

--- a/web/src/components/chat/message-timeline.tsx
+++ b/web/src/components/chat/message-timeline.tsx
@@ -10,6 +10,7 @@ import { cliDelegationsByToolIdAtom } from "@/stores/cli-delegations";
 import { MessageImage } from "./message-image";
 import { MessageSkeleton } from "./message-skeleton";
 import { MessageText } from "./message-text";
+import { isSkillInvocationText, SkillInvocationMessage } from "./skill-invocation-message";
 import { CopyButton } from "@/components/ui/copy-button";
 import s from "./message-timeline.module.css";
 import { summarizeToolActivity } from "./tool-activity";
@@ -781,6 +782,7 @@ function MessageBubble({ message, turnStartedAt, sessionUsage, progressModel, sp
   const speechStatus = speech?.state.messageId === message.id ? speech.state.status : "idle";
   const speechBusy = speechStatus === "preparing" || speechStatus === "speaking";
   const hasBlocks = !isUser && Boolean(message.blocks?.length);
+  const hasSkillInvocation = isUser && isSkillInvocationText(message.text);
   const messageStats = message.stats ?? sessionUsageFallbackStats(message, sessionUsage);
 
   if (isToolOnly) {
@@ -860,7 +862,11 @@ function MessageBubble({ message, turnStartedAt, sessionUsage, progressModel, sp
             />
           ) : (
             <>
-              {message.text ? <MessageText text={message.text} streaming={streaming} /> : null}
+              {message.text ? (
+                hasSkillInvocation
+                  ? <SkillInvocationMessage text={message.text} />
+                  : <MessageText text={message.text} streaming={streaming} />
+              ) : null}
               {message.images?.length ? (
                 <div className={s.messageImages}>
                   {message.images.map((image, index) => (

--- a/web/src/components/chat/message-timeline.tsx
+++ b/web/src/components/chat/message-timeline.tsx
@@ -10,13 +10,14 @@ import { cliDelegationsByToolIdAtom } from "@/stores/cli-delegations";
 import { MessageImage } from "./message-image";
 import { MessageSkeleton } from "./message-skeleton";
 import { MessageText } from "./message-text";
-import { isSkillInvocationText, SkillInvocationMessage } from "./skill-invocation-message";
+import { SkillInvocationMessage } from "./skill-invocation-message";
 import { CopyButton } from "@/components/ui/copy-button";
 import s from "./message-timeline.module.css";
 import { summarizeToolActivity } from "./tool-activity";
 import { groupConsecutiveTools, groupElapsedMs } from "./group-tools";
 import { truncateMiddle } from "@/lib/truncate-middle";
 import { sanitizeTextForSpeech, speakText, voiceErrorMessage } from "@/lib/voice";
+import { isSkillInvocationText } from "@/lib/skill-invocation";
 import {
   formatDurationMs,
   formatElapsedTimer,
@@ -782,8 +783,31 @@ function MessageBubble({ message, turnStartedAt, sessionUsage, progressModel, sp
   const speechStatus = speech?.state.messageId === message.id ? speech.state.status : "idle";
   const speechBusy = speechStatus === "preparing" || speechStatus === "speaking";
   const hasBlocks = !isUser && Boolean(message.blocks?.length);
-  const hasSkillInvocation = isUser && isSkillInvocationText(message.text);
+  const hasSkillInvocation = isSkillInvocationText(message.text);
   const messageStats = message.stats ?? sessionUsageFallbackStats(message, sessionUsage);
+
+  if (hasSkillInvocation) {
+    return (
+      <div className={s.messageRow} data-role="system" data-system-kind="skill-invocation">
+        <div
+          className={s.systemNotice}
+          data-kind="skill-invocation"
+          role="status"
+        >
+          <Info
+            className={s.systemNoticeIcon}
+            size={15}
+            strokeWidth={1.75}
+            aria-hidden="true"
+          />
+          <div className={s.systemNoticeBody}>
+            <div className={s.systemNoticeTitle}>Skill 指令已加载</div>
+            <SkillInvocationMessage text={message.text ?? ""} />
+          </div>
+        </div>
+      </div>
+    );
+  }
 
   if (isToolOnly) {
     return (
@@ -862,11 +886,7 @@ function MessageBubble({ message, turnStartedAt, sessionUsage, progressModel, sp
             />
           ) : (
             <>
-              {message.text ? (
-                hasSkillInvocation
-                  ? <SkillInvocationMessage text={message.text} />
-                  : <MessageText text={message.text} streaming={streaming} />
-              ) : null}
+              {message.text ? <MessageText text={message.text} streaming={streaming} /> : null}
               {message.images?.length ? (
                 <div className={s.messageImages}>
                   {message.images.map((image, index) => (
@@ -979,7 +999,7 @@ export function MessageTimeline({
   const turnAnchors = useMemo<TurnAnchor[]>(() => {
     const anchors: TurnAnchor[] = [];
     for (const message of visibleMessages) {
-      if (message.role !== "user") continue;
+      if (message.role !== "user" || isSkillInvocationText(message.text)) continue;
       const index = anchors.length;
       anchors.push({
         id: message.id,
@@ -1416,11 +1436,12 @@ export function MessageTimeline({
           const previous = visibleMessages[index - 1];
           const showDate = !previous || formatDay(previous.createdAt) !== formatDay(message.createdAt);
           const isLast = index === visibleMessages.length - 1;
+          const isUserTurn = message.role === "user" && !isSkillInvocationText(message.text);
           return (
             <div
               key={message.id}
-              ref={message.role === "user" ? (node) => setTurnAnchorNode(message.id, node) : undefined}
-              data-turn-anchor={message.role === "user" ? "true" : undefined}
+              ref={isUserTurn ? (node) => setTurnAnchorNode(message.id, node) : undefined}
+              data-turn-anchor={isUserTurn ? "true" : undefined}
             >
               {showDate ? <div className={s.dateSeparator}>{formatDay(message.createdAt)}</div> : null}
               <MessageBubble

--- a/web/src/components/chat/skill-invocation-message.test.tsx
+++ b/web/src/components/chat/skill-invocation-message.test.tsx
@@ -1,0 +1,44 @@
+import ReactDOMServer from "react-dom/server";
+import { describe, expect, it } from "vitest";
+
+import {
+  isSkillInvocationText,
+  SkillInvocationMessage,
+  skillInvocationPreview,
+} from "./skill-invocation-message";
+
+const singleSkill = [
+  '[IMPORTANT: The user has invoked the "codex" skill, indicating they want you to follow its instructions. The full skill content is loaded below.]',
+  "",
+  "# Codex",
+  "",
+  "Always use a PTY.",
+].join("\n");
+
+describe("SkillInvocationMessage", () => {
+  it("recognizes single, bundle and stacked skill activation messages", () => {
+    expect(isSkillInvocationText(singleSkill)).toBe(true);
+    expect(isSkillInvocationText('[IMPORTANT: The user has invoked the "review" skill bundle, loading 2 skills together.]')).toBe(true);
+    expect(isSkillInvocationText('[IMPORTANT: The user has invoked the "/a /b" stacked skill bundle, loading 2 skills together.]')).toBe(true);
+  });
+
+  it("does not collapse ordinary user messages", () => {
+    expect(isSkillInvocationText("请帮我调用 codex skill 修复这个问题")).toBe(false);
+    expect(isSkillInvocationText("引用：[IMPORTANT: The user has invoked the skill]")).toBe(false);
+  });
+
+  it("normalizes the collapsed preview into a compact line-clamped string", () => {
+    expect(skillInvocationPreview("第一行\n\n  第二行\t第三行")).toBe("第一行 第二行 第三行");
+  });
+
+  it("renders collapsed by default with an accessible expand control", () => {
+    const html = ReactDOMServer.renderToStaticMarkup(
+      <SkillInvocationMessage text={singleSkill} />,
+    );
+
+    expect(html).toContain('data-skill-invocation="true"');
+    expect(html).toContain('aria-expanded="false"');
+    expect(html).toContain("展开 Skill 内容");
+    expect(html).not.toContain("收起 Skill 内容");
+  });
+});

--- a/web/src/components/chat/skill-invocation-message.test.tsx
+++ b/web/src/components/chat/skill-invocation-message.test.tsx
@@ -1,11 +1,8 @@
 import ReactDOMServer from "react-dom/server";
 import { describe, expect, it } from "vitest";
 
-import {
-  isSkillInvocationText,
-  SkillInvocationMessage,
-  skillInvocationPreview,
-} from "./skill-invocation-message";
+import { isSkillInvocationText, skillInvocationPreview } from "@/lib/skill-invocation";
+import { SkillInvocationMessage } from "./skill-invocation-message";
 
 const singleSkill = [
   '[IMPORTANT: The user has invoked the "codex" skill, indicating they want you to follow its instructions. The full skill content is loaded below.]',

--- a/web/src/components/chat/skill-invocation-message.tsx
+++ b/web/src/components/chat/skill-invocation-message.tsx
@@ -1,0 +1,40 @@
+import { useState } from "react";
+import { ChevronDown, ChevronUp } from "lucide-react";
+
+import { MessageText } from "./message-text";
+import s from "./message-timeline.module.css";
+
+const SKILL_INVOCATION_RE = /^\s*\[IMPORTANT:\s*The user has invoked the "[^"\r\n]+" (?:stacked skill bundle|skill bundle|skill)\b/i;
+
+export function isSkillInvocationText(text: string | null | undefined): boolean {
+  return SKILL_INVOCATION_RE.test(text ?? "");
+}
+
+export function skillInvocationPreview(text: string): string {
+  return text.replace(/\s+/g, " ").trim();
+}
+
+export function SkillInvocationMessage({ text }: { text: string }) {
+  const [expanded, setExpanded] = useState(false);
+
+  return (
+    <div className={s.skillInvocation} data-skill-invocation="true">
+      {expanded ? (
+        <div className={s.skillInvocationBody}>
+          <MessageText text={text} />
+        </div>
+      ) : (
+        <div className={s.skillInvocationPreview}>{skillInvocationPreview(text)}</div>
+      )}
+      <button
+        type="button"
+        className={s.skillInvocationToggle}
+        aria-expanded={expanded}
+        onClick={() => setExpanded((current) => !current)}
+      >
+        {expanded ? <ChevronUp size={14} aria-hidden="true" /> : <ChevronDown size={14} aria-hidden="true" />}
+        {expanded ? "收起 Skill 内容" : "展开 Skill 内容"}
+      </button>
+    </div>
+  );
+}

--- a/web/src/components/chat/skill-invocation-message.tsx
+++ b/web/src/components/chat/skill-invocation-message.tsx
@@ -1,18 +1,9 @@
 import { useState } from "react";
 import { ChevronDown, ChevronUp } from "lucide-react";
 
+import { skillInvocationPreview } from "@/lib/skill-invocation";
 import { MessageText } from "./message-text";
 import s from "./message-timeline.module.css";
-
-const SKILL_INVOCATION_RE = /^\s*\[IMPORTANT:\s*The user has invoked the "[^"\r\n]+" (?:stacked skill bundle|skill bundle|skill)\b/i;
-
-export function isSkillInvocationText(text: string | null | undefined): boolean {
-  return SKILL_INVOCATION_RE.test(text ?? "");
-}
-
-export function skillInvocationPreview(text: string): string {
-  return text.replace(/\s+/g, " ").trim();
-}
 
 export function SkillInvocationMessage({ text }: { text: string }) {
   const [expanded, setExpanded] = useState(false);

--- a/web/src/components/chat/subagent-panel.module.css
+++ b/web/src/components/chat/subagent-panel.module.css
@@ -332,6 +332,84 @@
   overflow-wrap: anywhere;
 }
 
+/* Codex / Claude Code 元信息固定为会话、目录、Token 三行。整行都是复制
+   热区；值列必须 minmax(0, 1fr)，否则长路径会撑宽面板而不是省略。 */
+.cliDetailList {
+  display: grid;
+  gap: 1px;
+  min-width: 0;
+}
+
+.cliDetailRow {
+  display: grid;
+  grid-template-columns: 38px minmax(0, 1fr) 12px;
+  align-items: center;
+  gap: 6px;
+  width: 100%;
+  min-width: 0;
+  min-height: 20px;
+  padding: 2px 4px;
+  border-radius: var(--h-r-sm);
+  color: var(--h-text-3);
+  font-family: var(--h-font-mono);
+  font-size: 10.5px;
+  line-height: 1.5;
+  text-align: left;
+}
+
+.cliDetailRow[data-copyable="true"] {
+  cursor: copy;
+}
+
+.cliDetailRow[data-copyable="true"]:hover {
+  background: var(--h-bg-soft);
+  color: var(--h-text-2);
+}
+
+.cliDetailRow:focus-visible {
+  border-radius: var(--h-r-sm);
+}
+
+.cliDetailRow:disabled {
+  cursor: default;
+  opacity: 1;
+}
+
+.cliDetailLabel {
+  color: var(--h-text-4);
+  white-space: nowrap;
+}
+
+.cliDetailValue {
+  min-width: 0;
+  overflow: hidden;
+  text-overflow: ellipsis;
+  white-space: nowrap;
+}
+
+.cliDetailAction {
+  justify-self: end;
+  color: var(--h-text-4);
+  opacity: 0;
+  transition: opacity 0.12s ease;
+}
+
+.cliDetailRow[data-copyable="true"]:hover .cliDetailAction,
+.cliDetailRow[data-copy-state="copied"] .cliDetailAction,
+.cliDetailRow[data-copy-state="error"] .cliDetailAction {
+  opacity: 1;
+}
+
+.cliDetailRow[data-copy-state="copied"] .cliDetailValue,
+.cliDetailRow[data-copy-state="copied"] .cliDetailAction {
+  color: var(--h-ok);
+}
+
+.cliDetailRow[data-copy-state="error"] .cliDetailValue,
+.cliDetailRow[data-copy-state="error"] .cliDetailAction {
+  color: var(--h-err);
+}
+
 /* ── Children ────────────────────────────────────────────────────────────── */
 
 .children {

--- a/web/src/components/chat/subagent-panel.test.tsx
+++ b/web/src/components/chat/subagent-panel.test.tsx
@@ -1,0 +1,59 @@
+import ReactDOMServer from "react-dom/server";
+import { describe, expect, it } from "vitest";
+
+import type { CliDelegationEntry } from "@/stores/cli-delegations";
+import { CliDelegationDetails } from "./subagent-panel";
+
+function entry(overrides: Partial<CliDelegationEntry> = {}): CliDelegationEntry {
+  return {
+    id: "delegation-1",
+    agent: "codex",
+    origin: "events",
+    execution: "foreground",
+    status: "completed",
+    promptExcerpt: "测试委派详情",
+    startedAt: 1,
+    outputTail: "",
+    timeline: [],
+    ...overrides,
+  };
+}
+
+describe("CliDelegationDetails", () => {
+  it("将会话、目录和 Token 渲染为三个独立复制行", () => {
+    const html = ReactDOMServer.renderToStaticMarkup(
+      <CliDelegationDetails
+        entry={entry({
+          workdir: "/private/var/folders/a/very-long-work-directory",
+          result: {
+            sessionId: "019fa674-7d3e-7530-b7ba-3995815e6988",
+            totalTokens: 31_040,
+          },
+        })}
+        running={false}
+      />,
+    );
+
+    expect(html.match(/data-cli-detail-row=/g)).toHaveLength(3);
+    expect(html.match(/data-copyable="true"/g)).toHaveLength(3);
+    expect(html).toContain("会话");
+    expect(html).toContain("目录");
+    expect(html).toContain("Token");
+    expect(html).toContain("31.0k");
+    expect(html).toContain("点击复制会话");
+    expect(html).toContain("点击复制目录");
+    expect(html).toContain("点击复制Token");
+  });
+
+  it("运行中缺失的数据仍占三行但不可复制", () => {
+    const html = ReactDOMServer.renderToStaticMarkup(
+      <CliDelegationDetails entry={entry({ status: "running" })} running />,
+    );
+
+    expect(html.match(/data-cli-detail-row=/g)).toHaveLength(3);
+    expect(html.match(/data-copyable="false"/g)).toHaveLength(3);
+    expect(html).toContain("获取中");
+    expect(html).toContain("统计中");
+    expect(html).not.toContain("点击复制");
+  });
+});

--- a/web/src/components/chat/subagent-panel.tsx
+++ b/web/src/components/chat/subagent-panel.tsx
@@ -226,6 +226,18 @@ const CLI_ABNORMAL_STATUS_LABELS: Partial<Record<CliDelegationEntry["status"], s
   detached: "结果未跟踪",
 };
 
+function cliTokenTotal(entry: Pick<CliDelegationEntry, "result">): number {
+  const result = entry.result;
+  if (!result) return 0;
+  if (result.totalTokens !== undefined) return result.totalTokens;
+  return (
+    (result.inputTokens ?? 0) +
+    (result.outputTokens ?? 0) +
+    (result.cacheCreationInputTokens ?? 0) +
+    (result.cacheReadInputTokens ?? 0)
+  );
+}
+
 function CliStatusIcon({ status }: { status: CliDelegationEntry["status"] }) {
   if (status === "running") {
     return <Loader2 className={`${s.statusIcon} ${s.spin}`} data-tone="run" size={14} aria-label="执行中" />;
@@ -250,15 +262,25 @@ function cliStreamEntries(entry: CliDelegationEntry): SubagentStreamEntry[] {
       text = `${event.toolName ?? "工具"}${snippet}`;
     } else if (event.kind === "result") {
       kind = "summary";
+      const eventTokens =
+        event.totalTokens ??
+        ((event.inputTokens ?? 0) +
+          (event.outputTokens ?? 0) +
+          (event.cacheCreationInputTokens ?? 0) +
+          (event.cacheReadInputTokens ?? 0));
       text = [
         event.isError ? "子任务出错" : "子任务完成",
         event.numTurns !== undefined ? `${event.numTurns} 轮` : "",
-        event.outputTokens !== undefined ? `输出 ${formatTokens(event.outputTokens)} tok` : "",
+        eventTokens > 0 ? `${formatTokens(eventTokens)} tok` : "",
       ]
         .filter(Boolean)
         .join(" · ");
     } else if (event.kind === "init") {
-      text = "已连接";
+      text = [
+        "已连接",
+        event.model ?? "",
+        event.workdir ? `目录 ${event.workdir}` : "",
+      ].filter(Boolean).join(" · ");
     } else {
       text = event.text ?? "";
     }
@@ -285,9 +307,15 @@ function CliDelegationRow({ entry, now }: { entry: CliDelegationEntry; now: numb
   // 一行只说必要的话：代理名 ·（后台）·（异常态说明）。completed/running
   // 由左侧图标表达；时长右置常显；会话 id 等细节收进展开态。
   const abnormal = CLI_ABNORMAL_STATUS_LABELS[entry.status];
+  const tokens = cliTokenTotal(entry);
+  const model =
+    entry.result?.model ??
+    (typeof entry.flags?.model === "string" ? entry.flags.model : "");
   const subtitle = [
     CLI_AGENT_LABELS[entry.agent],
+    model,
     entry.execution === "background" ? "后台" : "",
+    tokens > 0 ? `${formatTokens(tokens)} tok` : "",
     abnormal ?? "",
   ].filter(Boolean);
 
@@ -298,7 +326,10 @@ function CliDelegationRow({ entry, now }: { entry: CliDelegationEntry; now: numb
         entry.mode ? (CLI_MODE_LABELS[entry.mode] ?? "") : "",
         entry.result?.sessionId ? `会话 ${entry.result.sessionId}` : "",
         entry.result?.numTurns !== undefined ? `${entry.result.numTurns} 轮` : "",
-        entry.workdir ? `目录 ${entry.workdir}` : "",
+        (entry.result?.workdir ?? entry.workdir)
+          ? `目录 ${entry.result?.workdir ?? entry.workdir}`
+          : (running ? "目录获取中" : "目录未提供"),
+        tokens > 0 ? `Token ${formatTokens(tokens)}` : (running ? "Token 统计中" : "Token 未提供"),
         entry.exitCode !== undefined && entry.exitCode !== null && entry.exitCode !== 0
           ? `退出码 ${entry.exitCode}`
           : "",
@@ -385,13 +416,19 @@ export function SubagentPanel({
     return () => window.clearInterval(id);
   }, [active]);
 
-  const failed = flat.filter((nd) => nd.status === "failed" || nd.status === "interrupted").length;
+  const failed =
+    flat.filter((nd) => nd.status === "failed" || nd.status === "interrupted").length +
+    cliDelegations.filter((entry) =>
+      entry.status === "failed" || entry.status === "killed" || entry.status === "lost"
+    ).length;
   const tools = flat.reduce((sum, nd) => sum + (nd.toolCount ?? 0), 0);
   const files = flat.reduce((sum, nd) => sum + nd.filesRead.length + nd.filesWritten.length, 0);
-  const tokens = flat.reduce((sum, nd) => sum + (nd.inputTokens ?? 0) + (nd.outputTokens ?? 0), 0);
+  const tokens =
+    flat.reduce((sum, nd) => sum + (nd.inputTokens ?? 0) + (nd.outputTokens ?? 0), 0) +
+    cliDelegations.reduce((sum, entry) => sum + cliTokenTotal(entry), 0);
 
   const summary = [
-    `${flat.length} 个子Agent`,
+    `${flat.length + cliDelegations.length} 个子Agent`,
     active > 0 ? `${active} 活跃` : "",
     failed > 0 ? `${failed} 失败` : "",
     tools > 0 ? `${tools} 工具` : "",

--- a/web/src/components/chat/subagent-panel.tsx
+++ b/web/src/components/chat/subagent-panel.tsx
@@ -1,6 +1,7 @@
 import { useEffect, useMemo, useState, type ReactNode } from "react";
 import { useAtomValue } from "jotai";
-import { AlertCircle, Bot, CheckCircle2, ChevronRight, Loader2, SquareTerminal, X } from "lucide-react";
+import { AlertCircle, Bot, CheckCircle2, ChevronRight, Copy, Loader2, SquareTerminal, X } from "lucide-react";
+import { CopyButton } from "@/components/ui/copy-button";
 import { formatTokens } from "@/lib/format";
 import {
   activeCliDelegationCount,
@@ -238,6 +239,82 @@ function cliTokenTotal(entry: Pick<CliDelegationEntry, "result">): number {
   );
 }
 
+function CliDetailRow({
+  label,
+  value,
+  placeholder,
+}: {
+  label: string;
+  value?: string;
+  placeholder: string;
+}) {
+  const content = (
+    <>
+      <span className={s.cliDetailLabel}>{label}</span>
+      <span className={s.cliDetailValue}>{value ?? placeholder}</span>
+    </>
+  );
+
+  if (!value) {
+    return (
+      <span className={s.cliDetailRow} data-cli-detail-row={label} data-copyable="false">
+        {content}
+      </span>
+    );
+  }
+
+  return (
+    <CopyButton
+      className={s.cliDetailRow}
+      text={value}
+      showStatusIcon={false}
+      copiedLabel={(
+        <>
+          <span className={s.cliDetailLabel}>{label}</span>
+          <span className={s.cliDetailValue}>已复制</span>
+          <CheckCircle2 className={s.cliDetailAction} size={11} aria-hidden />
+        </>
+      )}
+      errorLabel={(
+        <>
+          <span className={s.cliDetailLabel}>{label}</span>
+          <span className={s.cliDetailValue}>复制失败</span>
+          <AlertCircle className={s.cliDetailAction} size={11} aria-hidden />
+        </>
+      )}
+      title={`点击复制${label}：${value}`}
+      aria-label={`复制${label}：${value}`}
+      data-cli-detail-row={label}
+      data-copyable="true"
+    >
+      {content}
+      <Copy className={s.cliDetailAction} size={11} aria-hidden />
+    </CopyButton>
+  );
+}
+
+/** Codex / Claude Code 委派详情：固定三行，长值单行省略，可用整行复制。 */
+export function CliDelegationDetails({
+  entry,
+  running,
+}: {
+  entry: CliDelegationEntry;
+  running: boolean;
+}) {
+  const tokens = cliTokenTotal(entry);
+  const sessionId = entry.result?.sessionId;
+  const workdir = entry.result?.workdir ?? entry.workdir ?? undefined;
+  const tokenLabel = tokens > 0 ? formatTokens(tokens) : undefined;
+
+  return (
+    <div className={s.cliDetailList}>
+      <CliDetailRow label="会话" value={sessionId} placeholder={running ? "获取中" : "未提供"} />
+      <CliDetailRow label="目录" value={workdir} placeholder={running ? "获取中" : "未提供"} />
+      <CliDetailRow label="Token" value={tokenLabel} placeholder={running ? "统计中" : "未提供"} />
+    </div>
+  );
+}
+
 function CliStatusIcon({ status }: { status: CliDelegationEntry["status"] }) {
   if (status === "running") {
     return <Loader2 className={`${s.statusIcon} ${s.spin}`} data-tone="run" size={14} aria-label="执行中" />;
@@ -324,12 +401,7 @@ function CliDelegationRow({ entry, now }: { entry: CliDelegationEntry; now: numb
   const metaParts = open
     ? [
         entry.mode ? (CLI_MODE_LABELS[entry.mode] ?? "") : "",
-        entry.result?.sessionId ? `会话 ${entry.result.sessionId}` : "",
         entry.result?.numTurns !== undefined ? `${entry.result.numTurns} 轮` : "",
-        (entry.result?.workdir ?? entry.workdir)
-          ? `目录 ${entry.result?.workdir ?? entry.workdir}`
-          : (running ? "目录获取中" : "目录未提供"),
-        tokens > 0 ? `Token ${formatTokens(tokens)}` : (running ? "Token 统计中" : "Token 未提供"),
         entry.exitCode !== undefined && entry.exitCode !== null && entry.exitCode !== 0
           ? `退出码 ${entry.exitCode}`
           : "",
@@ -358,10 +430,12 @@ function CliDelegationRow({ entry, now }: { entry: CliDelegationEntry; now: numb
         </div>
       ) : null}
 
-      {metaParts.length > 0 ? (
+      {open ? (
         <div className={s.files}>
-          <span className={s.filesLabel}>详情</span>
-          <span className={s.fileLine}>{metaParts.join(" · ")}</span>
+          <span className={s.filesLabel}>
+            详情{metaParts.length > 0 ? ` · ${metaParts.join(" · ")}` : ""}
+          </span>
+          <CliDelegationDetails entry={entry} running={running} />
         </div>
       ) : null}
     </div>

--- a/web/src/hooks/use-gateway.ts
+++ b/web/src/hooks/use-gateway.ts
@@ -20,7 +20,10 @@ import {
 } from "@hermes/protocol";
 import { CN_BACKEND_PROVIDER_SLUGS } from "@/lib/cn-provider-slugs";
 import { getGatewayClient } from "@/lib/gateway-client";
-import { reattachAfterReconnect } from "@/lib/gateway-reconnect";
+import {
+  isDefinitiveMissingSessionError,
+  reattachAfterReconnect,
+} from "@/lib/gateway-reconnect";
 import {
   getCachedModelOptions,
   invalidateModelOptionsCache,
@@ -52,6 +55,11 @@ import {
 import { sessionTipRedirectAtom } from "@/stores/ui";
 import { recordTipRedirect } from "@/lib/session-tip-redirect";
 import { createDeltaCoalescer } from "@/lib/gateway-delta-coalescer";
+import { queryClient as appQueryClient } from "@/lib/query-client";
+import {
+  gatewayEventChangesSessionList,
+  invalidateSessionListQueries,
+} from "@/lib/session-query-sync";
 
 type GatewayState = ReturnType<typeof getGatewayClient>["state"];
 
@@ -115,14 +123,19 @@ async function reattachActiveSessionAfterReconnect(): Promise<void> {
         store.set(gwSessionIdAtom, gatewaySessionId);
         rememberSessionMapping(gatewaySessionId, persistentId);
       },
-      onResumeFailed: () => {
-        // The backend session is genuinely gone (reaped / crashed) — escalate
-        // the transient "reconnecting" turns to a real error so the UI is honest.
-        store.set(terminateAllStreamsAtom);
+      onResumeFailed: (error) => {
+        // A timeout or temporarily wedged backend does not mean the persistent
+        // session vanished. Keep the runtime in reconnecting state so it stays
+        // visible and can recover on the next reconnect. Only an explicit
+        // server-side "session missing" response is terminal.
+        if (isDefinitiveMissingSessionError(error)) {
+          store.set(terminateAllStreamsAtom);
+        }
       },
     });
   } finally {
     reattachInFlight = false;
+    void invalidateSessionListQueries(appQueryClient);
   }
 }
 
@@ -158,6 +171,9 @@ function ensureGatewayBridge(): GatewaySubscriptionBridge {
 
   bridge.unsubscribeState = client.onState((state) => {
     forEachSubscriber(bridge, (sub) => sub.setConnectionState(state));
+    if (state === "open") {
+      void invalidateSessionListQueries(appQueryClient);
+    }
     if (state === "open" && needsResumeOnReopen) {
       needsResumeOnReopen = false;
       void reattachActiveSessionAfterReconnect();
@@ -256,12 +272,19 @@ export function useGateway() {
   const setSessionTipRedirect = useSetAtom(sessionTipRedirectAtom);
   const terminateAllStreams = useSetAtom(terminateAllStreamsAtom);
 
+  const applyGatewayEventAndSync = useCallback((event: GatewayEvent) => {
+    applyGatewayEvent(event);
+    if (gatewayEventChangesSessionList(event)) {
+      void invalidateSessionListQueries(queryClient);
+    }
+  }, [applyGatewayEvent, queryClient]);
+
   const activeRuntime = gwSessionId ? runtimeBySession[gwSessionId] : undefined;
   const streamStatus = activeRuntime?.streamStatus ?? "idle";
 
   useEffect(() => {
-    return subscribeGateway(setConnectionState, applyGatewayEvent, terminateAllStreams);
-  }, [applyGatewayEvent, setConnectionState, terminateAllStreams]);
+    return subscribeGateway(setConnectionState, applyGatewayEventAndSync, terminateAllStreams);
+  }, [applyGatewayEventAndSync, setConnectionState, terminateAllStreams]);
 
   const ensureSubscribed = useCallback(() => {
     ensureGatewayBridge();
@@ -281,7 +304,8 @@ export function useGateway() {
     setGwSessionId(sessionId);
     resetChatSession(sessionId);
     void rememberPersistentSessionKey(sessionId);
-  }, [resetChatSession, setGwSessionId]);
+    void invalidateSessionListQueries(queryClient);
+  }, [queryClient, resetChatSession, setGwSessionId]);
 
   const createSession = useCallback(async (options?: CreateSessionOptions): Promise<string> => {
     ensureSubscribed();
@@ -303,7 +327,8 @@ export function useGateway() {
     ensureSubscribed();
     await getGatewayClient().request("session.close", { session_id: sessionId });
     setGwSessionId((current) => current === sessionId ? null : current);
-  }, [ensureSubscribed, setGwSessionId]);
+    void invalidateSessionListQueries(queryClient);
+  }, [ensureSubscribed, queryClient, setGwSessionId]);
 
   const beginPrompt = useCallback(
     (sessionId: string, text: string, now?: number, images?: ImageEntry[]) => {
@@ -340,8 +365,9 @@ export function useGateway() {
     // for. Record it so the detail route can project onto the live tip instead
     // of stranding the user on the now-empty pre-compression id (issue #305).
     setSessionTipRedirect((prev) => recordTipRedirect(prev, persistentSessionId, result.resumed));
+    void invalidateSessionListQueries(queryClient);
     return result.session_id;
-  }, [ensureSubscribed, resetChatSession, setGwSessionId, setSessionTipRedirect]);
+  }, [ensureSubscribed, queryClient, resetChatSession, setGwSessionId, setSessionTipRedirect]);
 
   const sendPrompt = useCallback(
     async (

--- a/web/src/lib/cli-delegation.test.ts
+++ b/web/src/lib/cli-delegation.test.ts
@@ -21,7 +21,7 @@ interface FixtureExpect {
   agent: "claude-code" | "codex";
   mode: string;
   prompt: string;
-  workdir?: string;
+  workdir?: string | null;
   flags?: Record<string, unknown>;
 }
 
@@ -189,6 +189,12 @@ const FIXTURES: Fixture[] = [
     expect: { agent: "codex", mode: "exec", prompt: "task", flags: { json: true, full_auto: true } },
   },
   {
+    name: "codex-dynamic-cd-not-reported-as-dollar",
+    command: "cd $(mktemp -d) && git init -q && codex exec 'task'",
+    args: {},
+    expect: { agent: "codex", mode: "exec", prompt: "task", workdir: null },
+  },
+  {
     name: "codex-review",
     command: "codex review --base origin/main",
     args: {},
@@ -292,9 +298,16 @@ describe("输出归一化", () => {
     expect(tool).toContainEqual({ kind: "text", text: "running" });
 
     const result = parseClaudeStreamJsonLine(
-      '{"type":"result","subtype":"success","session_id":"s-1","num_turns":3,"total_cost_usd":0.01,"is_error":false}',
+      '{"type":"result","subtype":"success","session_id":"s-1","num_turns":3,"total_cost_usd":0.01,"is_error":false,"usage":{"input_tokens":10,"output_tokens":5,"cache_read_input_tokens":20}}',
     );
-    expect(result[0]).toMatchObject({ kind: "result", sessionId: "s-1", numTurns: 3 });
+    expect(result[0]).toMatchObject({
+      kind: "result",
+      sessionId: "s-1",
+      numTurns: 3,
+      inputTokens: 10,
+      outputTokens: 5,
+      cacheReadInputTokens: 20,
+    });
 
     expect(
       parseClaudeStreamJsonLine('{"type":"stream_event","event":{"delta":{"type":"text_delta","text":"h"}}}'),
@@ -311,8 +324,8 @@ describe("输出归一化", () => {
     );
     expect(begin[0]).toMatchObject({ kind: "tool_use", toolName: "shell", text: "git status" });
 
-    expect(parseCodexJsonlLine('{"type":"thread.started","thread_id":"t-1"}')).toEqual([
-      { kind: "init", sessionId: "t-1" },
+    expect(parseCodexJsonlLine('{"type":"thread.started","thread_id":"t-1","cwd":"/repo"}')).toEqual([
+      { kind: "init", sessionId: "t-1", workdir: "/repo" },
     ]);
     const turn = parseCodexJsonlLine('{"type":"turn.completed","usage":{"input_tokens":10,"output_tokens":5}}');
     expect(turn[0]).toMatchObject({ kind: "result", inputTokens: 10, outputTokens: 5 });
@@ -345,6 +358,27 @@ describe("输出归一化", () => {
     expect(extractCodexResult("no json here")).toBeUndefined();
   });
 
+  it("extractCodexResult 从人类可读输出恢复目录、模型、会话和总 Token", () => {
+    const output = [
+      "OpenAI Codex v0.145.0",
+      "--------",
+      "workdir: /private/tmp/codex-run",
+      "model: gpt-5.6-sol",
+      "session id: 019fa2c2-test",
+      "--------",
+      "tokens used",
+      "10,654",
+      "你好",
+    ].join("\n");
+    expect(extractCodexResult(output)).toEqual({
+      workdir: "/private/tmp/codex-run",
+      model: "gpt-5.6-sol",
+      sessionId: "019fa2c2-test",
+      totalTokens: 10654,
+    });
+    expect(timelineFromOutput("codex", output).some((event) => event.kind === "raw")).toBe(true);
+  });
+
   it("timelineFromOutput 整段解析并 cap", () => {
     const line = '{"type":"assistant","message":{"content":[{"type":"text","text":"t"}]}}';
     const timeline = timelineFromOutput("claude-code", Array(300).fill(line).join("\n"), 200);
@@ -354,8 +388,14 @@ describe("输出归一化", () => {
 
   it("subEventFromWire 转换 snake_case 线上事件", () => {
     expect(
-      subEventFromWire({ kind: "result", session_id: "s", num_turns: 2, total_cost_usd: 0.1 }),
-    ).toMatchObject({ kind: "result", sessionId: "s", numTurns: 2, totalCostUsd: 0.1 });
+      subEventFromWire({
+        kind: "result",
+        session_id: "s",
+        workdir: "/repo",
+        num_turns: 2,
+        total_tokens: 123,
+      }),
+    ).toMatchObject({ kind: "result", sessionId: "s", workdir: "/repo", numTurns: 2, totalTokens: 123 });
     expect(subEventFromWire({ kind: "nope" })).toBeNull();
     expect(subEventFromWire("str")).toBeNull();
   });

--- a/web/src/lib/cli-delegation.ts
+++ b/web/src/lib/cli-delegation.ts
@@ -23,23 +23,32 @@ export interface CliDelegationSubEvent {
   toolName?: string;
   sessionId?: string;
   model?: string;
+  workdir?: string;
   numTurns?: number;
-  totalCostUsd?: number;
   subtype?: string;
   isError?: boolean;
   inputTokens?: number;
   outputTokens?: number;
+  cachedInputTokens?: number;
+  cacheCreationInputTokens?: number;
+  cacheReadInputTokens?: number;
+  totalTokens?: number;
 }
 
 export interface CliDelegationResult {
   sessionId?: string;
+  model?: string;
+  workdir?: string;
   numTurns?: number;
-  totalCostUsd?: number;
   subtype?: string;
   isError?: boolean;
   text?: string;
   inputTokens?: number;
   outputTokens?: number;
+  cachedInputTokens?: number;
+  cacheCreationInputTokens?: number;
+  cacheReadInputTokens?: number;
+  totalTokens?: number;
 }
 
 const PROMPT_EXCERPT_CAP = 200;
@@ -80,6 +89,10 @@ const ENV_ASSIGN_RE = /^[A-Za-z_][A-Za-z0-9_]*=/;
 const MAX_SHELL_RECURSION = 3;
 
 const oneline = (text: string, cap: number) => text.replace(/\s+/g, " ").trim().slice(0, cap);
+const staticWorkdir = (value: unknown): string | null => {
+  const text = typeof value === "string" ? value.trim() : "";
+  return text && !text.includes("$") && !text.includes("`") ? text : null;
+};
 
 const basename = (token: string) => {
   const parts = token.trim().split(/[\\/]/);
@@ -353,7 +366,7 @@ function classifyCodex(words: string[], args: TerminalArgs): CliDelegationSpec |
   const model = values.get("--model") ?? values.get("-m");
   if (model) flags.model = model;
 
-  const workdir = values.get("--cd") ?? values.get("-C") ?? null;
+  const workdir = staticWorkdir(values.get("--cd") ?? values.get("-C"));
   let prompt = positionals[0] ?? "";
   const mode = subcommand || "interactive";
   if (mode === "resume") {
@@ -403,8 +416,8 @@ function classifyCommand(command: string, args: TerminalArgs, depth = 0): CliDel
     }
     const spec = classifySegment(seg, args, depth);
     if (spec) {
-      const argsWorkdir = typeof args?.workdir === "string" && args.workdir ? args.workdir : null;
-      const workdir = argsWorkdir ?? spec.workdir ?? pendingWorkdir;
+      const argsWorkdir = staticWorkdir(args?.workdir);
+      const workdir = argsWorkdir ?? spec.workdir ?? staticWorkdir(pendingWorkdir);
       return workdir === spec.workdir ? spec : { ...spec, workdir };
     }
   }
@@ -461,7 +474,15 @@ export function parseClaudeStreamJsonLine(line: string): CliDelegationSubEvent[]
   if (!obj) return [];
   const type = obj.type;
   if (type === "system" && obj.subtype === "init") {
-    return [{ kind: "init", sessionId: strOrUndef(obj.session_id), model: strOrUndef(obj.model) }];
+    const sessionId = strOrUndef(obj.session_id);
+    const model = strOrUndef(obj.model);
+    const workdir = strOrUndef(obj.cwd) ?? strOrUndef(obj.workdir);
+    return [{
+      kind: "init",
+      ...(sessionId ? { sessionId } : {}),
+      ...(model ? { model } : {}),
+      ...(workdir ? { workdir } : {}),
+    }];
   }
   if (type === "assistant") {
     const message = asRecord(obj.message);
@@ -481,13 +502,19 @@ export function parseClaudeStreamJsonLine(line: string): CliDelegationSubEvent[]
     return events;
   }
   if (type === "result") {
+    const usage = asRecord(obj.usage);
     return [{
       kind: "result",
       sessionId: strOrUndef(obj.session_id),
+      model: strOrUndef(obj.model),
+      workdir: strOrUndef(obj.cwd) ?? strOrUndef(obj.workdir),
       numTurns: numOrUndef(obj.num_turns),
-      totalCostUsd: numOrUndef(obj.total_cost_usd),
       subtype: strOrUndef(obj.subtype),
       isError: obj.is_error === true ? true : undefined,
+      inputTokens: numOrUndef(usage?.input_tokens),
+      outputTokens: numOrUndef(usage?.output_tokens),
+      cacheCreationInputTokens: numOrUndef(usage?.cache_creation_input_tokens),
+      cacheReadInputTokens: numOrUndef(usage?.cache_read_input_tokens),
     }];
   }
   return [];
@@ -501,7 +528,15 @@ export function parseCodexJsonlLine(line: string): CliDelegationSubEvent[] {
   if (msg) {
     const mtype = msg.type;
     if (mtype === "session_configured") {
-      return [{ kind: "init", sessionId: strOrUndef(msg.session_id) }];
+      const sessionId = strOrUndef(msg.session_id);
+      const model = strOrUndef(msg.model);
+      const workdir = strOrUndef(msg.cwd) ?? strOrUndef(msg.workdir);
+      return [{
+        kind: "init",
+        ...(sessionId ? { sessionId } : {}),
+        ...(model ? { model } : {}),
+        ...(workdir ? { workdir } : {}),
+      }];
     }
     if (mtype === "agent_message" && msg.message) {
       return [{ kind: "text", text: clip(msg.message) }];
@@ -518,7 +553,15 @@ export function parseCodexJsonlLine(line: string): CliDelegationSubEvent[] {
 
   const otype = obj.type;
   if (otype === "thread.started") {
-    return [{ kind: "init", sessionId: strOrUndef(obj.thread_id) }];
+    const sessionId = strOrUndef(obj.thread_id);
+    const model = strOrUndef(obj.model);
+    const workdir = strOrUndef(obj.cwd) ?? strOrUndef(obj.workdir);
+    return [{
+      kind: "init",
+      ...(sessionId ? { sessionId } : {}),
+      ...(model ? { model } : {}),
+      ...(workdir ? { workdir } : {}),
+    }];
   }
   if (otype === "item.completed") {
     const item = asRecord(obj.item);
@@ -538,6 +581,7 @@ export function parseCodexJsonlLine(line: string): CliDelegationSubEvent[] {
       kind: "result",
       inputTokens: numOrUndef(usage?.input_tokens),
       outputTokens: numOrUndef(usage?.output_tokens),
+      cachedInputTokens: numOrUndef(usage?.cached_input_tokens),
     }];
   }
   if (otype === "turn.failed") return [{ kind: "result", isError: true }];
@@ -548,7 +592,10 @@ export function parseCodexJsonlLine(line: string): CliDelegationSubEvent[] {
 }
 
 export function normalizeOutputLine(agent: CliDelegationAgent, line: string): CliDelegationSubEvent[] {
-  return agent === "claude-code" ? parseClaudeStreamJsonLine(line) : parseCodexJsonlLine(line);
+  const events = agent === "claude-code" ? parseClaudeStreamJsonLine(line) : parseCodexJsonlLine(line);
+  if (events.length) return events;
+  if (!loadJsonLine(line) && clip(line)) return [{ kind: "raw", text: clip(line) }];
+  return [];
 }
 
 /** 把整段输出（前台结果 / 历史重载）解析为时间线子事件，cap 条数。 */
@@ -580,12 +627,16 @@ export function subEventFromWire(raw: unknown): CliDelegationSubEvent | null {
     toolName: strOrUndef(rec.tool_name),
     sessionId: strOrUndef(rec.session_id),
     model: strOrUndef(rec.model),
+    workdir: strOrUndef(rec.workdir),
     numTurns: numOrUndef(rec.num_turns),
-    totalCostUsd: numOrUndef(rec.total_cost_usd),
     subtype: strOrUndef(rec.subtype),
     isError: rec.is_error === true ? true : undefined,
     inputTokens: numOrUndef(rec.input_tokens),
     outputTokens: numOrUndef(rec.output_tokens),
+    cachedInputTokens: numOrUndef(rec.cached_input_tokens),
+    cacheCreationInputTokens: numOrUndef(rec.cache_creation_input_tokens),
+    cacheReadInputTokens: numOrUndef(rec.cache_read_input_tokens),
+    totalTokens: numOrUndef(rec.total_tokens),
   };
 }
 
@@ -594,13 +645,18 @@ export function resultFromWire(raw: unknown): CliDelegationResult | undefined {
   if (!rec) return undefined;
   const result: CliDelegationResult = {
     sessionId: strOrUndef(rec.session_id),
+    model: strOrUndef(rec.model),
+    workdir: strOrUndef(rec.workdir),
     numTurns: numOrUndef(rec.num_turns),
-    totalCostUsd: numOrUndef(rec.total_cost_usd),
     subtype: strOrUndef(rec.subtype),
     isError: rec.is_error === true ? true : undefined,
     text: strOrUndef(rec.text),
     inputTokens: numOrUndef(rec.input_tokens),
     outputTokens: numOrUndef(rec.output_tokens),
+    cachedInputTokens: numOrUndef(rec.cached_input_tokens),
+    cacheCreationInputTokens: numOrUndef(rec.cache_creation_input_tokens),
+    cacheReadInputTokens: numOrUndef(rec.cache_read_input_tokens),
+    totalTokens: numOrUndef(rec.total_tokens),
   };
   return Object.values(result).some((v) => v !== undefined) ? result : undefined;
 }
@@ -608,40 +664,58 @@ export function resultFromWire(raw: unknown): CliDelegationResult | undefined {
 export function extractClaudeResult(output: string): CliDelegationResult | undefined {
   if (!output) return undefined;
   const text = output.trim();
+  let lines = output.split("\n").slice(-400);
   if (text.startsWith("{")) {
     try {
       const whole = asRecord(JSON.parse(text));
       if (whole && (whole.type === "result" || "session_id" in whole)) {
-        return resultFromWire(whole);
+        lines = [JSON.stringify(whole)];
       }
     } catch {
       // 不是单对象 JSON，继续按行扫描。
     }
   }
-  const lines = output.split("\n").slice(-200);
-  for (let i = lines.length - 1; i >= 0; i -= 1) {
-    for (const event of parseClaudeStreamJsonLine(lines[i]!)) {
-      if (event.kind === "result") {
-        const { kind: _kind, toolName: _t, ...rest } = event;
-        return rest;
+  const result: CliDelegationResult = {};
+  for (const line of lines) {
+    for (const event of parseClaudeStreamJsonLine(line)) {
+      if (event.kind !== "init" && event.kind !== "result") continue;
+      const { kind: _kind, toolName: _toolName, ...fields } = event;
+      for (const [key, value] of Object.entries(fields)) {
+        if (value !== undefined) Object.assign(result, { [key]: value });
       }
     }
   }
-  return undefined;
+  return Object.values(result).some((value) => value !== undefined) ? result : undefined;
 }
 
 export function extractCodexResult(output: string): CliDelegationResult | undefined {
   if (!output) return undefined;
-  const lines = output.split("\n").slice(-200);
-  for (let i = lines.length - 1; i >= 0; i -= 1) {
-    for (const event of parseCodexJsonlLine(lines[i]!)) {
-      if (event.kind === "result") {
-        const { kind: _kind, toolName: _t, ...rest } = event;
-        return rest;
+  const result: CliDelegationResult = {};
+  for (const line of output.split("\n").slice(-400)) {
+    for (const event of parseCodexJsonlLine(line)) {
+      if (event.kind !== "init" && event.kind !== "result") continue;
+      const { kind: _kind, toolName: _toolName, ...fields } = event;
+      for (const [key, value] of Object.entries(fields)) {
+        if (value !== undefined) Object.assign(result, { [key]: value });
       }
     }
   }
-  return undefined;
+
+  const humanFields: Array<[keyof CliDelegationResult, RegExp]> = [
+    ["workdir", /^workdir:\s*(.+?)\s*$/im],
+    ["model", /^model:\s*(.+?)\s*$/im],
+    ["sessionId", /^session id:\s*(\S+)\s*$/im],
+  ];
+  for (const [key, pattern] of humanFields) {
+    const match = output.match(pattern);
+    if (match?.[1]) Object.assign(result, { [key]: match[1].trim() });
+  }
+  const totalTokens = output.match(/^tokens used\s*\r?\n\s*([0-9][0-9,]*)\s*$/im)?.[1];
+  if (totalTokens) {
+    const parsed = Number.parseInt(totalTokens.replaceAll(",", ""), 10);
+    if (Number.isFinite(parsed)) result.totalTokens = parsed;
+  }
+  return Object.values(result).some((value) => value !== undefined) ? result : undefined;
 }
 
 export function extractResult(agent: CliDelegationAgent, output: string): CliDelegationResult | undefined {

--- a/web/src/lib/gateway-reconnect.test.ts
+++ b/web/src/lib/gateway-reconnect.test.ts
@@ -1,5 +1,9 @@
 import { describe, it, expect, vi } from "vitest";
-import { reattachAfterReconnect, type ReattachAfterReconnectDeps } from "./gateway-reconnect";
+import {
+  isDefinitiveMissingSessionError,
+  reattachAfterReconnect,
+  type ReattachAfterReconnectDeps,
+} from "./gateway-reconnect";
 
 function makeDeps(overrides: Partial<ReattachAfterReconnectDeps> = {}): {
   deps: ReattachAfterReconnectDeps;
@@ -66,5 +70,23 @@ describe("reattachAfterReconnect", () => {
     await reattachAfterReconnect(deps);
     expect(onResumed).not.toHaveBeenCalled();
     expect(onResumeFailed).toHaveBeenCalledTimes(1);
+  });
+});
+
+describe("isDefinitiveMissingSessionError", () => {
+  it.each([
+    new Error("Session not found"),
+    new Error("unknown conversation id"),
+    "conversation was reaped",
+  ])("accepts explicit missing-session failures", (error) => {
+    expect(isDefinitiveMissingSessionError(error)).toBe(true);
+  });
+
+  it.each([
+    new Error("Request timed out after 300000ms"),
+    new Error("WebSocket disconnected"),
+    new Error("HTTP 503 Service Unavailable"),
+  ])("keeps transient resume failures recoverable", (error) => {
+    expect(isDefinitiveMissingSessionError(error)).toBe(false);
   });
 });

--- a/web/src/lib/gateway-reconnect.ts
+++ b/web/src/lib/gateway-reconnect.ts
@@ -35,6 +35,13 @@ export interface ReattachAfterReconnectDeps {
   onResumeFailed: (error: unknown) => void;
 }
 
+/** Only explicit server-side absence is terminal; timeouts are recoverable. */
+export function isDefinitiveMissingSessionError(error: unknown): boolean {
+  const message = error instanceof Error ? error.message : String(error ?? "");
+  return /(?:session|conversation).*(?:not found|does not exist|unknown|gone|reaped)/i.test(message)
+    || /(?:not found|does not exist|unknown|gone|reaped).*(?:session|conversation)/i.test(message);
+}
+
 export async function reattachAfterReconnect(deps: ReattachAfterReconnectDeps): Promise<void> {
   const activeSessionId = deps.getActiveSessionId();
   // Nothing open to re-pin — a fresh connect with no session is a no-op.

--- a/web/src/lib/session-activity.test.ts
+++ b/web/src/lib/session-activity.test.ts
@@ -66,6 +66,10 @@ describe("session activity", () => {
       ...createEmptyChatRuntime(1),
       streamStatus: "streaming" as const,
     };
+    const reconnectingRuntime = {
+      ...createEmptyChatRuntime(1),
+      streamStatus: "connecting" as const,
+    };
 
     expect(
       isSessionRunning(
@@ -74,6 +78,7 @@ describe("session activity", () => {
       ),
     ).toBe(false);
     expect(isRuntimeRunning(streamingRuntime)).toBe(true);
+    expect(isRuntimeRunning(reconnectingRuntime)).toBe(true);
     expect(
       isSessionRunning(
         session({ is_active: false, message_count: 2 }),

--- a/web/src/lib/session-query-sync.test.ts
+++ b/web/src/lib/session-query-sync.test.ts
@@ -1,0 +1,29 @@
+import { QueryClient } from "@tanstack/react-query";
+import { describe, expect, it, vi } from "vitest";
+import type { GatewayEvent } from "@hermes/protocol";
+import {
+  gatewayEventChangesSessionList,
+  invalidateSessionListQueries,
+} from "./session-query-sync";
+
+describe("session query sync", () => {
+  it("invalidates every session-list query variant", async () => {
+    const queryClient = new QueryClient();
+    const invalidate = vi
+      .spyOn(queryClient, "invalidateQueries")
+      .mockResolvedValue(undefined);
+
+    await invalidateSessionListQueries(queryClient);
+
+    expect(invalidate).toHaveBeenCalledWith({ queryKey: ["sessions"] });
+  });
+
+  it.each([
+    ["message.complete", true],
+    ["error", true],
+    ["message.delta", false],
+    ["tool.progress", false],
+  ])("classifies %s session-list invalidation", (type, expected) => {
+    expect(gatewayEventChangesSessionList({ type } as GatewayEvent)).toBe(expected);
+  });
+});

--- a/web/src/lib/session-query-sync.ts
+++ b/web/src/lib/session-query-sync.ts
@@ -1,0 +1,12 @@
+import type { QueryClient } from "@tanstack/react-query";
+import type { GatewayEvent } from "@hermes/protocol";
+
+/** Refresh every cached session-list variant (sidebar, history, archived). */
+export function invalidateSessionListQueries(queryClient: QueryClient): Promise<void> {
+  return queryClient.invalidateQueries({ queryKey: ["sessions"] });
+}
+
+/** Gateway terminal events persist status, token totals and the final preview. */
+export function gatewayEventChangesSessionList(event: GatewayEvent): boolean {
+  return event.type === "message.complete" || event.type === "error";
+}

--- a/web/src/lib/skill-invocation.ts
+++ b/web/src/lib/skill-invocation.ts
@@ -1,0 +1,10 @@
+const SKILL_INVOCATION_RE = /^\s*\[IMPORTANT:\s*The user has invoked the "[^"\r\n]+" (?:stacked skill bundle|skill bundle|skill)\b/i;
+
+/** Runtime 注入的 Skill 指令并非用户实际发送的聊天消息。 */
+export function isSkillInvocationText(text: string | null | undefined): boolean {
+  return SKILL_INVOCATION_RE.test(text ?? "");
+}
+
+export function skillInvocationPreview(text: string): string {
+  return text.replace(/\s+/g, " ").trim();
+}

--- a/web/src/stores/cli-delegations.test.ts
+++ b/web/src/stores/cli-delegations.test.ts
@@ -90,7 +90,7 @@ describe("事件源路径（新内核 delegation.cli.*）", () => {
         exit_code: 0,
         duration_s: 12.5,
         output_tail: "final tail",
-        result: { session_id: "cc-1", num_turns: 3, total_cost_usd: 0.02 },
+        result: { session_id: "cc-1", num_turns: 3, input_tokens: 120, output_tokens: 30 },
       }),
       2000,
     );
@@ -100,7 +100,7 @@ describe("事件源路径（新内核 delegation.cli.*）", () => {
       durationS: 12.5,
       outputTail: "final tail",
       completedAt: 2000,
-      result: { sessionId: "cc-1", numTurns: 3, totalCostUsd: 0.02 },
+      result: { sessionId: "cc-1", numTurns: 3, inputTokens: 120, outputTokens: 30 },
     });
   });
 
@@ -126,7 +126,7 @@ describe("事件源路径（新内核 delegation.cli.*）", () => {
     expect(list()[0]).toMatchObject({ origin: "events", startedAt: 500, promptExcerpt: "do it" });
   });
 
-  it("原生会话跳过 tool.complete 回退合成", () => {
+  it("原生终态丢失时由 tool.complete 收口，不再永久转圈", () => {
     const { route, list } = makeStore();
     route(ev("delegation.cli.started", { delegation_id: "call-3", agent: "codex", execution: "foreground" }));
     route(
@@ -134,10 +134,55 @@ describe("事件源路径（新内核 delegation.cli.*）", () => {
         tool_id: "call-3",
         name: "terminal",
         args: { command: "codex exec 'x'" },
-        result: { output: "done", exit_code: 0 },
+        result: {
+          output: "workdir: /repo\nmodel: gpt-5.6-sol\ntokens used\n1,024\ndone",
+          exit_code: 0,
+        },
       }),
     );
-    // 回退路径没跑：状态仍是 running（等 delegation.cli.completed）。
+    expect(list()[0]).toMatchObject({
+      status: "completed",
+      origin: "events",
+      workdir: "/repo",
+      result: { model: "gpt-5.6-sol", totalTokens: 1024 },
+    });
+  });
+
+  it("原生 completed 已到达时忽略晚到的 tool.complete", () => {
+    const { route, list } = makeStore();
+    route(ev("delegation.cli.started", { delegation_id: "call-3b", agent: "codex", execution: "foreground" }));
+    route(ev("delegation.cli.completed", {
+      delegation_id: "call-3b",
+      status: "completed",
+      output_tail: "native",
+      result: { total_tokens: 42 },
+    }));
+    route(ev("tool.complete", {
+      tool_id: "call-3b",
+      name: "terminal",
+      args: { command: "codex exec 'x'" },
+      result: { output: "fallback", exit_code: 0 },
+    }));
+    expect(list()[0]).toMatchObject({
+      status: "completed",
+      outputTail: "native",
+      result: { totalTokens: 42 },
+    });
+  });
+
+  it("原生后台的启动 tool.complete 不会提前标记结束", () => {
+    const { route, list } = makeStore();
+    route(ev("delegation.cli.started", {
+      delegation_id: "call-3c",
+      agent: "claude-code",
+      execution: "background",
+    }));
+    route(ev("tool.complete", {
+      tool_id: "call-3c",
+      name: "terminal",
+      args: { command: "claude -p x", background: true },
+      result: { output: "Background process started", session_id: "proc-1", exit_code: 0 },
+    }));
     expect(list()[0]!.status).toBe("running");
   });
 });

--- a/web/src/stores/cli-delegations.ts
+++ b/web/src/stores/cli-delegations.ts
@@ -88,6 +88,33 @@ const appendTimeline = (
   return [...timeline, ...events].slice(-TIMELINE_CAP);
 };
 
+const mergeResult = (
+  base: CliDelegationResult | undefined,
+  patch: CliDelegationResult | undefined,
+): CliDelegationResult | undefined => {
+  if (!patch) return base;
+  const defined = Object.fromEntries(
+    Object.entries(patch).filter(([, value]) => value !== undefined),
+  ) as CliDelegationResult;
+  return { ...(base ?? {}), ...defined };
+};
+
+const resultFromEvents = (
+  events: readonly CliDelegationSubEvent[],
+): CliDelegationResult | undefined => {
+  let result: CliDelegationResult | undefined;
+  for (const event of events) {
+    if (event.kind !== "init" && event.kind !== "result") continue;
+    const {
+      kind: _kind,
+      toolName: _toolName,
+      ...fields
+    } = event;
+    result = mergeResult(result, fields);
+  }
+  return result;
+};
+
 const capList = (list: CliDelegationEntry[]): CliDelegationEntry[] =>
   list.length > MAX_ENTRIES_PER_SESSION ? list.slice(-MAX_ENTRIES_PER_SESSION) : list;
 
@@ -141,10 +168,13 @@ export function applyOutput(
   const wireEvents = Array.isArray(payload.events)
     ? payload.events.map(subEventFromWire).filter((e): e is CliDelegationSubEvent => e !== null)
     : [];
+  const liveResult = resultFromEvents(wireEvents);
   const next: CliDelegationEntry = {
     ...prev,
+    workdir: liveResult?.workdir ?? prev.workdir,
     outputTail: appendTail(prev.outputTail, str(payload.chunk)),
     timeline: appendTimeline(prev.timeline, wireEvents),
+    result: mergeResult(prev.result, liveResult),
     truncated: payload.truncated === true ? true : prev.truncated,
   };
   return list.map((item) => (item.id === id ? next : item));
@@ -161,6 +191,7 @@ export function applyCompleted(
   if (idx < 0) return list;
   const prev = list[idx]!;
   const outputTail = str(payload.output_tail);
+  const completedResult = resultFromWire(payload.result);
   const next: CliDelegationEntry = {
     ...prev,
     status: asStatus(payload.status),
@@ -169,7 +200,8 @@ export function applyCompleted(
     exitCode:
       typeof payload.exit_code === "number" ? payload.exit_code : payload.exit_code === null ? null : prev.exitCode,
     outputTail: outputTail || prev.outputTail,
-    result: resultFromWire(payload.result) ?? prev.result,
+    workdir: completedResult?.workdir ?? prev.workdir,
+    result: mergeResult(prev.result, completedResult),
     timeline:
       prev.timeline.length === 0 && outputTail
         ? timelineFromOutput(prev.agent, outputTail, TIMELINE_CAP)
@@ -220,7 +252,7 @@ export function applyFallbackToolComplete(
   if (!id) return list;
   const idx = list.findIndex((item) => item.id === id);
   const prev = idx >= 0 ? list[idx]! : undefined;
-  if (prev && prev.origin === "events") return list; // 事件源不被回退降级
+  if (prev && TERMINAL_STATUSES.has(prev.status)) return list;
 
   const args = isRecord(payload.args) ? payload.args : undefined;
   const command = args ? str(args.command) : "";
@@ -240,6 +272,9 @@ export function applyFallbackToolComplete(
     (exitCode !== undefined && exitCode !== 0);
 
   const background = Boolean(spec.flags.background);
+  // 新内核后台 tool.complete 只是“进程已启动”，真正终态仍由原生 watcher
+  // 事件给出；仅启动失败时用通用 tool.complete 立即收口。
+  if (prev?.origin === "events" && background && !failed) return list;
   const status: CliDelegationStatus = background
     ? failed
       ? "failed"
@@ -247,25 +282,29 @@ export function applyFallbackToolComplete(
     : failed
       ? "failed"
       : "completed";
+  const extractedResult = background ? undefined : extractResult(spec.agent, output);
+  const parsedTimeline = background ? [] : timelineFromOutput(spec.agent, output, TIMELINE_CAP);
 
   const entry: CliDelegationEntry = {
     id,
     agent: spec.agent,
-    origin: "fallback",
+    origin: prev?.origin ?? "fallback",
     execution: background ? "background" : "foreground",
     status,
     mode: spec.mode,
     promptExcerpt: spec.promptExcerpt || prev?.promptExcerpt || "",
     command,
-    workdir: spec.workdir ?? prev?.workdir ?? null,
+    workdir: extractedResult?.workdir ?? spec.workdir ?? prev?.workdir ?? null,
     flags: spec.flags,
     startedAt: prev?.startedAt ?? now,
     completedAt: background && !failed ? undefined : now,
     durationS: numOrUndef(payload.duration_s),
     exitCode: exitCode ?? null,
-    outputTail: background ? "" : output.slice(-OUTPUT_TAIL_CAP),
-    timeline: background ? [] : timelineFromOutput(spec.agent, output, TIMELINE_CAP),
-    result: background ? undefined : extractResult(spec.agent, output),
+    outputTail: background ? (prev?.outputTail ?? "") : (output.slice(-OUTPUT_TAIL_CAP) || prev?.outputTail || ""),
+    timeline: background
+      ? (prev?.timeline ?? [])
+      : (parsedTimeline.length ? parsedTimeline : (prev?.timeline ?? [])),
+    result: background ? prev?.result : mergeResult(prev?.result, extractedResult),
   };
   return prev ? list.map((item) => (item.id === id ? entry : item)) : capList([...list, entry]);
 }
@@ -292,6 +331,7 @@ export function entryFromHistoryToolPart(part: {
 
   const output = isRecord(part.output) ? str((part.output as Record<string, unknown>).output) : str(part.output);
   const background = Boolean(spec.flags.background);
+  const extractedResult = background || !output ? undefined : extractResult(spec.agent, output);
   const status: CliDelegationStatus =
     part.state === "error" ? "failed" : part.state === "running" ? "running" : background ? "detached" : "completed";
   return {
@@ -303,13 +343,13 @@ export function entryFromHistoryToolPart(part: {
     mode: spec.mode,
     promptExcerpt: spec.promptExcerpt,
     command,
-    workdir: spec.workdir,
+    workdir: extractedResult?.workdir ?? spec.workdir,
     flags: spec.flags,
     startedAt: part.startedAt ?? 0,
     completedAt: part.completedAt,
     outputTail: background ? "" : output.slice(-OUTPUT_TAIL_CAP),
     timeline: background ? [] : timelineFromOutput(spec.agent, output, TIMELINE_CAP),
-    result: background || !output ? undefined : extractResult(spec.agent, output),
+    result: extractedResult,
   };
 }
 
@@ -377,7 +417,7 @@ export const routeCliDelegationGatewayEventAtom = atom(
       return;
     }
 
-    if (nativeCliSessions.has(sid)) return;
+    if (nativeCliSessions.has(sid) && type === "tool.start") return;
     if (type !== "tool.start" && type !== "tool.complete") return;
     if (payload.name !== "terminal") return;
 


### PR DESCRIPTION
## 变更

- 右侧子 Agent 面板实时展示 Codex 与 Claude Code 前台输出
- 原生 tool.complete 到达时收敛运行中任务，修复完成后仍转圈
- 展示编码代理、模型与实际工作目录
- 仅统计 Token，不展示或保存美元费用
- 兼容结构化流式输出与 Codex 人类可读回退输出

## 关联

- Core: Eynzof/Hermes-CN-Core#121

## 验证

- pnpm typecheck 通过
- pnpm test:unit 通过：1066 项
- cargo check 通过
- cargo test --all-features 全部通过
- 真实浏览器链路验证 Codex 与 Claude Code 均在完成前显示实时进度，完成后停止转圈并显示目录、模型与 Token
- Tauri managed runtime 真实启动，9120 与 9545 均可用，停止后端口已释放