### PR TITLE
feat: 添加 Token 消耗匿名埋点

### DIFF
--- a/web/src/app.tsx
+++ b/web/src/app.tsx
@@ -4,7 +4,7 @@ import { useEffect, type ReactNode } from "react";
 import { useSetAtom } from "jotai";
 import { useBootstrapActiveProfile } from "@/hooks/use-profiles";
 import { readUiValue } from "@/lib/ui-store";
-import { sendTelemetryPingIfDue } from "@/lib/telemetry";
+import { sendTelemetryPingIfDue, sendTokenUsageTelemetryIfDue } from "@/lib/telemetry";
 import { ErrorBoundary } from "@/components/error-boundary";
 import { ProfileSwitchOverlay } from "@/components/profile-switch-overlay";
 import { RuntimeUpdateOverlay } from "@/components/runtime-update-overlay";
@@ -120,6 +120,7 @@ export function App() {
   }, [hydrateTheme]);
   useEffect(() => {
     void sendTelemetryPingIfDue();
+    if (runtime.isBackendReady()) void sendTokenUsageTelemetryIfDue();
   }, []);
 
   const isGuide = location.pathname === "/guide";

--- a/web/src/lib/telemetry.test.ts
+++ b/web/src/lib/telemetry.test.ts
@@ -1,25 +1,45 @@
 import { beforeEach, describe, expect, it, vi } from "vitest";
 import { fetchExternalJSON } from "./transport";
 import {
+  buildTokenUsageTelemetryPayload,
   buildTelemetryPayload,
   isPingDue,
   PING_INTERVAL_MS,
   reportPromoClick,
   sendTelemetryPingIfDue,
+  sendTokenUsageTelemetryIfDue,
   TELEMETRY_ENABLED_KEY,
+  TOKEN_USAGE_LAST_REPORTED_KEY,
 } from "./telemetry";
-import { writeUiValue, __resetUiStoreForTests } from "./ui-store";
+import {
+  getUiTurnStatsWindow,
+  readUiValue,
+  writeUiValue,
+  __resetUiStoreForTests,
+  type UiTurnStats,
+} from "./ui-store";
 
 vi.mock("./transport", () => ({
   fetchExternalJSON: vi.fn(),
 }));
 
+vi.mock("./ui-store", async (importOriginal) => {
+  const actual = await importOriginal<typeof import("./ui-store")>();
+  return {
+    ...actual,
+    getUiTurnStatsWindow: vi.fn(),
+  };
+});
+
 const mockedFetch = vi.mocked(fetchExternalJSON);
+const mockedGetTurnStatsWindow = vi.mocked(getUiTurnStatsWindow);
 
 beforeEach(() => {
   __resetUiStoreForTests({});
   mockedFetch.mockReset();
   mockedFetch.mockResolvedValue(null);
+  mockedGetTurnStatsWindow.mockReset();
+  mockedGetTurnStatsWindow.mockResolvedValue([]);
 });
 
 describe("isPingDue", () => {
@@ -94,5 +114,185 @@ describe("buildTelemetryPayload", () => {
       "locale",
       "os",
     ]);
+  });
+});
+
+describe("buildTokenUsageTelemetryPayload", () => {
+  it("aggregates token usage by model without carrying session metadata", () => {
+    const rows: UiTurnStats[] = [
+      {
+        id: "row-1",
+        sessionId: "session-secret-1",
+        model: "gpt-5",
+        provider: "openai",
+        tokensInput: 10,
+        tokensOutput: 5,
+        tokensTotal: 15,
+        cacheRead: 2,
+        cacheWrite: 1,
+        reasoningTokens: 3,
+        apiCalls: 1,
+        metadata: { persistedId: "message-secret", profile: "research", content: "prompt text" },
+      },
+      {
+        id: "row-2",
+        sessionId: "session-secret-2",
+        model: "gpt-5",
+        provider: "openai",
+        tokensInput: 4,
+        tokensOutput: 6,
+        tokensTotal: 10,
+        apiCalls: 2,
+      },
+      {
+        id: "row-3",
+        sessionId: "session-secret-3",
+        model: "anthropic/claude-sonnet-4",
+        tokensInput: 8,
+        tokensTotal: 12,
+        cacheRead: 1,
+      },
+    ];
+
+    const payload = buildTokenUsageTelemetryPayload(rows, {
+      deviceId: "device-1",
+      periodStartMs: 1_000,
+      periodEndMs: 2_000,
+    });
+
+    expect(payload).toMatchObject({
+      event: "token_usage_daily",
+      device_id: "device-1",
+      period_start_ms: 1_000,
+      period_end_ms: 2_000,
+      totals: {
+        input_tokens: 22,
+        output_tokens: 15,
+        total_tokens: 37,
+        cache_read_tokens: 3,
+        cache_write_tokens: 1,
+        reasoning_tokens: 3,
+        api_calls: 3,
+        turns: 3,
+      },
+    });
+    expect(payload?.models).toEqual([
+      expect.objectContaining({
+        provider: "openai",
+        model: "gpt-5",
+        input_tokens: 14,
+        output_tokens: 11,
+        total_tokens: 25,
+        turns: 2,
+      }),
+      expect.objectContaining({
+        provider: "anthropic",
+        model: "anthropic/claude-sonnet-4",
+        input_tokens: 8,
+        output_tokens: 4,
+        total_tokens: 12,
+        turns: 1,
+      }),
+    ]);
+    expect(Object.keys(payload ?? {}).sort()).toEqual([
+      "app_version",
+      "catalog_version",
+      "device_id",
+      "event",
+      "locale",
+      "models",
+      "os",
+      "period_end_ms",
+      "period_start_ms",
+      "totals",
+    ]);
+    expect(Object.keys(payload?.totals ?? {}).sort()).toEqual([
+      "api_calls",
+      "cache_read_tokens",
+      "cache_write_tokens",
+      "input_tokens",
+      "output_tokens",
+      "reasoning_tokens",
+      "total_tokens",
+      "turns",
+    ]);
+    expect(Object.keys(payload?.models[0] ?? {}).sort()).toEqual([
+      "api_calls",
+      "cache_read_tokens",
+      "cache_write_tokens",
+      "input_tokens",
+      "model",
+      "output_tokens",
+      "provider",
+      "reasoning_tokens",
+      "total_tokens",
+      "turns",
+    ]);
+    const serialized = JSON.stringify(payload);
+    expect(serialized).not.toContain("session-secret");
+    expect(serialized).not.toContain("message-secret");
+    expect(serialized).not.toContain("prompt text");
+    expect(serialized).not.toContain("research");
+  });
+
+  it("returns null when there are no token totals to report", () => {
+    expect(buildTokenUsageTelemetryPayload([
+      { id: "row-1", sessionId: "s1", model: "gpt-5", tokensTotal: 0 },
+    ], {
+      deviceId: "device-1",
+      periodStartMs: 1_000,
+      periodEndMs: 2_000,
+    })).toBeNull();
+  });
+});
+
+describe("sendTokenUsageTelemetryIfDue", () => {
+  it("does not read or send token usage when telemetry is disabled", async () => {
+    writeUiValue(TELEMETRY_ENABLED_KEY, false);
+    expect(await sendTokenUsageTelemetryIfDue(5_000_000)).toBe(false);
+    expect(mockedGetTurnStatsWindow).not.toHaveBeenCalled();
+    expect(mockedFetch).not.toHaveBeenCalled();
+  });
+
+  it("sends daily token usage and records the successful report timestamp", async () => {
+    const now = PING_INTERVAL_MS + 5_000_000;
+    mockedGetTurnStatsWindow.mockResolvedValue([
+      {
+        id: "row-1",
+        sessionId: "s1",
+        model: "gpt-5",
+        provider: "openai",
+        tokensInput: 10,
+        tokensOutput: 5,
+        tokensTotal: 15,
+        apiCalls: 1,
+      },
+    ]);
+
+    const sent = await sendTokenUsageTelemetryIfDue(now);
+    expect(sent).toBe(true);
+    expect(mockedGetTurnStatsWindow).toHaveBeenCalledWith({ sinceMs: 5_000_000, limit: 20_000 });
+    expect(mockedFetch).toHaveBeenCalledTimes(1);
+    const payload = JSON.parse(String(mockedFetch.mock.calls[0]![1]?.body));
+    expect(payload).toMatchObject({
+      event: "token_usage_daily",
+      totals: { input_tokens: 10, output_tokens: 5, total_tokens: 15, api_calls: 1, turns: 1 },
+      models: [{ provider: "openai", model: "gpt-5", total_tokens: 15 }],
+    });
+    expect(readUiValue(TOKEN_USAGE_LAST_REPORTED_KEY, 0)).toBe(now);
+
+    expect(await sendTokenUsageTelemetryIfDue(now + 60_000)).toBe(false);
+    expect(mockedGetTurnStatsWindow).toHaveBeenCalledTimes(1);
+    expect(mockedFetch).toHaveBeenCalledTimes(1);
+  });
+
+  it("does not send an empty token usage payload", async () => {
+    mockedGetTurnStatsWindow.mockResolvedValue([
+      { id: "row-1", sessionId: "s1", model: "gpt-5", tokensTotal: 0 },
+    ]);
+
+    expect(await sendTokenUsageTelemetryIfDue(5_000_000)).toBe(false);
+    expect(mockedGetTurnStatsWindow).toHaveBeenCalledTimes(1);
+    expect(mockedFetch).not.toHaveBeenCalled();
   });
 });

--- a/web/src/lib/telemetry.ts
+++ b/web/src/lib/telemetry.ts
@@ -3,7 +3,12 @@
 // 语言这类聚合字段与一个本地随机生成的 device_id，不含对话内容、密钥或
 // 任何硬件指纹。默认开启，可在「设置 → 常规」关闭（hermes.telemetry-enabled）。
 import { fetchExternalJSON } from "./transport";
-import { readUiValue, writeUiValue } from "./ui-store";
+import {
+  getUiTurnStatsWindow,
+  readUiValue,
+  writeUiValue,
+  type UiTurnStats,
+} from "./ui-store";
 import { detectHostOS } from "./runtime";
 import { DESKTOP_VERSION } from "./build-info";
 import { BUILTIN_PROVIDER_CATALOG_VERSION } from "./provider-catalog";
@@ -11,10 +16,49 @@ import { BUILTIN_PROVIDER_CATALOG_VERSION } from "./provider-catalog";
 const DEFAULT_TELEMETRY_URL = "https://desktop.hermesagent.org.cn/api/telemetry";
 
 export const TELEMETRY_ENABLED_KEY = "hermes.telemetry-enabled";
+export const TOKEN_USAGE_LAST_REPORTED_KEY = "hermes.telemetry-token-usage-last-reported-at";
 const DEVICE_ID_KEY = "hermes.telemetry-device-id";
 const LAST_PING_KEY = "hermes.telemetry-last-ping-at";
 
 export const PING_INTERVAL_MS = 24 * 60 * 60 * 1000;
+const MAX_TOKEN_USAGE_MODELS = 50;
+
+export interface TokenUsageTelemetryMetrics {
+  input_tokens: number;
+  output_tokens: number;
+  total_tokens: number;
+  cache_read_tokens: number;
+  cache_write_tokens: number;
+  reasoning_tokens: number;
+  api_calls: number;
+  turns: number;
+}
+
+export interface TokenUsageTelemetryModel extends TokenUsageTelemetryMetrics {
+  provider: string;
+  model: string;
+}
+
+interface TelemetryBasePayload {
+  device_id: string;
+  app_version: string;
+  os: string;
+  locale: string;
+  catalog_version: string;
+}
+
+export interface BasicTelemetryPayload extends TelemetryBasePayload {
+  event: "ping" | "promo_click";
+  provider_id?: string;
+}
+
+export interface TokenUsageDailyTelemetryPayload extends TelemetryBasePayload {
+  event: "token_usage_daily";
+  period_start_ms: number;
+  period_end_ms: number;
+  totals: TokenUsageTelemetryMetrics;
+  models: TokenUsageTelemetryModel[];
+}
 
 function telemetryUrl(): string {
   const override = import.meta.env.VITE_HERMES_TELEMETRY_URL;
@@ -44,21 +88,13 @@ export function isPingDue(lastPingAt: unknown, now: number, interval = PING_INTE
   return now - last >= interval;
 }
 
-export interface TelemetryPayload {
-  event: "ping" | "promo_click";
-  device_id: string;
-  app_version: string;
-  os: string;
-  locale: string;
-  catalog_version: string;
-  provider_id?: string;
-}
+export type TelemetryPayload = BasicTelemetryPayload | TokenUsageDailyTelemetryPayload;
 
 export function buildTelemetryPayload(
-  event: TelemetryPayload["event"],
+  event: BasicTelemetryPayload["event"],
   deviceId: string,
   providerId?: string,
-): TelemetryPayload {
+): BasicTelemetryPayload {
   return {
     event,
     device_id: deviceId,
@@ -67,6 +103,107 @@ export function buildTelemetryPayload(
     locale: typeof navigator !== "undefined" ? navigator.language : "unknown",
     catalog_version: BUILTIN_PROVIDER_CATALOG_VERSION,
     ...(providerId ? { provider_id: providerId } : {}),
+  };
+}
+
+function numericTimestamp(value: unknown): number | null {
+  const n = typeof value === "number" ? value : Number(value);
+  return Number.isFinite(n) && n > 0 ? n : null;
+}
+
+function tokenMetric(value: number | null | undefined): number {
+  return typeof value === "number" && Number.isFinite(value) && value > 0
+    ? Math.trunc(value)
+    : 0;
+}
+
+function emptyTokenUsageMetrics(): TokenUsageTelemetryMetrics {
+  return {
+    input_tokens: 0,
+    output_tokens: 0,
+    total_tokens: 0,
+    cache_read_tokens: 0,
+    cache_write_tokens: 0,
+    reasoning_tokens: 0,
+    api_calls: 0,
+    turns: 0,
+  };
+}
+
+function normalizedDimension(value: string | undefined, fallback = "unknown", max = 128): string {
+  const trimmed = value?.trim();
+  return trimmed ? trimmed.slice(0, max) : fallback;
+}
+
+function providerFromStat(stat: UiTurnStats, model: string): string {
+  const provider = normalizedDimension(stat.provider, "", 64);
+  if (provider) return provider;
+  const slashIndex = model.indexOf("/");
+  return slashIndex > 0 ? model.slice(0, slashIndex).slice(0, 64) : "unknown";
+}
+
+function tokensForStat(stat: UiTurnStats): TokenUsageTelemetryMetrics {
+  const input = tokenMetric(stat.tokensInput);
+  const total = tokenMetric(stat.tokensTotal) || input + tokenMetric(stat.tokensOutput);
+  const output = tokenMetric(stat.tokensOutput) || Math.max(0, total - input);
+  return {
+    input_tokens: input,
+    output_tokens: output,
+    total_tokens: total,
+    cache_read_tokens: tokenMetric(stat.cacheRead),
+    cache_write_tokens: tokenMetric(stat.cacheWrite),
+    reasoning_tokens: tokenMetric(stat.reasoningTokens),
+    api_calls: tokenMetric(stat.apiCalls),
+    turns: total > 0 ? 1 : 0,
+  };
+}
+
+function addMetrics(target: TokenUsageTelemetryMetrics, source: TokenUsageTelemetryMetrics): void {
+  target.input_tokens += source.input_tokens;
+  target.output_tokens += source.output_tokens;
+  target.total_tokens += source.total_tokens;
+  target.cache_read_tokens += source.cache_read_tokens;
+  target.cache_write_tokens += source.cache_write_tokens;
+  target.reasoning_tokens += source.reasoning_tokens;
+  target.api_calls += source.api_calls;
+  target.turns += source.turns;
+}
+
+export function buildTokenUsageTelemetryPayload(
+  rows: UiTurnStats[],
+  input: { deviceId: string; periodStartMs: number; periodEndMs: number },
+): TokenUsageDailyTelemetryPayload | null {
+  const totals = emptyTokenUsageMetrics();
+  const byModel = new Map<string, TokenUsageTelemetryModel>();
+
+  for (const stat of rows) {
+    const metrics = tokensForStat(stat);
+    if (metrics.total_tokens <= 0) continue;
+
+    const model = normalizedDimension(stat.model, "unknown", 128);
+    const provider = providerFromStat(stat, model);
+    const key = `${provider}:${model}`;
+    const existing = byModel.get(key) ?? { ...emptyTokenUsageMetrics(), provider, model };
+    addMetrics(existing, metrics);
+    byModel.set(key, existing);
+    addMetrics(totals, metrics);
+  }
+
+  if (totals.total_tokens <= 0) return null;
+
+  return {
+    event: "token_usage_daily",
+    device_id: input.deviceId,
+    app_version: DESKTOP_VERSION,
+    os: detectHostOS(),
+    locale: typeof navigator !== "undefined" ? navigator.language : "unknown",
+    catalog_version: BUILTIN_PROVIDER_CATALOG_VERSION,
+    period_start_ms: input.periodStartMs,
+    period_end_ms: input.periodEndMs,
+    totals,
+    models: [...byModel.values()]
+      .sort((a, b) => b.total_tokens - a.total_tokens || b.turns - a.turns)
+      .slice(0, MAX_TOKEN_USAGE_MODELS),
   };
 }
 
@@ -90,6 +227,39 @@ export async function sendTelemetryPingIfDue(now = Date.now()): Promise<boolean>
   } catch {
     return false;
   }
+}
+
+let tokenUsageTelemetryInFlight: Promise<boolean> | null = null;
+
+async function sendTokenUsageTelemetry(now: number): Promise<boolean> {
+  if (!isTelemetryEnabled()) return false;
+  const lastReportedAt = numericTimestamp(readUiValue<unknown>(TOKEN_USAGE_LAST_REPORTED_KEY, 0));
+  if (!isPingDue(lastReportedAt, now)) return false;
+
+  const periodStartMs = lastReportedAt ?? Math.max(0, now - PING_INTERVAL_MS);
+  try {
+    const rows = await getUiTurnStatsWindow({ sinceMs: periodStartMs, limit: 20_000 });
+    const payload = buildTokenUsageTelemetryPayload(rows, {
+      deviceId: telemetryDeviceId(),
+      periodStartMs,
+      periodEndMs: now,
+    });
+    if (!payload) return false;
+    await post(payload);
+    writeUiValue(TOKEN_USAGE_LAST_REPORTED_KEY, now);
+    return true;
+  } catch {
+    return false;
+  }
+}
+
+/** 每 24h 最多一次的匿名 Token 消耗聚合上报。失败静默，绝不影响主流程。 */
+export async function sendTokenUsageTelemetryIfDue(now = Date.now()): Promise<boolean> {
+  if (tokenUsageTelemetryInFlight) return tokenUsageTelemetryInFlight;
+  tokenUsageTelemetryInFlight = sendTokenUsageTelemetry(now).finally(() => {
+    tokenUsageTelemetryInFlight = null;
+  });
+  return tokenUsageTelemetryInFlight;
 }
 
 /** 「前往官网」点击事件（fire-and-forget），用于评估各供应商推广位转化。 */


### PR DESCRIPTION
## 变更
- 新增 Desktop 端 token_usage_daily 匿名聚合埋点
- 按本机 turn_stats 聚合 Token 和模型维度，不上传会话正文或 session/profile 信息
- 沿用现有匿名统计开关，并补充 telemetry 单测

## 验证
- pnpm --filter @hermes/web test:unit -- src/lib/telemetry.test.ts
- pnpm --filter @hermes/web typecheck