### PR TITLE
fix: 明确档案切换与网关重启语义

### DIFF
--- a/tests/dashboard_spawn_retry.rs
+++ b/tests/dashboard_spawn_retry.rs
@@ -139,7 +139,7 @@ async fn ready_file_completes_spawn_without_http() {
     // completes the wait. argv: dashboard --host H --port P --no-open → $5.
     install_fake_runtime(
         runtime.path(),
-        "#!/bin/sh\nprintf '{\"port\": %s}' \"$5\" > \"$HERMES_DESKTOP_READY_FILE\"\nsleep 30\n",
+        "#!/bin/sh\nprintf '%s\n%s\n' \"$HERMES_DESKTOP_MANAGED\" \"$HERMES_HOME\" > \"$HERMES_HOME/spawn-env.txt\"\nprintf '{\"port\": %s}' \"$5\" > \"$HERMES_DESKTOP_READY_FILE\"\nsleep 30\n",
     );
 
     let port = free_port();
@@ -165,6 +165,13 @@ async fn ready_file_completes_spawn_without_http() {
     assert!(
         ready_file_leftovers(runtime.path()).is_empty(),
         "consumed ready file must be deleted"
+    );
+    let spawn_env = std::fs::read_to_string(home.join("spawn-env.txt"))
+        .expect("fake kernel should record Desktop/Core profile-routing contract");
+    assert_eq!(
+        spawn_env,
+        format!("1\n{}\n", home.to_string_lossy()),
+        "managed dashboard must receive the exact HERMES_HOME and managed marker"
     );
 
     // Reap the fake kernel so the sleep doesn't outlive the test.

--- a/web/src/lib/gateway-restart.test.ts
+++ b/web/src/lib/gateway-restart.test.ts
@@ -41,10 +41,10 @@ describe("gateway restart helpers", () => {
   });
 
   it("builds compact button labels and titles", () => {
-    expect(gatewayRestartButtonLabel("idle")).toBe("重启");
-    expect(gatewayRestartButtonLabel("running")).toBe("重启中…");
-    expect(gatewayRestartButtonLabel("success")).toBe("已完成");
-    expect(gatewayRestartButtonLabel("error")).toBe("重试");
+    expect(gatewayRestartButtonLabel("idle")).toBe("重启网关");
+    expect(gatewayRestartButtonLabel("running")).toBe("网关重启中…");
+    expect(gatewayRestartButtonLabel("success")).toBe("网关已重启");
+    expect(gatewayRestartButtonLabel("error")).toBe("重试网关");
     expect(gatewayRestartTitle("running", "自定义状态")).toBe("自定义状态");
   });
 

--- a/web/src/lib/gateway-restart.ts
+++ b/web/src/lib/gateway-restart.ts
@@ -53,10 +53,10 @@ export function isGatewayRestartLocked(phase: GatewayRestartPhase): boolean {
 }
 
 export function gatewayRestartButtonLabel(phase: GatewayRestartPhase): string {
-  if (phase === "starting" || phase === "running") return "重启中…";
-  if (phase === "success") return "已完成";
-  if (phase === "error") return "重试";
-  return "重启";
+  if (phase === "starting" || phase === "running") return "网关重启中…";
+  if (phase === "success") return "网关已重启";
+  if (phase === "error") return "重试网关";
+  return "重启网关";
 }
 
 export function gatewayRestartTitle(


### PR DESCRIPTION
## 问题

Profile 切换会重启整个 managed Dashboard/Core，但左下角的“重启”按钮实际只调用 Gateway 重启，容易让用户误以为它能完成档案切换所需的内核重启。

配套 Core 修复命名档案切回 default 时被旧 sticky profile 劫持的问题。

## 修改

- 把状态栏按钮改成明确的“重启网关 / 网关重启中 / 网关已重启 / 重试网关”
- 增加 Desktop 启动 Core 时 `HERMES_DESKTOP_MANAGED=1` 与精确 `HERMES_HOME` 的契约断言
- 更新前端单测

## 验证

- `pnpm typecheck`
- `pnpm test:unit`：protocol 70 + web 1089，全通过
- `cargo check`
- `cargo fmt --all -- --check`
- `cargo test --test dashboard_spawn_retry ready_file_completes_spawn_without_http -- --exact`
- `pnpm tauri:build:debug`
- 使用 patched Core 的 debug .app 完成 GUI 往返：default（PID 78856）→ aasdsad（PID 987）→ default（PID 7807）
- UI 当前档案、`/api/status.hermes_home`、sticky 文件全程一致

## 配套 PR

- Core：[Eynzof/Hermes-CN-Core#126](https://github.com/Eynzof/Hermes-CN-Core/pull/126)