### PR TITLE
Stop treating MiniMax providers as text-only for vision

### DIFF
--- a/web/src/routes/settings-models-section.tsx
+++ b/web/src/routes/settings-models-section.tsx
@@ -355,11 +355,10 @@ const AUXILIARY_PROVIDER_PRESETS: { id: string; name: string; hint: string; mode
   },
 ];
 
+// Vision capability is decided per model by the catalog `supportsVision` flag,
+// so provider ids must not blanket-block models that accept image input.
 const TEXT_ONLY_VISION_PROVIDERS = new Set([
   "deepseek",
-  "minimax",
-  "minimax-cn",
-  "minimax-oauth",
   "kimi-for-coding",
   "kimi-coding",
   "kimi-coding-cn",


### PR DESCRIPTION
Reason: MiniMax-M3 accepts image input, so the auxiliary vision UI must stop treating MiniMax providers as text-only.

## Changes

- Remove the MiniMax provider ids from the hardcoded `TEXT_ONLY_VISION_PROVIDERS` blocklist in the model settings page.
- Vision capability for these providers is now decided per model by the catalog `supportsVision` flag instead of a provider-level blocklist, so image-capable models (e.g. MiniMax-M3) no longer show the stale "cannot read images" warning in the auxiliary vision UI.

## Checks

- `pnpm --filter @hermes/web run typecheck`
- `pnpm --filter @hermes/web run test:unit` (129 files / 1106 tests passed)
