### PR TITLE
fix: correct StepFun API key env var to STEPFUN_API_KEY

### DIFF
--- a/web/src/lib/provider-catalog.ts
+++ b/web/src/lib/provider-catalog.ts
@@ -536,7 +536,7 @@ export const BUILTIN_PROVIDER_CATALOG: ProviderCatalog = {
       baseUrl: "https://api.stepfun.com/v1",
       apiMode: "chat_completions",
       transport: "openai_chat",
-      apiKeyLabel: "STEP_API_KEY",
+      apiKeyLabel: "STEPFUN_API_KEY",
       icon: "stepfun",
       websiteUrl: "https://platform.stepfun.com",
       docsUrl: "https://platform.stepfun.com/docs/zh/guides/developer/openai",


### PR DESCRIPTION
## 变更目的

桌面端「阶跃星辰 · API 按量付费」在设置中保存的 API Key 被写入 `~/.hermes/.env` 的 `STEP_API_KEY`，但 hermes-agent 后端实际读取的是 `STEPFUN_API_KEY`。导致用户即使在设置里保存了有效 Key，聊天请求仍报凭证缺失/无效。

## 主要实现点

- `web/src/lib/provider-catalog.ts`：将 `stepfun` provider 的 `apiKeyLabel` 从 `STEP_API_KEY` 改为 `STEPFUN_API_KEY`，使「保存配置」时通过 `syncProviderApiKeyToCanonicalEnv` 把 Key 写入后端真正读取的变量名。

## 验证

- 本地构建桌面端后，在 设置 → 模型 → 阶跃星辰 重新输入 Key 并保存。
- 确认 `.env` 中出现 `STEPFUN_API_KEY=<key>`（此前为 `STEP_API_KEY`）。
- 发起新对话，聊天正常响应。
- `pnpm test:unit`：`provider-catalog` 单测 58 个全部通过（该字段未被测试断言，无回归）。

## 影响

- 用户可见行为：已配置过阶跃星辰的用户需在设置中重新保存一次 Key（旧 `STEP_API_KEY` 变量不会自动迁移，且该变量本就不被后端读取）。
- 配置 / 数据迁移：无迁移逻辑；`.env` 变量名变化。
- 发布流程：无影响，纯前端目录数据改动。