### PR TITLE
fix: 处理 Windows Runtime 文件占用

### DIFF
--- a/src/commands/api_proxy.rs
+++ b/src/commands/api_proxy.rs
@@ -496,20 +496,7 @@ async fn api_request_impl_inner(
         return Ok(json_result(status, status_text, body));
     }
 
-    // 4. Runtime update intercept
-    if url_p == "/api/hermes/update" && method.to_uppercase() == "POST" {
-        let result = crate::process::runtime::install_runtime_update(None).await;
-        let status = if result.ok { 200 } else { 503 };
-        let status_text = if result.ok {
-            "OK"
-        } else {
-            "Runtime Update Failed"
-        };
-        let body = serde_json::to_value(&result).unwrap_or_default();
-        return Ok(json_result(status, status_text, body));
-    }
-
-    // 5. Proxy to dashboard
+    // 4. Proxy to dashboard
     let full_url = if path.starts_with("http://") || path.starts_with("https://") {
         // Validate same origin
         let base = url::Url::parse(api_base_url)?;
@@ -583,7 +570,7 @@ async fn api_request_impl_inner(
         .collect();
     let raw_body = res.text().await.unwrap_or_default();
 
-    // 6. Post-process: filter archived sessions
+    // 5. Post-process: filter archived sessions
     let body = session_archive::filter_archived_from_response(path, method, hermes_home, &raw_body);
 
     Ok(ApiRequestResult {
@@ -627,6 +614,25 @@ pub async fn api_request_from_state(
                 "ok": false,
                 "error": "当前连接的不是本机内核，无法更新桌面端 managed runtime"
             }),
+        ));
+    }
+
+    if mode == crate::connection::ConnectionMode::Managed
+        && url_path(&input.path) == "/api/hermes/update"
+        && input.method.as_deref().unwrap_or("GET").to_uppercase() == "POST"
+    {
+        let result =
+            crate::commands::runtime_manager::install_runtime_update_managed(state).await?;
+        let status = if result.ok { 200 } else { 503 };
+        let status_text = if result.ok {
+            "OK"
+        } else {
+            "Runtime Update Failed"
+        };
+        return Ok(json_result(
+            status,
+            status_text,
+            serde_json::to_value(&result).unwrap_or_default(),
         ));
     }
 

--- a/src/commands/restart.rs
+++ b/src/commands/restart.rs
@@ -11,8 +11,6 @@
 use std::sync::atomic::Ordering;
 use std::time::Duration;
 
-use tauri::State;
-
 use crate::error::AppError;
 use crate::process::dashboard;
 use crate::state::AppState;
@@ -32,7 +30,7 @@ pub fn host_and_port() -> (String, u16) {
 /// now owns the restart and must call [`end_restart`] when done; `false` if a
 /// restart is already in flight. The check-and-set happens under a single lock,
 /// so two concurrent callers cannot both win.
-pub fn try_begin_restart(state: &State<'_, AppState>) -> Result<bool, AppError> {
+pub fn try_begin_restart(state: &AppState) -> Result<bool, AppError> {
     let mut inner = state.inner.lock()?;
     if inner.dashboard_restart_in_flight {
         return Ok(false);
@@ -42,10 +40,24 @@ pub fn try_begin_restart(state: &State<'_, AppState>) -> Result<bool, AppError> 
 }
 
 /// Release the dashboard-restart guard claimed by [`try_begin_restart`].
-pub fn end_restart(state: &State<'_, AppState>) {
+pub fn end_restart(state: &AppState) {
     if let Ok(mut inner) = state.inner.lock() {
         inner.dashboard_restart_in_flight = false;
     }
+}
+
+pub struct RestartGuard<'a> {
+    state: &'a AppState,
+}
+
+impl Drop for RestartGuard<'_> {
+    fn drop(&mut self) {
+        end_restart(self.state);
+    }
+}
+
+pub fn try_begin_restart_guard(state: &AppState) -> Result<Option<RestartGuard<'_>>, AppError> {
+    Ok(try_begin_restart(state)?.then_some(RestartGuard { state }))
 }
 
 /// What a respawn ended up doing.
@@ -81,7 +93,7 @@ pub struct RespawnResult {
 /// command-specific state (`current_profile`, `yolo_mode`, sticky file) and
 /// must hold the [`try_begin_restart`] guard for the duration.
 pub async fn respawn_managed_dashboard(
-    state: &State<'_, AppState>,
+    state: &AppState,
     host: &str,
     port: u16,
     target_home: &str,
@@ -152,7 +164,7 @@ pub async fn respawn_managed_dashboard(
 /// the resulting connection into AppState. Returns the connection tuple on
 /// success. The session token is process-local and rotates on every restart.
 async fn spawn_and_adopt(
-    state: &State<'_, AppState>,
+    state: &AppState,
     host: &str,
     port: u16,
     hermes_home: &str,

--- a/src/commands/runtime_manager.rs
+++ b/src/commands/runtime_manager.rs
@@ -15,7 +15,7 @@ use crate::process::dashboard;
 use crate::process::runtime;
 use crate::state::AppState;
 use std::path::{Path, PathBuf};
-use std::sync::atomic::Ordering;
+use std::sync::atomic::{AtomicBool, Ordering};
 use std::time::{SystemTime, UNIX_EPOCH};
 use tokio::task;
 
@@ -177,19 +177,55 @@ pub async fn runtime_check_update() -> Result<runtime::RuntimeUpdateCheckResult,
 pub async fn runtime_install_update(
     state: State<'_, AppState>,
 ) -> Result<runtime::RuntimeInstallUpdateResult, AppError> {
+    install_runtime_update_managed(&state).await
+}
+
+pub(crate) async fn install_runtime_update_managed(
+    state: &AppState,
+) -> Result<runtime::RuntimeInstallUpdateResult, AppError> {
     {
         let inner = state.inner.lock()?;
         crate::connection::require_managed_mode(inner.connection_mode, "Runtime 更新")?;
     }
-    let result = runtime::install_runtime_update(None).await;
+    let Some(_restart_guard) = restart::try_begin_restart_guard(state)? else {
+        return Ok(runtime::RuntimeInstallUpdateResult {
+            ok: false,
+            installed: None,
+            previous: runtime::read_current_record(),
+            error: Some("内核操作正在进行中，请稍后重试".to_string()),
+        });
+    };
+
+    let backend_stopped = AtomicBool::new(false);
+    let mut result = runtime::install_runtime_update_with_pre_replace(None, || {
+        stop_managed_backend(state).map_err(|error| error.to_string())?;
+        backend_stopped.store(true, Ordering::Relaxed);
+        Ok(())
+    })
+    .await;
+    let restart_result = if result.ok || backend_stopped.load(Ordering::Relaxed) {
+        Some(restart_dashboard(state).await)
+    } else {
+        None
+    };
+
     if !result.ok {
+        if let Some(Err(error)) = restart_result {
+            let install_error = result
+                .error
+                .take()
+                .unwrap_or_else(|| "Runtime update failed".to_string());
+            result.error = Some(format!(
+                "{}; previous Runtime restart also failed: {}",
+                install_error, error
+            ));
+        }
         let mut inner = state.inner.lock()?;
         inner.last_runtime_error = result.error.clone();
         return Ok(result);
     }
 
-    // Restart dashboard after successful install
-    if let Err(e) = restart_dashboard(&state).await {
+    if let Some(Err(e)) = restart_result {
         let mut inner = state.inner.lock()?;
         inner.last_runtime_error = Some(e.to_string());
         return Ok(runtime::RuntimeInstallUpdateResult {
@@ -323,7 +359,7 @@ fn uninstall_runtime_payload_with(
     })
 }
 
-fn stop_managed_backend(state: &State<'_, AppState>) -> Result<(), AppError> {
+fn stop_managed_backend(state: &AppState) -> Result<(), AppError> {
     let mut inner = state.inner.lock()?;
     if inner.connection_mode != ConnectionMode::Managed {
         return Ok(());
@@ -382,14 +418,13 @@ pub async fn managed_runtime_install(
         desktop_control::set_managed_runtime_desired_state(ManagedRuntimeDesiredState::Stopped)?;
         return runtime_control_snapshot(&state, None);
     }
-    if !restart::try_begin_restart(&state)? {
+    let Some(_restart_guard) = restart::try_begin_restart_guard(&state)? else {
         return runtime_control_snapshot(
             &state,
             Some("内核操作正在进行中，请稍后重试".to_string()),
         );
-    }
+    };
     let install = install_runtime_payload(&app).await;
-    restart::end_restart(&state);
     if !install.ok || runtime::read_current_record().is_none() {
         let error = install
             .error
@@ -404,21 +439,18 @@ pub async fn managed_runtime_install(
 pub async fn managed_runtime_stop(
     state: State<'_, AppState>,
 ) -> Result<RuntimeControlResult, AppError> {
-    if !restart::try_begin_restart(&state)? {
+    let Some(_restart_guard) = restart::try_begin_restart_guard(&state)? else {
         return runtime_control_snapshot(
             &state,
             Some("内核操作正在进行中，请稍后重试".to_string()),
         );
-    }
+    };
     let result = stop_managed_backend(&state);
-    restart::end_restart(&state);
+    if result.is_ok() {
+        desktop_control::set_managed_runtime_desired_state(ManagedRuntimeDesiredState::Stopped)?;
+    }
     match result {
-        Ok(()) => {
-            desktop_control::set_managed_runtime_desired_state(
-                ManagedRuntimeDesiredState::Stopped,
-            )?;
-            runtime_control_snapshot(&state, None)
-        }
+        Ok(()) => runtime_control_snapshot(&state, None),
         Err(error) => runtime_control_snapshot(&state, Some(error.to_string())),
     }
 }
@@ -438,36 +470,28 @@ pub async fn managed_runtime_start(
             Some("当前正在使用外部 Hermes，请使用“启动并切换到内置内核”".to_string()),
         );
     }
-    if !restart::try_begin_restart(&state)? {
+    let Some(_restart_guard) = restart::try_begin_restart_guard(&state)? else {
         return runtime_control_snapshot(
             &state,
             Some("内核操作正在进行中，请稍后重试".to_string()),
         );
-    }
+    };
     desktop_control::set_managed_runtime_desired_state(ManagedRuntimeDesiredState::Running)?;
     let result = super::connection::apply_managed(&app, &state).await;
-    restart::end_restart(&state);
+    if !matches!(&result, Ok(applied) if applied.ok) {
+        desktop_control::set_managed_runtime_desired_state(ManagedRuntimeDesiredState::Stopped)?;
+    }
     match result {
         Ok(applied) if applied.ok => runtime_control_snapshot(&state, None),
-        Ok(applied) => {
-            desktop_control::set_managed_runtime_desired_state(
-                ManagedRuntimeDesiredState::Stopped,
-            )?;
-            runtime_control_snapshot(
-                &state,
-                Some(
-                    applied
-                        .error
-                        .unwrap_or_else(|| "内置内核启动失败".to_string()),
-                ),
-            )
-        }
-        Err(error) => {
-            desktop_control::set_managed_runtime_desired_state(
-                ManagedRuntimeDesiredState::Stopped,
-            )?;
-            runtime_control_snapshot(&state, Some(error.to_string()))
-        }
+        Ok(applied) => runtime_control_snapshot(
+            &state,
+            Some(
+                applied
+                    .error
+                    .unwrap_or_else(|| "内置内核启动失败".to_string()),
+            ),
+        ),
+        Err(error) => runtime_control_snapshot(&state, Some(error.to_string())),
     }
 }
 
@@ -475,31 +499,24 @@ pub async fn managed_runtime_start(
 pub async fn managed_runtime_uninstall(
     state: State<'_, AppState>,
 ) -> Result<RuntimeControlResult, AppError> {
-    if !restart::try_begin_restart(&state)? {
+    let Some(_restart_guard) = restart::try_begin_restart_guard(&state)? else {
         return runtime_control_snapshot(
             &state,
             Some("内核操作正在进行中，请稍后重试".to_string()),
         );
-    }
+    };
     if let Err(error) = stop_managed_backend(&state) {
-        restart::end_restart(&state);
         return runtime_control_snapshot(&state, Some(error.to_string()));
     }
     let outcome = uninstall_runtime_payload(&runtime::runtime_root());
-    restart::end_restart(&state);
+    desktop_control::set_managed_runtime_desired_state(if outcome.is_ok() {
+        ManagedRuntimeDesiredState::Uninstalled
+    } else {
+        ManagedRuntimeDesiredState::Stopped
+    })?;
     match outcome {
-        Ok(outcome) => {
-            desktop_control::set_managed_runtime_desired_state(
-                ManagedRuntimeDesiredState::Uninstalled,
-            )?;
-            runtime_control_snapshot(&state, outcome.cleanup_error)
-        }
-        Err(error) => {
-            desktop_control::set_managed_runtime_desired_state(
-                ManagedRuntimeDesiredState::Stopped,
-            )?;
-            runtime_control_snapshot(&state, Some(error.to_string()))
-        }
+        Ok(outcome) => runtime_control_snapshot(&state, outcome.cleanup_error),
+        Err(error) => runtime_control_snapshot(&state, Some(error.to_string())),
     }
 }
 
@@ -508,28 +525,25 @@ pub async fn managed_runtime_reinstall(
     app: tauri::AppHandle,
     state: State<'_, AppState>,
 ) -> Result<RuntimeControlResult, AppError> {
-    if !restart::try_begin_restart(&state)? {
+    let Some(_restart_guard) = restart::try_begin_restart_guard(&state)? else {
         return runtime_control_snapshot(
             &state,
             Some("内核操作正在进行中，请稍后重试".to_string()),
         );
-    }
+    };
     let was_managed = {
         let inner = state.inner.lock()?;
         inner.connection_mode == ConnectionMode::Managed
     };
     if let Err(error) = stop_managed_backend(&state) {
-        restart::end_restart(&state);
         return runtime_control_snapshot(&state, Some(error.to_string()));
     }
     if let Err(error) = uninstall_runtime_payload(&runtime::runtime_root()) {
-        restart::end_restart(&state);
         desktop_control::set_managed_runtime_desired_state(ManagedRuntimeDesiredState::Stopped)?;
         return runtime_control_snapshot(&state, Some(error.to_string()));
     }
     let install = install_runtime_payload(&app).await;
     if !install.ok || runtime::read_current_record().is_none() {
-        restart::end_restart(&state);
         desktop_control::set_managed_runtime_desired_state(
             ManagedRuntimeDesiredState::Uninstalled,
         )?;
@@ -552,7 +566,6 @@ pub async fn managed_runtime_reinstall(
     } else {
         None
     };
-    restart::end_restart(&state);
     match start_result {
         Some(Ok(applied)) if !applied.ok => runtime_control_snapshot(
             &state,
@@ -834,7 +847,7 @@ pub async fn runtime_rollback(
 }
 
 /// Stop the current dashboard and spawn a new one.
-pub(crate) async fn restart_dashboard(state: &State<'_, AppState>) -> Result<(), AppError> {
+pub(crate) async fn restart_dashboard(state: &AppState) -> Result<(), AppError> {
     let (host, port, hermes_home) = {
         let mut inner = state.inner.lock()?;
         crate::connection::require_managed_mode(inner.connection_mode, "内核重启")?;

--- a/src/process/dashboard.rs
+++ b/src/process/dashboard.rs
@@ -79,6 +79,8 @@ pub struct DashboardOwnershipMarker {
     pub runtime_root: String,
     pub gateway_runtime_dir: String,
     pub started_at_ms: u128,
+    #[serde(default, skip_serializing_if = "Option::is_none")]
+    pub dashboard_started_at_ms: Option<u128>,
     #[serde(skip_serializing_if = "Option::is_none")]
     pub runtime_version: Option<String>,
     /// Ports this desktop instance has claimed via the shared lock file.
@@ -170,6 +172,223 @@ fn read_ownership_marker() -> Option<DashboardOwnershipMarker> {
     serde_json::from_str(&content).ok()
 }
 
+fn marker_matches_runtime_target(
+    marker: &DashboardOwnershipMarker,
+    runtime_root: &Path,
+    runtime_version: &str,
+) -> bool {
+    marker.schema_version == OWNERSHIP_MARKER_SCHEMA_VERSION
+        && same_path(&marker.runtime_root, &runtime_root.to_string_lossy())
+        && marker.runtime_version.as_deref() == Some(runtime_version)
+}
+
+#[cfg(windows)]
+fn process_executable_path(pid: u32) -> Option<PathBuf> {
+    use std::os::windows::ffi::OsStringExt;
+    use windows_sys::Win32::Foundation::CloseHandle;
+    use windows_sys::Win32::System::Threading::{
+        OpenProcess, QueryFullProcessImageNameW, PROCESS_QUERY_LIMITED_INFORMATION,
+    };
+
+    let process = unsafe { OpenProcess(PROCESS_QUERY_LIMITED_INFORMATION, 0, pid) };
+    if process.is_null() {
+        return None;
+    }
+    let mut buffer = vec![0_u16; 32_768];
+    let mut size = buffer.len() as u32;
+    let ok = unsafe { QueryFullProcessImageNameW(process, 0, buffer.as_mut_ptr(), &mut size) };
+    unsafe { CloseHandle(process) };
+    if ok == 0 {
+        return None;
+    }
+    buffer.truncate(size as usize);
+    Some(PathBuf::from(std::ffi::OsString::from_wide(&buffer)))
+}
+
+#[cfg(target_os = "linux")]
+fn process_executable_path(pid: u32) -> Option<PathBuf> {
+    fs::read_link(format!("/proc/{pid}/exe")).ok()
+}
+
+#[cfg(all(unix, not(target_os = "linux")))]
+fn process_executable_path(pid: u32) -> Option<PathBuf> {
+    let output = Command::new("ps")
+        .args(["-p", &pid.to_string(), "-o", "comm="])
+        .output()
+        .ok()?;
+    if !output.status.success() {
+        return None;
+    }
+    let path = String::from_utf8_lossy(&output.stdout).trim().to_string();
+    (!path.is_empty()).then(|| PathBuf::from(path))
+}
+
+#[cfg(not(any(unix, windows)))]
+fn process_executable_path(_pid: u32) -> Option<PathBuf> {
+    None
+}
+
+fn process_matches_runtime_executable(pid: u32, executable_path: &Path) -> bool {
+    let Some(process_path) = process_executable_path(pid) else {
+        return false;
+    };
+    same_path(
+        &process_path.to_string_lossy(),
+        &executable_path.to_string_lossy(),
+    )
+}
+
+#[cfg(windows)]
+fn process_command_line(pid: u32) -> Option<String> {
+    let script = format!(
+        "$p = Get-CimInstance Win32_Process -Filter \"ProcessId = {}\"; if ($p) {{ $p.CommandLine }}",
+        pid
+    );
+    let output = Command::new("powershell")
+        .args(["-NoProfile", "-Command", &script])
+        .output()
+        .ok()?;
+    if !output.status.success() {
+        return None;
+    }
+    let command_line = String::from_utf8_lossy(&output.stdout).trim().to_string();
+    (!command_line.is_empty()).then_some(command_line)
+}
+
+#[cfg(windows)]
+fn process_started_at_ms(pid: u32) -> Option<u128> {
+    let script = format!(
+        "$p = Get-CimInstance Win32_Process -Filter \"ProcessId = {}\"; if ($p) {{ ([DateTimeOffset]$p.CreationDate).ToUnixTimeMilliseconds() }}",
+        pid
+    );
+    let output = Command::new("powershell")
+        .args(["-NoProfile", "-Command", &script])
+        .output()
+        .ok()?;
+    if !output.status.success() {
+        return None;
+    }
+    String::from_utf8_lossy(&output.stdout).trim().parse().ok()
+}
+
+#[cfg(any(windows, test))]
+fn command_line_runs_dashboard(command_line: &str) -> bool {
+    command_line
+        .split_whitespace()
+        .any(|argument| argument.trim_matches('"').eq_ignore_ascii_case("dashboard"))
+}
+
+#[cfg(windows)]
+fn process_matches_stale_dashboard(
+    pid: u32,
+    executable_path: &Path,
+    marker_started_at_ms: u128,
+) -> bool {
+    process_matches_runtime_executable(pid, executable_path)
+        && process_command_line(pid).is_some_and(|line| command_line_runs_dashboard(&line))
+        && process_started_at_ms(pid) == Some(marker_started_at_ms)
+}
+
+#[cfg(not(windows))]
+fn process_matches_stale_dashboard(
+    pid: u32,
+    executable_path: &Path,
+    _marker_started_at_ms: u128,
+) -> bool {
+    process_matches_runtime_executable(pid, executable_path)
+}
+
+/// Stop a dashboard tree left by a crashed desktop before replacing the
+/// runtime version that owns its executable. Live desktop owners are preserved.
+pub fn stop_stale_owned_runtime_before_replacement(runtime_version: &str) -> Result<bool, String> {
+    let Some(marker) = read_ownership_marker() else {
+        return Ok(false);
+    };
+    if !marker_matches_runtime_target(
+        &marker,
+        &crate::process::runtime::runtime_root(),
+        runtime_version,
+    ) {
+        return Ok(false);
+    }
+    if pid_is_running(marker.desktop_pid) {
+        return Err(format!(
+            "Runtime {} is owned by a live desktop process (pid {}); refusing to replace its files",
+            runtime_version, marker.desktop_pid
+        ));
+    }
+
+    let current_record = crate::process::runtime::read_current_record()
+        .filter(|record| record.runtime_version == runtime_version);
+    let dashboard_pid_running = pid_is_running(marker.dashboard_pid);
+    if dashboard_pid_running {
+        let Some(record) = current_record.as_ref() else {
+            return Err(format!(
+                "Runtime {} dashboard pid {} is still running, but current.json cannot verify its executable",
+                runtime_version, marker.dashboard_pid
+            ));
+        };
+        if !process_matches_stale_dashboard(
+            marker.dashboard_pid,
+            Path::new(&record.executable_path),
+            marker.dashboard_started_at_ms.ok_or_else(|| {
+                format!(
+                    "Runtime {} dashboard pid {} is still running, but its legacy ownership marker cannot verify process creation time",
+                    runtime_version, marker.dashboard_pid
+                )
+            })?,
+        ) {
+            return Err(format!(
+                "Refusing to stop dashboard pid {} because its process identity does not match Runtime {}",
+                marker.dashboard_pid, runtime_version
+            ));
+        }
+    }
+
+    log::warn!(
+        "Stopping stale desktop-owned Runtime {} before replacement (dashboard pid {})",
+        runtime_version,
+        marker.dashboard_pid
+    );
+    if dashboard_pid_running && !terminate_dashboard_pid_tree(marker.dashboard_pid) {
+        return Err(format!(
+            "Failed to confirm stale Runtime {} dashboard process {} exited",
+            runtime_version, marker.dashboard_pid
+        ));
+    }
+
+    let gateway_runtime_dir = PathBuf::from(&marker.gateway_runtime_dir);
+    if let Some(record) = current_record {
+        let gateway_lock_dir = gateway_runtime_dir.join("token-locks");
+        let report = crate::process::gateway::preflight_managed_gateway_restart(
+            &record,
+            &marker.hermes_home,
+            &gateway_runtime_dir,
+            &gateway_lock_dir,
+        )?;
+        if !report.remaining_pids.is_empty() || report.lock_active {
+            return Err(format!(
+                "Runtime {} Gateway did not release its files after shutdown: {}",
+                runtime_version,
+                report.summary()
+            ));
+        }
+    } else {
+        let (remaining_pids, lock_active) =
+            crate::process::gateway::managed_gateway_runtime_occupancy(&gateway_runtime_dir);
+        if !remaining_pids.is_empty() || lock_active {
+            return Err(format!(
+                "Runtime {} Gateway still owns files, but current.json cannot identify a safe stop helper (remaining_pids={:?}, lock_active={})",
+                runtime_version, remaining_pids, lock_active
+            ));
+        }
+    }
+
+    release_orphaned_port_locks(&marker.claimed_ports, Path::new(&marker.hermes_home));
+    remove_ownership_marker_path(None);
+    Ok(true)
+}
+
 fn write_ownership_marker(marker: &DashboardOwnershipMarker) -> Result<(), String> {
     let path = ownership_marker_path();
     if let Some(parent) = path.parent() {
@@ -192,6 +411,7 @@ fn rewrite_ownership_marker_for_current_desktop(
         runtime_root: marker.runtime_root.clone(),
         gateway_runtime_dir: marker.gateway_runtime_dir.clone(),
         started_at_ms: now_millis(),
+        dashboard_started_at_ms: marker.dashboard_started_at_ms,
         runtime_version: marker.runtime_version.clone(),
         claimed_ports: marker.claimed_ports.clone(),
     };
@@ -452,22 +672,26 @@ pub fn terminate_owned_dashboard_tree(
     }
 
     if let Some(pid) = fallback_pid {
-        #[cfg(unix)]
-        {
-            signal_process_group(pid, libc::SIGTERM);
-            thread::sleep(GRACEFUL_SHUTDOWN_TIMEOUT);
-            if pid_is_running(pid) {
-                signal_process_group(pid, libc::SIGKILL);
-            }
-        }
-        #[cfg(windows)]
-        {
-            force_kill_process_tree(pid);
-        }
-        return wait_for_pid_exit(pid, FORCE_SHUTDOWN_TIMEOUT);
+        return terminate_dashboard_pid_tree(pid);
     }
 
     true
+}
+
+fn terminate_dashboard_pid_tree(pid: u32) -> bool {
+    #[cfg(unix)]
+    {
+        signal_process_group(pid, libc::SIGTERM);
+        thread::sleep(GRACEFUL_SHUTDOWN_TIMEOUT);
+        if pid_is_running(pid) {
+            signal_process_group(pid, libc::SIGKILL);
+        }
+    }
+    #[cfg(windows)]
+    {
+        force_kill_process_tree(pid);
+    }
+    wait_for_pid_exit(pid, FORCE_SHUTDOWN_TIMEOUT)
 }
 
 fn probe_dashboard_port(api_base_url: &str) -> bool {
@@ -1181,6 +1405,16 @@ fn spawn_dashboard(
             .to_string(),
         gateway_runtime_dir: gateway_runtime_dir.to_string_lossy().to_string(),
         started_at_ms: now_millis(),
+        dashboard_started_at_ms: {
+            #[cfg(windows)]
+            {
+                process_started_at_ms(child.id())
+            }
+            #[cfg(not(windows))]
+            {
+                None
+            }
+        },
         runtime_version,
         claimed_ports: claimed_ports.clone(),
     };
@@ -1807,6 +2041,25 @@ mod tests {
     }
 
     #[test]
+    fn current_process_executable_identity_is_verified() {
+        let executable = std::env::current_exe().expect("current executable");
+        assert!(process_matches_runtime_executable(
+            std::process::id(),
+            &executable
+        ));
+    }
+
+    #[test]
+    fn dashboard_command_line_requires_dashboard_subcommand() {
+        assert!(command_line_runs_dashboard(
+            r#"C:\Hermes\hermes.exe dashboard --port 9120"#
+        ));
+        assert!(!command_line_runs_dashboard(
+            r#"C:\Hermes\hermes.exe gateway run"#
+        ));
+    }
+
+    #[test]
     fn gateway_url_without_token() {
         assert_eq!(
             build_gateway_url("http://127.0.0.1:9119", None),
@@ -1860,6 +2113,7 @@ mod tests {
             runtime_root: "/tmp/hermes-runtime-test".to_string(),
             gateway_runtime_dir: "/tmp/hermes-runtime-test/gateway".to_string(),
             started_at_ms: 1,
+            dashboard_started_at_ms: None,
             runtime_version: Some("test".to_string()),
             claimed_ports: vec![],
         }
@@ -1957,6 +2211,53 @@ mod tests {
             marker_owner_state(Some(&marker), "http://127.0.0.1:9120", &other_home),
             MarkerOwnerState::NotThisDashboard
         );
+    }
+
+    #[test]
+    #[serial]
+    fn runtime_replacement_cleans_matching_stale_desktop_owner() {
+        let runtime = tempfile::tempdir().expect("runtime root");
+        std::env::set_var("HERMES_DESKTOP_RUNTIME_ROOT", runtime.path());
+        let home = runtime.path().join("hermes-home");
+        std::fs::create_dir_all(&home).expect("home");
+        let mut marker = test_marker(0, "http://127.0.0.1:0", &home.to_string_lossy());
+        marker.runtime_root = runtime.path().to_string_lossy().to_string();
+        marker.gateway_runtime_dir = runtime
+            .path()
+            .join("gateway-runtime")
+            .to_string_lossy()
+            .to_string();
+        marker.runtime_version = Some("1.0.0-cn.1".to_string());
+        write_ownership_marker(&marker).expect("marker");
+
+        let stopped = stop_stale_owned_runtime_before_replacement("1.0.0-cn.1").unwrap();
+
+        assert!(stopped);
+        assert!(!ownership_marker_path().exists());
+        std::env::remove_var("HERMES_DESKTOP_RUNTIME_ROOT");
+    }
+
+    #[test]
+    #[serial]
+    fn runtime_replacement_preserves_live_desktop_owner() {
+        let runtime = tempfile::tempdir().expect("runtime root");
+        std::env::set_var("HERMES_DESKTOP_RUNTIME_ROOT", runtime.path());
+        let home = runtime.path().join("hermes-home");
+        std::fs::create_dir_all(&home).expect("home");
+        let mut marker = test_marker(
+            std::process::id(),
+            "http://127.0.0.1:0",
+            &home.to_string_lossy(),
+        );
+        marker.runtime_root = runtime.path().to_string_lossy().to_string();
+        marker.runtime_version = Some("1.0.0-cn.1".to_string());
+        write_ownership_marker(&marker).expect("marker");
+
+        let error = stop_stale_owned_runtime_before_replacement("1.0.0-cn.1").unwrap_err();
+
+        assert!(error.contains("live desktop process"));
+        assert!(ownership_marker_path().exists());
+        std::env::remove_var("HERMES_DESKTOP_RUNTIME_ROOT");
     }
 
     #[tokio::test]

--- a/src/process/gateway.rs
+++ b/src/process/gateway.rs
@@ -224,40 +224,60 @@ fn process_command_line(_pid: u32) -> Option<String> {
     None
 }
 
-fn live_record_pid_is_gateway(
+fn live_record_pid(record: &GatewayRuntimeRecord) -> Option<u32> {
+    let pid = record.pid?;
+    pid_is_running(pid).then_some(pid)
+}
+
+fn command_line_verifies_gateway(command_line: Option<&str>) -> bool {
+    command_line.is_some_and(command_line_looks_like_gateway)
+}
+
+fn live_record_pid_is_verified_gateway(
     record: &GatewayRuntimeRecord,
     source: GatewayRecordSource,
 ) -> Option<u32> {
-    let pid = record.pid?;
-    if !pid_is_running(pid) {
-        return None;
-    }
-
-    if let Some(command_line) = process_command_line(pid) {
-        if command_line_looks_like_gateway(&command_line) || record_looks_like_gateway(record) {
-            return Some(pid);
-        }
-        return None;
-    }
-
-    if source == GatewayRecordSource::PidFile || record_looks_like_gateway(record) {
+    let pid = live_record_pid(record)?;
+    if command_line_verifies_gateway(process_command_line(pid).as_deref()) {
         Some(pid)
     } else {
+        log::warn!(
+            "Skipping unverified Gateway pid {} from {:?}; record_claims_gateway={}",
+            pid,
+            source,
+            record_looks_like_gateway(record)
+        );
         None
     }
 }
 
-fn gateway_pid_candidates(runtime_dir: &Path) -> Vec<u32> {
-    let mut pids = BTreeSet::new();
-    for (path, source) in [
+fn gateway_record_paths(runtime_dir: &Path) -> [(PathBuf, GatewayRecordSource); 2] {
+    [
         (gateway_pid_path(runtime_dir), GatewayRecordSource::PidFile),
         (
             gateway_lock_path(runtime_dir),
             GatewayRecordSource::LockFile,
         ),
-    ] {
+    ]
+}
+
+fn gateway_pid_candidates(runtime_dir: &Path) -> Vec<u32> {
+    let mut pids = BTreeSet::new();
+    for (path, _) in gateway_record_paths(runtime_dir) {
         if let Some(record) = read_gateway_runtime_record(&path) {
-            if let Some(pid) = live_record_pid_is_gateway(&record, source) {
+            if let Some(pid) = live_record_pid(&record) {
+                pids.insert(pid);
+            }
+        }
+    }
+    pids.into_iter().collect()
+}
+
+fn verified_gateway_pid_candidates(runtime_dir: &Path) -> Vec<u32> {
+    let mut pids = BTreeSet::new();
+    for (path, source) in gateway_record_paths(runtime_dir) {
+        if let Some(record) = read_gateway_runtime_record(&path) {
+            if let Some(pid) = live_record_pid_is_verified_gateway(&record, source) {
                 pids.insert(pid);
             }
         }
@@ -331,6 +351,20 @@ fn managed_gateway_pid_candidates(
     pids.into_iter().collect()
 }
 
+fn verified_managed_gateway_pid_candidates(
+    runtime_dir: &Path,
+    gateway_lock_dir: &Path,
+    runtime_root: &Path,
+) -> Vec<u32> {
+    let mut pids = BTreeSet::new();
+    pids.extend(verified_gateway_pid_candidates(runtime_dir));
+    pids.extend(gateway_token_lock_pid_candidates(
+        gateway_lock_dir,
+        runtime_root,
+    ));
+    pids.into_iter().collect()
+}
+
 fn cleanup_stale_gateway_token_lock_files(gateway_lock_dir: &Path, _runtime_root: &Path) -> usize {
     let mut removed = 0;
     for path in token_lock_paths(gateway_lock_dir) {
@@ -391,6 +425,14 @@ pub fn cleanup_stale_gateway_runtime_files(runtime_dir: &Path) -> usize {
         }
     }
     removed
+}
+
+pub fn managed_gateway_runtime_occupancy(runtime_dir: &Path) -> (Vec<u32>, bool) {
+    let _ = cleanup_stale_gateway_runtime_files(runtime_dir);
+    (
+        gateway_pid_candidates(runtime_dir),
+        gateway_runtime_lock_active(runtime_dir),
+    )
 }
 
 fn wait_for_child_exit(child: &mut Child, timeout: Duration) -> Option<Option<i32>> {
@@ -523,45 +565,59 @@ pub fn preflight_managed_gateway_restart(
     let runtime_root = crate::process::runtime::runtime_root();
     report.stale_files_removed +=
         cleanup_stale_gateway_token_lock_files(gateway_lock_dir, &runtime_root);
-    let runtime_files_exist = gateway_pid_path(gateway_runtime_dir).exists()
-        || gateway_lock_path(gateway_runtime_dir).exists();
-
-    if runtime_files_exist
-        || !managed_gateway_pid_candidates(gateway_runtime_dir, gateway_lock_dir, &runtime_root)
-            .is_empty()
-        || gateway_runtime_lock_active(gateway_runtime_dir)
-    {
-        report.stop_attempted = true;
-        match spawn_gateway_stop_helper(record, hermes_home, gateway_runtime_dir, gateway_lock_dir)
-        {
-            Ok(mut child) => match wait_for_child_exit(&mut child, GATEWAY_STOP_HELPER_TIMEOUT) {
-                Some(code) => report.stop_exit_code = code,
-                None => {
-                    report.stop_timed_out = true;
-                    let _ = child.kill();
-                    let _ = child.wait();
-                }
-            },
-            Err(err) => {
-                log::warn!("{}", err);
-            }
-        }
-        let _ = wait_for_gateway_runtime_to_settle(
-            gateway_runtime_dir,
-            gateway_lock_dir,
-            &runtime_root,
-            GATEWAY_SETTLE_TIMEOUT,
-        );
+    let live_pids =
+        managed_gateway_pid_candidates(gateway_runtime_dir, gateway_lock_dir, &runtime_root);
+    let verified_pids = verified_managed_gateway_pid_candidates(
+        gateway_runtime_dir,
+        gateway_lock_dir,
+        &runtime_root,
+    );
+    let lock_active = gateway_runtime_lock_active(gateway_runtime_dir);
+    if live_pids.iter().any(|pid| !verified_pids.contains(pid)) {
+        report.remaining_pids = live_pids;
+        report.lock_active = lock_active;
+        return Ok(report);
     }
+    if live_pids.is_empty() {
+        if lock_active {
+            report.lock_active = true;
+        } else {
+            report.stale_files_removed += cleanup_stale_gateway_runtime_files(gateway_runtime_dir);
+        }
+        return Ok(report);
+    }
+    report.stop_attempted = true;
+    match spawn_gateway_stop_helper(record, hermes_home, gateway_runtime_dir, gateway_lock_dir) {
+        Ok(mut child) => match wait_for_child_exit(&mut child, GATEWAY_STOP_HELPER_TIMEOUT) {
+            Some(code) => report.stop_exit_code = code,
+            None => {
+                report.stop_timed_out = true;
+                let _ = child.kill();
+                let _ = child.wait();
+            }
+        },
+        Err(err) => {
+            log::warn!("{}", err);
+        }
+    }
+    let _ = wait_for_gateway_runtime_to_settle(
+        gateway_runtime_dir,
+        gateway_lock_dir,
+        &runtime_root,
+        GATEWAY_SETTLE_TIMEOUT,
+    );
 
     report.stale_files_removed += cleanup_stale_gateway_runtime_files(gateway_runtime_dir);
     report.stale_files_removed +=
         cleanup_stale_gateway_token_lock_files(gateway_lock_dir, &runtime_root);
 
-    let remaining =
-        managed_gateway_pid_candidates(gateway_runtime_dir, gateway_lock_dir, &runtime_root);
-    if !remaining.is_empty() {
-        for pid in &remaining {
+    let verified = verified_managed_gateway_pid_candidates(
+        gateway_runtime_dir,
+        gateway_lock_dir,
+        &runtime_root,
+    );
+    if !verified.is_empty() {
+        for pid in &verified {
             terminate_pid(*pid, false);
         }
         if !wait_for_gateway_runtime_to_settle(
@@ -570,9 +626,11 @@ pub fn preflight_managed_gateway_restart(
             &runtime_root,
             GATEWAY_FORCE_SETTLE_TIMEOUT,
         ) {
-            for pid in
-                managed_gateway_pid_candidates(gateway_runtime_dir, gateway_lock_dir, &runtime_root)
-            {
+            for pid in verified_managed_gateway_pid_candidates(
+                gateway_runtime_dir,
+                gateway_lock_dir,
+                &runtime_root,
+            ) {
                 terminate_pid(pid, true);
                 report.force_killed_pids.push(pid);
             }
@@ -630,6 +688,17 @@ mod tests {
             ],
         };
         assert!(record_looks_like_gateway(&record));
+    }
+
+    #[test]
+    fn gateway_process_identity_requires_live_command_line_match() {
+        assert!(command_line_verifies_gateway(Some(
+            r#"C:\Hermes\hermes.exe gateway run"#
+        )));
+        assert!(!command_line_verifies_gateway(Some(
+            r#"C:\Windows\System32\notepad.exe"#
+        )));
+        assert!(!command_line_verifies_gateway(None));
     }
 
     #[test]

--- a/src/process/runtime.rs
+++ b/src/process/runtime.rs
@@ -10,7 +10,7 @@ use std::path::{Path, PathBuf};
 use std::process::Command as StdCommand;
 use std::process::Stdio;
 use std::sync::LazyLock;
-use std::time::Duration;
+use std::time::{Duration, SystemTime, UNIX_EPOCH};
 
 use serde::{Deserialize, Serialize};
 use sha2::{Digest, Sha256};
@@ -75,6 +75,8 @@ fn smoke_timeout() -> Duration {
 // exits). This hardens both the real post-install path and the smoke-check test
 // under cargo's multi-threaded runner.
 const SMOKE_SPAWN_RETRIES: u32 = 5;
+const RUNTIME_REMOVE_RETRIES: u32 = 5;
+const RUNTIME_REMOVE_RETRY_DELAY: Duration = Duration::from_millis(150);
 static RUNTIME_HTTP_CLIENT: LazyLock<reqwest::Client> = LazyLock::new(|| {
     reqwest::Client::builder()
         .connect_timeout(RUNTIME_HTTP_CONNECT_TIMEOUT)
@@ -1514,10 +1516,10 @@ fn prepare_runtime_cache_target(target: &Path) -> Result<(), String> {
     }
 }
 
-fn remove_existing_runtime_target(target: &Path) -> Result<(), String> {
+fn validate_existing_runtime_target(target: &Path) -> Result<bool, String> {
     let metadata = match fs::symlink_metadata(target) {
         Ok(metadata) => metadata,
-        Err(error) if error.kind() == std::io::ErrorKind::NotFound => return Ok(()),
+        Err(error) if error.kind() == std::io::ErrorKind::NotFound => return Ok(false),
         Err(error) => {
             return Err(format!(
                 "Failed to inspect existing runtime target {}: {}",
@@ -1553,14 +1555,189 @@ fn remove_existing_runtime_target(target: &Path) -> Result<(), String> {
             canonical_target.display()
         ));
     }
+    Ok(true)
+}
 
-    fs::remove_dir_all(target).map_err(|error| {
-        format!(
-            "Failed to remove existing runtime target {}: {}",
-            target.display(),
-            error
-        )
-    })
+fn remove_existing_runtime_target_with(
+    target: &Path,
+    mut remove: impl FnMut(&Path) -> std::io::Result<()>,
+    mut wait: impl FnMut(Duration),
+) -> Result<(), String> {
+    if !validate_existing_runtime_target(target)? {
+        return Ok(());
+    }
+
+    for attempt in 0..=RUNTIME_REMOVE_RETRIES {
+        match remove(target) {
+            Ok(()) => return Ok(()),
+            Err(error) if error.kind() == std::io::ErrorKind::NotFound => return Ok(()),
+            Err(error)
+                if runtime_remove_error_is_retryable(&error)
+                    && attempt < RUNTIME_REMOVE_RETRIES =>
+            {
+                let delay = RUNTIME_REMOVE_RETRY_DELAY * (attempt + 1);
+                log::warn!(
+                    "Runtime target {} is still busy (attempt {}/{}): {}; retrying in {}ms",
+                    target.display(),
+                    attempt + 1,
+                    RUNTIME_REMOVE_RETRIES + 1,
+                    error,
+                    delay.as_millis()
+                );
+                wait(delay);
+            }
+            Err(error) => {
+                return Err(format!(
+                    "Failed to remove existing runtime target {} after {} attempt(s): {}. A Runtime or Gateway process may still hold files in this directory.",
+                    target.display(),
+                    attempt + 1,
+                    error
+                ));
+            }
+        }
+    }
+    unreachable!("runtime removal loop always returns")
+}
+
+fn runtime_remove_error_is_retryable(error: &std::io::Error) -> bool {
+    if error.kind() == std::io::ErrorKind::PermissionDenied {
+        return true;
+    }
+    #[cfg(windows)]
+    {
+        // ERROR_ACCESS_DENIED, ERROR_SHARING_VIOLATION and ERROR_DIR_NOT_EMPTY.
+        matches!(error.raw_os_error(), Some(5 | 32 | 145))
+    }
+    #[cfg(not(windows))]
+    {
+        false
+    }
+}
+
+fn remove_existing_runtime_target(target: &Path) -> Result<(), String> {
+    remove_existing_runtime_target_with(target, |path| fs::remove_dir_all(path), std::thread::sleep)
+}
+
+struct RuntimeTargetReplacement {
+    target: PathBuf,
+    backup: Option<PathBuf>,
+    committed: bool,
+}
+
+impl RuntimeTargetReplacement {
+    fn commit(mut self) {
+        self.committed = true;
+        if let Some(backup) = &self.backup {
+            if let Err(error) = remove_existing_runtime_target(backup) {
+                log::warn!(
+                    "Runtime replacement committed, but old target cleanup failed: {}",
+                    error
+                );
+            }
+        }
+    }
+}
+
+impl Drop for RuntimeTargetReplacement {
+    fn drop(&mut self) {
+        if self.committed {
+            return;
+        }
+        if self.target.exists() {
+            if let Err(error) = fs::remove_dir_all(&self.target) {
+                log::error!(
+                    "Failed to remove incomplete Runtime target {} during rollback: {}",
+                    self.target.display(),
+                    error
+                );
+                return;
+            }
+        }
+        if let Some(backup) = &self.backup {
+            if let Err(error) = fs::rename(backup, &self.target) {
+                log::error!(
+                    "Failed to restore Runtime target {} from {}: {}",
+                    self.target.display(),
+                    backup.display(),
+                    error
+                );
+            }
+        }
+    }
+}
+
+fn prepare_runtime_target_replacement(
+    target: &Path,
+    runtime_version: &str,
+) -> Result<RuntimeTargetReplacement, String> {
+    if target.exists() {
+        crate::process::dashboard::stop_stale_owned_runtime_before_replacement(runtime_version)?;
+    }
+    if !validate_existing_runtime_target(target)? {
+        return Ok(RuntimeTargetReplacement {
+            target: target.to_path_buf(),
+            backup: None,
+            committed: false,
+        });
+    }
+
+    let stamp = SystemTime::now()
+        .duration_since(UNIX_EPOCH)
+        .unwrap_or_default()
+        .as_nanos();
+    let file_name = target
+        .file_name()
+        .and_then(|name| name.to_str())
+        .ok_or_else(|| format!("Invalid Runtime target path: {}", target.display()))?;
+    let backup = target.with_file_name(format!(
+        ".{file_name}.replacing-{}-{stamp}",
+        std::process::id()
+    ));
+
+    for attempt in 0..=RUNTIME_REMOVE_RETRIES {
+        match fs::rename(target, &backup) {
+            Ok(()) => {
+                return Ok(RuntimeTargetReplacement {
+                    target: target.to_path_buf(),
+                    backup: Some(backup),
+                    committed: false,
+                })
+            }
+            Err(error)
+                if runtime_remove_error_is_retryable(&error)
+                    && attempt < RUNTIME_REMOVE_RETRIES =>
+            {
+                std::thread::sleep(RUNTIME_REMOVE_RETRY_DELAY * (attempt + 1));
+            }
+            Err(error) => {
+                return Err(format!(
+                    "Failed to prepare Runtime target {} for replacement after {} attempt(s): {}. A Runtime or Gateway process may still hold files in this directory.",
+                    target.display(),
+                    attempt + 1,
+                    error
+                ));
+            }
+        }
+    }
+    unreachable!("runtime replacement preparation loop always returns")
+}
+
+fn restore_current_record(previous: Option<&RuntimeInstallRecord>) {
+    let path = current_record_path();
+    match previous {
+        Some(previous) => {
+            if let Err(error) = write_json_file(&path, previous) {
+                log::error!("Failed to restore previous Runtime record: {}", error);
+            }
+        }
+        None => {
+            if let Err(error) = fs::remove_file(&path) {
+                if error.kind() != std::io::ErrorKind::NotFound {
+                    log::error!("Failed to remove incomplete Runtime record: {}", error);
+                }
+            }
+        }
+    }
 }
 
 async fn wait_for_smoke_child(
@@ -1671,6 +1848,7 @@ async fn install_runtime_zip(
     resolved: RuntimeUpdateManifest,
     zip_path: &Path,
     source: &str,
+    before_target_replace: impl FnOnce() -> Result<(), String> + Send,
 ) -> RuntimeInstallUpdateResult {
     let version_segment = match validate_manifest_for_current_platform(&resolved) {
         Ok(version_segment) => version_segment,
@@ -1779,14 +1957,25 @@ async fn install_runtime_zip(
     }
 
     let target = versions_root().join(&version_segment);
-    if let Err(e) = remove_existing_runtime_target(&target) {
+    if let Err(e) = before_target_replace() {
         return RuntimeInstallUpdateResult {
             ok: false,
             installed: None,
-            previous: None,
+            previous: read_current_record(),
             error: Some(e),
         };
     }
+    let replacement = match prepare_runtime_target_replacement(&target, &resolved.runtime_version) {
+        Ok(replacement) => replacement,
+        Err(e) => {
+            return RuntimeInstallUpdateResult {
+                ok: false,
+                installed: None,
+                previous: None,
+                error: Some(e),
+            }
+        }
+    };
     if let Err(e) = fs::rename(staging.path(), &target) {
         if let Err(e2) = copy_dir_all(staging.path(), &target) {
             return RuntimeInstallUpdateResult {
@@ -1819,8 +2008,24 @@ async fn install_runtime_zip(
         previous.as_ref(),
     );
 
-    let _ = write_json_file(&target.join(MANIFEST_FILE), &resolved);
-    let _ = write_json_file(&current_record_path(), &installed);
+    if let Err(error) = write_json_file(&target.join(MANIFEST_FILE), &resolved) {
+        return RuntimeInstallUpdateResult {
+            ok: false,
+            installed: None,
+            previous,
+            error: Some(format!("Failed to write Runtime manifest: {error}")),
+        };
+    }
+    if let Err(error) = write_json_file(&current_record_path(), &installed) {
+        restore_current_record(previous.as_ref());
+        return RuntimeInstallUpdateResult {
+            ok: false,
+            installed: None,
+            previous,
+            error: Some(format!("Failed to write current Runtime record: {error}")),
+        };
+    }
+    replacement.commit();
 
     RuntimeInstallUpdateResult {
         ok: true,
@@ -1907,14 +2112,17 @@ async fn install_runtime_tree(
     }
 
     let target = versions_root().join(&version_segment);
-    if let Err(e) = remove_existing_runtime_target(&target) {
-        return RuntimeInstallUpdateResult {
-            ok: false,
-            installed: None,
-            previous: None,
-            error: Some(e),
-        };
-    }
+    let replacement = match prepare_runtime_target_replacement(&target, &resolved.runtime_version) {
+        Ok(replacement) => replacement,
+        Err(e) => {
+            return RuntimeInstallUpdateResult {
+                ok: false,
+                installed: None,
+                previous: None,
+                error: Some(e),
+            }
+        }
+    };
     if let Err(e) = fs::rename(staging.path(), &target) {
         if let Err(e2) = copy_dir_all(staging.path(), &target) {
             return RuntimeInstallUpdateResult {
@@ -1947,8 +2155,24 @@ async fn install_runtime_tree(
         previous.as_ref(),
     );
 
-    let _ = write_json_file(&target.join(MANIFEST_FILE), &resolved);
-    let _ = write_json_file(&current_record_path(), &installed);
+    if let Err(error) = write_json_file(&target.join(MANIFEST_FILE), &resolved) {
+        return RuntimeInstallUpdateResult {
+            ok: false,
+            installed: None,
+            previous,
+            error: Some(format!("Failed to write Runtime manifest: {error}")),
+        };
+    }
+    if let Err(error) = write_json_file(&current_record_path(), &installed) {
+        restore_current_record(previous.as_ref());
+        return RuntimeInstallUpdateResult {
+            ok: false,
+            installed: None,
+            previous,
+            error: Some(format!("Failed to write current Runtime record: {error}")),
+        };
+    }
+    replacement.commit();
 
     RuntimeInstallUpdateResult {
         ok: true,
@@ -2093,7 +2317,7 @@ pub async fn install_bundled_runtime_if_needed(
     let mut result = if has_expanded_runtime {
         install_runtime_tree(manifest, &expanded_runtime_dir, "bundled").await
     } else {
-        install_runtime_zip(manifest, &artifact_path, "bundled").await
+        install_runtime_zip(manifest, &artifact_path, "bundled", || Ok(())).await
     };
     if result.ok {
         if let Some(installed) = &result.installed {
@@ -2111,6 +2335,13 @@ pub async fn install_bundled_runtime_if_needed(
 /// Download, verify, and install a runtime update.
 pub async fn install_runtime_update(
     manifest: Option<RuntimeUpdateManifest>,
+) -> RuntimeInstallUpdateResult {
+    install_runtime_update_with_pre_replace(manifest, || Ok(())).await
+}
+
+pub async fn install_runtime_update_with_pre_replace(
+    manifest: Option<RuntimeUpdateManifest>,
+    before_target_replace: impl FnOnce() -> Result<(), String> + Send,
 ) -> RuntimeInstallUpdateResult {
     let resolved = match manifest {
         Some(m) => m,
@@ -2232,7 +2463,7 @@ pub async fn install_runtime_update(
         };
     }
 
-    install_runtime_zip(resolved, &zip_path, "update").await
+    install_runtime_zip(resolved, &zip_path, "update", before_target_replace).await
 }
 
 /// Rollback to the previous runtime version.
@@ -3177,6 +3408,96 @@ mod tests {
         std::env::remove_var("HERMES_DESKTOP_RUNTIME_ROOT");
         assert!(error.contains("outside versions root"));
         assert!(versions.exists());
+    }
+
+    #[test]
+    #[serial]
+    fn existing_runtime_target_retries_transient_access_denied() {
+        let temp = TempDir::new().unwrap();
+        let runtime_root = temp.path().join("runtime-root");
+        let target = runtime_root.join("versions").join("1.0.0-cn.1");
+        std::fs::create_dir_all(&target).unwrap();
+        std::fs::write(target.join("hermes.exe"), b"runtime").unwrap();
+        std::env::set_var("HERMES_DESKTOP_RUNTIME_ROOT", &runtime_root);
+
+        let mut attempts = 0;
+        let mut delays = Vec::new();
+        remove_existing_runtime_target_with(
+            &target,
+            |path| {
+                attempts += 1;
+                if attempts < 3 {
+                    Err(std::io::Error::new(
+                        std::io::ErrorKind::PermissionDenied,
+                        "runtime file is busy",
+                    ))
+                } else {
+                    std::fs::remove_dir_all(path)
+                }
+            },
+            |delay| delays.push(delay),
+        )
+        .unwrap();
+
+        std::env::remove_var("HERMES_DESKTOP_RUNTIME_ROOT");
+        assert_eq!(attempts, 3);
+        assert_eq!(
+            delays,
+            vec![Duration::from_millis(150), Duration::from_millis(300)]
+        );
+        assert!(!target.exists());
+    }
+
+    #[test]
+    #[serial]
+    fn existing_runtime_target_reports_persistent_file_occupancy() {
+        let temp = TempDir::new().unwrap();
+        let runtime_root = temp.path().join("runtime-root");
+        let target = runtime_root.join("versions").join("1.0.0-cn.1");
+        std::fs::create_dir_all(&target).unwrap();
+        std::env::set_var("HERMES_DESKTOP_RUNTIME_ROOT", &runtime_root);
+
+        let mut attempts = 0;
+        let error = remove_existing_runtime_target_with(
+            &target,
+            |_| {
+                attempts += 1;
+                Err(std::io::Error::new(
+                    std::io::ErrorKind::PermissionDenied,
+                    "runtime file is busy",
+                ))
+            },
+            |_| {},
+        )
+        .unwrap_err();
+
+        std::env::remove_var("HERMES_DESKTOP_RUNTIME_ROOT");
+        assert_eq!(attempts, 6);
+        assert!(error.contains("after 6 attempt(s)"));
+        assert!(error.contains("Runtime or Gateway process"));
+        assert!(target.exists());
+    }
+
+    #[test]
+    #[serial]
+    fn runtime_target_replacement_restores_previous_tree_on_failure() {
+        let temp = TempDir::new().unwrap();
+        let runtime_root = temp.path().join("runtime-root");
+        let target = runtime_root.join("versions").join("1.0.0-cn.1");
+        std::fs::create_dir_all(&target).unwrap();
+        std::fs::write(target.join("hermes.exe"), b"previous").unwrap();
+        std::env::set_var("HERMES_DESKTOP_RUNTIME_ROOT", &runtime_root);
+
+        let replacement = prepare_runtime_target_replacement(&target, "1.0.0-cn.1").unwrap();
+        std::fs::create_dir_all(&target).unwrap();
+        std::fs::write(target.join("hermes.exe"), b"incomplete").unwrap();
+        drop(replacement);
+
+        std::env::remove_var("HERMES_DESKTOP_RUNTIME_ROOT");
+        assert_eq!(
+            std::fs::read(target.join("hermes.exe")).unwrap(),
+            b"previous"
+        );
     }
 
     #[cfg(unix)]

--- a/src/supervisor.rs
+++ b/src/supervisor.rs
@@ -72,7 +72,7 @@ pub async fn supervise_managed_dashboard(app: tauri::AppHandle) {
             if inner.dashboard_restart_in_flight {
                 continue;
             }
-            let exited = match inner.dashboard_handle.as_mut() {
+            let exited_or_missing = match inner.dashboard_handle.as_mut() {
                 Some(handle) if handle.owns_process => match handle.child.as_mut() {
                     // `Ok(Some(_))` means the process has already exited. A live
                     // (or still-booting) child returns `Ok(None)`, so this never
@@ -80,9 +80,10 @@ pub async fn supervise_managed_dashboard(app: tauri::AppHandle) {
                     Some(child) => matches!(child.try_wait(), Ok(Some(_))),
                     None => false,
                 },
+                None => true,
                 _ => false,
             };
-            if !exited {
+            if !exited_or_missing {
                 // Healthy. The crash-loop counter is reset by the HEALTHY_WINDOW
                 // check below whenever the next real restart is far enough out.
                 continue;


### PR DESCRIPTION
## 变更

- Windows 替换 managed Runtime 文件前，验证并停止 Desktop-owned Dashboard 与 Gateway 进程。
- 对临时文件占用执行有限重试；替换失败时恢复隔离的 Runtime 目录。
- 串行化 managed Runtime 生命周期操作，并在更新或重启后恢复期望运行状态。
- 无法确认进程身份时保持安全阻断，避免终止无关进程。

## 验证

- `cargo fmt --all -- --check`
- `cargo check`
- `cargo clippy --all-targets -- -D warnings -A clippy::inconsistent-digit-grouping`
- `cargo test --all-features --no-fail-fast`：Windows 主测试集 460 项及全部集成测试、doc-test target 通过。
- `pnpm typecheck`：license、version、grid、protocol 和 shared-ui 检查通过；切换到上游 `0.8.0-rc1` 后，本机沿用的旧依赖目录缺少上游新增测试依赖，web typecheck 交由全新依赖环境 CI 复核。
- `pnpm test:unit`：132 个测试文件、1171 项断言通过；旧依赖目录缺少 `jsdom`，导致一个上游新增测试 worker 未启动并最终返回非零状态。
- 在移植前的等价补丁上成功构建 bundled Windows NSIS 安装包。
- 覆盖安装 Desktop `0.7.0` 后，在 bundled Runtime `0.19.0-cn.7` 运行状态执行同版本重装；Runtime 正常恢复，未再出现 `os error 5`。

## 说明

- 当前提交基于最新 `main`（Desktop `0.8.0-rc1`）。
- bundled Runtime 防降级由 #540 独立处理。

Fixes #522
