### PR TITLE
perf: 提升桌面内核启动与会话创建速度

### DIFF
--- a/scripts/install-local-runtime.mjs
+++ b/scripts/install-local-runtime.mjs
@@ -68,8 +68,11 @@ function capture(command, args, options = {}) {
 }
 
 function findPython() {
+  const uvPython = capture("uv", ["python", "find", "3.14"]);
   const candidates = [
     process.env.PYTHON,
+    uvPython,
+    "python3.14",
     process.platform === "win32" ? "python" : "python3",
     "python",
   ].filter(Boolean);
@@ -77,9 +80,9 @@ function findPython() {
     const version = capture(candidate, ["-c", "import sys; print('.'.join(map(str, sys.version_info[:2])))"]);
     if (!version) continue;
     const [major, minor] = version.split(".").map(Number);
-    if (major > 3 || (major === 3 && minor >= 11)) return candidate;
+    if (major > 3 || (major === 3 && minor >= 14)) return candidate;
   }
-  throw new Error("Python 3.11+ was not found. Set PYTHON=/path/to/python3.11 and retry.");
+  throw new Error("Python 3.14+ was not found. Set PYTHON=/path/to/python3.14 and retry.");
 }
 
 function dataDir() {
@@ -132,6 +135,12 @@ function hermesExecutable(venv) {
     : join(venv, "bin", "hermes");
 }
 
+function desktopHostExecutable(venv) {
+  return process.platform === "win32"
+    ? join(venv, "Scripts", "hermes-core-host.exe")
+    : join(venv, "bin", "hermes-core-host");
+}
+
 function readCurrent(currentPath) {
   try {
     return JSON.parse(readFileSync(currentPath, "utf8"));
@@ -178,7 +187,8 @@ const currentMatchesSource =
   && currentSourceCommit === commit
   && (current?.localDirtyHash ?? null) === dirtyHash
   && current.executablePath
-  && existsSync(current.executablePath);
+  && existsSync(current.executablePath)
+  && existsSync(desktopHostExecutable(join(target, "venv")));
 
 function currentRecordIsV2(record) {
   return record?.schemaVersion === 2
@@ -186,7 +196,8 @@ function currentRecordIsV2(record) {
     && record?.kernelVersion === kernelVersion
     && record?.runtimeFlavor
     && record?.executablePath
-    && existsSync(record.executablePath);
+    && existsSync(record.executablePath)
+    && existsSync(desktopHostExecutable(join(target, "venv")));
 }
 
 function writeCurrentRecord(installedExecutable, installedAt = new Date().toISOString()) {
@@ -260,12 +271,23 @@ rmSync(join(sourceRoot, "build"), { recursive: true, force: true });
 if (!existsSync(hermesExecutable(venv))) {
   throw new Error(`hermes console script was not created at ${hermesExecutable(venv)}`);
 }
+if (!existsSync(desktopHostExecutable(venv))) {
+  throw new Error(`Desktop host script was not created at ${desktopHostExecutable(venv)}`);
+}
 
 run(hermesExecutable(venv), ["dashboard", "--help"], {
   env: {
     ...process.env,
     HERMES_HOME: join(target, "smoke-home"),
     HERMES_DASHBOARD_TUI: "1",
+  },
+});
+run(desktopHostExecutable(venv), ["--smoke-check"], {
+  env: {
+    ...process.env,
+    HERMES_HOME: join(target, "smoke-home"),
+    HERMES_DESKTOP: "1",
+    HERMES_DESKTOP_MANAGED: "1",
   },
 });
 
@@ -285,3 +307,4 @@ writeFileSync(join(target, "manifest.json"), `${JSON.stringify({
 
 console.log(`wrote ${currentPath}`);
 console.log(`managed runtime executable: ${installedExecutable}`);
+console.log(`managed Desktop host: ${desktopHostExecutable(join(target, "venv"))}`);

--- a/src/process/dashboard.rs
+++ b/src/process/dashboard.rs
@@ -946,12 +946,21 @@ pub fn dev_external_dashboard_enabled() -> bool {
 /// are not accepted, even in dev mode.
 fn resolve_hermes_command(allow_external_agent: bool) -> Result<(String, Vec<String>), AppError> {
     if let Some(record) = crate::process::runtime::read_current_record() {
-        log::info!(
-            "Using managed runtime v{} at {}",
+        if let Some(host) = crate::process::runtime::desktop_host_executable(&record) {
+            log::info!(
+                "Using dedicated managed Desktop host for runtime v{} at {}",
+                record.runtime_version,
+                host.display()
+            );
+            return Ok((host.to_string_lossy().to_string(), vec![]));
+        }
+
+        log::warn!(
+            "Managed runtime v{} has no dedicated Desktop host; using compatible CLI fallback at {}",
             record.runtime_version,
             record.executable_path
         );
-        return Ok((record.executable_path, vec![]));
+        return Ok((record.executable_path, vec!["dashboard".to_string()]));
     }
 
     if allow_external_agent || std::env::var("HERMES_DESKTOP_AGENT_COMMAND").is_ok() {
@@ -975,7 +984,6 @@ fn spawn_dashboard(
     let (program, mut prefix_args) = resolve_hermes_command(options.allow_external_agent)?;
 
     let api_args = vec![
-        "dashboard".to_string(),
         "--host".to_string(),
         options.host.clone(),
         "--port".to_string(),
@@ -1691,10 +1699,105 @@ pub async fn ensure_hermes_dashboard(
 #[cfg(test)]
 mod tests {
     use super::*;
+    use crate::process::runtime::RuntimeInstallRecord;
     use pretty_assertions::assert_eq;
     use serial_test::serial;
     use wiremock::matchers::{method, path};
     use wiremock::{Mock, MockServer, ResponseTemplate};
+
+    fn test_runtime_platform() -> &'static str {
+        if cfg!(target_os = "windows") {
+            "win32"
+        } else if cfg!(target_os = "macos") {
+            "darwin"
+        } else {
+            "linux"
+        }
+    }
+
+    fn test_runtime_arch() -> &'static str {
+        if cfg!(target_arch = "x86_64") {
+            "x64"
+        } else if cfg!(target_arch = "aarch64") {
+            "arm64"
+        } else {
+            std::env::consts::ARCH
+        }
+    }
+
+    fn write_managed_runtime_record(
+        runtime_root: &Path,
+        with_desktop_host: bool,
+    ) -> (String, String) {
+        let runtime_dir = runtime_root.join("versions").join("test-runtime");
+        std::fs::create_dir_all(&runtime_dir).unwrap();
+        let extension = if cfg!(target_os = "windows") {
+            ".exe"
+        } else {
+            ""
+        };
+        let runtime_cli = runtime_dir.join(format!("hermes-agent-cn-runtime{extension}"));
+        let desktop_host = runtime_dir.join(format!("hermes-core-host{extension}"));
+        std::fs::write(&runtime_cli, b"runtime").unwrap();
+        if with_desktop_host {
+            std::fs::write(&desktop_host, b"host").unwrap();
+        }
+
+        let record = RuntimeInstallRecord {
+            schema_version: 2,
+            runtime_version: "test-runtime".to_string(),
+            kernel_version: "1.0.0".to_string(),
+            runtime_flavor: "cn-local".to_string(),
+            runtime_revision: 0,
+            platform: test_runtime_platform().to_string(),
+            arch: test_runtime_arch().to_string(),
+            path: runtime_dir.to_string_lossy().to_string(),
+            executable_path: runtime_cli.to_string_lossy().to_string(),
+            source: "test".to_string(),
+            installed_at: "2026-01-01T00:00:00Z".to_string(),
+            source_repo: None,
+            source_commit: None,
+            local_dirty_hash: None,
+            artifact_sha256: None,
+            previous_runtime_version: None,
+        };
+        std::fs::write(
+            runtime_root.join("current.json"),
+            serde_json::to_vec_pretty(&record).unwrap(),
+        )
+        .unwrap();
+
+        (
+            runtime_cli.to_string_lossy().to_string(),
+            desktop_host.to_string_lossy().to_string(),
+        )
+    }
+
+    #[test]
+    #[serial]
+    fn managed_runtime_prefers_dedicated_desktop_host() {
+        let dir = tempfile::TempDir::new().unwrap();
+        let (_runtime_cli, desktop_host) = write_managed_runtime_record(dir.path(), true);
+        std::env::set_var("HERMES_DESKTOP_RUNTIME_ROOT", dir.path());
+
+        let resolved = resolve_hermes_command(false).unwrap();
+
+        std::env::remove_var("HERMES_DESKTOP_RUNTIME_ROOT");
+        assert_eq!(resolved, (desktop_host, vec![]));
+    }
+
+    #[test]
+    #[serial]
+    fn managed_runtime_falls_back_to_legacy_dashboard_cli() {
+        let dir = tempfile::TempDir::new().unwrap();
+        let (runtime_cli, _desktop_host) = write_managed_runtime_record(dir.path(), false);
+        std::env::set_var("HERMES_DESKTOP_RUNTIME_ROOT", dir.path());
+
+        let resolved = resolve_hermes_command(false).unwrap();
+
+        std::env::remove_var("HERMES_DESKTOP_RUNTIME_ROOT");
+        assert_eq!(resolved, (runtime_cli, vec!["dashboard".to_string()]));
+    }
 
     #[test]
     #[serial]

--- a/src/process/runtime.rs
+++ b/src/process/runtime.rs
@@ -17,6 +17,7 @@ use sha2::{Digest, Sha256};
 use tokio::process::Command;
 
 const RUNTIME_BASENAME: &str = "hermes-agent-cn-runtime";
+const DESKTOP_HOST_BASENAME: &str = "hermes-core-host";
 /// Managed runtime tree used by release / packaged installs.
 const RUNTIME_SUBDIR_RELEASE: &str = "runtime";
 /// Isolated tree for `tauri dev` and debug builds so dev-local kernels never
@@ -278,6 +279,23 @@ fn runtime_binary_names() -> Vec<String> {
         ),
         format!("{}{}", RUNTIME_BASENAME, ext),
     ]
+}
+
+fn desktop_host_path_for(executable_path: &Path, platform: &str) -> PathBuf {
+    let extension = if platform == "win32" { ".exe" } else { "" };
+    executable_path
+        .parent()
+        .unwrap_or_else(|| Path::new("."))
+        .join(format!("{}{}", DESKTOP_HOST_BASENAME, extension))
+}
+
+/// Return the narrow Desktop host shipped beside the generic runtime CLI.
+///
+/// Older runtime payloads do not contain it; callers must preserve the legacy
+/// `hermes dashboard` path as a compatibility fallback.
+pub fn desktop_host_executable(record: &RuntimeInstallRecord) -> Option<PathBuf> {
+    let path = desktop_host_path_for(Path::new(&record.executable_path), &record.platform);
+    path.is_file().then_some(path)
 }
 
 /// Get the runtime root directory.
@@ -1560,7 +1578,11 @@ async fn wait_for_smoke_child(
     }
 }
 
-async fn smoke_check_runtime(executable_path: &Path) -> Result<(), String> {
+async fn smoke_check_command(
+    executable_path: &Path,
+    args: &[&str],
+    label: &str,
+) -> Result<(), String> {
     let workdir = executable_path.parent().unwrap_or_else(|| Path::new("."));
     let executable_display = executable_path.display().to_string();
     let workdir_display = workdir.display().to_string();
@@ -1575,7 +1597,7 @@ async fn smoke_check_runtime(executable_path: &Path) -> Result<(), String> {
     let child = loop {
         match Command::new(executable_path)
             .current_dir(workdir)
-            .args(["dashboard", "--help"])
+            .args(args)
             .env("HERMES_DISABLE_LAZY_INSTALLS", "1")
             .env("HERMES_DASHBOARD_PREWARM_AGENT", "0")
             .stdout(Stdio::null())
@@ -1589,7 +1611,8 @@ async fn smoke_check_runtime(executable_path: &Path) -> Result<(), String> {
             }
             Err(e) => {
                 return Err(format!(
-                    "Smoke check spawn failed for {} (exists={}, file_size={}, cwd={}, workdir={}): {}",
+                    "{} smoke check spawn failed for {} (exists={}, file_size={}, cwd={}, workdir={}): {}",
+                    label,
                     executable_display,
                     executable_path.is_file(),
                     size,
@@ -1602,6 +1625,17 @@ async fn smoke_check_runtime(executable_path: &Path) -> Result<(), String> {
     };
 
     wait_for_smoke_child(child, SMOKE_TIMEOUT).await
+}
+
+async fn smoke_check_runtime(executable_path: &Path) -> Result<(), String> {
+    smoke_check_command(executable_path, &["dashboard", "--help"], "Runtime CLI").await?;
+
+    let desktop_host = desktop_host_path_for(executable_path, current_platform());
+    if desktop_host.is_file() {
+        smoke_check_command(&desktop_host, &["--smoke-check"], "Desktop host").await?;
+    }
+
+    Ok(())
 }
 
 /// True when the spawn error is ETXTBSY ("Text file busy"), which can briefly
@@ -2687,6 +2721,53 @@ mod tests {
     use serial_test::serial;
     use std::io::Write;
     use tempfile::TempDir;
+
+    fn fixture_install_record(executable_path: &Path, platform: &str) -> RuntimeInstallRecord {
+        RuntimeInstallRecord {
+            schema_version: MANIFEST_SCHEMA_VERSION,
+            runtime_version: "test-runtime".to_string(),
+            kernel_version: "1.0.0".to_string(),
+            runtime_flavor: "cn-local".to_string(),
+            runtime_revision: 0,
+            platform: platform.to_string(),
+            arch: "x64".to_string(),
+            path: executable_path
+                .parent()
+                .unwrap()
+                .to_string_lossy()
+                .to_string(),
+            executable_path: executable_path.to_string_lossy().to_string(),
+            source: "test".to_string(),
+            installed_at: "2026-01-01T00:00:00Z".to_string(),
+            source_repo: None,
+            source_commit: None,
+            local_dirty_hash: None,
+            artifact_sha256: None,
+            previous_runtime_version: None,
+        }
+    }
+
+    #[test]
+    fn desktop_host_is_resolved_beside_runtime_cli() {
+        let dir = TempDir::new().unwrap();
+        let runtime_cli = dir.path().join("hermes-agent-cn-runtime-win32-x64.exe");
+        let desktop_host = dir.path().join("hermes-core-host.exe");
+        std::fs::write(&runtime_cli, b"runtime").unwrap();
+        std::fs::write(&desktop_host, b"host").unwrap();
+
+        let record = fixture_install_record(&runtime_cli, "win32");
+        assert_eq!(desktop_host_executable(&record), Some(desktop_host));
+    }
+
+    #[test]
+    fn desktop_host_missing_preserves_legacy_runtime_compatibility() {
+        let dir = TempDir::new().unwrap();
+        let runtime_cli = dir.path().join("hermes-agent-cn-runtime-linux-x64");
+        std::fs::write(&runtime_cli, b"runtime").unwrap();
+
+        let record = fixture_install_record(&runtime_cli, "linux");
+        assert_eq!(desktop_host_executable(&record), None);
+    }
 
     #[test]
     fn format_rfc3339_utc_emits_parseable_timestamps() {

--- a/web/src/components/panel/panel-composer.tsx
+++ b/web/src/components/panel/panel-composer.tsx
@@ -12,7 +12,11 @@ import { resolveModelContextWindow } from "@/lib/model-context";
 import { readLastUsedModel, rememberLastUsedModel } from "@/lib/last-used-model";
 import { recordModelUsage } from "@/lib/model-usage-log";
 import { composerSubmitShortcutHint } from "@/lib/composer-submit-shortcut";
-import { shouldPrewarmDraftSession } from "@/lib/draft-session-prewarm";
+import {
+  draftSessionMatches,
+  shouldPrewarmDraftSession,
+} from "@/lib/draft-session-prewarm";
+import type { CreateSessionOptions } from "@/lib/session-create";
 import {
   normalizeWorkspacePath,
   rememberWorkspaceProject,
@@ -57,13 +61,29 @@ export function PanelComposer() {
   // Pre-warmed draft session (created by the effect below). Holds the backend
   // session id + the cwd it was built for, so send only reuses it while the
   // requested workspace still matches.
-  const draftRef = useRef<{ id: string; cwd: string } | null>(null);
+  const draftRef = useRef<{
+    id: string;
+    cwd: string;
+    model: string;
+    provider: string;
+  } | null>(null);
   const initialWorkspacePath = normalizeWorkspacePath(searchParams.get("workspace"));
   const submitShortcutHint = composerSubmitShortcutHint(composerSubmitShortcut);
   const enabledSkills = useMemo(
     () => (skillsQuery.data ?? []).filter((skill) => skill.enabled),
     [skillsQuery.data],
   );
+
+  const contextSelection = useMemo(() => {
+    const model = selectedModel?.model ?? modelInfo?.model;
+    if (!model) return null;
+    return {
+      model,
+      provider: selectedModel?.provider ?? modelInfo?.provider,
+      providerName: selectedModel?.providerName,
+      contextWindow: selectedModel?.contextWindow,
+    };
+  }, [modelInfo?.model, modelInfo?.provider, selectedModel]);
 
   useEffect(() => {
     if (!initialWorkspacePath) return;
@@ -89,18 +109,26 @@ export function PanelComposer() {
   // draftRef null and send falls back to a normal cold create.
   useEffect(() => {
     if (!shouldPrewarmDraftSession(window.__HERMES_RUNTIME__?.connectionMode)) return;
+    if (!contextSelection?.model) return;
     const cwd = initialWorkspacePath || "";
+    const model = contextSelection.model.trim();
+    const provider = contextSelection.provider?.trim() || "";
     let cancelled = false;
     void (async () => {
       try {
         await connect();
         if (cancelled) return;
-        const id = await createSession({ cwd: cwd || undefined, activate: false });
+        const id = await createSession({
+          cwd: cwd || undefined,
+          model,
+          provider: provider || undefined,
+          activate: false,
+        });
         if (cancelled) {
           void closeSession(id).catch(() => {});
           return;
         }
-        draftRef.current = { id, cwd };
+        draftRef.current = { id, cwd, model, provider };
       } catch {
         draftRef.current = null;
       }
@@ -111,18 +139,14 @@ export function PanelComposer() {
       draftRef.current = null;
       if (draft) void closeSession(draft.id).catch(() => {});
     };
-  }, [connect, createSession, closeSession, initialWorkspacePath]);
-
-  const contextSelection = useMemo(() => {
-    const model = selectedModel?.model ?? modelInfo?.model;
-    if (!model) return null;
-    return {
-      model,
-      provider: selectedModel?.provider ?? modelInfo?.provider,
-      providerName: selectedModel?.providerName,
-      contextWindow: selectedModel?.contextWindow,
-    };
-  }, [modelInfo?.model, modelInfo?.provider, selectedModel]);
+  }, [
+    closeSession,
+    connect,
+    contextSelection?.model,
+    contextSelection?.provider,
+    createSession,
+    initialWorkspacePath,
+  ]);
 
   const contextMax = useMemo(
     () =>
@@ -170,8 +194,16 @@ export function PanelComposer() {
     try {
       const draft = draftRef.current;
       const requestedCwd = payload.workspacePath?.trim() || "";
-      let options: { createSession: () => Promise<string> } | undefined;
-      if (draft && draft.cwd === requestedCwd) {
+      const requestedModel = payload.modelSelection?.model ?? contextSelection?.model;
+      const requestedProvider = payload.modelSelection?.provider ?? contextSelection?.provider;
+      let options: {
+        createSession: (sessionOptions?: CreateSessionOptions) => Promise<string>;
+      } | undefined;
+      if (draft && draftSessionMatches(draft, {
+        cwd: requestedCwd,
+        model: requestedModel,
+        provider: requestedProvider,
+      })) {
         // Reuse the pre-warmed draft — its agent has been building for this exact
         // cwd. Claim it (null the ref so unmount cleanup won't close it) and
         // adopt it as the live session, mirroring a normal create.
@@ -201,6 +233,8 @@ export function PanelComposer() {
     createAndSendSession,
     adoptCreatedSession,
     closeSession,
+    contextSelection?.model,
+    contextSelection?.provider,
   ]);
 
   return (

--- a/web/src/hooks/use-create-and-send-session.ts
+++ b/web/src/hooks/use-create-and-send-session.ts
@@ -2,6 +2,7 @@ import { useCallback } from "react";
 import { useSetAtom } from "jotai";
 import { useNavigate } from "react-router-dom";
 import { useGateway } from "@/hooks/use-gateway";
+import { useModelInfo } from "@/hooks/use-config";
 import type {
   ComposerSubmitControls,
   ComposerSubmitPayload,
@@ -12,13 +13,14 @@ import { resolveComposerSkillCommand } from "@/lib/composer-skills";
 import { rememberSessionModelOverride } from "@/lib/session-model-override";
 import { titleFromPrompt, titleWithSessionSuffix } from "@/lib/session-title";
 import { isRemoteConnection, readImageBytesFromPath, uploadAttachmentFile } from "@/lib/transport";
+import type { CreateSessionOptions } from "@/lib/session-create";
 import {
   rememberSessionWorkspace,
   rememberWorkspaceProject,
 } from "@/lib/workspaces";
 
 interface CreateAndSendOptions {
-  createSession?: (options?: { cwd?: string }) => Promise<string>;
+  createSession?: (options?: CreateSessionOptions) => Promise<string>;
 }
 
 export function useCreateAndSendSession() {
@@ -29,12 +31,12 @@ export function useCreateAndSendSession() {
     failPrompt,
     sendPrompt,
     setSessionTitle,
-    setSessionModel,
     dispatchCommand,
     attachImage,
     attachImageBytes,
     detectDroppedPath,
   } = useGateway();
+  const { data: modelInfo } = useModelInfo();
   const setActiveSessionId = useSetAtom(activeSessionIdAtom);
 
   return useCallback(async (
@@ -44,7 +46,13 @@ export function useCreateAndSendSession() {
   ) => {
     const submittedAt = Date.now();
     const workspacePath = payload.workspacePath?.trim() || undefined;
-    const sessionId = await (options?.createSession ?? createSession)({ cwd: workspacePath });
+    const requestedModel = payload.modelSelection?.model ?? modelInfo?.model;
+    const requestedProvider = payload.modelSelection?.provider ?? modelInfo?.provider;
+    const sessionId = await (options?.createSession ?? createSession)({
+      cwd: workspacePath,
+      model: requestedModel,
+      provider: requestedProvider,
+    });
     const title = titleFromPrompt(payload.text || payload.attachments[0]?.name || "");
     const optimisticDisplayText = buildComposerDisplayText(payload);
     const optimisticDisplayImages = payload.attachments
@@ -73,18 +81,6 @@ export function useCreateAndSendSession() {
 
     void (async () => {
       try {
-        if (payload.modelSelection?.model) {
-          // Composer selection is the user's explicit source of truth.  Do not
-          // skip this just because /api/model/info already reports the same
-          // model: that REST value comes from config.yaml, while the live
-          // gateway process may still carry an older HERMES_MODEL or a
-          // prewarmed draft session built before the config save.
-          await setSessionModel(
-            sessionId,
-            payload.modelSelection.model,
-            payload.modelSelection.provider,
-          );
-        }
         let transportText: string | undefined;
         const skillCommand = resolveComposerSkillCommand(
           payload.text,
@@ -142,10 +138,11 @@ export function useCreateAndSendSession() {
     detectDroppedPath,
     dispatchCommand,
     failPrompt,
+    modelInfo?.model,
+    modelInfo?.provider,
     navigate,
     sendPrompt,
     setActiveSessionId,
-    setSessionModel,
     setSessionTitle,
   ]);
 }

--- a/web/src/hooks/use-gateway.ts
+++ b/web/src/hooks/use-gateway.ts
@@ -60,6 +60,10 @@ import {
   gatewayEventChangesSessionList,
   invalidateSessionListQueries,
 } from "@/lib/session-query-sync";
+import {
+  buildSessionCreateParams,
+  type CreateSessionOptions,
+} from "@/lib/session-create";
 
 type GatewayState = ReturnType<typeof getGatewayClient>["state"];
 
@@ -250,11 +254,6 @@ async function rememberPersistentSessionKey(gatewaySessionId: string) {
   } catch {}
 }
 
-interface CreateSessionOptions {
-  activate?: boolean;
-  cwd?: string;
-}
-
 export function useGateway() {
   const queryClient = useQueryClient();
   const connectionState = useAtomValue(gwConnectionAtom);
@@ -312,7 +311,7 @@ export function useGateway() {
     const result = parseGatewayResult(
       SessionCreateResult,
       await getGatewayClient().request("session.create",
-        options?.cwd?.trim() ? { cwd: options.cwd.trim() } : {},
+        buildSessionCreateParams(options),
       ),
       "session.create",
     );

--- a/web/src/lib/draft-session-prewarm.test.ts
+++ b/web/src/lib/draft-session-prewarm.test.ts
@@ -1,5 +1,8 @@
 import { describe, expect, it } from "vitest";
-import { shouldPrewarmDraftSession } from "./draft-session-prewarm";
+import {
+  draftSessionMatches,
+  shouldPrewarmDraftSession,
+} from "./draft-session-prewarm";
 
 describe("shouldPrewarmDraftSession", () => {
   it("keeps first-message prewarm for the desktop-managed runtime", () => {
@@ -13,5 +16,23 @@ describe("shouldPrewarmDraftSession", () => {
 
   it("fails closed until the desktop runtime mode is known", () => {
     expect(shouldPrewarmDraftSession(undefined)).toBe(false);
+  });
+
+  it("reuses a draft only for the same workspace and model route", () => {
+    const draft = {
+      cwd: " C:/work/project ",
+      model: "deepseek-v4-flash",
+      provider: "deepseek",
+    };
+    expect(draftSessionMatches(draft, {
+      cwd: "C:/work/project",
+      model: "deepseek-v4-flash",
+      provider: "deepseek",
+    })).toBe(true);
+    expect(draftSessionMatches(draft, {
+      cwd: "C:/work/project",
+      model: "deepseek-v4-pro",
+      provider: "deepseek",
+    })).toBe(false);
   });
 });

--- a/web/src/lib/draft-session-prewarm.ts
+++ b/web/src/lib/draft-session-prewarm.ts
@@ -11,3 +11,24 @@ export function shouldPrewarmDraftSession(mode: ConnectionMode | undefined): boo
   // startup, before the desktop has exposed that it is actually local/remote.
   return mode === "managed";
 }
+
+export interface DraftSessionIdentity {
+  cwd?: string;
+  model?: string;
+  provider?: string;
+}
+
+function normalizeIdentityValue(value: string | undefined): string {
+  return value?.trim() ?? "";
+}
+
+export function draftSessionMatches(
+  draft: DraftSessionIdentity,
+  requested: DraftSessionIdentity,
+): boolean {
+  return (
+    normalizeIdentityValue(draft.cwd) === normalizeIdentityValue(requested.cwd)
+    && normalizeIdentityValue(draft.model) === normalizeIdentityValue(requested.model)
+    && normalizeIdentityValue(draft.provider) === normalizeIdentityValue(requested.provider)
+  );
+}

--- a/web/src/lib/session-create.test.ts
+++ b/web/src/lib/session-create.test.ts
@@ -1,0 +1,21 @@
+import { describe, expect, it } from "vitest";
+import { buildSessionCreateParams } from "./session-create";
+
+describe("buildSessionCreateParams", () => {
+  it("sends the selected provider and model with session.create", () => {
+    expect(buildSessionCreateParams({
+      cwd: " C:/work/project ",
+      model: " deepseek-v4-flash ",
+      provider: " deepseek ",
+      activate: false,
+    })).toEqual({
+      cwd: "C:/work/project",
+      model: "deepseek-v4-flash",
+      provider: "deepseek",
+    });
+  });
+
+  it("omits empty values and desktop-only activation metadata", () => {
+    expect(buildSessionCreateParams({ activate: true, model: " " })).toEqual({});
+  });
+});

--- a/web/src/lib/session-create.ts
+++ b/web/src/lib/session-create.ts
@@ -1,0 +1,25 @@
+export interface CreateSessionOptions {
+  activate?: boolean;
+  cwd?: string;
+  model?: string;
+  provider?: string;
+}
+
+export interface SessionCreateParams extends Record<string, unknown> {
+  cwd?: string;
+  model?: string;
+  provider?: string;
+}
+
+export function buildSessionCreateParams(
+  options?: CreateSessionOptions,
+): SessionCreateParams {
+  const params: SessionCreateParams = {};
+  const cwd = options?.cwd?.trim();
+  const model = options?.model?.trim();
+  const provider = options?.provider?.trim();
+  if (cwd) params.cwd = cwd;
+  if (model) params.model = model;
+  if (provider) params.provider = provider;
+  return params;
+}


### PR DESCRIPTION
## 变更

- Windows managed runtime 优先使用无控制台的 `hermes-core-host`
- `session.create` 直接携带 cwd、model、provider
- 按 cwd/model/provider 复用预热会话，移除新会话后的重复同模型切换

## 原因

桌面端此前在新会话创建后再切换模型，会额外阻塞响应链路；CLI host 也会带来控制台窗口与杀软误拦截风险。

## 验证

- `pnpm typecheck`
- `pnpm test:unit`（1162 passed）
- `cargo check`
- Windows 冷启动约 2 秒
- DeepSeek v4 Flash 首 token 1.24–1.58 秒