### PR TITLE
fix: 修复持久化界面设置启动后回退

### DIFF
--- a/web/src/stores/ui.test.ts
+++ b/web/src/stores/ui.test.ts
@@ -334,3 +334,59 @@ describe("assistant display profile atoms (persisted)", () => {
     expect(uiStore.readUiValue("hermes.assistant-avatar-data-url", "fallback")).toBe("");
   });
 });
+
+describe("persisted atoms follow late ui-store hydration (#480)", () => {
+  it("restores common settings when the snapshot arrives after module evaluation", async () => {
+    const {
+      assistantAvatarDataUrlAtom,
+      assistantDisplayNameAtom,
+      composerSubmitShortcutAtom,
+      showReasoningAtom,
+      uiStore,
+    } = await loadUi();
+    const store = createStore();
+    const atoms = [
+      showReasoningAtom,
+      composerSubmitShortcutAtom,
+      assistantDisplayNameAtom,
+      assistantAvatarDataUrlAtom,
+    ] as const;
+    const unsubscribes = atoms.map((targetAtom) => store.sub(targetAtom, () => {}));
+
+    expect(store.get(showReasoningAtom)).toBe(false);
+    expect(store.get(composerSubmitShortcutAtom)).toBe("enter");
+    expect(store.get(assistantDisplayNameAtom)).toBe("Hermes");
+    expect(store.get(assistantAvatarDataUrlAtom)).toBe("");
+
+    const avatar = "data:image/png;base64,AAAA";
+    uiStore.__resetUiStoreForTests({
+      "hermes.show-reasoning": true,
+      "hermes.composer-submit-shortcut": "ctrl-enter",
+      "hermes.assistant-display-name": "Claudia",
+      "hermes.assistant-avatar-data-url": avatar,
+    });
+
+    expect(store.get(showReasoningAtom)).toBe(true);
+    expect(store.get(composerSubmitShortcutAtom)).toBe("ctrl-enter");
+    expect(store.get(assistantDisplayNameAtom)).toBe("Claudia");
+    expect(store.get(assistantAvatarDataUrlAtom)).toBe(avatar);
+    unsubscribes.forEach((unsubscribe) => unsubscribe());
+  });
+
+  it("reads hydrated values on first mount without another notification", async () => {
+    const { composerSubmitShortcutAtom, showReasoningAtom, uiStore } = await loadUi();
+    uiStore.__resetUiStoreForTests({
+      "hermes.show-reasoning": true,
+      "hermes.composer-submit-shortcut": "ctrl-enter",
+    });
+
+    const store = createStore();
+    const unsubscribes = [
+      store.sub(showReasoningAtom, () => {}),
+      store.sub(composerSubmitShortcutAtom, () => {}),
+    ];
+    expect(store.get(showReasoningAtom)).toBe(true);
+    expect(store.get(composerSubmitShortcutAtom)).toBe("ctrl-enter");
+    unsubscribes.forEach((unsubscribe) => unsubscribe());
+  });
+});

--- a/web/src/stores/ui.ts
+++ b/web/src/stores/ui.ts
@@ -1,7 +1,17 @@
 import { atom } from "jotai";
 import type { ComposerSubmitShortcut } from "@/lib/composer-submit-shortcut";
-import { readUiValue, writeUiValue } from "@/lib/ui-store";
+import { readUiValue, subscribeUiStore, writeUiValue } from "@/lib/ui-store";
 import hermesDefaultAvatar from "@/assets/hermes-default-avatar.png";
+
+function persistedUiBaseAtom<T>(read: () => T) {
+  const baseAtom = atom<T>(read());
+  baseAtom.onMount = (setValue) => {
+    const syncFromUiStore = () => setValue(read());
+    syncFromUiStore();
+    return subscribeUiStore(syncFromUiStore);
+  };
+  return baseAtom;
+}
 
 export const activeSessionIdAtom = atom<string | null>(null);
 
@@ -17,8 +27,8 @@ export const sidebarSearchAtom = atom("");
 export const commandPaletteOpenAtom = atom(false);
 
 const APP_SIDEBAR_VISIBLE_KEY = "hermes.app-sidebar-visible";
-const appSidebarVisibleBaseAtom = atom<boolean>(
-  readUiValue<unknown>(APP_SIDEBAR_VISIBLE_KEY, true) !== false,
+const appSidebarVisibleBaseAtom = persistedUiBaseAtom<boolean>(
+  () => readUiValue<unknown>(APP_SIDEBAR_VISIBLE_KEY, true) !== false,
 );
 export const appSidebarVisibleAtom = atom(
   (get) => get(appSidebarVisibleBaseAtom),
@@ -94,8 +104,8 @@ export function normalizeAssistantAvatarDataUrl(value: unknown): string {
   return /^data:image\/(?:png|jpe?g|gif|webp|svg\+xml);base64,/i.test(text) ? text : "";
 }
 
-const conversationWidthModeBaseAtom = atom<ConversationWidthMode>(
-  normalizeConversationWidthMode(readUiValue(CONVERSATION_WIDTH_KEY, DEFAULT_CONVERSATION_WIDTH_MODE)),
+const conversationWidthModeBaseAtom = persistedUiBaseAtom<ConversationWidthMode>(
+  () => normalizeConversationWidthMode(readUiValue(CONVERSATION_WIDTH_KEY, DEFAULT_CONVERSATION_WIDTH_MODE)),
 );
 export const conversationWidthModeAtom = atom(
   (get) => get(conversationWidthModeBaseAtom),
@@ -106,8 +116,8 @@ export const conversationWidthModeAtom = atom(
   },
 );
 
-const conversationFontSizeBaseAtom = atom<ConversationFontSizeMode>(
-  normalizeConversationFontSizeMode(readUiValue(CONVERSATION_FONT_SIZE_KEY, DEFAULT_CONVERSATION_FONT_SIZE_MODE)),
+const conversationFontSizeBaseAtom = persistedUiBaseAtom<ConversationFontSizeMode>(
+  () => normalizeConversationFontSizeMode(readUiValue(CONVERSATION_FONT_SIZE_KEY, DEFAULT_CONVERSATION_FONT_SIZE_MODE)),
 );
 export const conversationFontSizeAtom = atom(
   (get) => get(conversationFontSizeBaseAtom),
@@ -128,7 +138,9 @@ export const conversationFontSizeAtom = atom(
 // Desktop 模式 (Electron) 下主进程 own dashboard 子进程，切换走 IPC →
 // stop + spawn，真正即时生效（direction B）。X-Hermes-Profile header 是给
 // 未来 fork 改造支持 per-request 路由用的占位（direction C）。
-const activeProfileBaseAtom = atom<string>(readUiValue("hermes.active-profile", "default"));
+const activeProfileBaseAtom = persistedUiBaseAtom<string>(
+  () => readUiValue("hermes.active-profile", "default"),
+);
 export const activeProfileAtom = atom(
   (get) => get(activeProfileBaseAtom),
   (_get, set, next: string) => {
@@ -143,8 +155,8 @@ export const activeProfileAtom = atom(
 // 切换活跃档案时清空。对齐官方 dashboard 的 management-profile scope。
 export const managementProfileAtom = atom<string | null>(null);
 
-const assistantDisplayNameBaseAtom = atom<string>(
-  normalizeAssistantDisplayName(readUiValue(ASSISTANT_DISPLAY_NAME_KEY, DEFAULT_ASSISTANT_DISPLAY_NAME)),
+const assistantDisplayNameBaseAtom = persistedUiBaseAtom<string>(
+  () => normalizeAssistantDisplayName(readUiValue(ASSISTANT_DISPLAY_NAME_KEY, DEFAULT_ASSISTANT_DISPLAY_NAME)),
 );
 export const assistantDisplayNameAtom = atom(
   (get) => get(assistantDisplayNameBaseAtom),
@@ -159,8 +171,8 @@ export const assistantDisplayNameAtom = atom(
   },
 );
 
-const assistantAvatarDataUrlBaseAtom = atom<string>(
-  normalizeAssistantAvatarDataUrl(readUiValue(ASSISTANT_AVATAR_KEY, "")),
+const assistantAvatarDataUrlBaseAtom = persistedUiBaseAtom<string>(
+  () => normalizeAssistantAvatarDataUrl(readUiValue(ASSISTANT_AVATAR_KEY, "")),
 );
 export const assistantAvatarDataUrlAtom = atom(
   (get) => get(assistantAvatarDataUrlBaseAtom),
@@ -177,7 +189,9 @@ export const assistantAvatarEffectiveAtom = atom(
   (get) => get(assistantAvatarDataUrlBaseAtom) || hermesDefaultAvatar,
 );
 
-const showReasoningBaseAtom = atom<boolean>(readUiValue("hermes.show-reasoning", false));
+const showReasoningBaseAtom = persistedUiBaseAtom<boolean>(
+  () => readUiValue("hermes.show-reasoning", false),
+);
 export const showReasoningAtom = atom(
   (get) => get(showReasoningBaseAtom),
   (_get, set, next: boolean) => {
@@ -189,7 +203,9 @@ export const showReasoningAtom = atom(
 // 匿名使用统计开关（默认开启）。发送端在 lib/telemetry.ts 直接读 ui-store，
 // 这个 atom 只服务设置页 UI。key 与 lib/telemetry.ts 的 TELEMETRY_ENABLED_KEY 一致。
 const TELEMETRY_ENABLED_UI_KEY = "hermes.telemetry-enabled";
-const telemetryEnabledBaseAtom = atom<boolean>(readUiValue<unknown>(TELEMETRY_ENABLED_UI_KEY, true) !== false);
+const telemetryEnabledBaseAtom = persistedUiBaseAtom<boolean>(
+  () => readUiValue<unknown>(TELEMETRY_ENABLED_UI_KEY, true) !== false,
+);
 export const telemetryEnabledAtom = atom(
   (get) => get(telemetryEnabledBaseAtom),
   (_get, set, next: boolean) => {
@@ -202,7 +218,9 @@ export const telemetryEnabledAtom = atom(
 // so the user's last choice survives reload; ⌘B toggles it. The active tab
 // lives in the `?panel=` query, not here (see lib/preview-rail.ts).
 const RIGHT_RAIL_VISIBLE_KEY = "hermes.right-rail-visible";
-const rightRailVisibleBaseAtom = atom<boolean>(readUiValue<unknown>(RIGHT_RAIL_VISIBLE_KEY, false) === true);
+const rightRailVisibleBaseAtom = persistedUiBaseAtom<boolean>(
+  () => readUiValue<unknown>(RIGHT_RAIL_VISIBLE_KEY, false) === true,
+);
 export const rightRailVisibleAtom = atom(
   (get) => get(rightRailVisibleBaseAtom),
   (_get, set, next: boolean) => {
@@ -217,8 +235,8 @@ function normalizeComposerSubmitShortcut(value: unknown): ComposerSubmitShortcut
   return value === "ctrl-enter" ? "ctrl-enter" : "enter";
 }
 
-const composerSubmitShortcutBaseAtom = atom<ComposerSubmitShortcut>(
-  normalizeComposerSubmitShortcut(readUiValue(COMPOSER_SUBMIT_SHORTCUT_KEY, "enter")),
+const composerSubmitShortcutBaseAtom = persistedUiBaseAtom<ComposerSubmitShortcut>(
+  () => normalizeComposerSubmitShortcut(readUiValue(COMPOSER_SUBMIT_SHORTCUT_KEY, "enter")),
 );
 export const composerSubmitShortcutAtom = atom(
   (get) => get(composerSubmitShortcutBaseAtom),
@@ -243,7 +261,7 @@ function readNotifyFlag(key: string): boolean {
 }
 
 function makeNotifyFlagAtom(key: string) {
-  const baseAtom = atom<boolean>(readNotifyFlag(key));
+  const baseAtom = persistedUiBaseAtom<boolean>(() => readNotifyFlag(key));
   return atom(
     (get) => get(baseAtom),
     (_get, set, next: boolean) => {


### PR DESCRIPTION
## 问题

`main.tsx` 在 `initUiStore()` 完成前经 `debug-install.ts -> transport.ts` 静态加载了 `stores/ui.ts`，持久化 atom 因而把默认值固定为初始状态。SQLite 中的数据仍然存在，但显示推理、发送快捷键、助手名称和头像等设置会在重启后显示为默认值。

PR #481 只延迟 React UI 渲染，无法改变 ES 模块已经完成求值的时序，因此不能修复该问题。

## 修复

- 新增持久化 base atom 工厂，在首次挂载时重新读取 ui-store。
- 订阅 ui-store 更新，使启动 hydrate、档案切换、备份恢复和配置迁移后的 reload 都能同步到 atom。
- 将当前全部持久化 UI atom 接入统一工厂，包括 #480 报告的四项设置。
- 新增晚到 hydrate 的精确回归测试。

## 验证

- `pnpm --filter @hermes/web exec vitest run src/stores/ui.test.ts`（34/34）
- `pnpm --filter @hermes/web typecheck`
- `git diff --check`

Fixes #480