### PR TITLE
fix: 恢复新任务推理强度选择

### DIFF
--- a/web/src/components/chat/composer-types.ts
+++ b/web/src/components/chat/composer-types.ts
@@ -48,6 +48,7 @@ export interface ComposerSubmitPayload {
   attachments: ComposerAttachment[];
   workspacePath?: string;
   modelSelection?: ComposerModelSelection;
+  reasoningEffort?: ReasoningEffort;
   skillCommandNames?: string[];
 }
 

--- a/web/src/components/chat/goose-composer.tsx
+++ b/web/src/components/chat/goose-composer.tsx
@@ -888,6 +888,7 @@ export function GooseComposer({
       attachments,
       workspacePath: workspacePath.trim() || undefined,
       modelSelection: selectedModelRef.current ?? undefined,
+      reasoningEffort: reasoningPicker?.value ?? undefined,
       skillCommandNames: skillPicker?.skills.map((skill) => skill.name),
     };
 

--- a/web/src/components/panel/panel-composer.test.tsx
+++ b/web/src/components/panel/panel-composer.test.tsx
@@ -1,0 +1,61 @@
+import ReactDOMServer from "react-dom/server";
+import { MemoryRouter } from "react-router-dom";
+import { describe, expect, it, vi } from "vitest";
+
+vi.mock("@/hooks/use-gateway", () => ({
+  useGateway: () => ({
+    connect: vi.fn(),
+    getModelOptions: vi.fn(),
+    completePath: vi.fn(),
+    createSession: vi.fn(),
+    closeSession: vi.fn(),
+    adoptCreatedSession: vi.fn(),
+  }),
+}));
+
+vi.mock("@/hooks/use-create-and-send-session", () => ({
+  useCreateAndSendSession: () => vi.fn(),
+}));
+
+vi.mock("@/hooks/use-config", () => ({
+  useConfig: () => ({ data: { agent: { reasoning_effort: "low" } } }),
+  useModelInfo: () => ({ data: { model: "test-model", provider: "test-provider" } }),
+  useSaveConfig: () => ({ mutate: vi.fn() }),
+}));
+
+vi.mock("@/hooks/use-model-options", () => ({
+  useModelOptions: () => ({ data: null }),
+}));
+
+vi.mock("@/hooks/use-skills", () => ({
+  useSkills: () => ({
+    data: [],
+    error: null,
+    isError: false,
+    isFetching: false,
+    isLoading: false,
+  }),
+}));
+
+vi.mock("@/hooks/use-sessions", () => ({
+  useSessions: () => ({ data: { sessions: [] } }),
+}));
+
+vi.mock("@/hooks/use-profiles", () => ({
+  useActiveProfileName: () => "default",
+}));
+
+import { PanelComposer } from "./panel-composer";
+
+describe("PanelComposer", () => {
+  it("在新任务工具栏显示当前推理强度入口", () => {
+    const html = ReactDOMServer.renderToStaticMarkup(
+      <MemoryRouter>
+        <PanelComposer />
+      </MemoryRouter>,
+    );
+
+    expect(html).toContain("思考强度：低");
+    expect(html).toContain(">思考<");
+  });
+});

--- a/web/src/components/panel/panel-composer.tsx
+++ b/web/src/components/panel/panel-composer.tsx
@@ -11,6 +11,10 @@ import { useActiveProfileName } from "@/hooks/use-profiles";
 import { resolveModelContextWindow } from "@/lib/model-context";
 import { readLastUsedModel, rememberLastUsedModel } from "@/lib/last-used-model";
 import { recordModelUsage } from "@/lib/model-usage-log";
+import {
+  reasoningEffortFromConfig,
+  type ReasoningEffort,
+} from "@/lib/reasoning-effort";
 import { composerSubmitShortcutHint } from "@/lib/composer-submit-shortcut";
 import { shouldPrewarmDraftSession } from "@/lib/draft-session-prewarm";
 import {
@@ -50,6 +54,8 @@ export function PanelComposer() {
   const [selectedModel, setSelectedModel] = useState<ComposerModelSelection | null>(
     () => readLastUsedModel(),
   );
+  const [reasoningEffortOverride, setReasoningEffortOverride] =
+    useState<ReasoningEffort | null>(null);
   const [prefilledDraft, setPrefilledDraft] = useState({ text: "", nonce: 0 });
   const [prefill, setPrefill] = useAtom(composerPrefillAtom);
   const composerSubmitShortcut = useAtomValue(composerSubmitShortcutAtom);
@@ -146,6 +152,13 @@ export function PanelComposer() {
     navigate(`/models#provider-${providerId}`);
   }, [navigate]);
 
+  const configReasoningEffort = useMemo(() => reasoningEffortFromConfig(config), [config]);
+  const reasoningEffort = reasoningEffortOverride ?? configReasoningEffort;
+
+  const onReasoningEffortSelect = useCallback((effort: ReasoningEffort) => {
+    setReasoningEffortOverride(effort);
+  }, []);
+
   const onSelectAndSetDefault = useCallback((selection: ComposerModelSelection) => {
     onModelSelect(selection);
     if (!config) return;
@@ -226,6 +239,11 @@ export function PanelComposer() {
           onSelect: onModelSelect,
           onSelectAndSetDefault,
           onConfigureProvider,
+          disabled: sending,
+        }}
+        reasoningPicker={{
+          value: reasoningEffort,
+          onSelect: onReasoningEffortSelect,
           disabled: sending,
         }}
         skillPicker={{

--- a/web/src/hooks/use-create-and-send-session.ts
+++ b/web/src/hooks/use-create-and-send-session.ts
@@ -30,6 +30,7 @@ export function useCreateAndSendSession() {
     sendPrompt,
     setSessionTitle,
     setSessionModel,
+    setSessionReasoningEffort,
     dispatchCommand,
     attachImage,
     attachImageBytes,
@@ -84,6 +85,9 @@ export function useCreateAndSendSession() {
             payload.modelSelection.model,
             payload.modelSelection.provider,
           );
+        }
+        if (payload.reasoningEffort) {
+          await setSessionReasoningEffort(sessionId, payload.reasoningEffort);
         }
         let transportText: string | undefined;
         const skillCommand = resolveComposerSkillCommand(
@@ -146,6 +150,7 @@ export function useCreateAndSendSession() {
     sendPrompt,
     setActiveSessionId,
     setSessionModel,
+    setSessionReasoningEffort,
     setSessionTitle,
   ]);
 }


### PR DESCRIPTION
## 变更
- 恢复工作台新任务 Composer 的推理强度入口
- 在首条消息发送前将选择写入新建或预热会话
- 增加新任务 Composer 回归测试

## 验证
- pnpm typecheck
- pnpm test:unit
- cargo check
- 本地界面实测默认值、完整菜单与选择更新