### PR TITLE
ci: 升级桌面端发布 Node 版本

### DIFF
--- a/.github/workflows/release-desktop.yml
+++ b/.github/workflows/release-desktop.yml
@@ -2,7 +2,7 @@
 # Release. Triggers on tags matching `v*` (e.g. `v0.8.0-rc1`).
 #
 # Desktop release build runs in parallel for Windows, macOS, and Linux. Each job:
-#   1. Installs Node + pnpm + Rust toolchain
+#   1. Installs Node 22 + pnpm + Rust toolchain
 #   2. Caches cargo registry and target dir
 #   3. `pnpm install`
 #   4. Stages the bundled dashboard frontend, bundled skills, bundled plugins,
@@ -74,7 +74,7 @@ jobs:
 
       - uses: actions/setup-node@v4
         with:
-          node-version: "20"
+          node-version: "22.22.0"
 
       - uses: pnpm/action-setup@v3
         with:


### PR DESCRIPTION
## 变更
- 将 release-desktop workflow 的 Node 版本从 20 升级到 22.22.0，匹配最新 Hermes-CN-Core dashboard 的 engines 要求
- 同步更新 workflow 注释

## 验证
- git diff --check
- pnpm run version:check