### PR TITLE
chore: 准备桌面端 0.7.0-rc.5

### DIFF
--- a/.codex/skills/desktop-release-preflight/SKILL.md
+++ b/.codex/skills/desktop-release-preflight/SKILL.md
@@ -30,7 +30,7 @@ description: Use BEFORE preparing or publishing any Hermes Agent CN Desktop rele
 1. ☑️ **identifier 没改**：`grep identifier tauri.conf.json` 仍是 `cn.org.hermesagent.desktop`。永不更改。
 2. ☑️ **`bundled_runtime_tag` 锁到 ≥ 线上 stable 最高 runtime，且是明确版本（不是 `latest`）**。这是**防内核静默降级**的关键（见下"坑 1"）。
    - 查线上 stable 最高 runtime：`gh release list -R Eynzof/Hermes-CN-Core | head` 或看 stable manifest。
-   - 触发 `release-desktop.yml` 时用 `workflow_dispatch` 输入 `bundled_runtime_tag=<该版本>`（输入定义在 `.github/workflows/release-desktop.yml:35`），或先把默认值 `:37,118,176`（当前 `runtime-v0.19.0-cn.5`）更新到该版本。
+   - 触发 `release-desktop.yml` 时用 `workflow_dispatch` 输入 `bundled_runtime_tag=<该版本>`（输入定义在 `.github/workflows/release-desktop.yml:35`），或先把默认值 `:37,118,176`（当前 `runtime-v0.19.0-cn.6`）更新到该版本。
 3. ☑️ **本次不 bump `MANIFEST_SCHEMA_VERSION`**（保持 `runtime.rs:29` 的 `2`）。schema→3（强升门改造）单独排期（见"坑 2"）。
 4. ☑️ **macOS 走完公证/装订**（`release-desktop.yml:153-293`）。未公证会被 Gatekeeper 拦。
 5. ☑️ **Windows 现状未签名**（无 Authenticode）→ 覆盖装会触发 SmartScreen。发版说明里明确告知用户点"仍要运行"，或本次补 Authenticode（见 `docs/hot-update-impl-plan.md` §5）。

--- a/.github/workflows/release-desktop.yml
+++ b/.github/workflows/release-desktop.yml
@@ -34,7 +34,7 @@ on:
         required: true
       bundled_runtime_tag:
         description: "Hermes-CN-Core runtime release tag to embed in desktop installers, or latest"
-        default: "runtime-v0.19.0-cn.5"
+        default: "runtime-v0.19.0-cn.6"
         required: false
 
 permissions:
@@ -115,7 +115,7 @@ jobs:
         shell: bash
         env:
           BUNDLED_RUNTIME_REPO: Eynzof/Hermes-CN-Core
-          BUNDLED_RUNTIME_TAG: ${{ github.event.inputs.bundled_runtime_tag || 'runtime-v0.19.0-cn.5' }}
+          BUNDLED_RUNTIME_TAG: ${{ github.event.inputs.bundled_runtime_tag || 'runtime-v0.19.0-cn.6' }}
           RUNTIME_PLATFORM: ${{ matrix.runtime_platform }}
           RUNTIME_ARCH: ${{ matrix.runtime_arch }}
         run: |
@@ -173,7 +173,7 @@ jobs:
           args=(
             scripts/stage-bundled-runtime.mjs
             --repo "Eynzof/Hermes-CN-Core"
-            --tag "${{ github.event.inputs.bundled_runtime_tag || 'runtime-v0.19.0-cn.5' }}"
+            --tag "${{ github.event.inputs.bundled_runtime_tag || 'runtime-v0.19.0-cn.6' }}"
             --platform "${{ matrix.runtime_platform }}"
             --arch "${{ matrix.runtime_arch }}"
           )


### PR DESCRIPTION
## 变更

- 将桌面端发布工作流的默认内置 runtime 从 runtime-v0.19.0-cn.5 更新为 runtime-v0.19.0-cn.6
- 同步发版预检技能中的当前 runtime 说明
- 应用内部版本保持 0.7.0

## 发布边界

- 本 PR 仅用于 v0.7.0-rc.5 内测发布
- 不修改 Landing、latest.json 或正式版 v0.7.0
- 不包含 Desktop #504 或 Core #124

## 验证

- pnpm version:check
- pnpm typecheck
- pnpm test:unit（1177 tests）
- cargo check
- Core runtime-v0.19.0-cn.6 四平台发布、manifest、SHA-256、Ed25519 与 macOS payload 签名均已通过
