### PR TITLE
fix: 重构编程代理页面与委派技能布局

### DIFF
--- a/web/src/routes/settings-coding-agents.test.tsx
+++ b/web/src/routes/settings-coding-agents.test.tsx
@@ -2,7 +2,7 @@ import ReactDOMServer from "react-dom/server";
 import { describe, expect, it } from "vitest";
 
 import type { CodingAgentStatus, SkillInfo } from "@hermes/protocol";
-import { DelegationSkillControl } from "./settings-coding-agents";
+import { CodingAgentToolbar, DelegationSkillControl } from "./settings-coding-agents";
 
 const agent: CodingAgentStatus = {
   id: "codex",
@@ -65,5 +65,23 @@ describe("DelegationSkillControl", () => {
     expect(html).toContain("未找到");
     expect(html).toContain("请升级或重新同步内核技能后再试");
     expect(html).not.toContain("<button");
+  });
+});
+
+describe("CodingAgentToolbar", () => {
+  it("为两个顶部操作使用同一按钮规格", () => {
+    const html = ReactDOMServer.renderToStaticMarkup(
+      <CodingAgentToolbar
+        isFetching={false}
+        hasBridge
+        onRefresh={() => undefined}
+        diagnostics={() => "{}"}
+      />,
+    );
+
+    expect(html).toContain('role="toolbar"');
+    expect(html.match(/data-coding-agent-action="true"/g)).toHaveLength(2);
+    expect(html).toContain("刷新检测");
+    expect(html).toContain("复制诊断 JSON");
   });
 });

--- a/web/src/routes/settings-coding-agents.test.tsx
+++ b/web/src/routes/settings-coding-agents.test.tsx
@@ -1,0 +1,69 @@
+import ReactDOMServer from "react-dom/server";
+import { describe, expect, it } from "vitest";
+
+import type { CodingAgentStatus, SkillInfo } from "@hermes/protocol";
+import { DelegationSkillControl } from "./settings-coding-agents";
+
+const agent: CodingAgentStatus = {
+  id: "codex",
+  label: "Codex",
+  installed: true,
+  version: "codex-cli 0.145.0",
+  path: "/Users/example/.local/bin/codex",
+  loginState: "logged_in",
+  loginDetail: "已通过 ChatGPT 账号登录",
+  configDir: "/Users/example/.codex",
+  skillName: "codex",
+  installHint: "npm install -g @openai/codex",
+  loginHint: "codex login",
+};
+
+function skill(overrides: Partial<SkillInfo> = {}): SkillInfo {
+  return {
+    name: "codex",
+    description: "Delegate coding tasks to Codex",
+    category: "coding",
+    enabled: true,
+    ...overrides,
+  };
+}
+
+describe("DelegationSkillControl", () => {
+  it("将技能名称、状态、说明和操作渲染为独立的委派设置区", () => {
+    const html = ReactDOMServer.renderToStaticMarkup(
+      <DelegationSkillControl
+        agent={agent}
+        skill={skill()}
+        onToggle={() => undefined}
+        pending={false}
+      />,
+    );
+
+    expect(html).toContain('data-delegation-skill="true"');
+    expect(html).toContain('data-state="enabled"');
+    expect(html).toContain('aria-label="Codex 委派技能"');
+    expect(html).toContain("委派技能");
+    expect(html).toContain("codex");
+    expect(html).toContain("已启用");
+    expect(html).toContain("停用技能");
+    expect(html).toContain("Hermes 会通过此技能把编码任务交给 Codex");
+    expect(html).not.toContain("hermes 委派技能「");
+  });
+
+  it("技能缺失时使用完整的告警区域而不是裸提示文字", () => {
+    const html = ReactDOMServer.renderToStaticMarkup(
+      <DelegationSkillControl
+        agent={agent}
+        skill={undefined}
+        onToggle={() => undefined}
+        pending={false}
+      />,
+    );
+
+    expect(html).toContain('data-state="missing"');
+    expect(html).toContain('role="status"');
+    expect(html).toContain("未找到");
+    expect(html).toContain("请升级或重新同步内核技能后再试");
+    expect(html).not.toContain("<button");
+  });
+});

--- a/web/src/routes/settings-coding-agents.tsx
+++ b/web/src/routes/settings-coding-agents.tsx
@@ -76,7 +76,7 @@ function RuntimeField({ label, value, mono, wide }: {
   );
 }
 
-function SkillRow({ agent, skill, onToggle, pending }: {
+export function DelegationSkillControl({ agent, skill, onToggle, pending }: {
   agent: CodingAgentStatus;
   skill: SkillInfo | undefined;
   onToggle: (name: string, enabled: boolean) => void;
@@ -84,22 +84,57 @@ function SkillRow({ agent, skill, onToggle, pending }: {
 }) {
   if (!skill) {
     return (
-      <p className={s.desc}>
-        内核里未找到「{agent.skillName}」技能——内核版本过旧或技能未同步；升级内核后重试。
-      </p>
+      <div
+        className={s.delegationSkillControl}
+        data-delegation-skill="true"
+        data-state="missing"
+        role="status"
+      >
+        <span className={s.delegationSkillIcon} aria-hidden>
+          <AlertTriangle size={15} />
+        </span>
+        <div className={s.delegationSkillBody}>
+          <div className={s.delegationSkillMeta}>
+            <span className={s.delegationSkillEyebrow}>委派技能</span>
+            <span className={s.envStatusTag} data-status="warning">未找到</span>
+          </div>
+          <code className={s.delegationSkillName}>{agent.skillName}</code>
+          <p className={s.delegationSkillDescription}>
+            当前内核未提供此技能。请升级或重新同步内核技能后再试。
+          </p>
+        </div>
+      </div>
     );
   }
+
+  const state = skill.enabled ? "enabled" : "disabled";
   return (
-    <div className={s.envCheckHeader}>
-      <div className={s.envCheckTitle}>
-        <Bot size={13} aria-hidden />
-        <span className={s.envCheckLabel}>hermes 委派技能「{skill.name}」</span>
-        <span className={s.envStatusTag} data-status={skill.enabled ? "ok" : "warning"}>
-          {skill.enabled ? "已启用" : "已停用"}
-        </span>
+    <div
+      className={s.delegationSkillControl}
+      data-delegation-skill="true"
+      data-state={state}
+      role="group"
+      aria-label={`${agent.label} 委派技能`}
+    >
+      <span className={s.delegationSkillIcon} aria-hidden>
+        <Bot size={15} />
+      </span>
+      <div className={s.delegationSkillBody}>
+        <div className={s.delegationSkillMeta}>
+          <span className={s.delegationSkillEyebrow}>委派技能</span>
+          <span className={s.envStatusTag} data-status={skill.enabled ? "ok" : "warning"}>
+            {skill.enabled ? "已启用" : "已停用"}
+          </span>
+        </div>
+        <code className={s.delegationSkillName}>{skill.name}</code>
+        <p className={s.delegationSkillDescription}>
+          {skill.enabled
+            ? `Hermes 会通过此技能把编码任务交给 ${agent.label}。`
+            : `启用后，Hermes 才能把编码任务交给 ${agent.label}。`}
+        </p>
       </div>
       <button
-        className={s.btn}
+        className={[s.btn, s.delegationSkillAction].join(" ")}
         type="button"
         disabled={pending}
         onClick={() => onToggle(skill.name, !skill.enabled)}
@@ -182,7 +217,12 @@ function AgentCard({ agent, skill, onToggle, togglePending, onOpenPath }: {
         ) : null}
       </div>
 
-      <SkillRow agent={agent} skill={skill} onToggle={onToggle} pending={togglePending} />
+      <DelegationSkillControl
+        agent={agent}
+        skill={skill}
+        onToggle={onToggle}
+        pending={togglePending}
+      />
     </section>
   );
 }

--- a/web/src/routes/settings-coding-agents.tsx
+++ b/web/src/routes/settings-coding-agents.tsx
@@ -145,6 +145,41 @@ export function DelegationSkillControl({ agent, skill, onToggle, pending }: {
   );
 }
 
+export function CodingAgentToolbar({ isFetching, hasBridge, onRefresh, diagnostics }: {
+  isFetching: boolean;
+  hasBridge: boolean;
+  onRefresh: () => void;
+  diagnostics: () => string;
+}) {
+  const actionClassName = [s.btn, s.codingAgentToolbarButton].join(" ");
+  return (
+    <div className={s.codingAgentToolbar} role="toolbar" aria-label="编程Agent 操作">
+      <button
+        className={actionClassName}
+        type="button"
+        data-coding-agent-action="true"
+        onClick={onRefresh}
+        disabled={isFetching || !hasBridge}
+      >
+        <RefreshCw
+          className={s.codingAgentRefreshIcon}
+          data-spinning={isFetching ? "true" : undefined}
+          size={13}
+        />
+        {isFetching ? "检测中" : "刷新检测"}
+      </button>
+      <CopyButton
+        className={actionClassName}
+        data-coding-agent-action="true"
+        text={diagnostics}
+      >
+        <Copy size={13} />
+        复制诊断 JSON
+      </CopyButton>
+    </div>
+  );
+}
+
 function AgentCard({ agent, skill, onToggle, togglePending, onOpenPath }: {
   agent: CodingAgentStatus;
   skill: SkillInfo | undefined;
@@ -154,38 +189,39 @@ function AgentCard({ agent, skill, onToggle, togglePending, onOpenPath }: {
 }) {
   const status = agentCardStatus(agent);
   return (
-    <section className={s.debugCard} data-wide="true">
-      <div className={s.debugCardHeader}>
-        <div className={s.debugCardIcon}>
-          <SquareTerminal size={15} />
-        </div>
-        <div>
-          <h3>{agent.label}</h3>
-          <p>{agent.id === "claude-code" ? "Anthropic 自主编程Agent CLI" : "OpenAI 自主编程Agent CLI"}</p>
-        </div>
-      </div>
-
-      <div className={s.envCheckItem} data-status={status}>
-        <div className={s.envCheckHeader}>
-          <div className={s.envCheckTitle}>
-            <span className={s.envCheckIcon} data-status={status}>
-              <StatusIcon status={status} />
-            </span>
-            <span className={s.envCheckLabel}>{agent.installed ? "已安装" : "未安装"}</span>
-            {agent.installed ? (
-              <span className={s.envStatusTag} data-status={agent.loginState === "logged_in" ? "ok" : status}>
-                <KeyRound size={11} aria-hidden /> {LOGIN_LABELS[agent.loginState]}
-              </span>
-            ) : null}
+    <section className={s.codingAgentCard} data-coding-agent-card="true">
+      <header className={s.codingAgentCardHeader}>
+        <div className={s.codingAgentIdentity}>
+          <div className={s.debugCardIcon}>
+            <SquareTerminal size={15} />
+          </div>
+          <div className={s.codingAgentIdentityText}>
+            <h3>{agent.label}</h3>
+            <p>{agent.id === "claude-code" ? "Anthropic 自主编程Agent CLI" : "OpenAI 自主编程Agent CLI"}</p>
           </div>
         </div>
+        <div className={s.codingAgentStatusGroup} aria-label={`${agent.label} 当前状态`}>
+          <span className={s.envStatusTag} data-status={status}>
+            <StatusIcon status={status} />
+            {agent.installed ? "已安装" : "未安装"}
+          </span>
+          {agent.installed ? (
+            <span className={s.envStatusTag} data-status={agent.loginState === "logged_in" ? "ok" : status}>
+              <KeyRound size={11} aria-hidden />
+              {LOGIN_LABELS[agent.loginState]}
+            </span>
+          ) : null}
+        </div>
+      </header>
+
+      <div className={[s.envCheckItem, s.codingAgentDetails].join(" ")} data-status={status}>
         <p className={s.envCheckSummary} data-status={status}>{agentStatusLine(agent)}</p>
 
-        <div className={[s.runtimeGrid, s.envCheckDetails].join(" ")}>
-          {agent.installed && agent.version ? <RuntimeField label="版本" value={agent.version} mono wide /> : null}
+        <div className={[s.runtimeGrid, s.envCheckDetails, s.codingAgentRuntimeGrid].join(" ")}>
+          {agent.installed && agent.version ? <RuntimeField label="版本" value={agent.version} mono /> : null}
+          {agent.loginDetail ? <RuntimeField label="登录状态" value={agent.loginDetail} /> : null}
           {agent.installed && agent.path ? <RuntimeField label="路径" value={agent.path} mono wide /> : null}
           <RuntimeField label="配置目录" value={agent.configDir} mono wide />
-          {agent.loginDetail ? <RuntimeField label="登录状态" value={agent.loginDetail} wide /> : null}
           {!agent.installed ? (
             <RuntimeField
               label="安装"
@@ -255,9 +291,12 @@ export function CodingAgentsSection({ showHeading = true }: { showHeading?: bool
     JSON.stringify({ generatedAt: new Date().toISOString(), codingAgents: data ?? null }, null, 2);
 
   return (
-    <div>
+    <div className={s.codingAgentsPage}>
       {showHeading && <h2 className={s.heading}>编程Agent</h2>}
-      <div className={s.aboutHero} data-ok={allReady && data ? "true" : undefined}>
+      <div
+        className={[s.aboutHero, s.codingAgentsHero].join(" ")}
+        data-ok={allReady && data ? "true" : undefined}
+      >
         <div className={s.aboutHeroMark}>
           <SquareTerminal size={24} />
         </div>
@@ -266,12 +305,12 @@ export function CodingAgentsSection({ showHeading = true }: { showHeading?: bool
           <h3>
             {data
               ? allReady
-                ? "编程Agent 就绪，hermes 可以调度它们干活"
+                ? "编程Agent 就绪，Hermes 可以调度它们干活"
                 : "部分编程Agent 未就绪"
               : "正在检测编程Agent"}
           </h3>
           <p>
-            hermes 可以通过内置技能把编码任务委派给本机的 Claude Code 与 Codex CLI，
+            Hermes 可以通过内置技能把编码任务委派给本机的 Claude Code 与 Codex CLI，
             聊天中会以「委派卡片」实时展示它们的执行过程；侧栏「子Agent」面板可总览全部委派。
             本页只做检测与指引，不会改写 CLI 自身的配置文件（多账号/中转切换请使用 cc-switch）。
           </p>
@@ -284,21 +323,12 @@ export function CodingAgentsSection({ showHeading = true }: { showHeading?: bool
         </span>
       </div>
 
-      <div className={s.debugActionBar}>
-        <button
-          className={s.btn}
-          type="button"
-          onClick={() => void query.refetch()}
-          disabled={query.isFetching || !hasBridge}
-        >
-          <RefreshCw size={13} />
-          {query.isFetching ? "检测中" : "刷新检测"}
-        </button>
-        <CopyButton className={s.btn} text={diagnostics}>
-          <Copy size={13} />
-          复制诊断 JSON
-        </CopyButton>
-      </div>
+      <CodingAgentToolbar
+        isFetching={query.isFetching}
+        hasBridge={hasBridge}
+        onRefresh={() => void query.refetch()}
+        diagnostics={diagnostics}
+      />
 
       {!hasBridge && (
         <div className={s.runtimeMessage} data-tone="error">
@@ -312,7 +342,7 @@ export function CodingAgentsSection({ showHeading = true }: { showHeading?: bool
       )}
 
       {data && (
-        <div className={s.aboutDebugGrid}>
+        <div className={s.codingAgentList}>
           {data.agents.map((agent) => (
             <AgentCard
               key={agent.id}

--- a/web/src/routes/settings.module.css
+++ b/web/src/routes/settings.module.css
@@ -934,6 +934,113 @@
   margin: 12px 0 18px;
 }
 
+.codingAgentsPage {
+  width: 100%;
+  max-width: 1180px;
+  margin: 0 auto;
+}
+
+.codingAgentsHero {
+  margin-bottom: 0;
+  padding: 16px 18px;
+}
+
+.codingAgentToolbar {
+  display: grid;
+  grid-template-columns: repeat(2, 140px);
+  gap: 10px;
+  margin: 12px 0 16px;
+}
+
+.codingAgentToolbarButton {
+  box-sizing: border-box;
+  width: 140px;
+  min-height: 34px;
+  padding: 7px 12px;
+  white-space: nowrap;
+}
+
+.codingAgentRefreshIcon[data-spinning="true"] {
+  animation: hermesButtonSpin 0.9s linear infinite;
+}
+
+.codingAgentList {
+  display: grid;
+  gap: 16px;
+}
+
+.codingAgentCard {
+  min-width: 0;
+  padding: 16px;
+  border: 1px solid var(--h-line);
+  border-radius: 14px;
+  background: var(--h-bg-app);
+}
+
+.codingAgentCardHeader {
+  display: flex;
+  gap: 16px;
+  align-items: center;
+  justify-content: space-between;
+  min-width: 0;
+  margin-bottom: 12px;
+}
+
+.codingAgentIdentity {
+  display: flex;
+  gap: 10px;
+  align-items: center;
+  min-width: 0;
+}
+
+.codingAgentIdentityText {
+  min-width: 0;
+}
+
+.codingAgentIdentityText h3 {
+  margin: 0;
+  color: var(--h-text);
+  font-size: 13px;
+  font-weight: 650;
+}
+
+.codingAgentIdentityText p {
+  margin: 3px 0 0;
+  overflow: hidden;
+  color: var(--h-text-3);
+  font-size: 11.5px;
+  line-height: 1.45;
+  text-overflow: ellipsis;
+  white-space: nowrap;
+}
+
+.codingAgentStatusGroup {
+  display: flex;
+  flex: 0 0 auto;
+  flex-wrap: wrap;
+  gap: 7px;
+  align-items: center;
+  justify-content: flex-end;
+}
+
+.codingAgentStatusGroup .envStatusTag {
+  gap: 5px;
+}
+
+.codingAgentDetails {
+  gap: 10px;
+  padding: 13px 14px;
+}
+
+.codingAgentRuntimeGrid {
+  grid-template-columns: repeat(2, minmax(0, 1fr));
+  gap: 10px 18px;
+}
+
+.codingAgentCard .delegationSkillControl {
+  margin-top: 12px;
+}
+
 .debugHeroActions {
   display: flex;
   flex-direction: column;
@@ -2805,6 +2912,29 @@ button.providerWebsiteButton:hover {
   .debugHeroActions {
     grid-column: 1 / -1;
     align-items: flex-start;
+  }
+
+  .codingAgentToolbar {
+    grid-template-columns: repeat(2, minmax(0, 1fr));
+  }
+
+  .codingAgentToolbarButton {
+    width: 100%;
+    min-width: 0;
+  }
+
+  .codingAgentCardHeader {
+    align-items: flex-start;
+    flex-direction: column;
+    gap: 10px;
+  }
+
+  .codingAgentStatusGroup {
+    justify-content: flex-start;
+  }
+
+  .codingAgentRuntimeGrid {
+    grid-template-columns: minmax(0, 1fr);
   }
 
   .delegationSkillControl {

--- a/web/src/routes/settings.module.css
+++ b/web/src/routes/settings.module.css
@@ -1510,6 +1510,96 @@
   margin-top: 0;
 }
 
+.delegationSkillControl {
+  display: grid;
+  grid-template-columns: 32px minmax(0, 1fr) auto;
+  gap: 11px;
+  align-items: center;
+  min-width: 0;
+  margin-top: 14px;
+  padding: 12px 14px;
+  border: 1px solid var(--h-line-soft);
+  border-radius: 10px;
+  background: var(--h-bg-pane);
+}
+
+.delegationSkillControl[data-state="enabled"] {
+  border-color: color-mix(in srgb, var(--h-ok) 24%, var(--h-line-soft));
+  background: color-mix(in srgb, var(--h-ok-soft) 28%, var(--h-bg-pane));
+}
+
+.delegationSkillControl[data-state="missing"] {
+  border-color: color-mix(in srgb, var(--h-warn) 28%, var(--h-line-soft));
+  background: color-mix(in srgb, var(--h-warn-soft) 22%, var(--h-bg-pane));
+}
+
+.delegationSkillIcon {
+  display: inline-flex;
+  width: 32px;
+  height: 32px;
+  align-items: center;
+  justify-content: center;
+  border-radius: 9px;
+  color: var(--h-text-2);
+  background: var(--h-bg-chip);
+}
+
+.delegationSkillControl[data-state="enabled"] .delegationSkillIcon {
+  color: var(--h-ok);
+  background: var(--h-ok-soft);
+}
+
+.delegationSkillControl[data-state="missing"] .delegationSkillIcon {
+  color: var(--h-warn);
+  background: var(--h-warn-soft);
+}
+
+.delegationSkillBody {
+  min-width: 0;
+}
+
+.delegationSkillMeta {
+  display: flex;
+  flex-wrap: wrap;
+  gap: 7px;
+  align-items: center;
+  min-width: 0;
+}
+
+.delegationSkillEyebrow {
+  color: var(--h-text-3);
+  font-size: 10.5px;
+  font-weight: 600;
+  letter-spacing: 0.04em;
+}
+
+.delegationSkillName {
+  display: block;
+  min-width: 0;
+  margin-top: 3px;
+  overflow: hidden;
+  color: var(--h-text);
+  font-family: var(--h-font-mono);
+  font-size: 12px;
+  font-weight: 600;
+  line-height: 1.5;
+  text-overflow: ellipsis;
+  white-space: nowrap;
+}
+
+.delegationSkillDescription {
+  margin: 2px 0 0;
+  color: var(--h-text-3);
+  font-size: 11px;
+  line-height: 1.5;
+}
+
+.delegationSkillAction {
+  min-width: 88px;
+  flex: 0 0 auto;
+  white-space: nowrap;
+}
+
 .commitList {
   display: grid;
   gap: 8px;
@@ -2715,6 +2805,16 @@ button.providerWebsiteButton:hover {
   .debugHeroActions {
     grid-column: 1 / -1;
     align-items: flex-start;
+  }
+
+  .delegationSkillControl {
+    grid-template-columns: 32px minmax(0, 1fr);
+    align-items: start;
+  }
+
+  .delegationSkillAction {
+    grid-column: 2;
+    justify-self: start;
   }
 
   .contactLayout {


### PR DESCRIPTION
## 变更

- 将 Coding Agent 卡片底部的委派技能横条重构为独立设置区
- 统一“刷新检测”和“复制诊断 JSON”两个顶部操作按钮的宽度与高度
- 为页面主体设置合理最大宽度，避免大屏下卡片被无限拉长
- 重组 Agent 卡片的信息层级：身份与状态位于卡片头部，版本与登录状态同排，路径信息保持完整宽度
- 增加窄窗口响应式布局，避免按钮、状态徽标和路径操作溢出
- 为启用、停用和技能缺失状态补充视觉语义
- 新增组件级回归测试，锁定委派设置区与顶部操作区结构

## 根因

页面此前大量复用通用调试卡片与环境检测标题样式：顶部按钮依内容自然撑开，Agent 卡片没有专属宽度、层级与响应式规则，委派技能区也缺少自己的容器，导致按钮尺寸不一致、大屏信息过散、窄屏内容挤压。

## 验证

- `pnpm typecheck`
- `pnpm test:unit`（Protocol 66 项；Web 112 个测试文件、1022 项）
- `cargo check`
- 独立 Vite 预览 + Playwright 视觉验证
  - 1600px：两个操作按钮均为 140×37；两张 Agent 卡片均为 1180×430
  - 760px：两个操作按钮均为 227×37；卡片切换为单列且无溢出