### PR TITLE
fix: 修复回合进行中消息裂成两条

### DIFF
--- a/web/src/components/chat/message-adapter.midturn-split.safety.test.ts
+++ b/web/src/components/chat/message-adapter.midturn-split.safety.test.ts
@@ -1,0 +1,156 @@
+// 安全边界：中间态 stored 行只在「同一回合仍在流式」时才让位，不能变成历史丢失。
+//
+// isStoredRowAbsorbedByStreamingLive 会在回合进行中丢掉已被 live 覆盖的 stored
+// 半行。必须确认：
+//   1. 回合结束（live 不再 streaming / live 清空）后，stored 行原样回来；
+//   2. 不同回合（toolCallId 不同）的 stored 行绝不会被误吞；
+//   3. 无工具的纯文本 stored 行不受影响。
+import { describe, expect, it } from "vitest";
+
+import type { HermesUIMessage, SessionMessage } from "@hermes/protocol";
+
+import {
+  legacySessionMessagesToHermesUIMessages,
+  mergeHermesUIMessages,
+} from "./message-adapter";
+
+const SID = "sess-safety";
+const T0 = 1784090000;
+
+const TOOL_OLD = "call_safety_old_1111"; // 上一回合
+const TOOL_CUR = "call_safety_cur_2222"; // 当前回合，stored 已落库
+const TOOL_NEW = "call_safety_new_3333"; // 当前回合，仅 live 有
+
+function row(partial: Partial<SessionMessage> & { role: string; id: number }): SessionMessage {
+  return { session_id: SID, content: "", ...partial } as SessionMessage;
+}
+
+function toolCall(id: string, name: string) {
+  return { id, type: "function" as const, function: { name, arguments: "{}" } };
+}
+
+function toolPart(id: string, name: string, output: string) {
+  return { type: "tool" as const, toolCallId: id, name, state: "done" as const, output };
+}
+
+// 上一回合（已完结）+ 当前回合的中间态半行。
+function storedRows(): SessionMessage[] {
+  return [
+    row({ id: 1, role: "user", content: "第一个问题", timestamp: T0 }),
+    row({
+      id: 2,
+      role: "assistant",
+      content: "上一回合的结论。",
+      timestamp: T0 + 5,
+      finish_reason: "tool_calls",
+      tool_calls: [toolCall(TOOL_OLD, "search_files")],
+    }),
+    row({
+      id: 3,
+      role: "tool",
+      tool_call_id: TOOL_OLD,
+      tool_name: "search_files",
+      content: "old hit",
+      timestamp: T0 + 5,
+    }),
+    row({ id: 4, role: "user", content: "第二个问题", timestamp: T0 + 100 }),
+    row({
+      id: 5,
+      role: "assistant",
+      content: "正在处理第二个问题。",
+      timestamp: T0 + 110,
+      finish_reason: "tool_calls",
+      tool_calls: [toolCall(TOOL_CUR, "read_file")],
+    }),
+    row({
+      id: 6,
+      role: "tool",
+      tool_call_id: TOOL_CUR,
+      tool_name: "read_file",
+      content: "cur content",
+      timestamp: T0 + 110,
+    }),
+  ];
+}
+
+function liveTurn(status: "streaming" | "complete"): HermesUIMessage[] {
+  return [
+    {
+      id: "live-assistant-current",
+      sessionId: SID,
+      role: "assistant",
+      createdAt: (T0 + 100) * 1000,
+      status,
+      parts: [
+        toolPart(TOOL_CUR, "read_file", "cur content"),
+        { type: "text", text: "正在处理第二个问题。" },
+        toolPart(TOOL_NEW, "read_file", "new content"),
+      ],
+    },
+  ];
+}
+
+describe("中间态吞并的安全边界", () => {
+  it("回合仍在流式：当前回合的 stored 半行让位，但上一回合完好无损", () => {
+    const stored = legacySessionMessagesToHermesUIMessages(storedRows());
+    const merged = mergeHermesUIMessages(stored, liveTurn("streaming"));
+
+    // 上一回合的工具卡必须还在。
+    const allTools = merged.flatMap((m) =>
+      m.parts.filter((p) => p.type === "tool").map((p) => (p as { toolCallId: string }).toolCallId),
+    );
+    expect(allTools).toContain(TOOL_OLD);
+
+    // 当前回合只剩一条（仍在流式的那条）。
+    const streaming = merged.filter((m) => m.role === "assistant" && m.status === "streaming");
+    expect(streaming).toHaveLength(1);
+  });
+
+  it("回合已结束（live 不再 streaming）：stored 行不被丢弃", () => {
+    const stored = legacySessionMessagesToHermesUIMessages(storedRows());
+    const merged = mergeHermesUIMessages(stored, liveTurn("complete"));
+
+    const allTools = merged.flatMap((m) =>
+      m.parts.filter((p) => p.type === "tool").map((p) => (p as { toolCallId: string }).toolCallId),
+    );
+    // 两个回合的工具卡都要在，一个都不能少。
+    expect(allTools).toContain(TOOL_OLD);
+    expect(allTools).toContain(TOOL_CUR);
+  });
+
+  it("live 清空（刷新后纯历史渲染）：stored 全量保留", () => {
+    const stored = legacySessionMessagesToHermesUIMessages(storedRows());
+    const merged = mergeHermesUIMessages(stored, []);
+
+    expect(merged).toEqual(stored);
+    const allTools = merged.flatMap((m) =>
+      m.parts.filter((p) => p.type === "tool").map((p) => (p as { toolCallId: string }).toolCallId),
+    );
+    expect(allTools).toEqual([TOOL_OLD, TOOL_CUR]);
+  });
+
+  it("纯文本 stored 行（无工具）不受影响", () => {
+    const textOnly: SessionMessage[] = [
+      row({ id: 1, role: "user", content: "你好", timestamp: T0 }),
+      row({ id: 2, role: "assistant", content: "你好，有什么可以帮你？", timestamp: T0 + 2 }),
+    ];
+    const stored = legacySessionMessagesToHermesUIMessages(textOnly);
+    const live: HermesUIMessage[] = [
+      {
+        id: "live-assistant-text",
+        sessionId: SID,
+        role: "assistant",
+        createdAt: (T0 + 50) * 1000,
+        status: "streaming",
+        parts: [toolPart(TOOL_NEW, "read_file", "x"), { type: "text", text: "你好，有什么可以帮你？" }],
+      },
+    ];
+
+    const merged = mergeHermesUIMessages(stored, live);
+    // 那条纯文本历史回复必须还在。
+    const texts = merged.flatMap((m) =>
+      m.parts.filter((p) => p.type === "text").map((p) => (p as { text: string }).text),
+    );
+    expect(texts).toContain("你好，有什么可以帮你？");
+  });
+});

--- a/web/src/components/chat/message-adapter.midturn-split.test.ts
+++ b/web/src/components/chat/message-adapter.midturn-split.test.ts
@@ -1,0 +1,154 @@
+// 复现：回合进行中消息「裂开」成两条——上面一条在更新进度，下面一条是死的。
+//
+// 真实形态（对照 ~/.hermes/state.db 的行序）：Core 在回合**进行中**就把每个
+// tool_calls 步骤各写成一行 assistant。此时若 session-messages 被重新拉取
+// （refetchOnWindowFocus，或上一回合 message.complete 后 500ms 的 invalidate
+// 落到了新回合里），stored 里就出现「半个回合」。
+//
+// live 侧是一整条 streaming 的 assistant，且它比 stored 半行**跑得更远**
+// （已经发起了 stored 里还没有的下一个工具调用）。此时：
+//   - 工具身份守卫：双方工具集不同 → isSameCanonicalMessage 直接否决；
+//   - isReplayDuplicateLiveMessage：要求 stored 是 complete 且 live 工具集是
+//     stored 的前缀 —— 这里方向相反（live 是超集），不命中；
+//   - isSupersededByStoredTurn：要求 live 已 complete —— 流式中不命中。
+// 于是 stored 半行原样保留、live 整条被追加 → 两条 assistant 同时在列。
+//
+// 排序：live 的 createdAt = turnStartedAt（回合开始），stored 半行的
+// timestamp 是回合中途，因此 live 在上、stored 死行在下 —— 正是截图形态：
+// 上面那条实时更新进度，下面那条永远不动。
+import { describe, expect, it } from "vitest";
+
+import type { HermesUIMessage, SessionMessage } from "@hermes/protocol";
+
+import {
+  legacySessionMessagesToHermesUIMessages,
+  mergeHermesUIMessages,
+} from "./message-adapter";
+
+const SID = "sess-midturn";
+
+// 回合时间线（秒，对照真实库里的 timestamp 间隔）
+const T_USER = 1784085354;
+const T_STEP1 = 1784085367; // 第一个 tool_calls 步骤落库
+const T_STEP2 = 1784085386; // 第二个步骤落库，且这一行已带正文
+
+const TOOL_1 = "call_midturn_aaaa1111";
+const TOOL_2 = "call_midturn_bbbb2222";
+const TOOL_3 = "call_midturn_cccc3333"; // live 已发起、stored 尚未落库
+
+function row(partial: Partial<SessionMessage> & { role: string; id: number }): SessionMessage {
+  return {
+    session_id: SID,
+    content: "",
+    ...partial,
+  } as SessionMessage;
+}
+
+function toolCall(id: string, name: string, args: Record<string, unknown>) {
+  return {
+    id,
+    type: "function" as const,
+    function: { name, arguments: JSON.stringify(args) },
+  };
+}
+
+function toolPart(id: string, name: string, output: string) {
+  return { type: "tool" as const, toolCallId: id, name, state: "done" as const, output };
+}
+
+// stored：回合**还没结束**时拉到的半个回合。
+function midTurnStoredRows(): SessionMessage[] {
+  return [
+    row({ id: 1, role: "user", content: "帮我查一下这个问题", timestamp: T_USER }),
+    row({
+      id: 2,
+      role: "assistant",
+      content: "",
+      timestamp: T_STEP1,
+      finish_reason: "tool_calls",
+      tool_calls: [toolCall(TOOL_1, "search_files", { pattern: "foo" })],
+    }),
+    row({
+      id: 3,
+      role: "tool",
+      tool_call_id: TOOL_1,
+      tool_name: "search_files",
+      content: "hit a.ts\nhit b.ts",
+      timestamp: T_STEP1,
+    }),
+    row({
+      id: 4,
+      role: "assistant",
+      content: "我先看看这两个文件。",
+      timestamp: T_STEP2,
+      finish_reason: "tool_calls",
+      tool_calls: [toolCall(TOOL_2, "read_file", { path: "a.ts" })],
+    }),
+    row({
+      id: 5,
+      role: "tool",
+      tool_call_id: TOOL_2,
+      tool_name: "read_file",
+      content: "export const a = 1;",
+      timestamp: T_STEP2,
+    }),
+  ];
+}
+
+// live：一整条仍在流式的 assistant，已经跑到 stored 之后的第三个工具。
+function liveStreamingTurn(): HermesUIMessage[] {
+  return [
+    {
+      id: "live-user-1784085354000",
+      sessionId: SID,
+      role: "user",
+      createdAt: T_USER * 1000,
+      status: "complete",
+      parts: [{ type: "text", text: "帮我查一下这个问题" }],
+    },
+    {
+      id: "live-assistant-1784085354000",
+      sessionId: SID,
+      role: "assistant",
+      // 关键：reducer 用 turnStartedAt 作为 createdAt，即回合开始时刻，
+      // 早于 stored 半行的中途 timestamp。
+      createdAt: T_USER * 1000,
+      status: "streaming",
+      parts: [
+        toolPart(TOOL_1, "search_files", "hit a.ts\nhit b.ts"),
+        { type: "text", text: "我先看看这两个文件。" },
+        toolPart(TOOL_2, "read_file", "export const a = 1;"),
+        // live 比 stored 跑得更远：这一步 stored 里还没有。
+        toolPart(TOOL_3, "read_file", "export const b = 2;"),
+        { type: "progress", text: "正在读取文件…" },
+      ],
+    },
+  ];
+}
+
+describe("回合进行中被重新拉取历史：消息不应裂成两条", () => {
+  it("stored 半个回合 + live 流式整条，合并后只保留一条 assistant", () => {
+    const stored = legacySessionMessagesToHermesUIMessages(midTurnStoredRows());
+    const merged = mergeHermesUIMessages(stored, liveStreamingTurn());
+    const assistants = merged.filter((m) => m.role === "assistant");
+
+    expect(assistants).toHaveLength(1);
+  });
+
+  it("裂开时的形态：live(streaming) 在上、stored 死行(complete) 在下", () => {
+    const stored = legacySessionMessagesToHermesUIMessages(midTurnStoredRows());
+    const merged = mergeHermesUIMessages(stored, liveStreamingTurn());
+    const assistants = merged.filter((m) => m.role === "assistant");
+
+    // 若 bug 复现，这里就是截图里的两条：上面 streaming、下面 complete。
+    expect(assistants.map((m) => m.status)).toEqual(["streaming"]);
+  });
+
+  it("仍在流式的那条必须存活（进度能继续更新）", () => {
+    const stored = legacySessionMessagesToHermesUIMessages(midTurnStoredRows());
+    const merged = mergeHermesUIMessages(stored, liveStreamingTurn());
+    const streaming = merged.filter((m) => m.role === "assistant" && m.status === "streaming");
+
+    expect(streaming).toHaveLength(1);
+  });
+});

--- a/web/src/components/chat/message-adapter.ts
+++ b/web/src/components/chat/message-adapter.ts
@@ -1006,6 +1006,48 @@ function isSupersededByStoredTurn(
   return true;
 }
 
+// 回合**进行中**的「消息裂开」：上面一条在实时更新进度，下面一条是死的。
+//
+// Core 在回合进行中就把每个 tool_calls 步骤各写成一行 assistant（见
+// ~/.hermes/state.db 行序：assistant(tool_calls) / tool / assistant(tool_calls)…）。
+// 只要此刻 session-messages 被重新拉取（全局 refetchOnWindowFocus，或上一回合
+// message.complete 后 500ms 的 invalidate 落进了新回合），stored 就拿到「半个
+// 回合」——而 live 那条整合的 streaming 消息已经跑得更远。
+//
+// 这种方向上现有守卫都不命中：isReplayDuplicateLiveMessage 要求 live 是 stored
+// 的前缀（这里相反，live 是超集），isSupersededByStoredTurn 要求 live 已
+// complete（这里仍在流式），isSameCanonicalMessage 又被工具身份守卫否决（工具
+// 集不同）。于是 stored 半行原样保留 + live 整条追加 = 两条并存；再按 createdAt
+// 排序（live 用 turnStartedAt，早于 stored 半行的中途 timestamp），就成了
+// 「live 在上、死行在下」。
+//
+// 反过来判定：stored 这半行的工具身份（toolCallId 后端唯一）若是某条仍在流式的
+// live 消息工具身份的**连续子串**，且文本也被其包含，那它就是同一回合已被 live
+// 覆盖的中间态——丢掉 stored，让那条还在更新的 live 独占这一回合。
+// 只在 live 仍 streaming 时生效；回合收尾后仍由 isSupersededByStoredTurn 等
+// 让 canonical stored 行取胜，不影响历史渲染。
+function isStoredRowAbsorbedByStreamingLive(
+  stored: HermesUIMessage,
+  liveMessages: HermesUIMessage[],
+): boolean {
+  if (stored.role !== "assistant") return false;
+  // 工具身份是唯一可靠的「同一回合」判据；纯文本行交给文本匹配路径。
+  const storedTools = canonicalToolIdentityComparable(stored);
+  if (!storedTools) return false;
+
+  const storedText = looseComparableText(canonicalText(stored));
+
+  return liveMessages.some((live) => {
+    if (live.role !== "assistant" || live.status !== "streaming") return false;
+    const liveTools = canonicalToolIdentityComparable(live);
+    if (!liveTools) return false;
+    // stored 的工具序列必须原样出现在 live 里（连续、同序）。
+    if (!liveTools.includes(storedTools)) return false;
+    if (!storedText) return true;
+    return looseComparableText(canonicalText(live)).includes(storedText);
+  });
+}
+
 function isInterruptedLiveSuperset(
   stored: HermesUIMessage,
   live: HermesUIMessage,
@@ -1174,6 +1216,9 @@ export function mergeHermesUIMessages(
     );
 
     if (liveIndex === -1) {
+      // 回合进行中落库的中间态 assistant 行：已被仍在流式的 live 整条覆盖，
+      // 保留它就会在实时更新的那条下面多出一条永不更新的「死消息」。
+      if (isStoredRowAbsorbedByStreamingLive(storedMessage, consolidatedLive)) continue;
       merged.push(storedMessage);
       continue;
     }


### PR DESCRIPTION
## 问题

回合进行中，Hermes 的回复会裂成两条：上面那条在实时更新进度，下面那条是死的、永远不动。存在多个版本了。

## 原因

不是流式渲染的问题，而是**历史(stored)与实时(live)合并**的问题。两个事实撞在一起：

**1. Core 在回合进行中就往库里写 assistant 行。** 每个 `tool_calls` 步骤各写一行，回合还没结束就已落库。对着本机 `~/.hermes/state.db` 验证：

```
4645|assistant|...|tool_calls        ← 回合中途落库
4646|tool     |...|skill_view
4649|assistant|...|tool_calls        ← 回合中途落库
4664|assistant|830 字符|tool_calls   ← 中途行，已经带正文了
4674|assistant|945 字符|stop         ← 只有这一行才是回合真正结束
```

**2. 有东西在回合进行中重新拉了历史。** `refetchOnWindowFocus: true` 是全局的（`web/src/lib/query-client.ts:7`）；`hooks/use-session-usage-polling.ts:56` 会在 `message.complete` 后 500ms invalidate `session-messages`，若紧接着开了新回合，这个 invalidate 就落进了**新回合里面**。

于是回合中途 UI 手里同时有 stored 的**半个回合**和 live 的**完整流式回合**，而现有三道去重守卫在这个方向上全都不命中：

| 守卫 | 为什么不命中 |
|---|---|
| `isSameCanonicalMessage` | 被工具身份守卫否决（两边工具集不同） |
| `isReplayDuplicateLiveMessage` | 要求 live 是 stored 的**前缀**；这里方向相反，live 是**超集** |
| `isSupersededByStoredTurn` | 要求 live 已 `complete`；而它仍在 `streaming` |

结果 stored 半行原样保留 + live 整条被追加 = 两条并存。最后按 `createdAt` 排序解释了截图里的确切形态：live 用 `turnStartedAt`（回合开始），stored 半行的 timestamp 是回合中途，所以 **live 排在上面**，死行掉在下面。

修之前先复现，断言输出与现象完全一致：

```
expected [ 'streaming', 'complete' ] to deeply equal [ 'streaming' ]
```

## 修复

新增 `isStoredRowAbsorbedByStreamingLive`：若某条 stored assistant 行的 `toolCallId` 序列是某条**仍在流式**的 live 消息工具序列的连续子串（且文本被其包含），即判定为回合中间态，丢弃它、让那条 live 独占这一回合。

判定只在 `status === "streaming"` 时生效——回合一结束，canonical 的 stored 行照旧取胜，历史渲染不受影响。

## 验证

- **1182 个测试全过**，0 error
- `pnpm typecheck` 全绿（license/version/4px grid + 三个 workspace）
- 未改动 Rust，无需 `cargo check`

安全边界随测试固定（`message-adapter.midturn-split.safety.test.ts`）：

- 上一回合的工具卡完好无损
- 回合结束后 stored 行会回来，不丢历史
- `live: []`（刷新后纯历史渲染）时 stored 全量保留
- 跨回合绝不误吞——`toolCallId` 后端唯一
- 纯文本 stored 行不受影响

## 遗留

**Core 里另一个独立的 bug（本 PR 未动）**：`_run_prompt_submit` 自己会发 `message.start`（`tui_gateway/server.py:9660`），但 7564 / 9312 / 9398 / 9476 / 10464 在调它之前又各发了一次——一个回合发两次。10421 行注释其实已经写了这个坑："_run_prompt_submit emits message.start itself, so don't pre-emit here (that would double-fire it)."

目前前端能吸收（`isStreamingStatus` 会复用同一个气泡），所以**不是本 issue 的原因**；但很脆，万一第一次 `message.start` 慢了，第二次就会新建气泡。没动是因为那几处是 auto-continue / 通知 / goal 续跑路径，预先 emit 对不走正常路径的回合可能是必需的，建议单独开一条线。

**更深的设计问题**：网关事件**没有稳定的 turn id**，这正是这个合并层攒了这么多守卫的根本原因。只要 `message.start` / `message.complete` 带上 `turn_id`，这些守卫全可以塌缩成一次 id 比较。

🤖 Generated with [Claude Code](https://claude.com/claude-code)