### PR TITLE
Expose MiniMax-M3 vision capability

### DIFF
--- a/web/src/components/chat/goose-composer-model-picker.test.ts
+++ b/web/src/components/chat/goose-composer-model-picker.test.ts
@@ -30,6 +30,7 @@ describe("buildCandidates", () => {
       contextWindow: 1_000_000,
       supportsTools: true,
       supportsReasoning: true,
+      supportsVision: true,
     });
   });
 

--- a/web/src/lib/provider-catalog.test.ts
+++ b/web/src/lib/provider-catalog.test.ts
@@ -534,6 +534,7 @@ describe("provider catalog config updates", () => {
       contextWindow: 1_000_000,
       supportsTools: true,
       supportsReasoning: true,
+      supportsVision: true,
     });
     expect(preset!.models[0]?.id).toBe("MiniMax-M3");
 
@@ -551,6 +552,7 @@ describe("provider catalog config updates", () => {
       context_length: 1_000_000,
       supports_tools: true,
       supports_reasoning: true,
+      supports_vision: true,
     });
   });
 

--- a/web/src/lib/provider-catalog.ts
+++ b/web/src/lib/provider-catalog.ts
@@ -633,7 +633,7 @@ export const BUILTIN_PROVIDER_CATALOG: ProviderCatalog = {
       docsUrl: "https://platform.minimaxi.com/document",
       defaultModel: "MiniMax-M3",
       models: [
-        { id: "MiniMax-M3", contextWindow: 1_000_000, supportsTools: true, supportsReasoning: true },
+        { id: "MiniMax-M3", contextWindow: 1_000_000, supportsTools: true, supportsReasoning: true, supportsVision: true },
         { id: "MiniMax-M2.7", contextWindow: 204_800, supportsTools: true, supportsReasoning: true },
         { id: "MiniMax-M2.7-highspeed", contextWindow: 204_800, supportsTools: true, supportsReasoning: true },
         { id: "MiniMax-M2.5", contextWindow: 204_800, supportsTools: true },


### PR DESCRIPTION
Reason: MiniMax-M3 accepts image input, but its built-in MiniMax CN catalog entry did not expose vision support.

## Changes

- Mark MiniMax-M3 as vision-capable in the built-in catalog.
- Verify provider settings serialization emits `supports_vision`.
- Verify the model picker receives the vision capability.

## Checks

- `pnpm --filter @hermes/web exec vitest run src/lib/provider-catalog.test.ts src/components/chat/goose-composer-model-picker.test.ts`
- `pnpm typecheck`
- `pnpm test:unit`
- `cargo check`
