### PR TITLE
feat: 支持浏览器伴生模式

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -1984,6 +1984,7 @@ name = "hermes-agent-cn-desktop"
 version = "0.7.0"
 dependencies = [
  "base64 0.22.1",
+ "bytes",
  "cookie",
  "dirs",
  "dotenvy",
@@ -1992,6 +1993,9 @@ dependencies = [
  "fs2",
  "futures-util",
  "getrandom 0.3.4",
+ "http-body-util",
+ "hyper",
+ "hyper-util",
  "libc",
  "log",
  "notify",

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -46,6 +46,11 @@ open = "5"
 # debounces before re-reading.
 notify = "6"
 futures-util = "0.3"
+# Loopback-only HTTP/WebSocket server used by the browser companion mode.
+bytes = "1"
+http-body-util = "0.1"
+hyper = { version = "1", features = ["http1", "server"] }
+hyper-util = { version = "0.1", features = ["tokio"] }
 # WebSocket relay to the runtime's native /api/ws (commands/ws_proxy.rs).
 # The relay also carries remote-mode connections (src/connection.rs), which
 # may be wss://, so a rustls backend is required.

--- a/src/commands/api_proxy.rs
+++ b/src/commands/api_proxy.rs
@@ -595,13 +595,13 @@ async fn api_request_impl_inner(
     })
 }
 
-/// The main API proxy command. Handles local route intercepts and proxies
-/// to the dashboard for everything else.
-#[tauri::command]
-pub async fn api_request(
-    app: tauri::AppHandle,
+/// Shared desktop proxy path used by both Tauri IPC and the loopback browser
+/// companion. Keeping it here preserves local archive/session-log intercepts,
+/// OAuth cookies and token-refresh behavior for both renderers.
+pub async fn api_request_from_state(
+    app: &tauri::AppHandle,
     input: ApiRequestInput,
-    state: State<'_, AppState>,
+    state: &AppState,
 ) -> Result<ApiRequestResult, AppError> {
     let (api_base_url, auth, hermes_home, hermes_home_base, mode) = {
         let inner = state.inner.lock()?;
@@ -646,7 +646,7 @@ pub async fn api_request(
             crate::oauth_session::persist_if_dirty(&api_base_url, session);
         }
         if result.status == 401 && is_auth_expired_body(&result.body) {
-            emit_auth_expired(&app, &state, &api_base_url, &result.body);
+            emit_auth_expired(app, state, &api_base_url, &result.body);
         }
         return Ok(result);
     }
@@ -703,6 +703,17 @@ pub async fn api_request(
     .await
 }
 
+/// The main API proxy command. Handles local route intercepts and proxies
+/// to the dashboard for everything else.
+#[tauri::command]
+pub async fn api_request(
+    app: tauri::AppHandle,
+    input: ApiRequestInput,
+    state: State<'_, AppState>,
+) -> Result<ApiRequestResult, AppError> {
+    api_request_from_state(&app, input, &state).await
+}
+
 /// True when a 401 body carries the gated-auth envelope signalling the remote
 /// session is dead (needs re-login), vs a generic loopback `{detail:...}` 401.
 fn is_auth_expired_body(body: &str) -> bool {
@@ -718,12 +729,7 @@ fn is_auth_expired_body(body: &str) -> bool {
 
 /// Emit `connection-auth-expired` to the frontend so it can surface the
 /// re-login banner. Debounced to 5s (a burst of 401s must not storm the UI).
-fn emit_auth_expired(
-    app: &tauri::AppHandle,
-    state: &State<'_, AppState>,
-    base_url: &str,
-    body: &str,
-) {
+fn emit_auth_expired(app: &tauri::AppHandle, state: &AppState, base_url: &str, body: &str) {
     use tauri::Emitter;
     {
         let mut inner = match state.inner.lock() {

--- a/src/commands/browser_companion.rs
+++ b/src/commands/browser_companion.rs
@@ -1,0 +1,783 @@
+//! Loopback browser companion for the packaged desktop UI.
+//!
+//! The browser never receives the Core dashboard token or OAuth cookies. It
+//! authenticates to this process with a separate process-lifetime bearer token;
+//! Rust then forwards REST and the official `/api/ws` protocol using the live
+//! desktop connection state.
+
+use std::convert::Infallible;
+use std::net::Ipv4Addr;
+use std::sync::LazyLock;
+use std::time::Duration;
+
+use base64::engine::general_purpose::URL_SAFE_NO_PAD;
+use base64::Engine;
+use bytes::Bytes;
+use futures_util::{SinkExt, StreamExt};
+use http_body_util::{BodyExt, Full};
+use hyper::body::Incoming;
+use hyper::header::{
+    HeaderName, HeaderValue, ACCESS_CONTROL_ALLOW_HEADERS, ACCESS_CONTROL_ALLOW_METHODS,
+    ACCESS_CONTROL_ALLOW_ORIGIN, AUTHORIZATION, CACHE_CONTROL, CONNECTION, CONTENT_SECURITY_POLICY,
+    CONTENT_TYPE, HOST, ORIGIN, SEC_WEBSOCKET_ACCEPT, SEC_WEBSOCKET_KEY, SEC_WEBSOCKET_VERSION,
+    UPGRADE, VARY,
+};
+use hyper::server::conn::http1;
+use hyper::service::service_fn;
+use hyper::{Method, Request, Response, StatusCode};
+use hyper_util::rt::TokioIo;
+use serde::Serialize;
+use tauri::Manager;
+use tokio::net::TcpListener;
+use tokio_tungstenite::tungstenite::handshake::derive_accept_key;
+use tokio_tungstenite::tungstenite::protocol::{CloseFrame, Role};
+use tokio_tungstenite::tungstenite::{Message, Utf8Bytes};
+use tokio_tungstenite::WebSocketStream;
+
+use crate::commands::api_proxy::{api_request_from_state, ApiRequestInput};
+use crate::commands::ws_proxy::connect_gateway_stream;
+use crate::error::AppError;
+use crate::state::{AppState, BrowserCompanionHandle, DashboardAuth};
+
+const PREFERRED_PORT: u16 = 9546;
+const MAX_REQUEST_BYTES: u64 = 100 * 1024 * 1024;
+const COMPANION_TOKEN_HEADER: &str = "x-hermes-browser-token";
+
+type CompanionBody = Full<Bytes>;
+
+static PROXY_HTTP_CLIENT: LazyLock<reqwest::Client> = LazyLock::new(|| {
+    reqwest::Client::builder()
+        .timeout(Duration::from_secs(180))
+        .redirect(reqwest::redirect::Policy::none())
+        .build()
+        .expect("valid browser companion HTTP client")
+});
+
+#[derive(Debug, Serialize)]
+#[serde(rename_all = "camelCase")]
+pub struct OpenBrowserCompanionResult {
+    pub ok: bool,
+    pub url: String,
+    pub port: u16,
+}
+
+#[derive(Debug, Serialize)]
+#[serde(rename_all = "camelCase")]
+struct BrowserRuntimeConfig {
+    platform: &'static str,
+    api_base_url: String,
+    gateway_url: String,
+    session_token: String,
+    current_profile: String,
+    connection_mode: String,
+    backend_ready: bool,
+    guide_state: String,
+    managed_runtime_desired_state: String,
+    managed_runtime_lifecycle_state: String,
+    portable: bool,
+    browser_companion: bool,
+}
+
+#[tauri::command]
+pub async fn open_browser_companion(
+    app: tauri::AppHandle,
+) -> Result<OpenBrowserCompanionResult, AppError> {
+    let existing = {
+        let state = app.state::<AppState>();
+        let existing = state.inner.lock()?.browser_companion.clone();
+        existing
+    };
+
+    let handle = match existing {
+        Some(handle) => handle,
+        None => start_companion_server(&app).await?,
+    };
+
+    let companion_origin = format!("http://127.0.0.1:{}", handle.port);
+    // In `tauri dev` the frontend assets are intentionally not embedded. Use
+    // the live Vite page there, while keeping API/WS on the companion origin.
+    // Debug bundles and release builds have web/dist and stay same-origin.
+    let page_origin = if cfg!(dev) {
+        "http://localhost:9545".to_string()
+    } else {
+        companion_origin.clone()
+    };
+    let launch_url = format!(
+        "{}/#hermes-browser-origin={}&hermes-browser-token={}",
+        page_origin.trim_end_matches('/'),
+        urlencoding::encode(&companion_origin),
+        urlencoding::encode(&handle.token),
+    );
+
+    open::that(&launch_url)
+        .map_err(|error| AppError::Internal(format!("无法打开系统浏览器: {error}")))?;
+
+    Ok(OpenBrowserCompanionResult {
+        ok: true,
+        url: page_origin,
+        port: handle.port,
+    })
+}
+
+async fn start_companion_server(
+    app: &tauri::AppHandle,
+) -> Result<BrowserCompanionHandle, AppError> {
+    let listener = match TcpListener::bind((Ipv4Addr::LOCALHOST, PREFERRED_PORT)).await {
+        Ok(listener) => listener,
+        Err(_) => TcpListener::bind((Ipv4Addr::LOCALHOST, 0))
+            .await
+            .map_err(|error| {
+                AppError::Internal(format!("浏览器伴生服务无法监听本机端口: {error}"))
+            })?,
+    };
+    let port = listener
+        .local_addr()
+        .map_err(|error| AppError::Internal(format!("无法读取浏览器伴生端口: {error}")))?
+        .port();
+    let token = generate_companion_token()?;
+    let handle = BrowserCompanionHandle { port, token };
+
+    {
+        let state = app.state::<AppState>();
+        state.inner.lock()?.browser_companion = Some(handle.clone());
+    }
+
+    let server_app = app.clone();
+    let server_token = handle.token.clone();
+    tauri::async_runtime::spawn(async move {
+        if let Err(error) = serve(listener, server_app, server_token, port).await {
+            log::error!("Browser companion server stopped: {error}");
+        }
+    });
+
+    Ok(handle)
+}
+
+fn generate_companion_token() -> Result<String, AppError> {
+    let mut bytes = [0u8; 32];
+    getrandom::fill(&mut bytes)
+        .map_err(|error| AppError::Internal(format!("无法生成浏览器伴生令牌: {error}")))?;
+    Ok(URL_SAFE_NO_PAD.encode(bytes))
+}
+
+async fn serve(
+    listener: TcpListener,
+    app: tauri::AppHandle,
+    token: String,
+    port: u16,
+) -> Result<(), AppError> {
+    loop {
+        let (stream, _) = listener
+            .accept()
+            .await
+            .map_err(|error| AppError::Internal(format!("浏览器伴生连接失败: {error}")))?;
+        let io = TokioIo::new(stream);
+        let request_app = app.clone();
+        let request_token = token.clone();
+        tauri::async_runtime::spawn(async move {
+            let service = service_fn(move |request| {
+                let app = request_app.clone();
+                let token = request_token.clone();
+                async move { handle_request(request, app, token, port).await }
+            });
+            if let Err(error) = http1::Builder::new()
+                .serve_connection(io, service)
+                .with_upgrades()
+                .await
+            {
+                log::debug!("Browser companion connection ended: {error}");
+            }
+        });
+    }
+}
+
+async fn handle_request(
+    mut request: Request<Incoming>,
+    app: tauri::AppHandle,
+    token: String,
+    port: u16,
+) -> Result<Response<CompanionBody>, Infallible> {
+    if !valid_host(request.headers().get(HOST), port) {
+        return Ok(text_response(StatusCode::FORBIDDEN, "Forbidden host"));
+    }
+
+    let cors_origin = request
+        .headers()
+        .get(ORIGIN)
+        .and_then(|value| value.to_str().ok())
+        .filter(|origin| is_loopback_origin(origin))
+        .and_then(|origin| HeaderValue::from_str(origin).ok());
+    if request.headers().contains_key(ORIGIN) && cors_origin.is_none() {
+        return Ok(text_response(StatusCode::FORBIDDEN, "Forbidden origin"));
+    }
+
+    if request.method() == Method::OPTIONS {
+        return Ok(with_cors(
+            empty_response(StatusCode::NO_CONTENT),
+            cors_origin.as_ref(),
+        ));
+    }
+
+    let path = request.uri().path().to_string();
+    if path == "/api/ws" {
+        if !has_companion_token(&request, &token) {
+            return Ok(with_cors(
+                text_response(StatusCode::UNAUTHORIZED, "Unauthorized"),
+                cors_origin.as_ref(),
+            ));
+        }
+        return Ok(websocket_upgrade(&mut request, app));
+    }
+
+    if path == "/__hermes_runtime" {
+        if !has_companion_token(&request, &token) {
+            return Ok(with_cors(
+                text_response(StatusCode::UNAUTHORIZED, "Unauthorized"),
+                cors_origin.as_ref(),
+            ));
+        }
+        let response = match runtime_config_response(&app, &token, port) {
+            Ok(response) => response,
+            Err(error) => text_response(StatusCode::INTERNAL_SERVER_ERROR, &error.to_string()),
+        };
+        return Ok(with_cors(response, cors_origin.as_ref()));
+    }
+
+    if path.starts_with("/api/") || path.starts_with("/__hermes_") {
+        if !has_companion_token(&request, &token) {
+            return Ok(with_cors(
+                text_response(StatusCode::UNAUTHORIZED, "Unauthorized"),
+                cors_origin.as_ref(),
+            ));
+        }
+        let response = if path == "/api/upload" {
+            proxy_http(request, &app).await
+        } else {
+            proxy_desktop_api(request, &app).await
+        };
+        return Ok(with_cors(response, cors_origin.as_ref()));
+    }
+
+    Ok(serve_asset(&app, &path))
+}
+
+async fn proxy_desktop_api(
+    request: Request<Incoming>,
+    app: &tauri::AppHandle,
+) -> Response<CompanionBody> {
+    let method = request.method().as_str().to_string();
+    let path = request
+        .uri()
+        .path_and_query()
+        .map(|value| value.as_str())
+        .unwrap_or("/")
+        .to_string();
+    let headers = request
+        .headers()
+        .iter()
+        .filter(|(name, _)| should_forward_request_header(name.as_str()))
+        .filter_map(|(name, value)| {
+            value
+                .to_str()
+                .ok()
+                .map(|value| (name.as_str().to_string(), value.to_string()))
+        })
+        .collect();
+    let body = match request
+        .into_body()
+        .collect()
+        .await
+        .map(|collected| collected.to_bytes())
+    {
+        Ok(body) if body.len() as u64 <= MAX_REQUEST_BYTES => body,
+        Ok(_) => return text_response(StatusCode::PAYLOAD_TOO_LARGE, "Request body too large"),
+        Err(error) => return text_response(StatusCode::BAD_REQUEST, &error.to_string()),
+    };
+    let body = if body.is_empty() {
+        None
+    } else {
+        match String::from_utf8(body.to_vec()) {
+            Ok(body) => Some(body),
+            Err(_) => return text_response(StatusCode::BAD_REQUEST, "Request body must be UTF-8"),
+        }
+    };
+    let state = app.state::<AppState>();
+    let result = match api_request_from_state(
+        app,
+        ApiRequestInput {
+            path,
+            method: Some(method),
+            headers: Some(headers),
+            body,
+        },
+        &state,
+    )
+    .await
+    {
+        Ok(result) => result,
+        Err(error) => return text_response(StatusCode::BAD_GATEWAY, &error.to_string()),
+    };
+
+    let mut response = Response::new(Full::new(Bytes::from(result.body)));
+    *response.status_mut() =
+        StatusCode::from_u16(result.status).unwrap_or(StatusCode::INTERNAL_SERVER_ERROR);
+    for (name, value) in result.headers {
+        if !should_forward_response_header(&name) {
+            continue;
+        }
+        let Ok(name) = HeaderName::from_bytes(name.as_bytes()) else {
+            continue;
+        };
+        let Ok(value) = HeaderValue::from_str(&value) else {
+            continue;
+        };
+        response.headers_mut().append(name, value);
+    }
+    response
+}
+
+fn valid_host(value: Option<&HeaderValue>, port: u16) -> bool {
+    let Some(host) = value.and_then(|value| value.to_str().ok()) else {
+        return false;
+    };
+    host == format!("127.0.0.1:{port}") || host == format!("localhost:{port}")
+}
+
+fn is_loopback_origin(origin: &str) -> bool {
+    let Ok(url) = url::Url::parse(origin) else {
+        return false;
+    };
+    if url.scheme() != "http" {
+        return false;
+    }
+    match url.host_str() {
+        Some("localhost") => true,
+        Some(host) => host
+            .parse::<std::net::IpAddr>()
+            .is_ok_and(|ip| ip.is_loopback()),
+        None => false,
+    }
+}
+
+fn has_companion_token(request: &Request<Incoming>, expected: &str) -> bool {
+    let bearer = request
+        .headers()
+        .get(AUTHORIZATION)
+        .and_then(|value| value.to_str().ok())
+        .and_then(|value| value.strip_prefix("Bearer "));
+    let explicit = request
+        .headers()
+        .get(COMPANION_TOKEN_HEADER)
+        .and_then(|value| value.to_str().ok());
+    let query = request.uri().query().and_then(|query| {
+        url::form_urlencoded::parse(query.as_bytes())
+            .find(|(key, _)| key == "token")
+            .map(|(_, value)| value.into_owned())
+    });
+    bearer == Some(expected) || explicit == Some(expected) || query.as_deref() == Some(expected)
+}
+
+fn runtime_config_response(
+    app: &tauri::AppHandle,
+    token: &str,
+    port: u16,
+) -> Result<Response<CompanionBody>, AppError> {
+    let state = app.state::<AppState>();
+    let inner = state.inner.lock()?;
+    let control = crate::desktop_control::read();
+    let installed = crate::process::runtime::read_current_record().is_some();
+    let managed_running = inner.connection_mode == crate::connection::ConnectionMode::Managed
+        && inner
+            .dashboard_handle
+            .as_ref()
+            .is_some_and(|handle| handle.owns_process);
+    let lifecycle =
+        crate::desktop_control::managed_runtime_lifecycle_state(installed, managed_running);
+    let origin = format!("http://127.0.0.1:{port}");
+    let payload = BrowserRuntimeConfig {
+        platform: "web",
+        api_base_url: origin.clone(),
+        gateway_url: format!(
+            "ws://127.0.0.1:{port}/api/ws?token={}",
+            urlencoding::encode(token)
+        ),
+        session_token: token.to_string(),
+        current_profile: inner.current_profile.clone(),
+        connection_mode: inner.connection_mode.as_str().to_string(),
+        backend_ready: inner.dashboard_handle.is_some() && !inner.api_base_url.trim().is_empty(),
+        guide_state: control.guide_state.as_str().to_string(),
+        managed_runtime_desired_state: control.managed_runtime_desired_state.as_str().to_string(),
+        managed_runtime_lifecycle_state: lifecycle.to_string(),
+        portable: crate::process::runtime::portable_mode_active(),
+        browser_companion: true,
+    };
+    json_response(StatusCode::OK, &payload)
+}
+
+async fn proxy_http(request: Request<Incoming>, app: &tauri::AppHandle) -> Response<CompanionBody> {
+    let (base_url, auth) = {
+        let state = app.state::<AppState>();
+        let inner = match state.inner.lock() {
+            Ok(inner) => inner,
+            Err(error) => {
+                return text_response(StatusCode::INTERNAL_SERVER_ERROR, &error.to_string())
+            }
+        };
+        (inner.api_base_url.clone(), inner.dashboard_auth())
+    };
+    if base_url.trim().is_empty() {
+        return text_response(StatusCode::SERVICE_UNAVAILABLE, "Hermes Core 尚未就绪");
+    }
+
+    let method = match reqwest::Method::from_bytes(request.method().as_str().as_bytes()) {
+        Ok(method) => method,
+        Err(_) => return text_response(StatusCode::BAD_REQUEST, "Unsupported method"),
+    };
+    let path = request
+        .uri()
+        .path_and_query()
+        .map(|value| value.as_str())
+        .unwrap_or("/")
+        .to_string();
+    let target = format!("{}{}", base_url.trim_end_matches('/'), path);
+    let request_headers = request.headers().clone();
+    let body = match request
+        .into_body()
+        .collect()
+        .await
+        .map(|collected| collected.to_bytes())
+    {
+        Ok(body) if body.len() as u64 <= MAX_REQUEST_BYTES => body,
+        Ok(_) => return text_response(StatusCode::PAYLOAD_TOO_LARGE, "Request body too large"),
+        Err(error) => return text_response(StatusCode::BAD_REQUEST, &error.to_string()),
+    };
+
+    let mut upstream = match &auth {
+        DashboardAuth::Token(_) => PROXY_HTTP_CLIENT.request(method, &target),
+        DashboardAuth::Oauth(session) => session.client().request(method, &target),
+    };
+    if let DashboardAuth::Token(Some(real_token)) = &auth {
+        upstream = upstream
+            .header(AUTHORIZATION.as_str(), format!("Bearer {real_token}"))
+            .header("x-hermes-session-token", real_token);
+    }
+    for (name, value) in &request_headers {
+        if should_forward_request_header(name.as_str()) {
+            upstream = upstream.header(name.as_str(), value.as_bytes());
+        }
+    }
+    if !body.is_empty() {
+        upstream = upstream.body(body);
+    }
+
+    let result = match upstream.send().await {
+        Ok(result) => result,
+        Err(error) => return text_response(StatusCode::BAD_GATEWAY, &error.to_string()),
+    };
+    if let DashboardAuth::Oauth(session) = &auth {
+        if session.take_dirty() {
+            crate::oauth_session::persist_if_dirty(&base_url, session);
+        }
+    }
+
+    let status = result.status();
+    let headers = result.headers().clone();
+    let body = match result.bytes().await {
+        Ok(body) => body,
+        Err(error) => return text_response(StatusCode::BAD_GATEWAY, &error.to_string()),
+    };
+    let mut response = Response::new(Full::new(body));
+    *response.status_mut() = status;
+    for (name, value) in &headers {
+        if should_forward_response_header(name.as_str()) {
+            response.headers_mut().append(name.clone(), value.clone());
+        }
+    }
+    response
+}
+
+fn should_forward_request_header(name: &str) -> bool {
+    !matches!(
+        name.to_ascii_lowercase().as_str(),
+        "authorization"
+            | "x-hermes-session-token"
+            | COMPANION_TOKEN_HEADER
+            | "host"
+            | "content-length"
+            | "connection"
+            | "origin"
+            | "accept-encoding"
+            | "upgrade"
+    )
+}
+
+fn should_forward_response_header(name: &str) -> bool {
+    !matches!(
+        name.to_ascii_lowercase().as_str(),
+        "content-length"
+            | "connection"
+            | "transfer-encoding"
+            | "set-cookie"
+            | "access-control-allow-origin"
+            | "access-control-allow-headers"
+            | "access-control-allow-methods"
+    )
+}
+
+fn websocket_upgrade(
+    request: &mut Request<Incoming>,
+    app: tauri::AppHandle,
+) -> Response<CompanionBody> {
+    let key = request
+        .headers()
+        .get(SEC_WEBSOCKET_KEY)
+        .and_then(|value| value.to_str().ok());
+    let version_ok = request
+        .headers()
+        .get(SEC_WEBSOCKET_VERSION)
+        .is_some_and(|value| value == "13");
+    let upgrade_ok = request
+        .headers()
+        .get(UPGRADE)
+        .and_then(|value| value.to_str().ok())
+        .is_some_and(|value| value.eq_ignore_ascii_case("websocket"));
+    let connection_ok = request
+        .headers()
+        .get(CONNECTION)
+        .and_then(|value| value.to_str().ok())
+        .is_some_and(|value| {
+            value
+                .split(',')
+                .any(|part| part.trim().eq_ignore_ascii_case("upgrade"))
+        });
+    let Some(key) = key.filter(|_| version_ok && upgrade_ok && connection_ok) else {
+        return text_response(StatusCode::BAD_REQUEST, "Invalid WebSocket upgrade");
+    };
+
+    let accept = derive_accept_key(key.as_bytes());
+    let on_upgrade = hyper::upgrade::on(request);
+    tauri::async_runtime::spawn(async move {
+        let upgraded = match on_upgrade.await {
+            Ok(upgraded) => upgraded,
+            Err(error) => {
+                log::debug!("Browser companion WebSocket upgrade failed: {error}");
+                return;
+            }
+        };
+        let client =
+            WebSocketStream::from_raw_socket(TokioIo::new(upgraded), Role::Server, None).await;
+        if let Err(error) = relay_websocket(client, app).await {
+            log::debug!("Browser companion WebSocket relay ended: {error}");
+        }
+    });
+
+    Response::builder()
+        .status(StatusCode::SWITCHING_PROTOCOLS)
+        .header(UPGRADE, "websocket")
+        .header(CONNECTION, "Upgrade")
+        .header(SEC_WEBSOCKET_ACCEPT, accept)
+        .body(Full::new(Bytes::new()))
+        .expect("valid WebSocket upgrade response")
+}
+
+async fn relay_websocket<S>(
+    mut client: WebSocketStream<S>,
+    app: tauri::AppHandle,
+) -> Result<(), AppError>
+where
+    S: tokio::io::AsyncRead + tokio::io::AsyncWrite + Unpin,
+{
+    let state = app.state::<AppState>();
+    let mut upstream = match connect_gateway_stream(&app, &state).await {
+        Ok(upstream) => upstream,
+        Err(error) => {
+            let reason = Utf8Bytes::from(error.to_string().chars().take(100).collect::<String>());
+            let _ = client
+                .send(Message::Close(Some(CloseFrame {
+                    code: tokio_tungstenite::tungstenite::protocol::frame::coding::CloseCode::Error,
+                    reason,
+                })))
+                .await;
+            return Err(error);
+        }
+    };
+    let mut keepalive = tokio::time::interval(Duration::from_secs(10));
+    keepalive.set_missed_tick_behavior(tokio::time::MissedTickBehavior::Delay);
+
+    loop {
+        tokio::select! {
+            item = client.next() => match item {
+                Some(Ok(Message::Close(frame))) => {
+                    let _ = upstream.send(Message::Close(frame)).await;
+                    break;
+                }
+                Some(Ok(Message::Frame(_))) => {}
+                Some(Ok(message)) => {
+                    if upstream.send(message).await.is_err() { break; }
+                }
+                Some(Err(error)) => return Err(AppError::GatewayWs(error.to_string())),
+                None => break,
+            },
+            item = upstream.next() => match item {
+                Some(Ok(Message::Close(frame))) => {
+                    let _ = client.send(Message::Close(frame)).await;
+                    break;
+                }
+                Some(Ok(Message::Frame(_))) => {}
+                Some(Ok(message)) => {
+                    if client.send(message).await.is_err() { break; }
+                }
+                Some(Err(error)) => return Err(AppError::GatewayWs(error.to_string())),
+                None => break,
+            },
+            _ = keepalive.tick() => {
+                if upstream.send(Message::Ping(Default::default())).await.is_err() { break; }
+            }
+        }
+    }
+
+    let _ = client.close(None).await;
+    let _ = upstream.close(None).await;
+    Ok(())
+}
+
+fn resolve_asset(app: &tauri::AppHandle, path: &str) -> Option<tauri::Asset> {
+    app.asset_resolver()
+        .get(path.to_string())
+        .or_else(|| app.asset_resolver().get(format!("/{path}")))
+}
+
+fn serve_asset(app: &tauri::AppHandle, request_path: &str) -> Response<CompanionBody> {
+    let requested = normalize_asset_path(request_path);
+    let asset = requested
+        .as_deref()
+        .and_then(|path| resolve_asset(app, path))
+        .or_else(|| {
+            requested
+                .as_deref()
+                .filter(|path| !path.rsplit('/').next().unwrap_or_default().contains('.'))
+                .and_then(|_| resolve_asset(app, "index.html"))
+        });
+    let Some(asset) = asset else {
+        return text_response(
+            StatusCode::NOT_FOUND,
+            "Browser UI assets are unavailable; start the desktop dev server on port 9545.",
+        );
+    };
+
+    let mime = asset.mime_type().to_string();
+    let csp = asset.csp_header().map(str::to_string);
+    let bytes = Bytes::copy_from_slice(asset.bytes());
+    let mut response = Response::new(Full::new(bytes));
+    response.headers_mut().insert(
+        CONTENT_TYPE,
+        HeaderValue::from_str(&mime)
+            .unwrap_or_else(|_| HeaderValue::from_static("application/octet-stream")),
+    );
+    if let Some(csp) = csp.and_then(|value| HeaderValue::from_str(&value).ok()) {
+        response.headers_mut().insert(CONTENT_SECURITY_POLICY, csp);
+    }
+    response
+}
+
+fn normalize_asset_path(request_path: &str) -> Option<String> {
+    let path = request_path.trim_start_matches('/');
+    if path.is_empty() {
+        return Some("index.html".to_string());
+    }
+    if path.split('/').any(|part| part == "..") {
+        return None;
+    }
+    Some(path.to_string())
+}
+
+fn json_response<T: Serialize>(
+    status: StatusCode,
+    value: &T,
+) -> Result<Response<CompanionBody>, AppError> {
+    let body = serde_json::to_vec(value)
+        .map_err(|error| AppError::Internal(format!("序列化浏览器响应失败: {error}")))?;
+    let mut response = Response::new(Full::new(Bytes::from(body)));
+    *response.status_mut() = status;
+    response
+        .headers_mut()
+        .insert(CONTENT_TYPE, HeaderValue::from_static("application/json"));
+    response
+        .headers_mut()
+        .insert(CACHE_CONTROL, HeaderValue::from_static("no-store"));
+    Ok(response)
+}
+
+fn text_response(status: StatusCode, message: &str) -> Response<CompanionBody> {
+    let mut response = Response::new(Full::new(Bytes::copy_from_slice(message.as_bytes())));
+    *response.status_mut() = status;
+    response.headers_mut().insert(
+        CONTENT_TYPE,
+        HeaderValue::from_static("text/plain; charset=utf-8"),
+    );
+    response
+}
+
+fn empty_response(status: StatusCode) -> Response<CompanionBody> {
+    let mut response = Response::new(Full::new(Bytes::new()));
+    *response.status_mut() = status;
+    response
+}
+
+fn with_cors(
+    mut response: Response<CompanionBody>,
+    origin: Option<&HeaderValue>,
+) -> Response<CompanionBody> {
+    if let Some(origin) = origin {
+        response
+            .headers_mut()
+            .insert(ACCESS_CONTROL_ALLOW_ORIGIN, origin.clone());
+        response
+            .headers_mut()
+            .insert(VARY, HeaderValue::from_static("Origin"));
+        response.headers_mut().insert(
+            ACCESS_CONTROL_ALLOW_METHODS,
+            HeaderValue::from_static("GET, POST, PUT, PATCH, DELETE, OPTIONS"),
+        );
+        response.headers_mut().insert(
+            ACCESS_CONTROL_ALLOW_HEADERS,
+            HeaderValue::from_static(
+                "Authorization, Content-Type, X-Hermes-Session-Token, X-Hermes-Browser-Token, X-Hermes-Profile",
+            ),
+        );
+    }
+    response
+}
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+
+    #[test]
+    fn only_loopback_http_origins_are_allowed() {
+        assert!(is_loopback_origin("http://localhost:9545"));
+        assert!(is_loopback_origin("http://127.0.0.1:9546"));
+        assert!(!is_loopback_origin("https://example.com"));
+        assert!(!is_loopback_origin("http://example.com"));
+    }
+
+    #[test]
+    fn asset_paths_reject_parent_traversal_and_map_root() {
+        assert_eq!(normalize_asset_path("/"), Some("index.html".to_string()));
+        assert_eq!(
+            normalize_asset_path("/assets/app.js"),
+            Some("assets/app.js".to_string())
+        );
+        assert_eq!(normalize_asset_path("/../secret"), None);
+    }
+
+    #[test]
+    fn host_must_match_the_loopback_listener() {
+        let good = HeaderValue::from_static("127.0.0.1:9546");
+        let localhost = HeaderValue::from_static("localhost:9546");
+        let wrong = HeaderValue::from_static("example.com:9546");
+        assert!(valid_host(Some(&good), 9546));
+        assert!(valid_host(Some(&localhost), 9546));
+        assert!(!valid_host(Some(&wrong), 9546));
+    }
+}

--- a/src/commands/mod.rs
+++ b/src/commands/mod.rs
@@ -1,5 +1,6 @@
 pub mod api_proxy;
 pub mod backup;
+pub mod browser_companion;
 pub mod coding_agents;
 pub mod config_migration;
 pub mod connection;

--- a/src/commands/ws_proxy.rs
+++ b/src/commands/ws_proxy.rs
@@ -30,6 +30,7 @@ use serde::{Deserialize, Serialize};
 use tauri::{Emitter, Manager, State};
 use tokio::sync::{mpsc, Notify};
 use tokio_tungstenite::tungstenite::Message;
+use tokio_tungstenite::{MaybeTlsStream, WebSocketStream};
 
 use crate::error::AppError;
 use crate::process::dashboard::{
@@ -85,6 +86,95 @@ fn shutdown_active(state: &State<'_, AppState>) -> Result<(), AppError> {
     Ok(())
 }
 
+pub type GatewayWebSocket = WebSocketStream<MaybeTlsStream<tokio::net::TcpStream>>;
+
+/// Open the currently configured Core gateway with the desktop-owned auth.
+/// Both the webview relay and the browser companion use this one path so token
+/// refresh and gated-remote OAuth ticket behavior cannot drift apart.
+pub async fn connect_gateway_stream(
+    app: &tauri::AppHandle,
+    state: &AppState,
+) -> Result<GatewayWebSocket, AppError> {
+    let (api_base_url, auth, is_remote) = {
+        let inner = state.inner.lock()?;
+        (
+            inner.api_base_url.clone(),
+            inner.dashboard_auth(),
+            inner.connection_mode == crate::connection::ConnectionMode::Remote,
+        )
+    };
+
+    match &auth {
+        // Gated remote: mint a single-use 30s ticket per connect. A 401 mint
+        // means the session is dead → surface an auth error (frontend prompts
+        // re-login); one retry covers a TTL race between mint and connect.
+        crate::state::DashboardAuth::Oauth(session) => {
+            let ticket = match session.mint_ws_ticket().await {
+                Ok(t) => t,
+                Err(err) => {
+                    if let AppError::AuthSessionExpired(_) = &err {
+                        emit_ws_auth_expired(app, &api_base_url);
+                    }
+                    return Err(err);
+                }
+            };
+            let url = build_gateway_ws_url_with_ticket(&api_base_url, &ticket);
+            match tokio_tungstenite::connect_async(url).await {
+                Ok((ws, _)) => Ok(ws),
+                Err(_) => {
+                    // Ticket may have expired (single-use, 30s); mint fresh once.
+                    let ticket2 = match session.mint_ws_ticket().await {
+                        Ok(t) => t,
+                        Err(err) => {
+                            if let AppError::AuthSessionExpired(_) = &err {
+                                emit_ws_auth_expired(app, &api_base_url);
+                            }
+                            return Err(err);
+                        }
+                    };
+                    let url2 = build_gateway_ws_url_with_ticket(&api_base_url, &ticket2);
+                    tokio_tungstenite::connect_async(url2)
+                        .await
+                        .map(|(ws, _)| ws)
+                        .map_err(map_ws_connect_error)
+                }
+            }
+        }
+        crate::state::DashboardAuth::Token(token) => {
+            let token = token.clone();
+            match tokio_tungstenite::connect_async(build_gateway_url(
+                &api_base_url,
+                token.as_deref(),
+            ))
+            .await
+            {
+                Ok((ws, _resp)) => Ok(ws),
+                // Remote tokens are static; scraping the remote's HTML for a
+                // fresh one would just hammer it with a doomed retry.
+                Err(first_err) if is_remote => Err(AppError::GatewayWs(first_err.to_string())),
+                Err(first_err) => {
+                    // Token may have rotated (dashboard restarted). Refresh once.
+                    match fetch_session_token(&api_base_url).await {
+                        Some(fresh) => {
+                            let fresh_url = build_gateway_url(&api_base_url, Some(&fresh));
+                            {
+                                let mut inner = state.inner.lock()?;
+                                inner.session_token = Some(fresh.clone());
+                                inner.gateway_url = fresh_url.clone();
+                            }
+                            tokio_tungstenite::connect_async(fresh_url)
+                                .await
+                                .map(|(ws, _)| ws)
+                                .map_err(|e| AppError::GatewayWs(e.to_string()))
+                        }
+                        None => Err(AppError::GatewayWs(first_err.to_string())),
+                    }
+                }
+            }
+        }
+    }
+}
+
 /// Open the official `/api/ws` WebSocket from Rust and start relaying frames.
 ///
 /// Resolves once the handshake completes; the JS shim treats that as `onopen`.
@@ -98,87 +188,7 @@ pub async fn gateway_ws_open(
 ) -> Result<(), AppError> {
     let connection_id = input.connection_id;
     shutdown_active(&state)?;
-
-    let (api_base_url, auth, is_remote) = {
-        let inner = state.inner.lock()?;
-        (
-            inner.api_base_url.clone(),
-            inner.dashboard_auth(),
-            inner.connection_mode == crate::connection::ConnectionMode::Remote,
-        )
-    };
-
-    let stream = match &auth {
-        // Gated remote: mint a single-use 30s ticket per connect. A 401 mint
-        // means the session is dead → surface an auth error (frontend prompts
-        // re-login); one retry covers a TTL race between mint and connect.
-        crate::state::DashboardAuth::Oauth(session) => {
-            let ticket = match session.mint_ws_ticket().await {
-                Ok(t) => t,
-                Err(err) => {
-                    if let AppError::AuthSessionExpired(_) = &err {
-                        emit_ws_auth_expired(&app, &api_base_url);
-                    }
-                    return Err(err);
-                }
-            };
-            let url = build_gateway_ws_url_with_ticket(&api_base_url, &ticket);
-            match tokio_tungstenite::connect_async(url).await {
-                Ok((ws, _)) => ws,
-                Err(_) => {
-                    // Ticket may have expired (single-use, 30s); mint fresh once.
-                    let ticket2 = match session.mint_ws_ticket().await {
-                        Ok(t) => t,
-                        Err(err) => {
-                            if let AppError::AuthSessionExpired(_) = &err {
-                                emit_ws_auth_expired(&app, &api_base_url);
-                            }
-                            return Err(err);
-                        }
-                    };
-                    let url2 = build_gateway_ws_url_with_ticket(&api_base_url, &ticket2);
-                    match tokio_tungstenite::connect_async(url2).await {
-                        Ok((ws, _)) => ws,
-                        Err(e) => return Err(map_ws_connect_error(e)),
-                    }
-                }
-            }
-        }
-        crate::state::DashboardAuth::Token(token) => {
-            let token = token.clone();
-            match tokio_tungstenite::connect_async(build_gateway_url(
-                &api_base_url,
-                token.as_deref(),
-            ))
-            .await
-            {
-                Ok((ws, _resp)) => ws,
-                // Remote tokens are static; scraping the remote's HTML for a
-                // fresh one would just hammer it with a doomed retry.
-                Err(first_err) if is_remote => {
-                    return Err(AppError::GatewayWs(first_err.to_string()))
-                }
-                Err(first_err) => {
-                    // Token may have rotated (dashboard restarted). Refresh once.
-                    match fetch_session_token(&api_base_url).await {
-                        Some(fresh) => {
-                            let fresh_url = build_gateway_url(&api_base_url, Some(&fresh));
-                            {
-                                let mut inner = state.inner.lock()?;
-                                inner.session_token = Some(fresh.clone());
-                                inner.gateway_url = fresh_url.clone();
-                            }
-                            match tokio_tungstenite::connect_async(fresh_url).await {
-                                Ok((ws, _resp)) => ws,
-                                Err(e) => return Err(AppError::GatewayWs(e.to_string())),
-                            }
-                        }
-                        None => return Err(AppError::GatewayWs(first_err.to_string())),
-                    }
-                }
-            }
-        }
-    };
+    let stream = connect_gateway_stream(&app, &state).await?;
 
     let (mut sink, mut read) = stream.split();
     let (tx, mut rx) = mpsc::unbounded_channel::<String>();

--- a/src/main.rs
+++ b/src/main.rs
@@ -511,6 +511,7 @@ fn main() {
             commands::connection_auth::connection_oauth_logout,
             commands::backup::backup_export_profile,
             commands::backup::backup_import_profile,
+            commands::browser_companion::open_browser_companion,
             commands::config_migration::config_migration_scan,
             commands::config_migration::config_migration_import,
             commands::im_onboarding::im_onboarding_state,

--- a/src/state.rs
+++ b/src/state.rs
@@ -29,6 +29,14 @@ pub struct GatewayWsHandle {
     pub notify: Arc<Notify>,
 }
 
+/// Process-lifetime browser companion endpoint. The bearer token is distinct
+/// from the dashboard credential and is accepted only by the loopback server.
+#[derive(Clone)]
+pub struct BrowserCompanionHandle {
+    pub port: u16,
+    pub token: String,
+}
+
 /// Windows Job Object handle used to bind the dashboard process tree to the
 /// desktop lifecycle. On non-Windows this is a zero-sized placeholder so the
 /// DashboardHandle shape stays uniform across platforms.
@@ -206,6 +214,8 @@ pub struct AppStateInner {
     /// on the relay socket path. `None` on webview-direct WS or before the
     /// first relay connect.
     pub gateway_ws: Option<GatewayWsHandle>,
+    /// Lazily started when the user chooses “在浏览器中打开社区桌面版”.
+    pub browser_companion: Option<BrowserCompanionHandle>,
     /// Set while a managed-dashboard restart is in progress (profile switch or
     /// YOLO toggle). Guards against two restarts racing on `dashboard_handle`.
     pub dashboard_restart_in_flight: bool,
@@ -268,6 +278,7 @@ impl AppState {
                 current_profile: "default".to_string(),
                 dashboard_handle: None,
                 gateway_ws: None,
+                browser_companion: None,
                 dashboard_restart_in_flight: false,
                 last_runtime_error: None,
                 yolo_mode: false,

--- a/web/src/lib/browser-companion.test.ts
+++ b/web/src/lib/browser-companion.test.ts
@@ -1,0 +1,55 @@
+import { afterEach, describe, expect, it, vi } from "vitest";
+import { installBrowserCompanionRuntime, parseBrowserCompanionLaunch } from "./browser-companion";
+
+afterEach(() => {
+  delete (globalThis as { window?: unknown }).window;
+});
+
+describe("browser companion bootstrap", () => {
+  it("accepts only a loopback companion origin", () => {
+    expect(parseBrowserCompanionLaunch({
+      hash: "#hermes-browser-origin=http%3A%2F%2F127.0.0.1%3A9546&hermes-browser-token=abc",
+      pathname: "/",
+      search: "",
+    })).toEqual({ origin: "http://127.0.0.1:9546", token: "abc" });
+    expect(parseBrowserCompanionLaunch({
+      hash: "#hermes-browser-origin=https%3A%2F%2Fexample.com&hermes-browser-token=abc",
+      pathname: "/",
+      search: "",
+    })).toBeNull();
+  });
+
+  it("loads runtime config with the companion token and clears the fragment", async () => {
+    const replaceState = vi.fn();
+    (globalThis as { window?: unknown }).window = {
+      location: {
+        hash: "#hermes-browser-origin=http%3A%2F%2Flocalhost%3A9550&hermes-browser-token=secret",
+        pathname: "/connection",
+        search: "?tab=advanced",
+      },
+      history: { replaceState },
+    };
+    const config = {
+      platform: "web" as const,
+      apiBaseUrl: "http://localhost:9550",
+      gatewayUrl: "ws://localhost:9550/api/ws?token=secret",
+      sessionToken: "secret",
+      browserCompanion: true,
+    };
+    const fetchImpl = vi.fn(async () => new Response(JSON.stringify(config), {
+      status: 200,
+      headers: { "Content-Type": "application/json" },
+    }));
+
+    await expect(installBrowserCompanionRuntime(fetchImpl as typeof fetch)).resolves.toBe(true);
+    expect(fetchImpl).toHaveBeenCalledWith("http://localhost:9550/__hermes_runtime", {
+      headers: {
+        Authorization: "Bearer secret",
+        "X-Hermes-Browser-Token": "secret",
+      },
+    });
+    expect(window.__HERMES_RUNTIME__).toEqual(config);
+    expect(window.__HERMES_SESSION_TOKEN__).toBe("secret");
+    expect(replaceState).toHaveBeenCalledWith(null, "", "/connection?tab=advanced");
+  });
+});

--- a/web/src/lib/browser-companion.ts
+++ b/web/src/lib/browser-companion.ts
@@ -1,0 +1,56 @@
+interface BrowserCompanionLaunch {
+  origin: string;
+  token: string;
+}
+
+interface BrowserCompanionLocation {
+  hash: string;
+  pathname: string;
+  search: string;
+}
+
+function isLoopbackHttpOrigin(value: string): boolean {
+  try {
+    const url = new URL(value);
+    if (url.protocol !== "http:") return false;
+    return url.hostname === "localhost" || url.hostname === "127.0.0.1" || url.hostname === "[::1]";
+  } catch {
+    return false;
+  }
+}
+
+export function parseBrowserCompanionLaunch(
+  location: BrowserCompanionLocation,
+): BrowserCompanionLaunch | null {
+  const params = new URLSearchParams(location.hash.replace(/^#/, ""));
+  const origin = params.get("hermes-browser-origin")?.replace(/\/$/, "") ?? "";
+  const token = params.get("hermes-browser-token") ?? "";
+  if (!origin || !token || !isLoopbackHttpOrigin(origin)) return null;
+  return { origin, token };
+}
+
+export async function installBrowserCompanionRuntime(
+  fetchImpl: typeof fetch = fetch,
+): Promise<boolean> {
+  const launch = parseBrowserCompanionLaunch(window.location);
+  if (!launch) return false;
+
+  const response = await fetchImpl(`${launch.origin}/__hermes_runtime`, {
+    headers: {
+      Authorization: `Bearer ${launch.token}`,
+      "X-Hermes-Browser-Token": launch.token,
+    },
+  });
+  if (!response.ok) {
+    throw new Error(`浏览器伴生服务连接失败（HTTP ${response.status}）`);
+  }
+
+  const config = await response.json() as NonNullable<Window["__HERMES_RUNTIME__"]>;
+  if (!config.browserCompanion || !config.sessionToken || !config.apiBaseUrl || !config.gatewayUrl) {
+    throw new Error("浏览器伴生服务返回了无效的运行时配置");
+  }
+  window.__HERMES_RUNTIME__ = config;
+  window.__HERMES_SESSION_TOKEN__ = config.sessionToken;
+  window.history.replaceState(null, "", `${window.location.pathname}${window.location.search}`);
+  return true;
+}

--- a/web/src/lib/runtime.ts
+++ b/web/src/lib/runtime.ts
@@ -438,6 +438,8 @@ declare global {
       managedRuntimeLifecycleState?: import("@hermes/protocol").ManagedRuntimeLifecycleState;
       /** Running as the portable (unzip-and-run) desktop distribution. */
       portable?: boolean;
+      /** UI is running in a system browser through the desktop loopback relay. */
+      browserCompanion?: boolean;
     };
     hermesDesktop?: {
       windowType: "electron" | "tauri";
@@ -451,6 +453,7 @@ declare global {
       createWorkspaceProject?(): Promise<ElectronFilePickerResult>;
       openWorkspacePath?(input: { path: string }): Promise<ElectronApiRequestResult>;
       openExternalUrl?(input: { url: string }): Promise<ElectronSimpleResult>;
+      openBrowserCompanion?(): Promise<{ ok: boolean; url: string; port: number }>;
       exportLogSnapshot?(input: ExportLogSnapshotInput): Promise<ExportLogSnapshotResult>;
       exportSessionJson?(input: ExportSessionJsonInput): Promise<ExportSessionJsonResult>;
       exportDebugBundle?(input?: ExportDebugBundleInput): Promise<ExportDebugBundleResult>;

--- a/web/src/lib/tauri-bridge.ts
+++ b/web/src/lib/tauri-bridge.ts
@@ -306,6 +306,10 @@ const tauriBridge = {
     return invokeCommand("open_external_url", { input });
   },
 
+  async openBrowserCompanion(): Promise<{ ok: boolean; url: string; port: number }> {
+    return invokeCommand("open_browser_companion");
+  },
+
   async toggleDevtools(): Promise<void> {
     return invokeCommand("toggle_devtools");
   },

--- a/web/src/main.tsx
+++ b/web/src/main.tsx
@@ -34,6 +34,11 @@ async function fetchDevToken() {
 }
 
 async function bootstrap() {
+  if (!window.__TAURI_INTERNALS__ && !window.__HERMES_RUNTIME__) {
+    const { installBrowserCompanionRuntime } = await import("./lib/browser-companion");
+    await installBrowserCompanionRuntime();
+  }
+
   if (window.__TAURI_INTERNALS__ && !window.__HERMES_RUNTIME__) {
     const { installTauriBridge } = await import("./lib/tauri-bridge");
     await installTauriBridge();

--- a/web/src/routes/settings-connection-section.tsx
+++ b/web/src/routes/settings-connection-section.tsx
@@ -6,6 +6,7 @@ import {
   AlertTriangle,
   Cable,
   CheckCircle2,
+  ExternalLink,
   Globe2,
   HardDrive,
   Loader2,
@@ -107,6 +108,7 @@ export function ConnectionSection({
 }: SettingsSectionProps) {
   const desktop = typeof window !== "undefined" ? window.hermesDesktop : undefined;
   const supported = Boolean(desktop?.getConnectionConfig);
+  const browserCompanion = Boolean(window.__HERMES_RUNTIME__?.browserCompanion);
 
   const [config, setConfig] = useState<ConnectionConfigView | null>(null);
   const [loadError, setLoadError] = useState("");
@@ -127,6 +129,7 @@ export function ConnectionSection({
   const [testing, setTesting] = useState(false);
   const [saving, setSaving] = useState(false);
   const [applying, setApplying] = useState(false);
+  const [openingBrowser, setOpeningBrowser] = useState(false);
   const [message, setMessage] = useState<ConnectionMessage | null>(null);
 
   useEffect(() => {
@@ -333,7 +336,39 @@ export function ConnectionSection({
     }
   };
 
+  const handleOpenBrowser = async () => {
+    if (!desktop?.openBrowserCompanion) return;
+    setOpeningBrowser(true);
+    setMessage(null);
+    try {
+      await desktop.openBrowserCompanion();
+      setMessage({ tone: "ok", text: "已在系统浏览器中打开社区桌面版" });
+    } catch (error) {
+      setMessage({
+        tone: "error",
+        text: error instanceof Error ? error.message : String(error),
+      });
+    } finally {
+      setOpeningBrowser(false);
+    }
+  };
+
   if (!supported) {
+    if (browserCompanion) {
+      return (
+        <div>
+          {showHeading && <h2 className={s.heading}>连接</h2>}
+          <SettingsHero
+            ok
+            icon={<Globe2 size={24} />}
+            eyebrow="浏览器伴生模式"
+            title="已通过社区桌面版连接"
+            description="当前浏览器的 REST 与实时网关通信均由桌面端安全转发；连接目标由桌面端统一管理。需要切换内核时，请回到桌面端的连接页面操作。"
+            badge={<span className={s.statusBadge} data-on="true">已连接</span>}
+          />
+        </div>
+      );
+    }
     return (
       <div>
         {showHeading && <h2 className={s.heading}>连接</h2>}
@@ -373,6 +408,27 @@ export function ConnectionSection({
           description={connectionDescription}
           badge={<span className={s.statusBadge} data-on={connectionLoaded}>{connectionBadge}</span>}
         />
+      )}
+
+      {!externalOnly && desktop?.openBrowserCompanion && (
+        <div className={s.row}>
+          <div className={s.rowLeft}>
+            <div className={s.rowLabel}>在浏览器中使用社区桌面版</div>
+            <div className={s.rowSub}>由当前桌面端安全转发内核连接，无需在浏览器里复制会话令牌。</div>
+          </div>
+          <div className={s.rowRight}>
+            <Button
+              type="button"
+              variant="outline"
+              onClick={() => void handleOpenBrowser()}
+              disabled={openingBrowser}
+              aria-busy={openingBrowser}
+            >
+              {openingBrowser ? <Loader2 size={13} className={s.connSpin} /> : <ExternalLink size={13} />}
+              在浏览器中打开社区桌面版
+            </Button>
+          </div>
+        </div>
       )}
 
       {loadError && <div className={s.connResult} data-tone="error">{loadError}</div>}


### PR DESCRIPTION
## 变更

- 在 `/connection` 页面增加“在浏览器中打开社区桌面版”入口，复用现有设置行样式
- 新增仅监听回环地址的浏览器伴生服务，并使用独立随机令牌鉴权
- 复用桌面端现有 REST 代理、WebSocket 网关连接与远程 OAuth 会话
- 浏览器启动时安装伴生运行时配置，清除地址栏中的临时令牌
- 补充回环来源、Host 校验、静态资源路径与浏览器启动配置测试

## 范围

本 PR 仅包含浏览器伴生连接所需的 14 个功能与测试文件，不包含主题、设计令牌、CSS 重构、4px 网格或其他界面视觉调整。

## 验证

- `pnpm typecheck`
- `pnpm test:unit`（Web 124 个测试文件、1089 条测试；协议包 3 个测试文件、70 条测试）
- `cargo fmt --check`
- `cargo check`
- `cargo test browser_companion --lib`
- `cargo test api_proxy --lib`
