### PR TITLE
fix: 修复 Composer 草稿和附件预览

### DIFF
--- a/e2e/fake-model/server.py
+++ b/e2e/fake-model/server.py
@@ -136,6 +136,9 @@ def _reply_for(messages: list[dict[str, Any]]) -> str:
     text = _text_of(last_user.get("content")).strip()
     if STREAM_ORDER_MARKER in text:
         return STREAM_ORDER_REPLY
+    if text.startswith("return-image-e2e:"):
+        path = text.split(":", 1)[1].strip()
+        return f"模型生成图片：![生成图]({path})"
     if text == "scroll-follow-e2e":
         return " ".join(f"scroll-follow-token-{index}" for index in range(300))
     # Echo a stable marker plus the prompt so specs can assert on either.

--- a/e2e/specs/composer-drafts.spec.ts
+++ b/e2e/specs/composer-drafts.spec.ts
@@ -1,0 +1,59 @@
+import { expect, test, type Page } from "@playwright/test";
+
+const composer = (page: Page) => page.getByRole("textbox", { name: "输入消息" });
+const sendButton = (page: Page) => page.getByRole("button", { name: "发送消息" });
+
+async function createSession(page: Page, prompt: string): Promise<string> {
+  await page.goto("/");
+  await expect(composer(page)).toBeVisible();
+  await composer(page).fill(prompt);
+  await sendButton(page).click();
+  await expect(page).toHaveURL(/\/tasks\/.+/, { timeout: 20_000 });
+  await expect(page.getByRole("log").locator('[data-role="assistant"]').last()).toContainText(prompt, {
+    timeout: 25_000,
+  });
+  return page.url();
+}
+
+test("composer drafts survive navigation and stay scoped per target", async ({ page }) => {
+  const stamp = Date.now();
+  const newTaskDraft = `new-task-draft-${stamp}`;
+  const sessionADraft = `session-a-draft-${stamp}`;
+  const sessionBDraft = `session-b-draft-${stamp}`;
+
+  await page.goto("/");
+  await expect(composer(page)).toBeVisible();
+  await composer(page).fill(newTaskDraft);
+  await page.goto("/history");
+  await page.goto("/");
+  await expect(composer(page)).toHaveValue(newTaskDraft);
+  await composer(page).fill("");
+  await expect(composer(page)).toHaveValue("");
+
+  const sessionAUrl = await createSession(page, `draft-session-a-seed-${stamp}`);
+  const sessionBUrl = await createSession(page, `draft-session-b-seed-${stamp}`);
+
+  await page.goto(sessionAUrl);
+  await expect(composer(page)).toBeVisible();
+  await composer(page).fill(sessionADraft);
+
+  await page.goto(sessionBUrl);
+  await expect(composer(page)).toBeVisible();
+  await expect(composer(page)).toHaveValue("");
+  await composer(page).fill(sessionBDraft);
+
+  await page.goto(sessionAUrl);
+  await expect(composer(page)).toHaveValue(sessionADraft);
+  await page.reload();
+  await expect(composer(page)).toHaveValue(sessionADraft);
+
+  await sendButton(page).click();
+  await expect(page.getByRole("log").locator('[data-role="assistant"]').last()).toContainText(sessionADraft, {
+    timeout: 25_000,
+  });
+  await page.reload();
+  await expect(composer(page)).toHaveValue("");
+
+  await page.goto(sessionBUrl);
+  await expect(composer(page)).toHaveValue(sessionBDraft);
+});

--- a/e2e/specs/image-paste.spec.ts
+++ b/e2e/specs/image-paste.spec.ts
@@ -1,5 +1,8 @@
 import { test, expect } from "@playwright/test";
+import { mkdirSync, writeFileSync } from "node:fs";
+import { join } from "node:path";
 import { PNG_BASE64, PNG_BYTE_LENGTH } from "../fixtures/red-square.mjs";
+import { HERMES_HOME } from "../harness/config.mjs";
 
 // The image closed loop: paste an image into the composer, send, and assert the
 // model "read" it. This drives the real production path — the composer sends the
@@ -33,8 +36,57 @@ test("paste an image → it attaches → the model reads it", async ({ page }) =
   await page.getByRole("button", { name: "发送消息" }).click();
 
   await expect(page).toHaveURL(/\/tasks\/.+/, { timeout: 20_000 });
+  const lastUser = page.getByRole("log").locator('[data-role="user"]').last();
+  await expect(lastUser.getByRole("img", { name: "shot.png" })).toBeVisible({ timeout: 10_000 });
+  await expect(lastUser).not.toContainText("图片暂不能直接预览");
+
   const lastAssistant = page.getByRole("log").locator('[data-role="assistant"]').last();
   await expect(lastAssistant).toContainText("我看到一张图片", { timeout: 30_000 });
   // The exact decoded byte count proves the real image bytes reached the model.
   await expect(lastAssistant).toContainText(String(PNG_BYTE_LENGTH));
+});
+
+test("paste a PDF → it stays a file attachment, not a PNG preview", async ({ page }) => {
+  await page.goto("/");
+  await expect(page.getByRole("textbox", { name: "输入消息" })).toBeVisible();
+
+  await page.evaluate(async () => {
+    const dt = new DataTransfer();
+    dt.items.add(new File(["%PDF-1.7\n1 0 obj\n<<>>\nendobj\n"], "report.pdf", { type: "application/pdf" }));
+    const ta = document.querySelector('textarea[aria-label="输入消息"]');
+    const event = new ClipboardEvent("paste", { bubbles: true, cancelable: true });
+    Object.defineProperty(event, "clipboardData", { value: dt });
+    ta?.dispatchEvent(event);
+  });
+
+  await expect(
+    page.locator('span[data-kind="file"][data-status="ready"]'),
+  ).toBeVisible({ timeout: 10_000 });
+
+  await page.getByRole("textbox", { name: "输入消息" }).fill("总结这个 PDF");
+  await page.getByRole("button", { name: "发送消息" }).click();
+
+  await expect(page).toHaveURL(/\/tasks\/.+/, { timeout: 20_000 });
+  const lastUser = page.getByRole("log").locator('[data-role="user"]').last();
+  await expect(lastUser).toContainText("附件：report.pdf", { timeout: 10_000 });
+  await expect(lastUser.getByRole("img", { name: /report\.pdf/i })).toHaveCount(0);
+  await expect(lastUser).not.toContainText("clipboard-");
+});
+
+test("assistant Markdown image with a local path is previewable", async ({ page }) => {
+  const imageDir = join(HERMES_HOME, "images", "generated previews");
+  const imagePath = join(imageDir, "model output.png");
+  mkdirSync(imageDir, { recursive: true });
+  writeFileSync(imagePath, Buffer.from(PNG_BASE64, "base64"));
+
+  await page.goto("/");
+  await expect(page.getByRole("textbox", { name: "输入消息" })).toBeVisible();
+  await page.getByRole("textbox", { name: "输入消息" }).fill(`return-image-e2e:${imagePath}`);
+  await page.getByRole("button", { name: "发送消息" }).click();
+
+  await expect(page).toHaveURL(/\/tasks\/.+/, { timeout: 20_000 });
+  const lastAssistant = page.getByRole("log").locator('[data-role="assistant"]').last();
+  await expect(lastAssistant).toContainText("模型生成图片", { timeout: 30_000 });
+  await expect(lastAssistant.getByRole("img", { name: "生成图" })).toBeVisible({ timeout: 10_000 });
+  await expect(lastAssistant).not.toContainText("图片暂不能直接预览");
 });

--- a/packages/protocol/src/hermes-api.ts
+++ b/packages/protocol/src/hermes-api.ts
@@ -1466,6 +1466,16 @@ export const AttachmentUploadResult = z.object({
 }).passthrough();
 export type AttachmentUploadResult = z.infer<typeof AttachmentUploadResult>;
 
+export const FileAttachResult = z.object({
+  attached: z.boolean().optional(),
+  name: z.string().optional(),
+  path: z.string().optional(),
+  ref_path: z.string().optional(),
+  ref_text: z.string().optional(),
+  uploaded: z.boolean().optional(),
+}).passthrough();
+export type FileAttachResult = z.infer<typeof FileAttachResult>;
+
 // `/api/fs/list` entry. Upstream's handler returns `isDirectory`; the fork's
 // original P-004 handler returned `is_dir`. Accept either off the wire and
 // normalize to a single canonical `is_dir` so every consumer (and the inferred

--- a/src/commands/preview.rs
+++ b/src/commands/preview.rs
@@ -42,6 +42,8 @@ const PREVIEW_FILE_CHANGED: &str = "preview-file-changed";
 const TEXT_PREVIEW_MAX_BYTES: u64 = 512 * 1024;
 /// Cap inline image data URLs so a giant asset can't balloon the IPC payload.
 const IMAGE_PREVIEW_MAX_BYTES: u64 = 8 * 1024 * 1024;
+/// Match the upstream desktop bridge cap for arbitrary file data URLs.
+const FILE_DATA_URL_MAX_BYTES: u64 = 16 * 1024 * 1024;
 /// Bytes sampled from the head of a file to decide text vs binary.
 const BINARY_SNIFF_BYTES: usize = 4096;
 /// Match the upstream `hermes:fs:writeText` cap (1 MB). The spot editor's save
@@ -56,6 +58,13 @@ pub struct ReadWorkspaceFileInput {
     pub path: String,
     /// Session workspace root. Reads are confined to this directory.
     pub root: String,
+}
+
+#[derive(Deserialize)]
+#[serde(rename_all = "camelCase")]
+pub struct ReadFileDataUrlInput {
+    /// Absolute local file path, or a `file://` URL.
+    pub path: String,
 }
 
 #[derive(Debug, Default, Serialize)]
@@ -230,6 +239,69 @@ fn image_mime(ext: &str) -> Option<&'static str> {
     }
 }
 
+fn data_url_mime(ext: &str) -> &'static str {
+    match ext {
+        "apng" => "image/apng",
+        "avif" => "image/avif",
+        "bmp" => "image/bmp",
+        "gif" => "image/gif",
+        "heic" => "image/heic",
+        "heif" => "image/heif",
+        "ico" => "image/x-icon",
+        "jpg" | "jpeg" => "image/jpeg",
+        "png" => "image/png",
+        "svg" => "image/svg+xml",
+        "tif" | "tiff" => "image/tiff",
+        "webp" => "image/webp",
+        "pdf" => "application/pdf",
+        "csv" => "text/csv",
+        "htm" | "html" => "text/html",
+        "json" => "application/json",
+        "md" | "markdown" => "text/markdown",
+        "txt" => "text/plain",
+        "xml" => "application/xml",
+        "zip" => "application/zip",
+        _ => "application/octet-stream",
+    }
+}
+
+fn decode_file_url_path(raw: &str) -> AppResult<PathBuf> {
+    if !raw.starts_with("file://") {
+        return Ok(PathBuf::from(raw));
+    }
+    let parsed = url::Url::parse(raw)?;
+    parsed
+        .to_file_path()
+        .map_err(|_| AppError::InvalidRequest("Invalid file URL".to_string()))
+}
+
+fn read_file_data_url_impl(path: &str) -> AppResult<String> {
+    let raw = path.trim();
+    if raw.is_empty() {
+        return Err(AppError::InvalidRequest("Path is required".to_string()));
+    }
+    let resolved = decode_file_url_path(raw)?.canonicalize()?;
+    let meta = fs::metadata(&resolved)?;
+    if !meta.is_file() {
+        return Err(AppError::FileError("Not a regular file".to_string()));
+    }
+    if meta.len() > FILE_DATA_URL_MAX_BYTES {
+        return Err(AppError::InvalidRequest(format!(
+            "file is too large ({} bytes; limit {} bytes)",
+            meta.len(),
+            FILE_DATA_URL_MAX_BYTES
+        )));
+    }
+    let ext = resolved
+        .extension()
+        .and_then(|e| e.to_str())
+        .map(|s| s.to_ascii_lowercase())
+        .unwrap_or_default();
+    let bytes = fs::read(&resolved)?;
+    let b64 = base64::engine::general_purpose::STANDARD.encode(bytes);
+    Ok(format!("data:{};base64,{}", data_url_mime(&ext), b64))
+}
+
 /// Heuristic binary sniff over a head sample: any NUL byte, or a high ratio of
 /// non-text control characters, marks the content binary.
 fn looks_binary(sample: &[u8]) -> bool {
@@ -319,6 +391,15 @@ pub fn read_workspace_file(
 ) -> AppResult<FilePreview> {
     require_local_preview(&state)?;
     read_file_preview(&input.root, &input.path)
+}
+
+#[tauri::command]
+pub fn read_file_data_url(
+    input: ReadFileDataUrlInput,
+    state: State<'_, AppState>,
+) -> AppResult<String> {
+    require_local_preview(&state)?;
+    read_file_data_url_impl(&input.path)
 }
 
 /// Core, AppHandle-free write logic so it can be unit-tested directly. Mirrors

--- a/src/main.rs
+++ b/src/main.rs
@@ -569,6 +569,7 @@ fn main() {
             commands::terminal::terminal_write,
             commands::terminal::terminal_resize,
             commands::terminal::terminal_close,
+            commands::preview::read_file_data_url,
             commands::preview::read_workspace_file,
             commands::preview::write_workspace_file,
             commands::preview::watch_preview_file,

--- a/web/src/components/chat/goose-composer.test.tsx
+++ b/web/src/components/chat/goose-composer.test.tsx
@@ -83,6 +83,12 @@ describe("GooseComposer slash hints", () => {
 });
 
 describe("GooseComposer workspace picker", () => {
+  it("renders initial draft text in the textarea", () => {
+    const html = renderComposer(<GooseComposer initial="恢复的草稿" />);
+
+    expect(html).toContain("恢复的草稿");
+  });
+
   it("renders a clear workspace action when a workspace is selected", () => {
     const html = renderComposer(
       <GooseComposer initialWorkspacePath="/Users/enzo/Project" />,

--- a/web/src/components/chat/goose-composer.tsx
+++ b/web/src/components/chat/goose-composer.tsx
@@ -102,7 +102,7 @@ import {
 import { WorkspacePickerModal } from "@/components/composer/workspace-picker";
 import { UrlDialog } from "@/components/composer/url-dialog";
 import { isSingleUrl, urlReferenceText } from "@/lib/composer-url";
-import { imageFileFromClipboardData, readClipboardImageAsFile } from "@/lib/clipboard-image";
+import { filesFromClipboardData, imageFileFromClipboardData, readClipboardImageAsFile } from "@/lib/clipboard-image";
 import { downloadExternalImageFile } from "@/lib/transport";
 import { runtime } from "@/lib/runtime";
 import { ReasoningEffortMenu } from "@/components/composer/reasoning-effort-menu";
@@ -154,6 +154,7 @@ interface GooseComposerProps {
   skillPicker?: ComposerSkillPickerProps;
   mentionPicker?: ComposerMentionPickerProps;
   contextUsage?: ComposerContextUsage | null;
+  onDraftChange?: (text: string) => void;
   /** Hide `/compress` affordances when the composer is not bound to an existing session. */
   showCompressCommand?: boolean;
   initialWorkspacePath?: string;
@@ -230,6 +231,7 @@ export function GooseComposer({
   skillPicker,
   mentionPicker,
   contextUsage,
+  onDraftChange,
   showCompressCommand = true,
   initialWorkspacePath = "",
   voiceConfig = null,
@@ -518,11 +520,12 @@ export function GooseComposer({
 
   useEffect(() => {
     valueRef.current = value;
+    onDraftChange?.(value);
     const textarea = textareaRef.current;
     if (!textarea) return;
     textarea.style.height = "auto";
     textarea.style.height = `${Math.min(textarea.scrollHeight, 196)}px`;
-  }, [value]);
+  }, [onDraftChange, value]);
 
   useEffect(() => {
     voiceStatusRef.current = voiceStatus;
@@ -896,6 +899,7 @@ export function GooseComposer({
     markAttachmentsProcessing();
     try {
       await onSend?.(payload, { updateAttachment });
+      onDraftChange?.("");
       setValue("");
       setSelectedSkill(null);
       setSelectionStart(0);
@@ -1007,6 +1011,12 @@ export function GooseComposer({
     if (controlsDisabled) return;
     const clipboardData = event.clipboardData;
     const text = clipboardData.getData("text/plain");
+    const pastedFiles = filesFromClipboardData(clipboardData);
+    if (pastedFiles.length) {
+      event.preventDefault();
+      addBrowserFiles(pastedFiles);
+      return;
+    }
     const pastedImage = imageFileFromClipboardData(clipboardData);
     if (pastedImage) {
       event.preventDefault();

--- a/web/src/components/chat/markdown-renderer.tsx
+++ b/web/src/components/chat/markdown-renderer.tsx
@@ -16,6 +16,7 @@ import { harden } from "rehype-harden";
 import { Streamdown } from "streamdown";
 import "katex/dist/katex.min.css";
 import { MessageImage } from "./message-image";
+import { isImageReference } from "@/lib/message-images";
 import s from "./markdown-renderer.module.css";
 
 interface MarkdownTextProps {
@@ -58,6 +59,8 @@ const streamdownControls: ComponentProps<typeof Streamdown>["controls"] = {
 const streamdownTranslations: ComponentProps<typeof Streamdown>["translations"] = {
   copyCode: "复制代码",
 };
+
+const MARKDOWN_IMAGE_DEST_RE = /!\[([^\]\n]*)\]\(\s*([^<\n)]*?\.(?:apng|avif|bmp|gif|heic|heif|jpe?g|png|tiff?|webp)(?:[?#][^\n)]*)?)\s*\)/gi;
 
 const markdownSanitizeSchema: SanitizeSchema = {
   ...defaultSchema,
@@ -193,6 +196,14 @@ function normalizeTexMathDelimiters(text: string): string {
   }
 
   return result;
+}
+
+function normalizeMarkdownImageDestinations(text: string): string {
+  return text.replace(MARKDOWN_IMAGE_DEST_RE, (match, alt: string, rawUrl: string) => {
+    const url = rawUrl.trim();
+    if (!/\s/.test(url) || !isImageReference(url)) return match;
+    return `![${alt}](<${url}>)`;
+  });
 }
 
 function safeHref(value: unknown): string | undefined {
@@ -561,7 +572,10 @@ export const MarkdownText = memo(function MarkdownText({
   text,
   streaming = false,
 }: MarkdownTextProps) {
-  const normalizedText = useMemo(() => normalizeTexMathDelimiters(text), [text]);
+  const normalizedText = useMemo(
+    () => normalizeTexMathDelimiters(normalizeMarkdownImageDestinations(text)),
+    [text],
+  );
 
   return (
     <Streamdown

--- a/web/src/components/chat/message-adapter.test.ts
+++ b/web/src/components/chat/message-adapter.test.ts
@@ -181,6 +181,30 @@ describe("message adapter", () => {
     expect(message?.text).toBe("阅读这张图片的内容\n\n附件：ga.png");
   });
 
+  it("extracts stored image attached-at paths without rendering the transport line", () => {
+    const path = "/Users/enzo/Library/Application Support/cn.org.hermesagent.desktop/runtime/hermes-home/images/upload.png";
+    const message = storedMessageToChatMessage(sessionMessage({
+      id: 10,
+      session_id: "s1",
+      role: "user",
+      content: [
+        "[Hermes UI Image]",
+        "name=upload.png",
+        "description:",
+        "[User attached image: upload.png]",
+        "[/Hermes UI Image]",
+        "",
+        "图里是什么？",
+        "",
+        `[Image attached at: ${path}]`,
+        "[screenshot]",
+      ].join("\n"),
+    }));
+
+    expect(message?.text).toBe("图里是什么？\n\n附件：upload.png");
+    expect(message?.images?.[0]?.url).toBe(path);
+  });
+
   it("normalizes injected Skill instructions from user to system messages", () => {
     const message = hermesUIMessageToChatMessage(uiMessage({
       id: "skill-invocation",

--- a/web/src/components/chat/message-adapter.ts
+++ b/web/src/components/chat/message-adapter.ts
@@ -63,6 +63,7 @@ function displayUnknown(value: unknown): string | undefined {
 
 const HERMES_UI_IMAGE_BLOCK_RE = /\[Hermes UI Image\]\nname=([^\n]*)\ndescription:\n([\s\S]*?)\n\[\/Hermes UI Image\]/g;
 const IMAGE_FALLBACK_RE = /\[You can examine it with vision_analyze using image_url: ([^\]\n]+)\]/g;
+const IMAGE_ATTACHED_AT_RE = /\[Image attached at:\s*([^\]\n]+)\]/g;
 
 function parseJsonContent(value: string | null | undefined): unknown | undefined {
   const text = value?.trim();
@@ -118,6 +119,13 @@ function imagePartsFromTransportText(text: string | null | undefined): HermesIma
     if (part) parts.push(part);
   }
 
+  for (const match of text.matchAll(IMAGE_ATTACHED_AT_RE)) {
+    const path = match[1]?.trim();
+    if (!path) continue;
+    const part = imagePartFromSource(path);
+    if (part) parts.push(part);
+  }
+
   for (const match of text.matchAll(HERMES_UI_IMAGE_BLOCK_RE)) {
     const name = match[1]?.trim();
     const description = match[2]?.trim();
@@ -129,8 +137,6 @@ function imagePartsFromTransportText(text: string | null | undefined): HermesIma
       })));
       continue;
     }
-    const part = imagePartFromSource({ name, alt: name || "图片附件" });
-    if (part) parts.push(part);
   }
 
   return dedupeImageParts(parts);

--- a/web/src/components/chat/message-image.tsx
+++ b/web/src/components/chat/message-image.tsx
@@ -1,6 +1,6 @@
 import { useEffect, useMemo, useState } from "react";
 import { ImageOff } from "lucide-react";
-import { isLikelyLocalFilePath, safeImageSrc } from "@/lib/message-images";
+import { isLikelyLocalFilePath, normalizeLocalFilePath, safeImageSrc } from "@/lib/message-images";
 import { fetchMediaDataUrl } from "@/lib/transport";
 import type { ChatImageItem } from "./chat-types";
 import s from "./message-timeline.module.css";
@@ -65,7 +65,7 @@ export function MessageImage({ image }: MessageImageProps) {
   const directSrc = useMemo(() => safeImageSrc(image.url), [image.url]);
   const localPath = useMemo(() => {
     const source = image.url?.trim();
-    return !directSrc && source && isLikelyLocalFilePath(source) ? source : undefined;
+    return !directSrc && source && isLikelyLocalFilePath(source) ? normalizeLocalFilePath(source) : undefined;
   }, [directSrc, image.url]);
   const label = imageLabel(image);
 

--- a/web/src/components/panel/panel-composer.tsx
+++ b/web/src/components/panel/panel-composer.tsx
@@ -12,6 +12,12 @@ import { resolveModelContextWindow } from "@/lib/model-context";
 import { readLastUsedModel, rememberLastUsedModel } from "@/lib/last-used-model";
 import { recordModelUsage } from "@/lib/model-usage-log";
 import {
+  composerDraftStorageKey,
+  forgetComposerDraftByKey,
+  readComposerDraftByKey,
+  writeComposerDraftByKey,
+} from "@/lib/composer-drafts";
+import {
   reasoningEffortFromConfig,
   type ReasoningEffort,
 } from "@/lib/reasoning-effort";
@@ -66,6 +72,15 @@ export function PanelComposer() {
   const draftRef = useRef<{ id: string; cwd: string } | null>(null);
   const initialWorkspacePath = normalizeWorkspacePath(searchParams.get("workspace"));
   const submitShortcutHint = composerSubmitShortcutHint(composerSubmitShortcut);
+  const newTaskDraftKey = useMemo(
+    () => composerDraftStorageKey({ kind: "new", profile: activeProfile }),
+    [activeProfile],
+  );
+  const storedDraft = useMemo(
+    () => readComposerDraftByKey(newTaskDraftKey),
+    [newTaskDraftKey],
+  );
+  const composerInitial = prefilledDraft.nonce > 0 ? prefilledDraft.text : storedDraft;
   const enabledSkills = useMemo(
     () => (skillsQuery.data ?? []).filter((skill) => skill.enabled),
     [skillsQuery.data],
@@ -203,6 +218,7 @@ export function PanelComposer() {
         void closeSession(draft.id).catch(() => {});
       }
       await createAndSendSession(payload, controls, options);
+      forgetComposerDraftByKey(newTaskDraftKey);
     } catch (err) {
       console.error("Failed to create session:", err);
       throw err;
@@ -214,16 +230,22 @@ export function PanelComposer() {
     createAndSendSession,
     adoptCreatedSession,
     closeSession,
+    newTaskDraftKey,
   ]);
+
+  const onDraftChange = useCallback((text: string) => {
+    writeComposerDraftByKey(newTaskDraftKey, text);
+  }, [newTaskDraftKey]);
 
   return (
     <div ref={wrapperRef}>
       <GooseComposer
-        key={initialWorkspacePath || "default-workspace"}
+        key={`${initialWorkspacePath || "default-workspace"}:${newTaskDraftKey ?? "draft"}`}
         onSend={onSend}
-        initial={prefilledDraft.text}
+        initial={composerInitial}
         initialNonce={prefilledDraft.nonce}
         initialWorkspacePath={initialWorkspacePath}
+        onDraftChange={onDraftChange}
         placeholder={`描述你想完成的任务，${submitShortcutHint}…`}
         variant="big"
         headerLabel="新任务"

--- a/web/src/hooks/use-create-and-send-session.ts
+++ b/web/src/hooks/use-create-and-send-session.ts
@@ -11,7 +11,7 @@ import { buildComposerDisplayText, prepareComposerPrompt } from "@/lib/composer-
 import { resolveComposerSkillCommand } from "@/lib/composer-skills";
 import { rememberSessionModelOverride } from "@/lib/session-model-override";
 import { titleFromPrompt, titleWithSessionSuffix } from "@/lib/session-title";
-import { isRemoteConnection, readImageBytesFromPath, uploadAttachmentFile } from "@/lib/transport";
+import { isRemoteConnection, readFileDataUrl, readImageBytesFromPath, uploadAttachmentFile } from "@/lib/transport";
 import {
   rememberSessionWorkspace,
   rememberWorkspaceProject,
@@ -19,6 +19,18 @@ import {
 
 interface CreateAndSendOptions {
   createSession?: (options?: { cwd?: string }) => Promise<string>;
+}
+
+function readFileAsDataUrl(file: File): Promise<string | undefined> {
+  if (typeof FileReader === "undefined") return Promise.resolve(undefined);
+  return new Promise((resolve) => {
+    const reader = new FileReader();
+    reader.addEventListener("load", () => {
+      resolve(typeof reader.result === "string" ? reader.result : undefined);
+    }, { once: true });
+    reader.addEventListener("error", () => resolve(undefined), { once: true });
+    reader.readAsDataURL(file);
+  });
 }
 
 export function useCreateAndSendSession() {
@@ -34,6 +46,7 @@ export function useCreateAndSendSession() {
     dispatchCommand,
     attachImage,
     attachImageBytes,
+    attachFile,
     detectDroppedPath,
   } = useGateway();
   const setActiveSessionId = useSetAtom(activeSessionIdAtom);
@@ -48,17 +61,17 @@ export function useCreateAndSendSession() {
     const sessionId = await (options?.createSession ?? createSession)({ cwd: workspacePath });
     const title = titleFromPrompt(payload.text || payload.attachments[0]?.name || "");
     const optimisticDisplayText = buildComposerDisplayText(payload);
-    const optimisticDisplayImages = payload.attachments
+    const optimisticDisplayImages = await Promise.all(payload.attachments
       .filter((attachment) => attachment.kind === "image")
-      .map((attachment) => ({
-        url: attachment.previewUrl && !attachment.previewUrl.startsWith("blob:")
-          ? attachment.previewUrl
-          : attachment.path,
+      .map(async (attachment) => ({
+        url: attachment.file
+          ? await readFileAsDataUrl(attachment.file)
+          : attachment.previewUrl || attachment.path,
         alt: attachment.name,
         title: attachment.name,
         name: attachment.name,
         mimeType: attachment.mimeType,
-      }));
+      })));
 
     if (payload.modelSelection?.model) {
       rememberSessionModelOverride(sessionId, payload.modelSelection);
@@ -107,8 +120,10 @@ export function useCreateAndSendSession() {
         const prepared = await prepareComposerPrompt(sessionId, payload, {
           attachImage,
           attachImageBytes,
+          attachFile,
           remote: isRemoteConnection(),
           readImageBytes: readImageBytesFromPath,
+          readFileDataUrl,
           detectDroppedPath,
           uploadFile: uploadAttachmentFile,
           onAttachmentUpdate: controls.updateAttachment,
@@ -141,6 +156,7 @@ export function useCreateAndSendSession() {
   }, [
     attachImage,
     attachImageBytes,
+    attachFile,
     beginPrompt,
     createSession,
     detectDroppedPath,

--- a/web/src/hooks/use-gateway.ts
+++ b/web/src/hooks/use-gateway.ts
@@ -4,6 +4,7 @@ import { getDefaultStore, useAtomValue, useSetAtom } from "jotai";
 import {
   ConfigSetResult,
   CommandDispatchResult,
+  FileAttachResult,
   ImageAttachResult,
   InputDetectDropResult,
   ModelOptionsResult,
@@ -745,6 +746,28 @@ export function useGateway() {
     [ensureSubscribed],
   );
 
+  const attachFile = useCallback(
+    async (
+      sessionId: string,
+      path?: string,
+      dataUrl?: string,
+      name?: string,
+    ): Promise<FileAttachResult> => {
+      ensureSubscribed();
+      return parseGatewayResult(
+        FileAttachResult,
+        await getGatewayClient().request("file.attach", {
+          session_id: sessionId,
+          ...(path ? { path } : {}),
+          ...(dataUrl ? { data_url: dataUrl } : {}),
+          ...(name ? { name } : {}),
+        }),
+        "file.attach",
+      );
+    },
+    [ensureSubscribed],
+  );
+
   const detectDroppedPath = useCallback(
     async (sessionId: string, path: string): Promise<InputDetectDropResult> => {
       ensureSubscribed();
@@ -839,6 +862,7 @@ export function useGateway() {
     setSessionReasoningEffort,
     attachImage,
     attachImageBytes,
+    attachFile,
     detectDroppedPath,
     interruptSession,
     setSessionTitle,

--- a/web/src/lib/clipboard-image.test.ts
+++ b/web/src/lib/clipboard-image.test.ts
@@ -1,5 +1,6 @@
 import { describe, expect, it, vi } from "vitest";
 import {
+  filesFromClipboardData,
   imageFileFromClipboardData,
   readClipboardImageAsFile,
   type NativeClipboardImage,
@@ -37,6 +38,11 @@ describe("clipboard image helpers", () => {
   it("ignores non-image paste files", () => {
     const file = new File(["txt"], "note.txt", { type: "text/plain" });
     expect(imageFileFromClipboardData(clipboardDataWithFile(file))).toBeNull();
+  });
+
+  it("preserves non-image paste files for the composer attachment path", () => {
+    const file = new File(["%PDF-"], "report.pdf", { type: "application/pdf" });
+    expect(filesFromClipboardData(clipboardDataWithFile(file))).toEqual([file]);
   });
 
   it("falls back to native clipboard image when paste data has no image", async () => {

--- a/web/src/lib/clipboard-image.ts
+++ b/web/src/lib/clipboard-image.ts
@@ -26,18 +26,36 @@ function isImageFile(file: File): boolean {
   return file.type.startsWith("image/") || isLikelyImageUrl(file.name);
 }
 
-export function imageFileFromClipboardData(clipboardData?: DataTransfer | null): File | null {
-  if (!clipboardData) return null;
+export function filesFromClipboardData(clipboardData?: DataTransfer | null): File[] {
+  if (!clipboardData) return [];
+
+  const files: File[] = [];
+  const seen = new Set<string>();
+  const add = (file: File | null) => {
+    if (!file) return;
+    const key = `${file.name}:${file.size}:${file.lastModified}:${file.type}`;
+    if (seen.has(key)) return;
+    seen.add(key);
+    files.push(file);
+  };
 
   for (const file of Array.from(clipboardData.files ?? [])) {
-    if (isImageFile(file)) return file;
+    add(file);
   }
 
   for (const item of Array.from(clipboardData.items ?? [])) {
     if (item.kind !== "file") continue;
-    if (item.type && !item.type.startsWith("image/")) continue;
-    const file = item.getAsFile();
-    if (file && isImageFile(file)) return file;
+    add(item.getAsFile());
+  }
+
+  return files;
+}
+
+export function imageFileFromClipboardData(clipboardData?: DataTransfer | null): File | null {
+  if (!clipboardData) return null;
+
+  for (const file of filesFromClipboardData(clipboardData)) {
+    if (isImageFile(file)) return file;
   }
 
   return null;

--- a/web/src/lib/composer-drafts.test.ts
+++ b/web/src/lib/composer-drafts.test.ts
@@ -1,0 +1,66 @@
+import { afterEach, beforeEach, describe, expect, it } from "vitest";
+import {
+  composerDraftStorageKey,
+  readComposerDraft,
+  writeComposerDraft,
+} from "./composer-drafts";
+import { __resetUiStoreForTests } from "./ui-store";
+
+function setRuntime(input: Partial<NonNullable<Window["__HERMES_RUNTIME__"]>> = {}) {
+  (globalThis as any).window = (globalThis as any).window ?? {};
+  window.__HERMES_RUNTIME__ = {
+    connectionMode: "managed",
+    apiBaseUrl: "http://127.0.0.1:9120",
+    currentProfile: "default",
+    ...input,
+  };
+}
+
+beforeEach(() => {
+  __resetUiStoreForTests();
+  setRuntime();
+});
+
+afterEach(() => {
+  delete (globalThis as { window?: unknown }).window;
+});
+
+describe("composer draft storage", () => {
+  it("keeps the new-task draft separate from session drafts", () => {
+    writeComposerDraft({ kind: "new", profile: "default" }, "new task draft");
+    writeComposerDraft({ kind: "session", sessionId: "s1", profile: "default" }, "session draft");
+
+    expect(readComposerDraft({ kind: "new", profile: "default" })).toBe("new task draft");
+    expect(readComposerDraft({ kind: "session", sessionId: "s1", profile: "default" })).toBe("session draft");
+    expect(readComposerDraft({ kind: "session", sessionId: "s2", profile: "default" })).toBe("");
+  });
+
+  it("isolates drafts by profile and runtime target", () => {
+    writeComposerDraft({ kind: "session", sessionId: "s1", profile: "default" }, "managed default");
+    writeComposerDraft({ kind: "session", sessionId: "s1", profile: "work" }, "managed work");
+
+    expect(readComposerDraft({ kind: "session", sessionId: "s1", profile: "default" })).toBe("managed default");
+    expect(readComposerDraft({ kind: "session", sessionId: "s1", profile: "work" })).toBe("managed work");
+
+    setRuntime({ connectionMode: "remote", apiBaseUrl: "https://remote.example/hermes" });
+    expect(readComposerDraft({ kind: "session", sessionId: "s1", profile: "default" })).toBe("");
+    writeComposerDraft({ kind: "session", sessionId: "s1", profile: "default" }, "remote default");
+    expect(readComposerDraft({ kind: "session", sessionId: "s1", profile: "default" })).toBe("remote default");
+
+    setRuntime();
+    expect(readComposerDraft({ kind: "session", sessionId: "s1", profile: "default" })).toBe("managed default");
+  });
+
+  it("removes a draft when the text is blank", () => {
+    const target = { kind: "new", profile: "default" } as const;
+    writeComposerDraft(target, "  keep spacing  ");
+    expect(readComposerDraft(target)).toBe("  keep spacing  ");
+
+    writeComposerDraft(target, "   ");
+    expect(readComposerDraft(target)).toBe("");
+  });
+
+  it("does not create a key for an empty session id", () => {
+    expect(composerDraftStorageKey({ kind: "session", sessionId: "  ", profile: "default" })).toBeNull();
+  });
+});

--- a/web/src/lib/composer-drafts.ts
+++ b/web/src/lib/composer-drafts.ts
@@ -1,0 +1,67 @@
+import { readUiValue, removeUiValue, writeUiValue } from "@/lib/ui-store";
+
+const STORAGE_KEY_PREFIX = "hermes-cn-ui.composerDraft";
+
+export type ComposerDraftTarget =
+  | { kind: "new"; profile?: string | null }
+  | { kind: "session"; sessionId?: string | null; profile?: string | null };
+
+function cleanPart(value: string | null | undefined, fallback: string): string {
+  const text = (value ?? "").trim();
+  return encodeURIComponent(text || fallback);
+}
+
+function runtimeScopeParts(): string[] {
+  const runtime = typeof window !== "undefined" ? window.__HERMES_RUNTIME__ : undefined;
+  const mode = runtime?.connectionMode ?? "managed";
+  const baseUrl = runtime?.dashboardApiBaseUrl ?? runtime?.apiBaseUrl ?? "relative";
+  return [cleanPart(mode, "managed"), cleanPart(baseUrl, "relative")];
+}
+
+export function composerDraftStorageKey(target: ComposerDraftTarget | null | undefined): string | null {
+  if (!target) return null;
+  const profile = cleanPart(target.profile, "default");
+  const [mode, baseUrl] = runtimeScopeParts();
+  if (target.kind === "new") {
+    return [STORAGE_KEY_PREFIX, mode, baseUrl, profile, "new"].join(":");
+  }
+
+  const sessionId = (target.sessionId ?? "").trim();
+  if (!sessionId) return null;
+  return [
+    STORAGE_KEY_PREFIX,
+    mode,
+    baseUrl,
+    profile,
+    "session",
+    encodeURIComponent(sessionId),
+  ].join(":");
+}
+
+export function readComposerDraftByKey(key: string | null | undefined): string {
+  if (!key) return "";
+  const value = readUiValue<unknown>(key, "");
+  return typeof value === "string" ? value : "";
+}
+
+export function writeComposerDraftByKey(key: string | null | undefined, text: string): void {
+  if (!key) return;
+  if (!text.trim()) {
+    removeUiValue(key);
+    return;
+  }
+  writeUiValue(key, text);
+}
+
+export function forgetComposerDraftByKey(key: string | null | undefined): void {
+  if (!key) return;
+  removeUiValue(key);
+}
+
+export function readComposerDraft(target: ComposerDraftTarget | null | undefined): string {
+  return readComposerDraftByKey(composerDraftStorageKey(target));
+}
+
+export function writeComposerDraft(target: ComposerDraftTarget | null | undefined, text: string): void {
+  writeComposerDraftByKey(composerDraftStorageKey(target), text);
+}

--- a/web/src/lib/composer-prompt.test.ts
+++ b/web/src/lib/composer-prompt.test.ts
@@ -129,6 +129,101 @@ describe("composer prompt preparation", () => {
     expect(readImageBytes).not.toHaveBeenCalled();
   });
 
+  it("attaches an in-browser PDF File via file.attach with a data URL", async () => {
+    vi.stubGlobal("FileReader", FakeFileReader);
+    const bytes = new TextEncoder().encode("%PDF-1.7");
+    const file = {
+      name: "report.pdf",
+      type: "application/pdf",
+      size: bytes.byteLength,
+      arrayBuffer: async () => bytes.buffer,
+    } as unknown as File;
+    const attachFile = vi.fn(async () => ({
+      attached: true,
+      name: "report.pdf",
+      path: "/workspace/.hermes/desktop-attachments/report.pdf",
+      ref_path: ".hermes/desktop-attachments/report.pdf",
+      ref_text: "@file:.hermes/desktop-attachments/report.pdf",
+      uploaded: true,
+    }));
+    const uploadFile = vi.fn();
+    const detectDroppedPath = vi.fn();
+
+    const result = await prepareComposerPrompt(
+      "s1",
+      {
+        text: "读一下 PDF",
+        attachments: [{
+          id: "a1",
+          source: "browser",
+          file,
+          name: "report.pdf",
+          kind: "file",
+          status: "ready",
+          mimeType: "application/pdf",
+        }],
+      },
+      {
+        attachImage: vi.fn(),
+        attachFile,
+        uploadFile,
+        detectDroppedPath,
+      },
+    );
+
+    expect(attachFile).toHaveBeenCalledWith(
+      "s1",
+      undefined,
+      "data:application/pdf;base64,JVBERi0xLjc=",
+      "report.pdf",
+    );
+    expect(uploadFile).not.toHaveBeenCalled();
+    expect(detectDroppedPath).not.toHaveBeenCalled();
+    expect(result.promptText).toBe("@file:.hermes/desktop-attachments/report.pdf\n\n读一下 PDF");
+    expect(result.displayText).toBe("读一下 PDF\n\n附件：report.pdf");
+  });
+
+  it("attaches a local non-image path via file.attach before detect_drop", async () => {
+    const attachFile = vi.fn(async () => ({
+      attached: true,
+      name: "report.pdf",
+      path: "/workspace/.hermes/desktop-attachments/report.pdf",
+      ref_text: "@file:.hermes/desktop-attachments/report.pdf",
+      uploaded: false,
+    }));
+    const detectDroppedPath = vi.fn();
+
+    const result = await prepareComposerPrompt(
+      "s1",
+      {
+        text: "总结",
+        attachments: [{
+          id: "a1",
+          source: "path",
+          path: "/Users/enzo/Downloads/report.pdf",
+          name: "report.pdf",
+          kind: "file",
+          status: "ready",
+          mimeType: "application/pdf",
+        }],
+      },
+      {
+        attachImage: vi.fn(),
+        attachFile,
+        detectDroppedPath,
+      },
+    );
+
+    expect(attachFile).toHaveBeenCalledWith(
+      "s1",
+      "/Users/enzo/Downloads/report.pdf",
+      undefined,
+      "report.pdf",
+    );
+    expect(detectDroppedPath).not.toHaveBeenCalled();
+    expect(result.promptText).toBe("@file:.hermes/desktop-attachments/report.pdf\n\n总结");
+  });
+
   it("includes image attach/vision text in the transport prompt but hides it from display text", async () => {
     const result = await prepareComposerPrompt(
       "s1",

--- a/web/src/lib/composer-prompt.ts
+++ b/web/src/lib/composer-prompt.ts
@@ -3,7 +3,7 @@ import {
   type ComposerAttachment,
   type ComposerSubmitPayload,
 } from "@/components/chat/composer-types";
-import type { AttachmentUploadResult, ImageAttachResult, InputDetectDropResult } from "@hermes/protocol";
+import type { AttachmentUploadResult, FileAttachResult, ImageAttachResult, InputDetectDropResult } from "@hermes/protocol";
 
 const WORKSPACE_BLOCK_START = "[Hermes UI Workspace]";
 const WORKSPACE_BLOCK_END = "[/Hermes UI Workspace]";
@@ -11,6 +11,7 @@ const WORKSPACE_BLOCK_RE = /\n?\[Hermes UI Workspace\]\nworkspace=[^\n]*\ninstru
 const IMAGE_BLOCK_START = "[Hermes UI Image]";
 const IMAGE_BLOCK_END = "[/Hermes UI Image]";
 const IMAGE_BLOCK_RE = /\n?\[Hermes UI Image\]\nname=([^\n]*)\ndescription:\n[\s\S]*?\n\[\/Hermes UI Image\]\n?/g;
+const IMAGE_ATTACHED_AT_RE = /\n?\[Image attached at: [^\]\n]+\]\n?(?:\[[^\]\n]*\])?\n?/g;
 const IMAGE_FALLBACK_PREAMBLE_RE = /\n?\[The user attached an image(?: but analysis failed)?\.\]\n\[You can examine it with vision_analyze using image_url: [^\]\n]+\]\n?/g;
 const IMAGE_FULL_PREAMBLE_RE = /\n?\[The user attached an image[\s\S]*?\]\n?\[(?:If you need a closer look,? use|You can examine it with) vision_analyze (?:with |using )?image_url: [^\]\n]+\]\n?/g;
 const LEGACY_IMAGE_BLOCK_RE = /^\s*\[User attached image: ([^\]\n]+)\]\n[\s\S]*$/;
@@ -64,6 +65,7 @@ function stripLegacyImageContext(value: string, labels: string[]): string {
 
 export function stripHermesUiWorkspaceContext(text: string | null | undefined): string {
   let value = (text ?? "")
+    .replace(IMAGE_ATTACHED_AT_RE, "")
     .replace(IMAGE_FALLBACK_PREAMBLE_RE, "")
     .replace(IMAGE_FULL_PREAMBLE_RE, "")
     .replace(WORKSPACE_BLOCK_RE, "");
@@ -145,6 +147,12 @@ export async function prepareComposerPrompt(
       contentBase64: string,
       filename?: string,
     ): Promise<ImageAttachResult>;
+    attachFile?(
+      sessionId: string,
+      path?: string,
+      dataUrl?: string,
+      name?: string,
+    ): Promise<FileAttachResult>;
     // True when attached to a remote gateway: it can't read this machine's
     // paths, so image bytes must be uploaded (matches the official desktop's
     // `remote ? attach_bytes : attach{path}`).
@@ -154,6 +162,7 @@ export async function prepareComposerPrompt(
     readImageBytes?(
       path: string,
     ): Promise<{ contentBase64: string; filename: string } | null>;
+    readFileDataUrl?(path: string): Promise<string | null>;
     detectDroppedPath(sessionId: string, path: string): Promise<InputDetectDropResult>;
     onAttachmentUpdate?(id: string, patch: Partial<ComposerAttachment>): void;
   },
@@ -277,9 +286,56 @@ export async function prepareComposerPrompt(
         continue;
       }
 
-      // Non-image attachments. A browser File with no path still needs the REST
-      // upload (uncommon in the desktop: pickers/drag supply real paths, paste
-      // produces images).
+      if (attachment.kind === "directory") {
+        if (!path) {
+          throw new Error("附件缺少可读取路径");
+        }
+        helpers.onAttachmentUpdate?.(attachment.id, { status: "processing" });
+        parts.push(`[User attached directory: ${path}]`);
+        helpers.onAttachmentUpdate?.(attachment.id, { status: "done", progress: 100 });
+        continue;
+      }
+
+      if (helpers.attachFile) {
+        helpers.onAttachmentUpdate?.(attachment.id, {
+          status: "uploading",
+          progress: attachment.file ? 0 : undefined,
+          error: undefined,
+        });
+        const name = attachment.name || uploadedName || fileNameFromPath(path);
+        const dataUrl = attachment.file
+          ? await readFileAsDataUrl(attachment.file)
+          : helpers.remote && path && helpers.readFileDataUrl
+            ? await helpers.readFileDataUrl(path)
+            : undefined;
+        if (!path && !dataUrl) {
+          throw new Error("无法读取文件数据");
+        }
+        const attached = await helpers.attachFile(sessionId, path || undefined, dataUrl || undefined, name);
+        if (attached.attached === false) {
+          throw new Error(attached.ref_text || "文件附件未能添加");
+        }
+        const refText = attached.ref_text || (attached.ref_path ? `@file:${attached.ref_path}` : "");
+        if (refText) {
+          parts.push(refText);
+        } else if (attached.path) {
+          parts.push(`[User attached file: ${attached.path}]`);
+        } else {
+          parts.push(`[User attached file: ${path || name}]`);
+        }
+        helpers.onAttachmentUpdate?.(attachment.id, {
+          source: "uploaded",
+          uploadedPath: attached.path,
+          uploadedName: attached.name || uploadedName || name,
+          path: attached.path || path,
+          mimeType: attachment.mimeType,
+          status: "done",
+          progress: 100,
+        });
+        continue;
+      }
+
+      // Legacy fallback for runtimes without the gateway file.attach method.
       if (!path && attachment.file) {
         if (!helpers.uploadFile) {
           throw new Error("当前环境不支持上传这个附件");
@@ -314,12 +370,6 @@ export async function prepareComposerPrompt(
       }
 
       helpers.onAttachmentUpdate?.(attachment.id, { status: "processing" });
-      if (attachment.kind === "directory") {
-        parts.push(`[User attached directory: ${path}]`);
-        helpers.onAttachmentUpdate?.(attachment.id, { status: "done", progress: 100 });
-        continue;
-      }
-
       const dropped = await helpers.detectDroppedPath(sessionId, path);
       if (dropped.matched && typeof dropped.text === "string" && dropped.text.trim()) {
         parts.push(dropped.text.trim());

--- a/web/src/lib/message-images.test.ts
+++ b/web/src/lib/message-images.test.ts
@@ -1,0 +1,32 @@
+import { describe, expect, it } from "vitest";
+import { extractImagePartsFromUnknown, extractMarkdownImageParts, normalizeLocalFilePath } from "./message-images";
+
+describe("message image extraction", () => {
+  it("extracts Markdown image paths that contain spaces", () => {
+    const parts = extractMarkdownImageParts(
+      "结果：![预览](/Users/enzo/Library/Application Support/cn.org.hermesagent.desktop/runtime/hermes-home/images/out.png)",
+    );
+
+    expect(parts).toEqual([{
+      type: "image",
+      url: "/Users/enzo/Library/Application Support/cn.org.hermesagent.desktop/runtime/hermes-home/images/out.png",
+      alt: "预览",
+      name: "预览",
+    }]);
+  });
+
+  it("extracts bare local image paths that contain spaces", () => {
+    const parts = extractImagePartsFromUnknown(
+      "图片保存在 /Users/enzo/Library/Application Support/cn.org.hermesagent.desktop/runtime/hermes-home/images/out.png",
+    );
+
+    expect(parts[0]?.url).toBe(
+      "/Users/enzo/Library/Application Support/cn.org.hermesagent.desktop/runtime/hermes-home/images/out.png",
+    );
+  });
+
+  it("decodes encoded local image paths before media loading", () => {
+    expect(normalizeLocalFilePath("/Users/enzo/Library/Application%20Support/out.png"))
+      .toBe("/Users/enzo/Library/Application Support/out.png");
+  });
+});

--- a/web/src/lib/message-images.ts
+++ b/web/src/lib/message-images.ts
@@ -3,8 +3,9 @@ import { fileNameFromPath, isImagePath } from "@/lib/composer-prompt";
 
 export type HermesImagePart = Extract<HermesMessagePart, { type: "image" }>;
 
-const MARKDOWN_IMAGE_RE = /!\[([^\]\n]*)\]\(\s*(?:<([^>\n]+)>|([^\s)"'\n]+))(?:\s+["'][^"'\n]*["'])?\s*\)/g;
+const MARKDOWN_IMAGE_RE = /!\[([^\]\n]*)\]\(\s*(?:<([^>\n]+)>|([^\n)]+))\s*\)/g;
 const BARE_IMAGE_RE = /(?:data:image\/[a-z0-9.+-]+;[^\s<>"')]+|https?:\/\/[^\s<>"')]+\.(?:apng|avif|bmp|gif|heic|heif|jpe?g|png|tiff?|webp)(?:[?#][^\s<>"')]*)?|(?:\.{0,2}\/|\/|[A-Za-z]:[\\/]|\\\\|~[\\/])?[^\s<>"')]+\.(?:apng|avif|bmp|gif|heic|heif|jpe?g|png|tiff?|webp)(?:[?#][^\s<>"')]*)?)/gi;
+const LOCAL_IMAGE_WITH_SPACES_RE = /(?:file:\/\/)?(?:\/(?:Applications|Library|System|Users|Volumes|private|tmp|var)|~\/)[^\n<>"')]+?\.(?:apng|avif|bmp|gif|heic|heif|jpe?g|png|tiff?|webp)(?:[?#][^\s<>"')]*)?/gi;
 
 const IMAGE_TYPE_VALUES = new Set([
   "image",
@@ -81,6 +82,22 @@ export function isLikelyLocalFilePath(value: string): boolean {
     /^(?:~[\\/]|[A-Za-z]:[\\/]|\\\\)/.test(trimmed) ||
     /^\/(?:Applications|Library|System|Users|Volumes|bin|dev|etc|home|opt|private|sbin|tmp|usr|var)(?:\/|$)/.test(trimmed)
   );
+}
+
+export function normalizeLocalFilePath(value: string): string {
+  const trimmed = value.trim();
+  if (/^file:/i.test(trimmed)) {
+    try {
+      return decodeURIComponent(new URL(trimmed).pathname);
+    } catch {
+      return trimmed;
+    }
+  }
+  try {
+    return decodeURI(trimmed);
+  } catch {
+    return trimmed;
+  }
 }
 
 export function isImageReference(value: string): boolean {
@@ -170,7 +187,9 @@ export function extractMarkdownImageParts(text: string): HermesImagePart[] {
   const parts: HermesImagePart[] = [];
   for (const match of text.matchAll(MARKDOWN_IMAGE_RE)) {
     const alt = match[1]?.trim();
-    const url = (match[2] ?? match[3] ?? "").trim();
+    const rawUrl = (match[2] ?? match[3] ?? "").trim();
+    const titled = rawUrl.match(/^(\S+)\s+["'][^"'\n]*["']$/);
+    const url = (titled?.[1] ?? rawUrl).trim();
     const part = imagePartFromTrustedString(url, alt || undefined);
     if (part) {
       parts.push({
@@ -184,7 +203,26 @@ export function extractMarkdownImageParts(text: string): HermesImagePart[] {
 
 function extractBareImageParts(text: string): HermesImagePart[] {
   const parts: HermesImagePart[] = [];
+  const localMatches = [...text.matchAll(LOCAL_IMAGE_WITH_SPACES_RE)];
+  const localRanges = localMatches.map((match) => ({
+    start: match.index ?? -1,
+    end: (match.index ?? -1) + (match[0]?.length ?? 0),
+  }));
+  const coveredByLocalMatch = (match: RegExpMatchArray) => {
+    const start = match.index ?? -1;
+    const end = start + (match[0]?.length ?? 0);
+    return localRanges.some((range) => start >= range.start && end <= range.end);
+  };
+
+  for (const match of localMatches) {
+    const raw = match[0]?.trim();
+    if (!raw || !isImageReference(raw)) continue;
+    const part = imagePartFromTrustedString(raw);
+    if (part) parts.push(part);
+  }
+
   for (const match of text.matchAll(BARE_IMAGE_RE)) {
+    if (coveredByLocalMatch(match)) continue;
     const raw = match[0]?.trim();
     if (!raw || !isImageReference(raw)) continue;
     const part = imagePartFromTrustedString(raw);

--- a/web/src/lib/runtime.ts
+++ b/web/src/lib/runtime.ts
@@ -517,6 +517,7 @@ declare global {
       terminalResize?(input: { terminalId: string; cols: number; rows: number }): Promise<boolean>;
       terminalClose?(input: { terminalId: string }): Promise<boolean>;
       onTerminalOutput?(handler: (event: TerminalEventPayload) => void): () => void;
+      readFileDataUrl?(path: string): Promise<string>;
       readWorkspaceFile?(input: ReadWorkspaceFileInput): Promise<FilePreview>;
       writeWorkspaceFile?(input: WriteWorkspaceFileInput): Promise<WriteWorkspaceFileResult>;
       /** Git ops backing the review pane (issue #328). */

--- a/web/src/lib/tauri-bridge.ts
+++ b/web/src/lib/tauri-bridge.ts
@@ -572,6 +572,10 @@ const tauriBridge = {
     return invokeCommand("read_workspace_file", { input });
   },
 
+  async readFileDataUrl(path: string): Promise<string> {
+    return invokeCommand("read_file_data_url", { input: { path } });
+  },
+
   async writeWorkspaceFile(input: WriteWorkspaceFileInput): Promise<WriteWorkspaceFileResult> {
     return invokeCommand("write_workspace_file", { input });
   },

--- a/web/src/lib/transport.test.ts
+++ b/web/src/lib/transport.test.ts
@@ -98,6 +98,22 @@ describe("transport · debug-bus integration", () => {
     );
   });
 
+  it("fetchMediaDataUrl prefers the desktop file bridge for local images", async () => {
+    const readFileDataUrl = vi.fn(async () => "data:image/png;base64,REVT");
+    window.hermesDesktop = {
+      windowType: "tauri",
+      request: vi.fn(),
+      readFileDataUrl,
+    };
+    stubFetch(() => makeResponse(500, "should not fetch"));
+
+    await expect(fetchMediaDataUrl("/Users/me/Library/Application Support/Hermes/out.png"))
+      .resolves.toBe("data:image/png;base64,REVT");
+
+    expect(readFileDataUrl).toHaveBeenCalledWith("/Users/me/Library/Application Support/Hermes/out.png");
+    expect(globalThis.fetch).not.toHaveBeenCalled();
+  });
+
   it("fetchMediaDataUrl rejects a malformed media response", async () => {
     stubFetch(() => makeResponse(200, '{"data_url":"https://example.com/not-inline.png"}'));
 

--- a/web/src/lib/transport.ts
+++ b/web/src/lib/transport.ts
@@ -164,6 +164,18 @@ export async function fetchJSON<T>(
  * confined `/api/media` endpoint.
  */
 export async function fetchMediaDataUrl(path: string): Promise<string> {
+  const readFileDataUrl = window.hermesDesktop?.readFileDataUrl;
+  if (readFileDataUrl) {
+    try {
+      const dataUrl = await readFileDataUrl(path);
+      if (typeof dataUrl === "string" && dataUrl.startsWith("data:image/")) {
+        return dataUrl;
+      }
+    } catch {
+      // Fall back to Core's media endpoint when the path is not on this machine.
+    }
+  }
+
   const result = await fetchJSON<{ data_url?: unknown }>(
     `/api/media?path=${encodeURIComponent(path)}`,
   );
@@ -171,6 +183,17 @@ export async function fetchMediaDataUrl(path: string): Promise<string> {
     throw new Error("Media response did not contain an image data URL");
   }
   return result.data_url;
+}
+
+export async function readFileDataUrl(path: string): Promise<string | null> {
+  const reader = window.hermesDesktop?.readFileDataUrl;
+  if (!reader) return null;
+  try {
+    const dataUrl = await reader(path);
+    return dataUrl || null;
+  } catch {
+    return null;
+  }
 }
 
 const EXTERNAL_FETCH_TIMEOUT_MS = 15_000;
@@ -398,6 +421,15 @@ function attachmentFileName(path: string): string {
 export async function readImageBytesFromPath(
   path: string,
 ): Promise<{ contentBase64: string; filename: string } | null> {
+  const dataUrl = await readFileDataUrl(path);
+  if (dataUrl?.startsWith("data:image/")) {
+    const comma = dataUrl.indexOf(",");
+    const contentBase64 = comma >= 0 ? dataUrl.slice(comma + 1) : dataUrl;
+    return contentBase64
+      ? { contentBase64, filename: attachmentFileName(path) }
+      : null;
+  }
+
   const read = window.hermesDesktop?.readWorkspaceFile;
   if (!read) return null;
   try {

--- a/web/src/routes/detail.tsx
+++ b/web/src/routes/detail.tsx
@@ -30,6 +30,11 @@ import { useSessionResolution } from "@/hooks/use-session-resolution";
 import { useSessionUsagePolling } from "@/hooks/use-session-usage-polling";
 import { recordModelUsage } from "@/lib/model-usage-log";
 import { readSessionModelOverride } from "@/lib/session-model-override";
+import {
+  composerDraftStorageKey,
+  readComposerDraftByKey,
+  writeComposerDraftByKey,
+} from "@/lib/composer-drafts";
 import { prepareComposerPrompt } from "@/lib/composer-prompt";
 import { parseBuiltinComposerCommand } from "@/lib/builtin-commands";
 import { resolveComposerSkillCommand } from "@/lib/composer-skills";
@@ -48,7 +53,7 @@ import {
   readSessionTitleOverrides,
   subscribeSessionUiStateChanges,
 } from "@/lib/session-ui-state";
-import { isRemoteConnection, readImageBytesFromPath, uploadAttachmentFile } from "@/lib/transport";
+import { isRemoteConnection, readFileDataUrl, readImageBytesFromPath, uploadAttachmentFile } from "@/lib/transport";
 import { voiceAutoTtsFromConfig } from "@/lib/voice";
 import {
   rememberSessionWorkspace,
@@ -86,6 +91,12 @@ import {
 } from "@/components/chat/message-adapter";
 import s from "./detail.module.css";
 
+interface ComposerPrefillState {
+  text: string;
+  nonce: number;
+  sessionId?: string;
+}
+
 export function DetailRoute() {
   // URL drives the *initial* selection (deep links, browser back/forward),
   // but `activeSessionIdAtom` is the runtime source of truth. This lets
@@ -116,6 +127,7 @@ export function DetailRoute() {
     completePath,
     attachImage,
     attachImageBytes,
+    attachFile,
     detectDroppedPath,
   } = useGateway();
   const { data: config } = useConfig();
@@ -204,6 +216,21 @@ export function DetailRoute() {
     () => resolveSessionWorkspace(sessionData?.cwd ?? sessionSummary?.cwd, [restSessionId, taskId]),
     [sessionData?.cwd, sessionSummary?.cwd, restSessionId, taskId],
   );
+  const composerDraftKey = useMemo(
+    () => composerDraftStorageKey({
+      kind: "session",
+      sessionId: restSessionId ?? taskId,
+      profile: activeProfile,
+    }),
+    [activeProfile, restSessionId, taskId],
+  );
+  const storedComposerDraft = useMemo(
+    () => readComposerDraftByKey(composerDraftKey),
+    [composerDraftKey],
+  );
+  const onComposerDraftChange = useCallback((text: string) => {
+    writeComposerDraftByKey(composerDraftKey, text);
+  }, [composerDraftKey]);
 
   // Sync URL → atom on mount and whenever URL changes (browser back/forward
   // or a deep-link entry). Sidebar / history clicks already update the atom
@@ -414,8 +441,10 @@ export function DetailRoute() {
     const prepared = await prepareComposerPrompt(gatewaySessionId, payload, {
       attachImage,
       attachImageBytes,
+      attachFile,
       remote: isRemoteConnection(),
       readImageBytes: readImageBytesFromPath,
+      readFileDataUrl,
       detectDroppedPath,
       uploadFile: uploadAttachmentFile,
       onAttachmentUpdate: updateAttachment,
@@ -424,7 +453,7 @@ export function DetailRoute() {
       displayText: prepared.displayText,
       displayImages: prepared.displayImages,
     });
-  }, [attachImage, attachImageBytes, detectDroppedPath, dispatchCommand, ensureGatewaySession, restSessionId, sendPrompt, taskId]);
+  }, [attachFile, attachImage, attachImageBytes, detectDroppedPath, dispatchCommand, ensureGatewaySession, restSessionId, sendPrompt, taskId]);
 
   const onSend = useCallback(async (
     payload: ComposerSubmitPayload,
@@ -448,7 +477,7 @@ export function DetailRoute() {
 
   // ---- Send queue (drain on settle, send-now / edit / delete) --------------
   const queuedPrompts = useQueuedPrompts(taskId);
-  const [composerPrefill, setComposerPrefill] = useState({ text: "", nonce: 0 });
+  const [composerPrefill, setComposerPrefill] = useState<ComposerPrefillState>({ text: "", nonce: 0 });
   const drainingRef = useRef(false);
   const previousBusyRef = useRef(runtimeIsBusy);
   const userInterruptedRef = useRef(false);
@@ -499,7 +528,7 @@ export function DetailRoute() {
   }, [drainEntry, queuedPrompts]);
 
   const onQueueEdit = useCallback((entry: QueuedPromptEntry) => {
-    setComposerPrefill((prefill) => ({ text: entry.text, nonce: prefill.nonce + 1 }));
+    setComposerPrefill((prefill) => ({ text: entry.text, nonce: prefill.nonce + 1, sessionId: taskId }));
     removeQueuedPrompt(taskId, entry.id);
   }, [taskId]);
 
@@ -624,6 +653,9 @@ export function DetailRoute() {
     estimatedUsed: estimatedContextUsed,
   });
   const autoTts = voiceAutoTtsFromConfig(config);
+  const hasActiveComposerPrefill = composerPrefill.sessionId === taskId && composerPrefill.nonce > 0;
+  const composerInitial = hasActiveComposerPrefill ? composerPrefill.text : storedComposerDraft;
+  const composerInitialNonce = hasActiveComposerPrefill ? composerPrefill.nonce : 0;
   const pageStyle = useMemo(
     () => {
       const font = conversationFontSizeVars(conversationFontSizeMode);
@@ -732,11 +764,12 @@ export function DetailRoute() {
               onDelete={onQueueDelete}
             />
             <GooseComposer
-              key={taskId}
+              key={`${taskId}:${composerDraftKey ?? "draft"}`}
               flushBottom
               initialWorkspacePath={sessionWorkspace}
-              initial={composerPrefill.text}
-              initialNonce={composerPrefill.nonce}
+              initial={composerInitial}
+              initialNonce={composerInitialNonce}
+              onDraftChange={onComposerDraftChange}
               onSend={onSend}
               loadingPlaceholder={composerLoadingPlaceholder}
               showMeta={false}


### PR DESCRIPTION
## 变更内容

- 为新任务页和已有会话页增加按 profile/runtime/session 隔离的 Composer 文本草稿缓存。
- 修复 Composer 发送图片和普通文件时的上传/预览路径，避免 PDF 等文件被错误显示成 PNG 预览。
- 修复消息内容中本地图片路径、Markdown 图片和模型返回图片无法预览的问题。
- 增加 Tauri 文件 data URL 读取桥接，并补充单测与 E2E 覆盖。

## 原因与影响

之前 Composer 文本在切换会话后会丢失，附件路径也混用了图片上传和普通文件上传逻辑，导致图片无法稳定预览、PDF 等文件显示异常。该修复让草稿按目标隔离保存，并让图片/文件/模型返回图片走正确的解析和预览链路。

## 验证

- `pnpm --filter @hermes/web exec vitest run src/lib/composer-drafts.test.ts src/components/chat/goose-composer.test.tsx src/components/panel/panel-composer.test.tsx`
- `pnpm --filter @hermes/web exec vitest run src/lib/clipboard-image.test.ts src/lib/composer-prompt.test.ts src/lib/message-images.test.ts src/lib/transport.test.ts src/components/chat/message-adapter.test.ts src/components/chat/message-timeline.test.tsx`
- `pnpm --filter @hermes/web typecheck`
- `pnpm typecheck`
- `cargo check`
- `CI=1 HERMES_CORE_DIR=/Users/enzo/Documents/GithubProjects/hermes/CNDesktop/Hermes-CN-Core E2E_DASHBOARD_PORT=19120 E2E_VITE_PORT=19545 E2E_FAKE_MODEL_PORT=18099 pnpm test:e2e`
- `CI=1 HERMES_CORE_DIR=/Users/enzo/Documents/GithubProjects/hermes/CNDesktop/Hermes-CN-Core E2E_DASHBOARD_PORT=19120 E2E_VITE_PORT=19545 E2E_FAKE_MODEL_PORT=18099 pnpm --filter @hermes/e2e exec playwright test specs/image-paste.spec.ts --retries=0`
- 本地 `pnpm tauri:dev -- --source /Users/enzo/Documents/GithubProjects/hermes/CNDesktop/Hermes-CN-Core --force` 启动后完成草稿和附件预览验收。