### PR TITLE
feat: 按后端回合 id 判定消息归属

### DIFF
--- a/packages/protocol/src/hermes-api.ts
+++ b/packages/protocol/src/hermes-api.ts
@@ -1727,6 +1727,10 @@ export type GatewayKnownEvent = z.infer<typeof GatewayKnownEvent>;
 export const RawGatewayEvent = z.object({
   type: z.string(),
   session_id: z.string().optional(),
+  // Stable per-turn id stamped by Core on every event of a turn. Optional:
+  // older runtimes don't send it, and idle/global frames have no turn.
+  // Consumers must treat "absent" as "unknown turn", never as "same turn".
+  turn_id: z.string().optional(),
   payload: z.unknown().optional(),
 }).passthrough();
 export type RawGatewayEvent = z.infer<typeof RawGatewayEvent>;

--- a/web/src/lib/gateway-client.ts
+++ b/web/src/lib/gateway-client.ts
@@ -298,6 +298,12 @@ export class GatewayClient {
       const ev = parseGatewayEvent({
         type: frame.params.type,
         session_id: frame.params.session_id,
+        // Core stamps every event of a turn with a stable turn_id. This
+        // projection is explicit (not a spread), so a field omitted here is
+        // dropped before the reducer ever sees it — turn_id must be carried
+        // through by name. Absent on older runtimes; the reducer falls back to
+        // its activeAssistantId heuristic then.
+        turn_id: frame.params.turn_id,
         payload: frame.params.payload,
       });
       this.emit(ev);

--- a/web/src/stores/chat.ts
+++ b/web/src/stores/chat.ts
@@ -77,6 +77,18 @@ export interface ChatSessionRuntime {
   turnStartedAt?: number;
   turnFirstTokenAt?: number;
   activeAssistantId?: string;
+  /**
+   * Core's stable id for the turn that {@link activeAssistantId} belongs to
+   * (stamped on every gateway event of that turn). When present it is the
+   * authoritative answer to "same turn or new turn?", replacing the
+   * stream-status heuristic: a duplicated `message.start` carries the same
+   * turn_id and is therefore idempotent, while a genuinely new turn carries a
+   * different one.
+   *
+   * Absent on older runtimes that don't send `turn_id` — the reducer then falls
+   * back to the pre-existing heuristic. Never treat "absent" as "same turn".
+   */
+  activeTurnId?: string;
   interrupted?: boolean;
 }
 
@@ -168,6 +180,7 @@ function resetStream(runtime: ChatSessionRuntime, now: number): ChatSessionRunti
     statusKind: undefined,
     statusUpdatedAt: undefined,
     activeAssistantId: undefined,
+    activeTurnId: undefined,
     turnStartedAt: undefined,
     turnFirstTokenAt: undefined,
     updatedAt: now,
@@ -194,6 +207,30 @@ function sessionIdFor(runtime: ChatSessionRuntime, event: GatewayEvent): string 
 
 function isStreamingStatus(status: StreamStatus): boolean {
   return status === "streaming" || status === "connecting";
+}
+
+/** Core's stable per-turn id, when the runtime is new enough to send one. */
+function turnIdOf(event: GatewayEvent): string | undefined {
+  const raw = (event as { turn_id?: unknown }).turn_id;
+  return typeof raw === "string" && raw ? raw : undefined;
+}
+
+/**
+ * Decide whether an incoming `message.start` continues the live bubble or opens
+ * a new one.
+ *
+ * With a turn id this is exact: same id ⇒ same turn (so the duplicate
+ * `message.start` that several Core dispatch paths emit is idempotent),
+ * different id ⇒ genuinely a new turn. Without one (older Core) fall back to
+ * the original heuristic — mid-stream status implies the same turn.
+ */
+function shouldContinueActiveTurn(
+  runtime: ChatSessionRuntime,
+  turnId: string | undefined,
+): boolean {
+  if (!runtime.activeAssistantId) return false;
+  if (turnId && runtime.activeTurnId) return runtime.activeTurnId === turnId;
+  return isStreamingStatus(runtime.streamStatus);
 }
 
 function textFromParts(parts: HermesMessagePart[]): string {
@@ -614,10 +651,9 @@ function reduceGatewayEventInner(
 
   switch (event.type) {
     case "message.start": {
-      const id =
-        isStreamingStatus(runtime.streamStatus) && runtime.activeAssistantId
-          ? runtime.activeAssistantId
-          : assistantClientId(now);
+      const turnId = turnIdOf(event);
+      const continuing = shouldContinueActiveTurn(runtime, turnId);
+      const id = continuing ? runtime.activeAssistantId! : assistantClientId(now);
       return ensureAssistantMessage(
         {
           ...runtime,
@@ -626,7 +662,11 @@ function reduceGatewayEventInner(
           statusKind: undefined,
           statusUpdatedAt: undefined,
           activeAssistantId: id,
-          turnStartedAt: runtime.turnStartedAt ?? now,
+          activeTurnId: turnId ?? runtime.activeTurnId,
+          // A continued turn keeps its original start time; a new turn restarts
+          // the clock (the old code reused turnStartedAt unconditionally, which
+          // backdated every follow-up turn to the first one).
+          turnStartedAt: continuing ? runtime.turnStartedAt ?? now : now,
           turnFirstTokenAt: undefined,
           updatedAt: now,
         },
@@ -840,6 +880,7 @@ function reduceGatewayEventInner(
         turnStartedAt: undefined,
         turnFirstTokenAt: undefined,
         activeAssistantId: undefined,
+        activeTurnId: undefined,
         interrupted: undefined,
         updatedAt: now,
       };
@@ -960,6 +1001,7 @@ function reduceGatewayEventInner(
         statusKind: "error",
         statusUpdatedAt: now,
         activeAssistantId: undefined,
+        activeTurnId: undefined,
         interrupted: undefined,
         updatedAt: now,
       };
@@ -982,6 +1024,7 @@ function reduceGatewayEventInner(
         statusKind: "error",
         statusUpdatedAt: now,
         activeAssistantId: undefined,
+        activeTurnId: undefined,
         updatedAt: now,
       };
     }
@@ -1165,6 +1208,12 @@ export const startPromptAtom = atom(
         turnStartedAt: now,
         turnFirstTokenAt: undefined,
         activeAssistantId: assistantId,
+        // The optimistic bubble predates the backend's turn, so no id is known
+        // yet. Clearing it (rather than inheriting the previous turn's) is what
+        // lets the first real `message.start` adopt this bubble: with no
+        // activeTurnId to compare against, shouldContinueActiveTurn falls back
+        // to the streaming check and reuses it instead of opening a second one.
+        activeTurnId: undefined,
       })),
     );
   },
@@ -1312,6 +1361,7 @@ export const setSessionErrorAtom = atom(
           statusKind: "error",
           statusUpdatedAt: now,
           activeAssistantId: undefined,
+          activeTurnId: undefined,
           turnStartedAt: undefined,
           turnFirstTokenAt: undefined,
           updatedAt: now,
@@ -1374,6 +1424,7 @@ export const terminateAllStreamsAtom = atom(null, (_get, set) => {
           statusKind: "error",
           statusUpdatedAt: now,
           activeAssistantId: undefined,
+          activeTurnId: undefined,
           updatedAt: now,
         };
       } else {

--- a/web/src/stores/chat.turn-id.test.ts
+++ b/web/src/stores/chat.turn-id.test.ts
@@ -1,0 +1,158 @@
+// 回合身份（turn_id）：把「同一回合还是新回合」从启发式改成后端权威。
+//
+// 此前网关事件只带 type + session_id，reducer 只能靠 activeAssistantId 指针 +
+// streamStatus 猜回合边界。于是重复的 message.start（Core 有 5 处调用点在
+// _run_prompt_submit 之前预先 emit 一次，它自己又 emit 一次）或重连重放看起来
+// 就跟新回合一模一样，一条回复被拆成两个气泡。
+//
+// Core 现在给一个回合的每个事件都盖上同一个 turn_id。关键契约：
+//   turn_id 相同   → 同一回合，追加
+//   turn_id 不同   → 新回合，新气泡
+//   turn_id 缺失   → 旧 Core，退回原有 activeAssistantId 启发式（绝不能当成同一回合）
+import { describe, expect, it } from "vitest";
+import type { GatewayEvent } from "@hermes/protocol";
+
+import { createEmptyChatRuntime, reduceGatewayEvent } from "./chat";
+
+const SID = "sess-turn-id";
+const T1 = "turn_aaaa1111bbbb2222";
+const T2 = "turn_cccc3333dddd4444";
+
+function ev(type: string, turnId?: string, payload?: unknown): GatewayEvent {
+  return {
+    type,
+    session_id: SID,
+    ...(turnId ? { turn_id: turnId } : {}),
+    ...(payload !== undefined ? { payload } : {}),
+  } as GatewayEvent;
+}
+
+function assistants(runtime: ReturnType<typeof createEmptyChatRuntime>) {
+  return runtime.messages.filter((m) => m.role === "assistant");
+}
+
+describe("turn_id：同一回合", () => {
+  it("重复的 message.start 带同一个 turn_id 时是幂等的，不新建气泡", () => {
+    let runtime = createEmptyChatRuntime(1_000);
+    // Core 预先 emit 一次，_run_prompt_submit 自己又 emit 一次。
+    runtime = reduceGatewayEvent(runtime, ev("message.start", T1), 1_000);
+    const firstId = runtime.activeAssistantId;
+    runtime = reduceGatewayEvent(runtime, ev("message.start", T1), 1_050);
+
+    expect(assistants(runtime)).toHaveLength(1);
+    expect(runtime.activeAssistantId).toBe(firstId);
+    expect(runtime.activeTurnId).toBe(T1);
+  });
+
+  it("即使 streamStatus 已不是 streaming，同一 turn_id 仍然续用同一气泡", () => {
+    let runtime = createEmptyChatRuntime(1_000);
+    runtime = reduceGatewayEvent(runtime, ev("message.start", T1), 1_000);
+    runtime = reduceGatewayEvent(runtime, ev("message.delta", T1, { text: "答案" }), 1_100);
+    const bubbleId = runtime.activeAssistantId;
+
+    // 人为把状态改成非流式（模拟旧启发式会误判为「新回合」的时刻）。
+    runtime = { ...runtime, streamStatus: "complete" };
+    runtime = reduceGatewayEvent(runtime, ev("message.start", T1), 1_200);
+
+    // turn_id 权威：仍是同一条。
+    expect(assistants(runtime)).toHaveLength(1);
+    expect(runtime.activeAssistantId).toBe(bubbleId);
+  });
+});
+
+describe("turn_id：新回合", () => {
+  it("turn_id 变化时开新气泡", () => {
+    let runtime = createEmptyChatRuntime(1_000);
+    runtime = reduceGatewayEvent(runtime, ev("message.start", T1), 1_000);
+    runtime = reduceGatewayEvent(runtime, ev("message.delta", T1, { text: "第一回合" }), 1_100);
+    runtime = reduceGatewayEvent(
+      runtime,
+      ev("message.complete", T1, { text: "第一回合" }),
+      1_200,
+    );
+
+    runtime = reduceGatewayEvent(runtime, ev("message.start", T2), 2_000);
+    runtime = reduceGatewayEvent(runtime, ev("message.delta", T2, { text: "第二回合" }), 2_100);
+
+    expect(assistants(runtime)).toHaveLength(2);
+    expect(runtime.activeTurnId).toBe(T2);
+  });
+
+  it("新回合重置 turnStartedAt，不沿用上一回合的开始时间", () => {
+    let runtime = createEmptyChatRuntime(1_000);
+    runtime = reduceGatewayEvent(runtime, ev("message.start", T1), 1_000);
+    expect(runtime.turnStartedAt).toBe(1_000);
+    runtime = reduceGatewayEvent(runtime, ev("message.complete", T1, { text: "x" }), 1_500);
+
+    runtime = reduceGatewayEvent(runtime, ev("message.start", T2), 9_000);
+
+    // 旧代码这里会是 1_000（turnStartedAt ?? now 无条件沿用），把后续每个
+    // 回合的计时都回填到第一个回合。
+    expect(runtime.turnStartedAt).toBe(9_000);
+  });
+
+  it("回合收尾后清掉 activeTurnId，陈旧 id 不会误配后续回合", () => {
+    let runtime = createEmptyChatRuntime(1_000);
+    runtime = reduceGatewayEvent(runtime, ev("message.start", T1), 1_000);
+    runtime = reduceGatewayEvent(runtime, ev("message.delta", T1, { text: "x" }), 1_100);
+    runtime = reduceGatewayEvent(runtime, ev("message.complete", T1, { text: "x" }), 1_200);
+
+    expect(runtime.activeTurnId).toBeUndefined();
+    expect(runtime.activeAssistantId).toBeUndefined();
+  });
+});
+
+describe("向后兼容：旧 Core 不发 turn_id", () => {
+  it("无 turn_id 时退回原有启发式：流式中续用同一气泡", () => {
+    let runtime = createEmptyChatRuntime(1_000);
+    runtime = reduceGatewayEvent(runtime, ev("message.start"), 1_000);
+    const bubbleId = runtime.activeAssistantId;
+    runtime = reduceGatewayEvent(runtime, ev("message.delta", undefined, { text: "hi" }), 1_100);
+    // 旧行为：流式中重复 start 复用同一气泡。
+    runtime = reduceGatewayEvent(runtime, ev("message.start"), 1_150);
+
+    expect(assistants(runtime)).toHaveLength(1);
+    expect(runtime.activeAssistantId).toBe(bubbleId);
+    expect(runtime.activeTurnId).toBeUndefined();
+  });
+
+  it("无 turn_id 且上一回合已收尾时开新气泡（不把缺失当成同一回合）", () => {
+    let runtime = createEmptyChatRuntime(1_000);
+    runtime = reduceGatewayEvent(runtime, ev("message.start"), 1_000);
+    runtime = reduceGatewayEvent(runtime, ev("message.delta", undefined, { text: "一" }), 1_100);
+    runtime = reduceGatewayEvent(runtime, ev("message.complete", undefined, { text: "一" }), 1_200);
+
+    runtime = reduceGatewayEvent(runtime, ev("message.start"), 2_000);
+    runtime = reduceGatewayEvent(runtime, ev("message.delta", undefined, { text: "二" }), 2_100);
+
+    expect(assistants(runtime)).toHaveLength(2);
+  });
+});
+
+describe("新旧混搭（升级中途的真实形态）", () => {
+  it("回合中途才开始带 turn_id：采纳它，不另起气泡", () => {
+    let runtime = createEmptyChatRuntime(1_000);
+    // 先来一个没有 turn_id 的 start（例如旧路径 / 预先 emit）。
+    runtime = reduceGatewayEvent(runtime, ev("message.start"), 1_000);
+    const bubbleId = runtime.activeAssistantId;
+    // 随后同一回合的事件带上了 turn_id。
+    runtime = reduceGatewayEvent(runtime, ev("message.start", T1), 1_050);
+
+    expect(assistants(runtime)).toHaveLength(1);
+    expect(runtime.activeAssistantId).toBe(bubbleId);
+    expect(runtime.activeTurnId).toBe(T1);
+  });
+
+  it("带 turn_id 的回合后面跟一个不带的 start：不误判为同一回合", () => {
+    let runtime = createEmptyChatRuntime(1_000);
+    runtime = reduceGatewayEvent(runtime, ev("message.start", T1), 1_000);
+    runtime = reduceGatewayEvent(runtime, ev("message.delta", T1, { text: "一" }), 1_100);
+    runtime = reduceGatewayEvent(runtime, ev("message.complete", T1, { text: "一" }), 1_200);
+
+    // 收尾已清掉 activeTurnId，缺失 → 退回启发式 → 非流式 → 新气泡。
+    runtime = reduceGatewayEvent(runtime, ev("message.start"), 2_000);
+    runtime = reduceGatewayEvent(runtime, ev("message.delta", undefined, { text: "二" }), 2_100);
+
+    expect(assistants(runtime)).toHaveLength(2);
+  });
+});


### PR DESCRIPTION
## 背景

网关事件过去没有稳定的回合身份,reducer 只能靠 `activeAssistantId` 指针加 `streamStatus` 猜回合边界。这是消息「裂开」那一类问题的**根本原因**——`message-adapter.ts` 里那一堆基于文本相似度和工具集包含关系的守卫,全都是在反推一件后端本来就知道的事。

Core 侧(Eynzof/Hermes-CN-Core#148)现在给一个回合的每个事件盖上同一个 `turn_id`。本 PR 消费它。

## 改动

判定从启发式改成后端权威:

```
turn_id 相同 → 同一回合,追加(Core 有几处调用点会重复发 message.start,据此天然幂等)
turn_id 不同 → 新回合,新气泡
turn_id 缺失 → 退回原有 activeAssistantId 启发式
```

**第三条分支必须原样保留。** 把「没有 id」当成「同一回合」的话,连着旧 Core 时整段对话会被合成一个巨型气泡——这是本次实现最容易踩的坑,四种新旧组合都有测试兜着。

### 一个容易漏的点

`gateway-client.ts:298` 那次事件投影是**逐字段显式列举**的,不是展开:

```ts
const ev = parseGatewayEvent({
  type: frame.params.type,
  session_id: frame.params.session_id,
  turn_id: frame.params.turn_id,   // ← 不按名字带过来就在到达 reducer 前被丢掉
  payload: frame.params.payload,
});
```

schema 是 `passthrough` 会让人以为字段自动透传,实际这里会静默吃掉它。

### 顺带修掉的计时问题

`message.start` 过去无条件沿用 `turnStartedAt ?? now`,把后续每个回合的开始时间都回填到第一个回合。现在只有续用同一回合才保留,新回合重新计时。

### 生命周期

- 回合收尾/报错的**六处**清理点都同步清掉 `activeTurnId`,避免陈旧 id 误配后续回合
- 中断与重连路径和 `activeAssistantId` 一致地**保留**它,迟到的终态帧才能收尾到正确的消息
- 乐观气泡(`startPromptAtom`)显式不带 id,好让第一个真实 `message.start` 采纳它而不是另起一条

## 验证

- 新增 `web/src/stores/chat.turn-id.test.ts`,**9 个测试**:同 id 幂等、非流式状态下同 id 仍续用、换 id 开新气泡、新回合重置计时、收尾清理 id、旧 Core 无 id 的两种走向、回合中途才开始带 id、带 id 回合后跟不带 id 的 start
- **全量 1184 个测试通过**,0 error
- `pnpm typecheck` 全绿(license / version / 4px grid + 三个 workspace)
- 未改动 Rust,无需 `cargo check`

## 关系

- Core 侧:Eynzof/Hermes-CN-Core#148。两边可独立发布,不要求客户端先行
- 这是**治本第一层**。#545 是同一问题的症状层修复,两者不冲突
- 第二层(落库行也带 `turn_id`,需要加列 + migration)才能让 `message-adapter.ts` 里那五个启发式守卫塌缩成一次 id 比较;本 PR 不含,建议按升级安全预检单独排

🤖 Generated with [Claude Code](https://claude.com/claude-code)