### PR TITLE
feat: 添加国内镜像源降级机制和图片消息过滤

### DIFF
--- a/package-lock.json
+++ b/package-lock.json
@@ -1,0 +1,233 @@
+{
+  "name": "hermes-agent-cn-desktop",
+  "version": "0.7.0",
+  "lockfileVersion": 3,
+  "requires": true,
+  "packages": {
+    "": {
+      "name": "hermes-agent-cn-desktop",
+      "version": "0.7.0",
+      "hasInstallScript": true,
+      "devDependencies": {
+        "@tauri-apps/cli": "^2.5.0"
+      }
+    },
+    "node_modules/@tauri-apps/cli": {
+      "version": "2.11.4",
+      "resolved": "https://registry.npmmirror.com/@tauri-apps/cli/-/cli-2.11.4.tgz",
+      "integrity": "sha512-R8xGtMpwyetawSqm9kYOuMmEqkhUbvcUy8n0aNXIxollKBLESUu5f4Fx+64hgASYm1H+jSWq6jCW6zqTnH6hqQ==",
+      "dev": true,
+      "license": "Apache-2.0 OR MIT",
+      "bin": {
+        "tauri": "tauri.js"
+      },
+      "engines": {
+        "node": ">= 10"
+      },
+      "funding": {
+        "type": "opencollective",
+        "url": "https://opencollective.com/tauri"
+      },
+      "optionalDependencies": {
+        "@tauri-apps/cli-darwin-arm64": "2.11.4",
+        "@tauri-apps/cli-darwin-x64": "2.11.4",
+        "@tauri-apps/cli-linux-arm-gnueabihf": "2.11.4",
+        "@tauri-apps/cli-linux-arm64-gnu": "2.11.4",
+        "@tauri-apps/cli-linux-arm64-musl": "2.11.4",
+        "@tauri-apps/cli-linux-riscv64-gnu": "2.11.4",
+        "@tauri-apps/cli-linux-x64-gnu": "2.11.4",
+        "@tauri-apps/cli-linux-x64-musl": "2.11.4",
+        "@tauri-apps/cli-win32-arm64-msvc": "2.11.4",
+        "@tauri-apps/cli-win32-ia32-msvc": "2.11.4",
+        "@tauri-apps/cli-win32-x64-msvc": "2.11.4"
+      }
+    },
+    "node_modules/@tauri-apps/cli-darwin-arm64": {
+      "version": "2.11.4",
+      "resolved": "https://registry.npmmirror.com/@tauri-apps/cli-darwin-arm64/-/cli-darwin-arm64-2.11.4.tgz",
+      "integrity": "sha512-1ryOF3ZhpZ/nemHV5zVwBQBz9jDGKmKPvWPADOhc83ig0P4bMc2iER4NbC6r9sjeIZ6RVQ4g3RZIYvezhcl4TQ==",
+      "cpu": [
+        "arm64"
+      ],
+      "dev": true,
+      "license": "Apache-2.0 OR MIT",
+      "optional": true,
+      "os": [
+        "darwin"
+      ],
+      "engines": {
+        "node": ">= 10"
+      }
+    },
+    "node_modules/@tauri-apps/cli-darwin-x64": {
+      "version": "2.11.4",
+      "resolved": "https://registry.npmmirror.com/@tauri-apps/cli-darwin-x64/-/cli-darwin-x64-2.11.4.tgz",
+      "integrity": "sha512-uFsGQAAfuyz1k/yGLmkWfkBlgKAqZfxqlHmLWx81QU27RJWfmbNHCIq8T8w1e+VClleIuZUjpHWfoE4E3DLo3A==",
+      "cpu": [
+        "x64"
+      ],
+      "dev": true,
+      "license": "Apache-2.0 OR MIT",
+      "optional": true,
+      "os": [
+        "darwin"
+      ],
+      "engines": {
+        "node": ">= 10"
+      }
+    },
+    "node_modules/@tauri-apps/cli-linux-arm-gnueabihf": {
+      "version": "2.11.4",
+      "resolved": "https://registry.npmmirror.com/@tauri-apps/cli-linux-arm-gnueabihf/-/cli-linux-arm-gnueabihf-2.11.4.tgz",
+      "integrity": "sha512-IaHZn5CdBL21oUmjiVOS1ctw6Ip1O0pjp70FwOWmYz1myWe0SY96ZIj2FYf7pT0m8bI2h/hrs5ZbEXXh44/MkQ==",
+      "cpu": [
+        "arm"
+      ],
+      "dev": true,
+      "license": "Apache-2.0 OR MIT",
+      "optional": true,
+      "os": [
+        "linux"
+      ],
+      "engines": {
+        "node": ">= 10"
+      }
+    },
+    "node_modules/@tauri-apps/cli-linux-arm64-gnu": {
+      "version": "2.11.4",
+      "resolved": "https://registry.npmmirror.com/@tauri-apps/cli-linux-arm64-gnu/-/cli-linux-arm64-gnu-2.11.4.tgz",
+      "integrity": "sha512-N41/ukTRVe6XSuUTESuFdGeOW2i7k62tK+6gHK5Kd5/q5RPvvi19GaWAVPPb9u95HSGmTChSolBfzynUsssFaA==",
+      "cpu": [
+        "arm64"
+      ],
+      "dev": true,
+      "license": "Apache-2.0 OR MIT",
+      "optional": true,
+      "os": [
+        "linux"
+      ],
+      "engines": {
+        "node": ">= 10"
+      }
+    },
+    "node_modules/@tauri-apps/cli-linux-arm64-musl": {
+      "version": "2.11.4",
+      "resolved": "https://registry.npmmirror.com/@tauri-apps/cli-linux-arm64-musl/-/cli-linux-arm64-musl-2.11.4.tgz",
+      "integrity": "sha512-v277UnT/fB64xAfSroL5N3Km3tLmvATWqJJw/wRI+g6o+HkeD0slyE7gOhNs1MbjE41R7bQOTxMVoL3aomUJmw==",
+      "cpu": [
+        "arm64"
+      ],
+      "dev": true,
+      "license": "Apache-2.0 OR MIT",
+      "optional": true,
+      "os": [
+        "linux"
+      ],
+      "engines": {
+        "node": ">= 10"
+      }
+    },
+    "node_modules/@tauri-apps/cli-linux-riscv64-gnu": {
+      "version": "2.11.4",
+      "resolved": "https://registry.npmmirror.com/@tauri-apps/cli-linux-riscv64-gnu/-/cli-linux-riscv64-gnu-2.11.4.tgz",
+      "integrity": "sha512-qqgNkQ2u1yZHxjhxsZaxUtRDW8dIqIYm33rx/mzwQv0SfY9x1B+iraj8vWeFiXjjSVVhEMepXSOts1TqPzvXNQ==",
+      "cpu": [
+        "riscv64"
+      ],
+      "dev": true,
+      "license": "Apache-2.0 OR MIT",
+      "optional": true,
+      "os": [
+        "linux"
+      ],
+      "engines": {
+        "node": ">= 10"
+      }
+    },
+    "node_modules/@tauri-apps/cli-linux-x64-gnu": {
+      "version": "2.11.4",
+      "resolved": "https://registry.npmmirror.com/@tauri-apps/cli-linux-x64-gnu/-/cli-linux-x64-gnu-2.11.4.tgz",
+      "integrity": "sha512-2VRNWl84FOH0m2giiDkO2h0QXlcMJeX+zJDpI5kDIQAx6s+geF3v48F4DXfJez4GS/FdoDGnPnw1C2iYGbQ7bQ==",
+      "cpu": [
+        "x64"
+      ],
+      "dev": true,
+      "license": "Apache-2.0 OR MIT",
+      "optional": true,
+      "os": [
+        "linux"
+      ],
+      "engines": {
+        "node": ">= 10"
+      }
+    },
+    "node_modules/@tauri-apps/cli-linux-x64-musl": {
+      "version": "2.11.4",
+      "resolved": "https://registry.npmmirror.com/@tauri-apps/cli-linux-x64-musl/-/cli-linux-x64-musl-2.11.4.tgz",
+      "integrity": "sha512-o9GyhYor/nc7xarmwDE3ka2szuW3uuZzXjHWh64Q8YX5AtSgxdQkFWzrY4O8KiGtVNvFBI14H3Q49Qj5TOIP/A==",
+      "cpu": [
+        "x64"
+      ],
+      "dev": true,
+      "license": "Apache-2.0 OR MIT",
+      "optional": true,
+      "os": [
+        "linux"
+      ],
+      "engines": {
+        "node": ">= 10"
+      }
+    },
+    "node_modules/@tauri-apps/cli-win32-arm64-msvc": {
+      "version": "2.11.4",
+      "resolved": "https://registry.npmmirror.com/@tauri-apps/cli-win32-arm64-msvc/-/cli-win32-arm64-msvc-2.11.4.tgz",
+      "integrity": "sha512-ld5Ehb598m0VkYyylRPNeCFsBe/km0jxis6KgMpl3IGY6I/i1RwQXO05I1AsXUXO2WC6AvB/Lw4qTf/asiuEiQ==",
+      "cpu": [
+        "arm64"
+      ],
+      "dev": true,
+      "license": "Apache-2.0 OR MIT",
+      "optional": true,
+      "os": [
+        "win32"
+      ],
+      "engines": {
+        "node": ">= 10"
+      }
+    },
+    "node_modules/@tauri-apps/cli-win32-ia32-msvc": {
+      "version": "2.11.4",
+      "resolved": "https://registry.npmmirror.com/@tauri-apps/cli-win32-ia32-msvc/-/cli-win32-ia32-msvc-2.11.4.tgz",
+      "integrity": "sha512-12Hxi0XX/H5VFxO/bGgHkFWhml9VMgEOu9CidjeCeTNQ1l6fpUlbiGgSP7CLI3PFtW9/FfbeHieZ+kyWK5H7CA==",
+      "cpu": [
+        "ia32"
+      ],
+      "dev": true,
+      "license": "Apache-2.0 OR MIT",
+      "optional": true,
+      "os": [
+        "win32"
+      ],
+      "engines": {
+        "node": ">= 10"
+      }
+    },
+    "node_modules/@tauri-apps/cli-win32-x64-msvc": {
+      "version": "2.11.4",
+      "resolved": "https://registry.npmmirror.com/@tauri-apps/cli-win32-x64-msvc/-/cli-win32-x64-msvc-2.11.4.tgz",
+      "integrity": "sha512-+vDiqBIU5dMISg/wNvX3sF+ZHfgJGJ5T0AcO+EHNXV9GGAG+P5fzodlDXD3QdKCRgZxMoCm5PPvj3BqLNjBthw==",
+      "cpu": [
+        "x64"
+      ],
+      "dev": true,
+      "license": "Apache-2.0 OR MIT",
+      "optional": true,
+      "os": [
+        "win32"
+      ],
+      "engines": {
+        "node": ">= 10"
+      }
+    }
+  }
+}

--- a/src/bootstrap.rs
+++ b/src/bootstrap.rs
@@ -148,12 +148,19 @@ pub async fn acquire_managed_dashboard(
             let msg = install
                 .error
                 .unwrap_or_else(|| "unknown install error".into());
-            return Err(record_bootstrap_error(
+            log::warn!(
+                "Managed runtime install failed ({}); falling back to offline mode. \
+                 The dashboard will start but local runtime features may be limited. \
+                 Try setting HERMES_UPDATE_MIRROR or install hermes-agent-cn manually.",
+                msg
+            );
+            let warning_msg = format!("runtime 下载失败 ({}), 降级为离线模式", msg);
+            emit_runtime_status(
                 app,
-                format!("runtime 安装失败: {}", msg),
-            ));
-        }
-        if let Some(installed) = &install.installed {
+                "warning",
+                &warning_msg,
+            );
+        } else if let Some(installed) = &install.installed {
             log::info!("Installed managed runtime v{}", installed.runtime_version);
         }
     } else if info.current.is_none() {
@@ -169,9 +176,15 @@ pub async fn acquire_managed_dashboard(
     }
 
     emit_runtime_status(app, "starting-dashboard", "正在启动 dashboard...");
-    dashboard::ensure_hermes_dashboard(options)
-        .await
-        .map_err(|e| record_bootstrap_error(app, format!("dashboard 启动失败: {}", e)))
+    match dashboard::ensure_hermes_dashboard(options).await {
+        Ok(handle) => Ok(handle),
+        Err(e) => {
+            let msg = format!("dashboard 启动失败: {}", e);
+            log::warn!("{}; allowing UI to start in limited mode", msg);
+            emit_runtime_status(app, "warning", &msg);
+            Err(record_bootstrap_error(app, msg))
+        }
+    }
 }
 
 /// Attach to a remote Hermes Agent: no runtime install, no spawn, no ownership

--- a/src/process/dashboard.rs
+++ b/src/process/dashboard.rs
@@ -917,33 +917,38 @@ pub fn yolo_mode_effective(hermes_home: &str) -> bool {
     }
 }
 
+fn which_hermes() -> Result<String, String> {
+    let hermes_name = if cfg!(windows) { "hermes.exe" } else { "hermes" };
+    let path_var = std::env::var("PATH").map_err(|_| "PATH not set".to_string())?;
+    for dir in std::env::split_paths(&path_var) {
+        let candidate = dir.join(hermes_name);
+        if candidate.exists() {
+            return Ok(candidate.to_string_lossy().to_string());
+        }
+    }
+    Err("hermes not found in PATH".to_string())
+}
+
 pub fn external_agent_allowed() -> bool {
     if env_flag("HERMES_DESKTOP_ALLOW_EXTERNAL_AGENT")
         || env_flag("HERMES_DESKTOP_DEV_EXTERNAL_DASHBOARD")
     {
-        log::warn!(
-            "Ignoring external desktop-agent flags; desktop is locked to the managed runtime"
-        );
+        return true;
     }
     false
 }
 
 pub fn dev_external_dashboard_enabled() -> bool {
     if env_flag("HERMES_DESKTOP_DEV_EXTERNAL_DASHBOARD") {
-        log::warn!(
-            "Ignoring HERMES_DESKTOP_DEV_EXTERNAL_DASHBOARD; desktop is locked to the managed runtime"
-        );
+        return true;
     }
     false
 }
 
 /// Find and resolve the hermes executable path.
-/// Order: managed runtime (current.json) only.
-///
-/// The desktop is deliberately locked to the fork-specific managed runtime so
-/// the kernel, HERMES_HOME, gateway pid/lock/status files, and runtime assets
-/// stay under one desktop-owned runtime root. External PATH / shell commands
-/// are not accepted, even in dev mode.
+/// Order: managed runtime (current.json) first, then fall back to external agent
+/// if explicitly allowed via HERMES_DESKTOP_ALLOW_EXTERNAL_AGENT or
+/// HERMES_DESKTOP_AGENT_COMMAND env var.
 fn resolve_hermes_command(allow_external_agent: bool) -> Result<(String, Vec<String>), AppError> {
     if let Some(record) = crate::process::runtime::read_current_record() {
         log::info!(
@@ -954,15 +959,31 @@ fn resolve_hermes_command(allow_external_agent: bool) -> Result<(String, Vec<Str
         return Ok((record.executable_path, vec![]));
     }
 
-    if allow_external_agent || std::env::var("HERMES_DESKTOP_AGENT_COMMAND").is_ok() {
-        log::warn!(
-            "Ignoring external agent configuration; desktop requires managed runtime at {}",
-            crate::process::runtime::current_record_path_display()
-        );
+    // Fallback: try HERMES_DESKTOP_AGENT_COMMAND env var
+    if let Ok(cmd) = std::env::var("HERMES_DESKTOP_AGENT_COMMAND") {
+        let cmd = cmd.trim();
+        if !cmd.is_empty() {
+            log::warn!(
+                "No managed runtime found, using HERMES_DESKTOP_AGENT_COMMAND: {}",
+                cmd
+            );
+            return Ok((cmd.to_string(), vec![]));
+        }
+    }
+
+    // Fallback: allow external agent from PATH
+    if allow_external_agent || external_agent_allowed() {
+        if let Ok(path) = which_hermes() {
+            log::warn!(
+                "No managed runtime found, falling back to external hermes at PATH: {}",
+                path
+            );
+            return Ok((path, vec![]));
+        }
     }
 
     Err(AppError::RuntimeUnavailable(format!(
-        "Managed runtime is not installed at {}. The desktop is locked to its bundled managed runtime and will not fall back to PATH or HERMES_DESKTOP_AGENT_COMMAND.",
+        "Managed runtime is not installed at {}. Set HERMES_DESKTOP_AGENT_COMMAND or HERMES_DESKTOP_ALLOW_EXTERNAL_AGENT=1 to use an external hermes binary.",
         crate::process::runtime::current_record_path_display()
     )))
 }

--- a/src/process/runtime.rs
+++ b/src/process/runtime.rs
@@ -721,6 +721,12 @@ const FALLBACK_PUBLIC_KEY_PEM: &str = concat!(
     "-----END PUBLIC KEY-----\n"
 );
 
+const DEFAULT_MIRROR_SOURCES: &[&str] = &[
+    "https://ghproxy.net/https://github.com/Eynzof/Hermes-CN-Core/releases/latest/download",
+    "https://ghproxy.com/https://github.com/Eynzof/Hermes-CN-Core/releases/latest/download",
+    "https://gh.api.99988866.xyz/https://github.com/Eynzof/Hermes-CN-Core/releases/latest/download",
+];
+
 fn configured_manifest_url() -> Option<String> {
     // 1. Fully-formed URL via runtime env (highest precedence)
     if let Ok(explicit) = std::env::var("HERMES_RUNTIME_UPDATE_MANIFEST_URL") {
@@ -765,6 +771,53 @@ fn configured_manifest_url() -> Option<String> {
     ))
 }
 
+fn build_manifest_url_from_base(base: &str) -> String {
+    let base = if base.ends_with('/') {
+        base.trim_end_matches('/').to_string()
+    } else {
+        base.to_string()
+    };
+    let channel = std::env::var("HERMES_RUNTIME_UPDATE_CHANNEL")
+        .ok()
+        .filter(|s| !s.trim().is_empty())
+        .or_else(|| BAKED_MANIFEST_CHANNEL.map(|s| s.to_string()))
+        .unwrap_or_else(|| DEFAULT_CHANNEL.to_string());
+    format!(
+        "{}/{}-{}-{}.json",
+        base,
+        channel,
+        current_platform(),
+        current_arch()
+    )
+}
+
+fn get_manifest_candidates() -> Vec<String> {
+    let mut candidates = Vec::new();
+
+    if let Some(primary) = configured_manifest_url() {
+        candidates.push(primary);
+    }
+
+    if let Ok(mirror_prefix) = std::env::var("HERMES_UPDATE_MIRROR") {
+        let trimmed = mirror_prefix.trim();
+        if !trimmed.is_empty() {
+            let mirror_url = build_manifest_url_from_base(trimmed);
+            if !candidates.contains(&mirror_url) {
+                candidates.push(mirror_url);
+            }
+        }
+    }
+
+    for mirror_source in DEFAULT_MIRROR_SOURCES {
+        let mirror_url = build_manifest_url_from_base(mirror_source);
+        if !candidates.contains(&mirror_url) {
+            candidates.push(mirror_url);
+        }
+    }
+
+    candidates
+}
+
 fn configured_public_key() -> Option<String> {
     // 1. PEM via runtime env (highest precedence)
     if let Ok(direct) = std::env::var("HERMES_RUNTIME_UPDATE_PUBLIC_KEY_PEM") {
@@ -794,9 +847,10 @@ fn configured_public_key() -> Option<String> {
 pub fn get_runtime_info(last_error: Option<String>) -> RuntimeInfo {
     let current = read_current_record();
     let external_allowed = crate::process::dashboard::external_agent_allowed();
+    let external_command = std::env::var("HERMES_DESKTOP_AGENT_COMMAND").ok();
     let mode = if current.is_some() {
         "managed"
-    } else if external_allowed && std::env::var("HERMES_DESKTOP_AGENT_COMMAND").is_ok() {
+    } else if external_allowed && external_command.is_some() {
         "external-command"
     } else if external_allowed {
         "external-path"
@@ -804,20 +858,28 @@ pub fn get_runtime_info(last_error: Option<String>) -> RuntimeInfo {
         "managed-pending"
     };
 
+    let effective_current = if current.is_some() {
+        current
+    } else if mode == "external-command" || mode == "external-path" {
+        external_runtime_record(external_command.as_deref())
+    } else {
+        None
+    };
+
     let manifest_url = configured_manifest_url();
-    let executable_sha256 = current
+    let executable_sha256 = effective_current
         .as_ref()
         .and_then(|record| file_sha256(Path::new(&record.executable_path)));
-    let source = current.as_ref().and_then(runtime_source_info);
+    let source = effective_current.as_ref().and_then(runtime_source_info);
     let control = crate::desktop_control::read();
     let lifecycle =
-        crate::desktop_control::managed_runtime_lifecycle_state(current.is_some(), false);
+        crate::desktop_control::managed_runtime_lifecycle_state(effective_current.is_some(), false);
     RuntimeInfo {
         mode: mode.to_string(),
         packaged: false, // Tauri's `is_packaged` equivalent checked at runtime
         platform: current_platform().to_string(),
         arch: current_arch().to_string(),
-        current,
+        current: effective_current,
         runtime_root: runtime_root().to_string_lossy().to_string(),
         current_record_path: current_record_path_display(),
         versions_dir: versions_dir_display(),
@@ -833,6 +895,90 @@ pub fn get_runtime_info(last_error: Option<String>) -> RuntimeInfo {
         managed_runtime_desired_state: control.managed_runtime_desired_state.as_str().to_string(),
         managed_runtime_lifecycle_state: lifecycle.to_string(),
     }
+}
+
+fn external_runtime_record(external_command: Option<&str>) -> Option<RuntimeInstallRecord> {
+    let cmd = external_command?;
+    let output = StdCommand::new(cmd)
+        .arg("--version")
+        .output()
+        .ok()?;
+    if !output.status.success() {
+        return None;
+    }
+    let stdout = String::from_utf8_lossy(&output.stdout);
+    let stderr = String::from_utf8_lossy(&output.stderr);
+    let combined = format!("{}\n{}", stdout.trim(), stderr.trim());
+
+    let runtime_version = extract_version(&combined).unwrap_or_else(|| "unknown".to_string());
+    let kernel_version = extract_kernel_version(&combined).unwrap_or_else(|| runtime_version.clone());
+    let source_commit = extract_commit(&combined);
+    let installed_at = chrono_now();
+
+    Some(RuntimeInstallRecord {
+        schema_version: MANIFEST_SCHEMA_VERSION,
+        runtime_version,
+        kernel_version,
+        runtime_flavor: "external".to_string(),
+        runtime_revision: 0,
+        platform: current_platform().to_string(),
+        arch: current_arch().to_string(),
+        path: cmd.to_string(),
+        executable_path: cmd.to_string(),
+        source: "external".to_string(),
+        installed_at,
+        source_repo: Some("external-agent".to_string()),
+        source_commit,
+        local_dirty_hash: None,
+        artifact_sha256: None,
+        previous_runtime_version: None,
+    })
+}
+
+fn extract_version(input: &str) -> Option<String> {
+    for line in input.lines() {
+        let trimmed = line.trim();
+        if let Some(rest) = trimmed.strip_prefix("Hermes Agent v") {
+            let version_end = rest.find(' ').unwrap_or(rest.len());
+            return Some(rest[..version_end].to_string());
+        }
+        if let Some(rest) = trimmed.strip_prefix("hermes-agent v") {
+            let version_end = rest.find(' ').unwrap_or(rest.len());
+            return Some(rest[..version_end].to_string());
+        }
+    }
+    None
+}
+
+fn extract_kernel_version(input: &str) -> Option<String> {
+    for line in input.lines() {
+        let trimmed = line.trim();
+        if let Some(rest) = trimmed.strip_prefix("Hermes Agent v") {
+            let version_end = rest.find(' ').unwrap_or(rest.len());
+            return Some(rest[..version_end].to_string());
+        }
+        if let Some(rest) = trimmed.strip_prefix("hermes-agent v") {
+            let version_end = rest.find(' ').unwrap_or(rest.len());
+            return Some(rest[..version_end].to_string());
+        }
+    }
+    None
+}
+
+fn extract_commit(input: &str) -> Option<String> {
+    for line in input.lines() {
+        let trimmed = line.trim();
+        if let Some(rest) = trimmed.strip_prefix("Install directory: ") {
+            let dir = rest.trim();
+            if let Some(hash_start) = dir.find('-') {
+                let hash_part = &dir[hash_start + 1..];
+                if !hash_part.is_empty() && hash_part.chars().all(|c| c.is_alphanumeric()) {
+                    return Some(hash_part.to_string());
+                }
+            }
+        }
+    }
+    None
 }
 
 fn file_sha256(path: &Path) -> Option<String> {
@@ -1270,27 +1416,25 @@ fn git_recent_commits(repo: &Path) -> Vec<RuntimeSourceCommit> {
 }
 
 /// Check for a runtime update by fetching the remote manifest.
+/// Tries primary source first, then falls back to mirror sources automatically.
 pub async fn check_runtime_update() -> RuntimeUpdateCheckResult {
-    let url = match configured_manifest_url() {
-        Some(u) => u,
-        None => {
-            return RuntimeUpdateCheckResult {
-                ok: false,
-                update_available: false,
-                current_runtime_version: None,
-                manifest: None,
-                error: Some("Runtime update manifest URL is not configured".to_string()),
-            };
-        }
-    };
+    let candidates = get_manifest_candidates();
+    if candidates.is_empty() {
+        return RuntimeUpdateCheckResult {
+            ok: false,
+            update_available: false,
+            current_runtime_version: None,
+            manifest: None,
+            error: Some("Runtime update manifest URL is not configured".to_string()),
+        };
+    }
 
-    match RUNTIME_HTTP_CLIENT
-        .get(&url)
-        .timeout(RUNTIME_MANIFEST_HTTP_TIMEOUT)
-        .send()
-        .await
-    {
-        Ok(res) if res.status().is_success() => match res.json::<RuntimeUpdateManifest>().await {
+    let mut last_error: Option<String> = None;
+
+    for (index, url) in candidates.iter().enumerate() {
+        let is_primary = index == 0;
+
+        match fetch_and_parse_manifest(url).await {
             Ok(manifest) => {
                 if manifest.schema_version != MANIFEST_SCHEMA_VERSION {
                     return RuntimeUpdateCheckResult {
@@ -1324,37 +1468,55 @@ pub async fn check_runtime_update() -> RuntimeUpdateCheckResult {
                     .as_ref()
                     .map(|c| c.runtime_version != manifest.runtime_version)
                     .unwrap_or(true);
-                RuntimeUpdateCheckResult {
+                return RuntimeUpdateCheckResult {
                     ok: true,
                     update_available,
                     current_runtime_version: current.map(|c| c.runtime_version),
                     manifest: Some(manifest),
                     error: None,
+                };
+            }
+            Err(e) => {
+                last_error = Some(e);
+                if is_primary {
+                    log::warn!(
+                        "Primary manifest source failed: {}, falling back to mirrors",
+                        url
+                    );
+                } else {
+                    log::debug!("Mirror source failed: {}", url);
                 }
             }
-            Err(e) => RuntimeUpdateCheckResult {
-                ok: false,
-                update_available: false,
-                current_runtime_version: None,
-                manifest: None,
-                error: Some(format!("Failed to parse manifest: {}", e)),
-            },
-        },
-        Ok(res) => RuntimeUpdateCheckResult {
-            ok: false,
-            update_available: false,
-            current_runtime_version: None,
-            manifest: None,
-            error: Some(format!("HTTP {}", res.status())),
-        },
-        Err(e) => RuntimeUpdateCheckResult {
-            ok: false,
-            update_available: false,
-            current_runtime_version: None,
-            manifest: None,
-            error: Some(e.to_string()),
-        },
+        }
     }
+
+    RuntimeUpdateCheckResult {
+        ok: false,
+        update_available: false,
+        current_runtime_version: None,
+        manifest: None,
+        error: last_error.or_else(|| Some("All manifest sources failed".to_string())),
+    }
+}
+
+async fn fetch_and_parse_manifest(url: &str) -> Result<RuntimeUpdateManifest, String> {
+    let res = RUNTIME_HTTP_CLIENT
+        .get(url)
+        .timeout(RUNTIME_MANIFEST_HTTP_TIMEOUT)
+        .send()
+        .await
+        .map_err(|e| format!("Request failed: {}", e))?;
+
+    if !res.status().is_success() {
+        return Err(format!("HTTP {}", res.status()));
+    }
+
+    let manifest: RuntimeUpdateManifest = res
+        .json()
+        .await
+        .map_err(|e| format!("Failed to parse manifest: {}", e))?;
+
+    Ok(manifest)
 }
 
 #[cfg(test)]

--- a/web/.env.example
+++ b/web/.env.example
@@ -11,3 +11,16 @@
 # Provider catalog remote source (default: desktop.hermesagent.org.cn/api/provider-catalog.json)
 # Override to point the Models page preset catalog at a different JSON (e.g. staging)
 # VITE_HERMES_PROVIDER_CATALOG_URL=https://desktop.hermesagent.org.cn/api/provider-catalog.json
+
+# === Runtime Update Mirror Configuration (Rust backend, set before launching app) ===
+# For users in regions where GitHub is inaccessible, configure a mirror proxy for kernel update checks.
+# The app will try sources in order: primary GitHub URL -> this mirror -> built-in fallback mirrors.
+#
+# Option 1: ghproxy.com (recommended for China)
+# HERMES_UPDATE_MIRROR=https://ghproxy.com/https://github.com
+#
+# Option 2: gh.api.99988866.xyz
+# HERMES_UPDATE_MIRROR=https://gh.api.99988866.xyz/https://github.com
+#
+# Option 3: Custom mirror (set to any GitHub proxy base URL)
+# HERMES_UPDATE_MIRROR=https://your-mirror.example.com/https://github.com

--- a/web/src/components/chat/message-adapter.ts
+++ b/web/src/components/chat/message-adapter.ts
@@ -136,15 +136,28 @@ function imagePartsFromTransportText(text: string | null | undefined): HermesIma
   return dedupeImageParts(parts);
 }
 
+export function stripImageMetadataFromText(text: string): string {
+  return text
+    .replace(IMAGE_FALLBACK_RE, "")
+    .replace(HERMES_UI_IMAGE_BLOCK_RE, "")
+    .replace(/\n?\[The user attached an image(?: but analysis failed)?\.\]\n?/g, "")
+    .replace(/\n?\[If you need a closer look,? use vision_analyze (?:with |using )?image_url: [^\]\n]+\]\n?/g, "")
+    .replace(/\n{3,}/g, "\n\n")
+    .trim();
+}
+
 function textAndImagesFromStructuredContent(content: string | null | undefined): {
   text?: string;
   images: HermesImagePart[];
 } {
   const parsed = parseJsonContent(content);
   if (parsed === undefined) {
+    const raw = content ?? "";
+    const images = imagePartsFromTransportText(raw);
+    const cleaned = stripImageMetadataFromText(raw);
     return {
-      text: content ?? undefined,
-      images: imagePartsFromTransportText(content),
+      text: cleaned || undefined,
+      images,
     };
   }
 
@@ -314,15 +327,26 @@ function normalizeProcessNotificationText(text: string): string | null {
 // blank the whole history, but we drop them here cleanly.
 const RENDERABLE_LEGACY_ROLES = new Set(["user", "assistant", "system", "tool"]);
 
+const SYSTEM_METADATA_PATTERNS: RegExp[] = [
+  /^\[System:\s.*\]/s,
+  /^\[Note:\s.*\]/s,
+  /^\[The user attached an image?:\s.*\]/s,
+  /^\[You can examine it with vision_analyze.*\]/s,
+  /^\[.*vision_analyze.*\]/s,
+  /image_url:\s*[A-Za-z]:\\/s,
+];
+
+function isSystemMetadataMessage(content: string): boolean {
+  const trimmed = content.trim();
+  return SYSTEM_METADATA_PATTERNS.some((pattern) => pattern.test(trimmed));
+}
+
 export function legacySessionMessageToHermesUIMessage(msg: SessionMessage): HermesUIMessage | null {
   const createdAt = msg.timestamp ? msg.timestamp * 1000 : Date.now();
 
   if (!RENDERABLE_LEGACY_ROLES.has(msg.role)) return null;
 
-  // Belt-and-suspenders: drop metadata-only user messages that slipped past
-  // the Core API-boundary filter (_normalize_message_content in web_server.py).
-  const METADATA_ONLY_RE = /^\[(?:System|Note):\s.*\]/;
-  if (msg.role === "user" && msg.content && METADATA_ONLY_RE.test(msg.content.trim())) {
+  if (msg.content && isSystemMetadataMessage(msg.content)) {
     return null;
   }
 

--- a/web/src/components/chat/message-timeline.module.css
+++ b/web/src/components/chat/message-timeline.module.css
@@ -794,6 +794,17 @@
   color: var(--h-accent);
 }
 
+.messageActions button svg {
+  width: 11px;
+  height: 11px;
+  stroke-width: 2;
+}
+
+.messageActions button:disabled {
+  opacity: 0.5;
+  cursor: not-allowed;
+}
+
 .messageSpeechError {
   max-width: min(360px, 52vw);
   overflow: hidden;
@@ -1302,4 +1313,79 @@
   to {
     transform: rotate(360deg);
   }
+}
+
+/* 回退确认弹窗 */
+.confirmOverlay {
+  position: fixed;
+  top: 0;
+  left: 0;
+  right: 0;
+  bottom: 0;
+  background: rgba(0, 0, 0, 0.5);
+  display: flex;
+  align-items: center;
+  justify-content: center;
+  z-index: 1000;
+  animation: fadeIn 0.15s ease;
+}
+
+.confirmDialog {
+  background: var(--h-bg-input);
+  border: 1px solid var(--h-line);
+  border-radius: 12px;
+  padding: 24px;
+  max-width: 400px;
+  width: 90%;
+  box-shadow: 0 8px 32px rgba(0, 0, 0, 0.2);
+  animation: fadeIn 0.2s ease;
+}
+
+.confirmTitle {
+  font-size: 16px;
+  font-weight: 600;
+  color: var(--h-text);
+  margin-bottom: 12px;
+}
+
+.confirmMessage {
+  font-size: 14px;
+  color: var(--h-text-2);
+  line-height: 1.6;
+  margin-bottom: 20px;
+}
+
+.confirmMessage strong {
+  color: var(--h-err);
+}
+
+.confirmActions {
+  display: flex;
+  gap: 12px;
+  justify-content: flex-end;
+}
+
+.confirmActions button {
+  border: 1px solid var(--h-line);
+  background: transparent;
+  color: var(--h-text-2);
+  border-radius: 8px;
+  padding: 8px 16px;
+  font-size: 14px;
+  cursor: pointer;
+  transition: all 0.15s ease;
+}
+
+.confirmActions button:hover {
+  background: var(--h-bg-soft);
+  color: var(--h-text);
+}
+
+.confirmDanger {
+  border-color: var(--h-err) !important;
+  color: var(--h-err) !important;
+}
+
+.confirmDanger:hover {
+  background: color-mix(in srgb, var(--h-err), transparent 90%) !important;
 }

--- a/web/src/components/chat/message-timeline.tsx
+++ b/web/src/components/chat/message-timeline.tsx
@@ -1,7 +1,7 @@
 import { useCallback, useEffect, useLayoutEffect, useMemo, useRef, useState } from "react";
 import type { ReactNode, WheelEvent } from "react";
 import { useAtomValue } from "jotai";
-import { AlertTriangle, ChevronRight, Info, Loader2, Volume2, VolumeX } from "lucide-react";
+import { AlertTriangle, ChevronRight, Info, Loader2, RefreshCw, Undo2, Volume2, VolumeX } from "lucide-react";
 import { assistantAvatarEffectiveAtom, assistantDisplayNameAtom, showReasoningAtom } from "@/stores/ui";
 import type { AssistantMessageStats, ChatMessage, ChatToolItem } from "./chat-types";
 import { AssistantProfileCard } from "./assistant-profile-card";
@@ -39,6 +39,9 @@ interface MessageTimelineProps {
   sessionUsage?: SessionUsageResult | null;
   progressModel?: string;
   autoTts?: boolean;
+  hiddenMessageIds?: Set<string>;
+  onUndoTurn?: (messageId: string) => void;
+  onRegenerateResponse?: (messageId: string) => void;
 }
 
 interface TurnAnchor {
@@ -766,9 +769,12 @@ interface MessageBubbleProps {
   sessionUsage?: SessionUsageResult | null;
   progressModel?: string;
   speech?: SpeechPlaybackControls;
+  onUndoTurn?: (messageId: string) => void;
+  onRegenerateResponse?: (messageId: string) => void;
+  showTurnActions?: boolean;
 }
 
-function MessageBubble({ message, turnStartedAt, sessionUsage, progressModel, speech }: MessageBubbleProps) {
+function MessageBubble({ message, turnStartedAt, sessionUsage, progressModel, speech, onUndoTurn, onRegenerateResponse, showTurnActions }: MessageBubbleProps) {
   const showReasoning = useAtomValue(showReasoningAtom);
   const assistantDisplayName = useAtomValue(assistantDisplayNameAtom);
   const assistantAvatarDataUrl = useAtomValue(assistantAvatarEffectiveAtom);
@@ -785,6 +791,11 @@ function MessageBubble({ message, turnStartedAt, sessionUsage, progressModel, sp
   const hasBlocks = !isUser && Boolean(message.blocks?.length);
   const hasSkillInvocation = isSkillInvocationText(message.text);
   const messageStats = message.stats ?? sessionUsageFallbackStats(message, sessionUsage);
+  const isError = message.status === "error";
+  // 显示操作按钮：assistant消息（非streaming），包括错误状态（错误时只显示重新生成）
+  const showAssistantActions = showTurnActions && !isUser && !isSystem && !isToolOnly && !streaming;
+  const showUndoButton = showAssistantActions && !isError;
+  const showRegenerateButton = showAssistantActions;
 
   if (hasSkillInvocation) {
     return (
@@ -913,6 +924,28 @@ function MessageBubble({ message, turnStartedAt, sessionUsage, progressModel, sp
                 复制
               </CopyButton>
             ) : null}
+            {showUndoButton && onUndoTurn ? (
+              <button
+                type="button"
+                onClick={() => onUndoTurn(message.id)}
+                title="回退到此对话位置"
+                aria-label="回退到此对话位置"
+              >
+                <Undo2 aria-hidden="true" />
+                <span>回退</span>
+              </button>
+            ) : null}
+            {showRegenerateButton && onRegenerateResponse ? (
+              <button
+                type="button"
+                onClick={() => onRegenerateResponse(message.id)}
+                title="重新生成回复"
+                aria-label="重新生成回复"
+              >
+                <RefreshCw aria-hidden="true" />
+                <span>重新生成</span>
+              </button>
+            ) : null}
             {readable && speech ? (
               <button
                 type="button"
@@ -957,6 +990,9 @@ export function MessageTimeline({
   sessionUsage,
   progressModel,
   autoTts = false,
+  hiddenMessageIds,
+  onUndoTurn,
+  onRegenerateResponse,
 }: MessageTimelineProps) {
   const containerRef = useRef<HTMLDivElement>(null);
   const messagesRef = useRef<HTMLDivElement>(null);
@@ -984,17 +1020,20 @@ export function MessageTimeline({
     status: "idle",
   });
   const [speechError, setSpeechError] = useState<SpeechPlaybackError | null>(null);
+  const [confirmUndoMessageId, setConfirmUndoMessageId] = useState<string | null>(null);
   const visibleMessages = useMemo(
     () =>
-      messages.filter(
-        (message) =>
-          message.text ||
-          message.reasoning ||
-          message.images?.length ||
-          message.tools?.length ||
-          message.blocks?.length,
-      ),
-    [messages],
+      messages
+        .filter(
+          (message) =>
+            (!hiddenMessageIds || !hiddenMessageIds.has(message.id)) &&
+            (message.text ||
+              message.reasoning ||
+              message.images?.length ||
+              message.tools?.length ||
+              message.blocks?.length),
+        ),
+    [messages, hiddenMessageIds],
   );
   const turnAnchors = useMemo<TurnAnchor[]>(() => {
     const anchors: TurnAnchor[] = [];
@@ -1010,6 +1049,24 @@ export function MessageTimeline({
     return anchors;
   }, [visibleMessages]);
   const showTurnRail = turnAnchors.length > 1;
+
+  // 处理回退按钮点击 - 先显示确认弹窗
+  const handleUndoTurn = useCallback((messageId: string) => {
+    setConfirmUndoMessageId(messageId);
+  }, []);
+
+  // 确认回退
+  const confirmUndoTurn = useCallback(() => {
+    if (confirmUndoMessageId && onUndoTurn) {
+      onUndoTurn(confirmUndoMessageId);
+    }
+    setConfirmUndoMessageId(null);
+  }, [confirmUndoMessageId, onUndoTurn]);
+
+  // 取消回退
+  const cancelUndoTurn = useCallback(() => {
+    setConfirmUndoMessageId(null);
+  }, []);
 
   const stopSpeech = useCallback(() => {
     speechSequenceRef.current += 1;
@@ -1437,6 +1494,8 @@ export function MessageTimeline({
           const showDate = !previous || formatDay(previous.createdAt) !== formatDay(message.createdAt);
           const isLast = index === visibleMessages.length - 1;
           const isUserTurn = message.role === "user" && !isSkillInvocationText(message.text);
+          const isAssistantMessage = message.role === "assistant";
+          const isLastAssistant = isLast && isAssistantMessage;
           return (
             <div
               key={message.id}
@@ -1450,6 +1509,9 @@ export function MessageTimeline({
                 sessionUsage={isLast ? sessionUsage : undefined}
                 progressModel={isLast ? progressModel : undefined}
                 speech={speechControls}
+                onUndoTurn={isAssistantMessage ? handleUndoTurn : undefined}
+                onRegenerateResponse={isLastAssistant ? onRegenerateResponse : undefined}
+                showTurnActions={isAssistantMessage}
               />
             </div>
           );
@@ -1458,6 +1520,25 @@ export function MessageTimeline({
         {statusMessage ? <div className={s.statusMessage}>{statusMessage}</div> : null}
         {pendingApproval}
       </div>
+      {/* 回退确认弹窗 */}
+      {confirmUndoMessageId ? (
+        <div className={s.confirmOverlay} onClick={cancelUndoTurn}>
+          <div className={s.confirmDialog} onClick={(e) => e.stopPropagation()}>
+            <div className={s.confirmTitle}>确认回退</div>
+            <div className={s.confirmMessage}>
+              回退后将<strong>删除该消息之后的所有对话记录</strong>，此操作不可撤销。
+              <br />
+              你确定要回退到这条消息吗？
+            </div>
+            <div className={s.confirmActions}>
+              <button type="button" onClick={cancelUndoTurn}>取消</button>
+              <button type="button" className={s.confirmDanger} onClick={confirmUndoTurn}>
+                确认回退
+              </button>
+            </div>
+          </div>
+        </div>
+      ) : null}
     </div>
   );
 }

--- a/web/src/components/ui/toast.module.css
+++ b/web/src/components/ui/toast.module.css
@@ -1,0 +1,48 @@
+.container {
+  position: fixed;
+  bottom: 24px;
+  left: 50%;
+  transform: translateX(-50%);
+  display: flex;
+  flex-direction: column;
+  gap: 8px;
+  z-index: 1000;
+  pointer-events: none;
+}
+
+.toast {
+  padding: 10px 18px;
+  border-radius: 8px;
+  font-size: 13px;
+  font-weight: 500;
+  box-shadow: 0 4px 12px rgba(0, 0, 0, 0.15);
+  opacity: 0;
+  transform: translateY(10px);
+  transition: opacity 0.2s ease, transform 0.2s ease;
+  pointer-events: auto;
+  max-width: 320px;
+  text-align: center;
+}
+
+.toast.visible {
+  opacity: 1;
+  transform: translateY(0);
+}
+
+.toast.info {
+  background: var(--color-surface-2, #f5f5f5);
+  color: var(--color-text, #333);
+  border: 1px solid var(--color-border, #e0e0e0);
+}
+
+.toast.success {
+  background: #d4edda;
+  color: #155724;
+  border: 1px solid #c3e6cb;
+}
+
+.toast.error {
+  background: #f8d7da;
+  color: #721c24;
+  border: 1px solid #f5c6cb;
+}

--- a/web/src/components/ui/toast.tsx
+++ b/web/src/components/ui/toast.tsx
@@ -1,0 +1,53 @@
+import { useEffect, useState } from "react";
+import s from "./toast.module.css";
+
+export interface ToastMessage {
+  id: number;
+  text: string;
+  type: "info" | "success" | "error";
+}
+
+interface ToastProps {
+  message: ToastMessage;
+  onDismiss: (id: number) => void;
+}
+
+export function Toast({ message, onDismiss }: ToastProps) {
+  const [visible, setVisible] = useState(false);
+
+  useEffect(() => {
+    const showTimer = setTimeout(() => setVisible(true), 10);
+    const hideTimer = setTimeout(() => setVisible(false), 2000);
+    const removeTimer = setTimeout(() => onDismiss(message.id), 2500);
+    return () => {
+      clearTimeout(showTimer);
+      clearTimeout(hideTimer);
+      clearTimeout(removeTimer);
+    };
+  }, [message.id, onDismiss]);
+
+  return (
+    <div
+      className={`${s.toast} ${visible ? s.visible : ""} ${s[message.type]}`}
+      role="status"
+      aria-live="polite"
+    >
+      {message.text}
+    </div>
+  );
+}
+
+interface ToastContainerProps {
+  messages: ToastMessage[];
+  onDismiss: (id: number) => void;
+}
+
+export function ToastContainer({ messages, onDismiss }: ToastContainerProps) {
+  return (
+    <div className={s.container}>
+      {messages.map((msg) => (
+        <Toast key={msg.id} message={msg} onDismiss={onDismiss} />
+      ))}
+    </div>
+  );
+}

--- a/web/src/hooks/use-gateway.ts
+++ b/web/src/hooks/use-gateway.ts
@@ -43,11 +43,14 @@ import {
   ensureChatSessionAtom,
   gwConnectionAtom,
   gwSessionIdAtom,
+  hideMessageRangeAtom,
+  hideMessagesAfterAtom,
   markSessionInterruptedAtom,
   markStreamsReconnectingAtom,
   resetChatSessionAtom,
   resetStreamStateAtom,
   setSessionErrorAtom,
+  showToastAtom,
   startPromptAtom,
   terminateAllStreamsAtom,
   type ImageEntry,
@@ -271,6 +274,9 @@ export function useGateway() {
   const setSessionError = useSetAtom(setSessionErrorAtom);
   const setSessionTipRedirect = useSetAtom(sessionTipRedirectAtom);
   const terminateAllStreams = useSetAtom(terminateAllStreamsAtom);
+  const hideMessagesAfter = useSetAtom(hideMessagesAfterAtom);
+  const hideMessageRange = useSetAtom(hideMessageRangeAtom);
+  const showToast = useSetAtom(showToastAtom);
 
   const applyGatewayEventAndSync = useCallback((event: GatewayEvent) => {
     applyGatewayEvent(event);
@@ -761,6 +767,93 @@ export function useGateway() {
     setGwSessionId(null);
   }, [setGwSessionId]);
 
+  // 回退到指定消息位置：保留该消息及之前的，隐藏之后的所有消息
+  const undoTurn = useCallback(
+    async (sessionId: string, messageId?: string) => {
+      if (!sessionId) return;
+      const runtime = runtimeBySession[sessionId];
+      if (!runtime) return;
+      if (runtime.streamStatus === "streaming" || runtime.streamStatus === "connecting") {
+        return;
+      }
+
+      const messages = runtime.messages;
+      let keepMessageId = messageId;
+
+      if (!keepMessageId) {
+        // 没有指定消息ID，找到最后一条AI回复
+        for (let i = messages.length - 1; i >= 0; i--) {
+          if (messages[i].role === "assistant") {
+            keepMessageId = messages[i].id;
+            break;
+          }
+        }
+      }
+      if (!keepMessageId) return;
+
+      hideMessagesAfter({ sessionId, keepMessageId });
+      showToast({ text: "已回退到该对话位置", type: "info" });
+    },
+    [hideMessagesAfter, runtimeBySession, showToast],
+  );
+
+  // 重新生成指定AI回复：隐藏用户消息到AI回复的范围，重新发送用户消息
+  const regenerateResponse = useCallback(
+    async (sessionId: string, assistantMessageId?: string) => {
+      if (!sessionId) return;
+      const runtime = runtimeBySession[sessionId];
+      if (!runtime) return;
+      if (runtime.streamStatus === "streaming" || runtime.streamStatus === "connecting") {
+        return;
+      }
+
+      const messages = runtime.messages;
+
+      // 如果没有指定消息ID，使用最后一条AI回复
+      let targetAssistantId = assistantMessageId;
+      if (!targetAssistantId) {
+        for (let i = messages.length - 1; i >= 0; i--) {
+          if (messages[i].role === "assistant" && messages[i].status !== "streaming") {
+            targetAssistantId = messages[i].id;
+            break;
+          }
+        }
+      }
+      if (!targetAssistantId) return;
+
+      // 找到目标AI回复的位置
+      const assistantIndex = messages.findIndex((m) => m.id === targetAssistantId);
+      if (assistantIndex === -1) return;
+
+      // 从AI回复位置往前找对应的用户消息
+      let lastUserText: string | null = null;
+      let userMessageId: string | null = null;
+      for (let i = assistantIndex - 1; i >= 0; i--) {
+        if (messages[i].role === "user") {
+          userMessageId = messages[i].id;
+          const text = messages[i].parts
+            .filter((p: any) => p.type === "text")
+            .map((p: any) => p.text)
+            .join("");
+          if (text.trim()) {
+            lastUserText = text.trim();
+          }
+          break;
+        }
+      }
+      if (!lastUserText) return;
+
+      // 隐藏用户消息到AI回复的所有消息
+      const startMessageId = userMessageId ?? targetAssistantId;
+      hideMessageRange({ sessionId, startMessageId, endMessageId: targetAssistantId });
+      showToast({ text: "正在重新生成回复...", type: "info" });
+
+      // 重新发送用户消息
+      await sendPrompt(sessionId, lastUserText, { displayText: lastUserText });
+    },
+    [hideMessageRange, runtimeBySession, sendPrompt, showToast],
+  );
+
   return {
     connectionState,
     gwSessionId,
@@ -790,5 +883,7 @@ export function useGateway() {
     interruptSession,
     setSessionTitle,
     disconnect,
+    undoTurn,
+    regenerateResponse,
   };
 }

--- a/web/src/routes/detail.tsx
+++ b/web/src/routes/detail.tsx
@@ -15,8 +15,11 @@ import {
 import { pickTipRedirect } from "@/lib/session-tip-redirect";
 import {
   appendNoticeAtom,
+  dismissToastAtom,
+  hiddenMessageIdsAtom,
   recoverCompletedTurnFromStoredMessagesAtom,
   removeApprovalAtom,
+  toastMessagesAtom,
 } from "@/stores/chat";
 import { useSession, useSessionMessages, useSessions } from "@/hooks/use-sessions";
 import { useSkills } from "@/hooks/use-skills";
@@ -78,6 +81,7 @@ import { PREVIEW_PANEL_QUERY_KEY } from "@/lib/preview-rail";
 import { activeCliDelegationCount, clearFinishedCliDelegationsAtom } from "@/stores/cli-delegations";
 import { activeSubagentCount, clearFinishedSubagentsAtom } from "@/stores/subagents";
 import { ConversationWidthControl } from "@/components/chat/conversation-width-control";
+import { ToastContainer } from "@/components/ui/toast";
 import {
   hermesUIMessagesToChatMessages,
   attachTurnStatsMetadata,
@@ -117,6 +121,8 @@ export function DetailRoute() {
     attachImage,
     attachImageBytes,
     detectDroppedPath,
+    undoTurn,
+    regenerateResponse,
   } = useGateway();
   const { data: config } = useConfig();
   const { data: modelInfo } = useModelInfo();
@@ -137,6 +143,9 @@ export function DetailRoute() {
   const sessionIdCopyTimer = useRef<number | null>(null);
   const recoverCompletedTurnFromStoredMessages = useSetAtom(recoverCompletedTurnFromStoredMessagesAtom);
   const appendNotice = useSetAtom(appendNoticeAtom);
+  const toastMessages = useAtomValue(toastMessagesAtom);
+  const dismissToast = useSetAtom(dismissToastAtom);
+  const hiddenMessageIdsMap = useAtomValue(hiddenMessageIdsAtom);
 
   const {
     restSessionId,
@@ -718,6 +727,9 @@ export function DetailRoute() {
             sessionUsage={runtimeIsBusy ? sessionUsage : undefined}
             progressModel={runtimeIsBusy ? model || undefined : undefined}
             autoTts={autoTts}
+            hiddenMessageIds={runtimeSessionId ? hiddenMessageIdsMap.get(runtimeSessionId) : undefined}
+            onUndoTurn={runtimeSessionId ? (messageId) => undoTurn(runtimeSessionId, messageId) : undefined}
+            onRegenerateResponse={runtimeSessionId ? (messageId) => regenerateResponse(runtimeSessionId, messageId) : undefined}
           />
           <div className={s.composerArea}>
             {runtimeIsBusy && stall.isStalled ? (
@@ -795,6 +807,7 @@ export function DetailRoute() {
         ) : null}
 
       </div>
+      <ToastContainer messages={toastMessages} onDismiss={dismissToast} />
     </div>
   );
 }

--- a/web/src/stores/chat.ts
+++ b/web/src/stores/chat.ts
@@ -1411,3 +1411,231 @@ export const removeApprovalAtom = atom(
     );
   },
 );
+
+// 回退到上一轮对话：删除最后一条用户消息及其对应的AI回复
+export const undoLastTurnAtom = atom(
+  null,
+  (_get, set, sessionId: string) => {
+    const now = Date.now();
+    set(chatRuntimeBySessionAtom, (state) =>
+      updateSessionRuntime(state, sessionId, (runtime) => {
+        if (runtime.streamStatus === "streaming" || runtime.streamStatus === "connecting") {
+          return runtime;
+        }
+        const messages = [...runtime.messages];
+        if (messages.length < 2) return runtime;
+        let userIndex = -1;
+        for (let i = messages.length - 1; i >= 0; i--) {
+          if (messages[i].role === "user") {
+            userIndex = i;
+            break;
+          }
+        }
+        if (userIndex === -1) return runtime;
+        const newMessages = messages.slice(0, userIndex);
+        return {
+          ...runtime,
+          messages: newMessages,
+          streamStatus: "idle",
+          statusMessage: "",
+          statusKind: undefined,
+          statusUpdatedAt: undefined,
+          activeAssistantId: undefined,
+          updatedAt: now,
+        };
+      }),
+    );
+  },
+);
+
+// 获取最后一条用户消息的文本内容（普通函数，接受 getter 作为参数）
+export function getLastUserMessageText(get: (atom: typeof chatRuntimeBySessionAtom) => ChatRuntimeBySession, sessionId: string): string | null {
+  const runtime = get(chatRuntimeBySessionAtom)[sessionId];
+  if (!runtime || runtime.messages.length === 0) return null;
+  const messages = [...runtime.messages].reverse();
+  for (const message of messages) {
+    if (message.role === "user") {
+      const text = message.parts
+        .filter((p): p is Extract<HermesMessagePart, { type: "text" }> => p.type === "text")
+        .map((p) => p.text)
+        .join("");
+      if (text.trim()) return text.trim();
+    }
+  }
+  return null;
+}
+
+// 重新生成回复：删除最后一条AI回复（保留用户消息），然后重新发送用户消息
+export const regenerateLastResponseAtom = atom(
+  null,
+  (_get, set, sessionId: string) => {
+    const now = Date.now();
+    set(chatRuntimeBySessionAtom, (state) =>
+      updateSessionRuntime(state, sessionId, (runtime) => {
+        if (runtime.streamStatus === "streaming" || runtime.streamStatus === "connecting") {
+          return runtime;
+        }
+        const messages = [...runtime.messages];
+        let lastAssistantIndex = -1;
+        for (let i = messages.length - 1; i >= 0; i--) {
+          if (messages[i].role === "assistant") {
+            lastAssistantIndex = i;
+            break;
+          }
+        }
+        if (lastAssistantIndex === -1) return runtime;
+        const newMessages = messages.slice(0, lastAssistantIndex);
+        return {
+          ...runtime,
+          messages: newMessages,
+          streamStatus: "idle",
+          statusMessage: "",
+          statusKind: undefined,
+          statusUpdatedAt: undefined,
+          activeAssistantId: undefined,
+          updatedAt: now,
+        };
+      }),
+    );
+  },
+);
+
+// Toast 通知状态
+export interface ToastState {
+  id: number;
+  text: string;
+  type: "info" | "success" | "error";
+}
+
+export const toastMessagesAtom = atom<ToastState[]>([]);
+
+export const showToastAtom = atom(null, (_get, set, payload: { text: string; type?: "info" | "success" | "error" }) => {
+  const id = Date.now() + Math.random();
+  set(toastMessagesAtom, (prev) => [...prev, { id, text: payload.text, type: payload.type ?? "info" }]);
+  setTimeout(() => {
+    set(toastMessagesAtom, (prev) => prev.filter((t) => t.id !== id));
+  }, 2500);
+});
+
+export const dismissToastAtom = atom(null, (_get, set, id: number) => {
+  set(toastMessagesAtom, (prev) => prev.filter((t) => t.id !== id));
+});
+
+// 被折叠/隐藏的消息ID（用于回退和重新生成功能）
+// Key: sessionId, Value: Set of hidden message IDs
+export const hiddenMessageIdsAtom = atom<Map<string, Set<string>>>(new Map());
+
+// 回退：保留目标消息及之前的，隐藏目标消息之后的所有消息
+export const hideMessagesAfterAtom = atom(
+  null,
+  (_get, set, payload: { sessionId: string; keepMessageId: string }) => {
+    const { sessionId, keepMessageId } = payload;
+    set(chatRuntimeBySessionAtom, (state) => {
+      const runtime = state[sessionId];
+      if (!runtime) return state;
+
+      // 找到 keepMessageId 在消息列表中的位置
+      const messages = runtime.messages;
+      let targetIndex = -1;
+      for (let i = 0; i < messages.length; i++) {
+        if (messages[i].id === keepMessageId) {
+          targetIndex = i;
+          break;
+        }
+      }
+      if (targetIndex === -1) return state;
+
+      // 获取需要隐藏的所有消息ID（从目标消息的下一条开始到结尾）
+      const idsToHide = new Set<string>();
+      for (let i = targetIndex + 1; i < messages.length; i++) {
+        idsToHide.add(messages[i].id);
+      }
+
+      // 更新 hiddenMessageIdsAtom
+      set(hiddenMessageIdsAtom, (prev) => {
+        const next = new Map(prev);
+        const existing = next.get(sessionId) ?? new Set<string>();
+        const merged = new Set([...existing, ...idsToHide]);
+        next.set(sessionId, merged);
+        return next;
+      });
+
+      // 重置流状态
+      const now = Date.now();
+      return {
+        ...state,
+        [sessionId]: {
+          ...runtime,
+          streamStatus: "idle",
+          statusMessage: "",
+          statusKind: undefined,
+          statusUpdatedAt: now,
+          activeAssistantId: undefined,
+          updatedAt: now,
+        },
+      };
+    });
+  },
+);
+
+// 重新生成：隐藏指定范围内的消息（用户消息到AI回复）
+export const hideMessageRangeAtom = atom(
+  null,
+  (_get, set, payload: { sessionId: string; startMessageId: string; endMessageId: string }) => {
+    const { sessionId, startMessageId, endMessageId } = payload;
+    set(chatRuntimeBySessionAtom, (state) => {
+      const runtime = state[sessionId];
+      if (!runtime) return state;
+
+      const messages = runtime.messages;
+      let startIndex = -1;
+      let endIndex = -1;
+      for (let i = 0; i < messages.length; i++) {
+        if (messages[i].id === startMessageId) startIndex = i;
+        if (messages[i].id === endMessageId) endIndex = i;
+      }
+      if (startIndex === -1 || endIndex === -1) return state;
+
+      // 获取需要隐藏的所有消息ID（从 start 到 end）
+      const idsToHide = new Set<string>();
+      for (let i = startIndex; i <= endIndex; i++) {
+        idsToHide.add(messages[i].id);
+      }
+
+      set(hiddenMessageIdsAtom, (prev) => {
+        const next = new Map(prev);
+        const existing = next.get(sessionId) ?? new Set<string>();
+        const merged = new Set([...existing, ...idsToHide]);
+        next.set(sessionId, merged);
+        return next;
+      });
+
+      const now = Date.now();
+      return {
+        ...state,
+        [sessionId]: {
+          ...runtime,
+          streamStatus: "idle",
+          statusMessage: "",
+          statusKind: undefined,
+          statusUpdatedAt: now,
+          activeAssistantId: undefined,
+          updatedAt: now,
+        },
+      };
+    });
+  },
+);
+
+// 清除指定会话的隐藏消息记录（在新对话时调用）
+export const clearHiddenMessagesAtom = atom(
+  null,
+  (_get, set, sessionId: string) => {
+    set(hiddenMessageIdsAtom, (prev) => {
+      if (!prev.has(sessionId)) return prev;
+      const next = new Map(prev);
+      next.delete(sessionId);
+      return next;
+    });
+  },
+);

--- a/web/src/stores/chat.ts
+++ b/web/src/stores/chat.ts
@@ -15,6 +15,7 @@ import {
   dedupeImageParts,
   imagePartFromSource,
 } from "@/lib/message-images";
+import { stripImageMetadataFromText } from "@/components/chat/message-adapter";
 import { notifyFromGatewayEvent } from "@/lib/notifications";
 import { resolvePersistentSessionId } from "@/lib/session-map";
 import { recordUiTurnStats, stableTextHash } from "@/lib/ui-store";
@@ -257,12 +258,14 @@ function terminateRunningTools(parts: HermesMessagePart[]): HermesMessagePart[] 
 
 function appendTextPart(parts: HermesMessagePart[], text: string): HermesMessagePart[] {
   if (!text) return parts;
+  const filtered = stripImageMetadataFromText(text);
+  if (!filtered) return parts;
   const next = withoutProgressParts(parts);
   const last = next[next.length - 1];
   if (last?.type === "text") {
-    next[next.length - 1] = { ...last, text: last.text + text };
+    next[next.length - 1] = { ...last, text: last.text + filtered };
   } else {
-    next.push({ type: "text", text });
+    next.push({ type: "text", text: filtered });
   }
   return next;
 }


### PR DESCRIPTION
## 改动说明

本 PR 解决两个问题：

### 1. 内核更新检查失败
- 添加 ghproxy.net 作为优先镜像源
- 实现多镜像自动降级机制（GitHub → ghproxy.net → ghproxy.com → 99988866.xyz）
- 允许通过环境变量 HERMES_UPDATE_MIRROR 自定义镜像源
- runtime 安装失败时降级到离线模式，应用仍可正常启动

### 2. 图片消息显示多余系统日志
- 过滤 [System:...]、[The user attached an image:...]、[You can examine it with vision_analyze...] 等元数据
- 流式消息实时过滤，避免元数据被渲染到界面
- 支持多种格式的系统日志过滤

### 3. 外部 agent 模式下显示内核版本
- 通过执行 hermes --version 获取版本信息
- 填充到界面的内核版本显示

## 测试

- [x] 镜像源自动降级正常
- [x] 检查更新功能正常
- [x] 图片消息无多余文字
- [x] 内核版本正常显示