### PR TITLE
fix(runtime): 防止 bundled Runtime 降级

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -2007,6 +2007,7 @@ dependencies = [
  "regex",
  "reqwest 0.12.28",
  "rusqlite",
+ "semver",
  "serde",
  "serde_json",
  "serde_yaml",

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -20,6 +20,7 @@ tauri-plugin-notification = "2"
 serde = { version = "1", features = ["derive"] }
 serde_json = "1"
 serde_yaml = "0.9"
+semver = "1"
 tokio = { version = "1", features = ["full"] }
 reqwest = { version = "0.12", default-features = false, features = [
     "cookies",

--- a/src/process/runtime.rs
+++ b/src/process/runtime.rs
@@ -12,6 +12,7 @@ use std::process::Stdio;
 use std::sync::LazyLock;
 use std::time::Duration;
 
+use semver::Version;
 use serde::{Deserialize, Serialize};
 use sha2::{Digest, Sha256};
 use tokio::process::Command;
@@ -2006,7 +2007,14 @@ pub async fn install_bundled_runtime_if_needed(
         };
     }
 
-    if let Some(current) = read_current_record() {
+    let current = read_current_record();
+    let should_install_bundled = should_install_bundled_runtime(
+        current
+            .as_ref()
+            .map(|record| record.runtime_version.as_str()),
+        &manifest.runtime_version,
+    );
+    if let Some(current) = current {
         // Dev/debug builds keep `local-source` runtimes (see dev-runtime tree).
         // Release builds archive the stale pointer and fall through to bundled
         // install so packaged launches never stick on an old dev-local kernel.
@@ -2057,6 +2065,18 @@ pub async fn install_bundled_runtime_if_needed(
                 previous: Some(current),
                 error: None,
             };
+        } else if !should_install_bundled {
+            log::info!(
+                "Keeping current managed runtime {} over bundled {}",
+                current.runtime_version,
+                manifest.runtime_version
+            );
+            return RuntimeInstallUpdateResult {
+                ok: true,
+                installed: None,
+                previous: Some(current),
+                error: None,
+            };
         }
     }
 
@@ -2085,6 +2105,20 @@ pub async fn install_bundled_runtime_if_needed(
         }
     }
     result
+}
+
+fn should_install_bundled_runtime(current_version: Option<&str>, bundled_version: &str) -> bool {
+    let Some(current_version) = current_version else {
+        return true;
+    };
+
+    match (
+        Version::parse(current_version),
+        Version::parse(bundled_version),
+    ) {
+        (Ok(current), Ok(bundled)) => current.cmp_precedence(&bundled).is_lt(),
+        _ => current_version != bundled_version,
+    }
 }
 
 /// Download, verify, and install a runtime update.
@@ -3059,6 +3093,35 @@ mod tests {
                 "must reject invalid runtimeVersion {version:?}"
             );
         }
+    }
+
+    #[test]
+    fn bundled_runtime_installs_when_current_version_is_missing() {
+        assert!(should_install_bundled_runtime(None, "0.19.0-cn.6"));
+    }
+
+    #[test]
+    fn bundled_runtime_installs_over_older_current_version() {
+        assert!(should_install_bundled_runtime(
+            Some("0.19.0-cn.5"),
+            "0.19.0-cn.6"
+        ));
+    }
+
+    #[test]
+    fn bundled_runtime_skips_matching_current_version() {
+        assert!(!should_install_bundled_runtime(
+            Some("0.19.0-cn.6"),
+            "0.19.0-cn.6"
+        ));
+    }
+
+    #[test]
+    fn bundled_runtime_does_not_downgrade_newer_current_version() {
+        assert!(!should_install_bundled_runtime(
+            Some("0.19.0-cn.7"),
+            "0.19.0-cn.6"
+        ));
     }
 
     #[test]


### PR DESCRIPTION
## 变更

- 使用 SemVer precedence 比较当前 managed Runtime 与安装包内置 Runtime。
- 当前 Runtime 缺失或版本更低时安装 bundled Runtime；版本相同时沿用资源同步逻辑；当前版本更高时保留现有 Runtime 和对应资源。
- 增加当前 Runtime 缺失、较旧、相同和较新四类回归测试。

## 验证

- `pnpm typecheck`
- `pnpm test:unit`（1178 项通过）
- `cargo check`
- `cargo fmt --all -- --check`
- `cargo test --all-features bundled_runtime_`（10 项通过）
- `cargo test --all-features --no-fail-fast`（495 项通过）
- `cargo clippy --all-targets -- -D warnings -A clippy::inconsistent-digit-grouping`
- `pnpm tauri:build:bundled-windows`
- 使用 bundled Runtime `0.19.0-cn.7` 构建并安装 Windows x64 NSIS 测试包，将 managed Runtime 记录模拟为 `0.19.0-cn.8` 后完成应用启动与托盘退出，确认 `current.json` 继续保持 `0.19.0-cn.8`；验证完成后恢复为 `0.19.0-cn.7`。

## 说明

- 验证环境：Windows x64、Rust 1.97.1、Node.js 24.15.0、pnpm 9.15.0。
- 完整 Clippy 会在未修改的 `src/process/port_lock.rs:244` 命中既有 Windows-only `clippy::inconsistent-digit-grouping`；仅允许该既有 lint 后验证通过。
- 用户可见变化仅发生在安装包内置 Runtime 低于当前 managed Runtime 时：保留较新的 Runtime，并保持其资源不受旧 bundled resources 覆盖。
- 配置与数据格式保持不变。

Fixes #522
