### PR TITLE
fix: 清理托管网关残留并准备 rc3

### DIFF
--- a/.github/workflows/release-desktop.yml
+++ b/.github/workflows/release-desktop.yml
@@ -1,5 +1,5 @@
 # Build hermes-agent-cn-desktop installers and attach them to a GitHub
-# Release. Triggers on tags matching `v*` (e.g. `v0.8.0-rc2`).
+# Release. Triggers on tags matching `v*` (e.g. `v0.8.0-rc3`).
 #
 # Desktop release build runs in parallel for Windows, macOS, and Linux. Each job:
 #   1. Installs Node 22 + pnpm + Rust toolchain
@@ -30,11 +30,11 @@ on:
   workflow_dispatch:
     inputs:
       tag:
-        description: "Tag name to associate the build with (e.g. v0.8.0-rc2)"
+        description: "Tag name to associate the build with (e.g. v0.8.0-rc3)"
         required: true
       bundled_runtime_tag:
         description: "Hermes-CN-Core runtime release tag to embed in desktop installers, or latest"
-        default: "runtime-v0.20.0-cn.4"
+        default: "runtime-v0.20.0-cn.5"
         required: false
 
 permissions:
@@ -115,7 +115,7 @@ jobs:
         shell: bash
         env:
           BUNDLED_RUNTIME_REPO: Eynzof/Hermes-CN-Core
-          BUNDLED_RUNTIME_TAG: ${{ github.event.inputs.bundled_runtime_tag || 'runtime-v0.20.0-cn.4' }}
+          BUNDLED_RUNTIME_TAG: ${{ github.event.inputs.bundled_runtime_tag || 'runtime-v0.20.0-cn.5' }}
           RUNTIME_PLATFORM: ${{ matrix.runtime_platform }}
           RUNTIME_ARCH: ${{ matrix.runtime_arch }}
         run: |
@@ -173,7 +173,7 @@ jobs:
           args=(
             scripts/stage-bundled-runtime.mjs
             --repo "Eynzof/Hermes-CN-Core"
-            --tag "${{ github.event.inputs.bundled_runtime_tag || 'runtime-v0.20.0-cn.4' }}"
+            --tag "${{ github.event.inputs.bundled_runtime_tag || 'runtime-v0.20.0-cn.5' }}"
             --platform "${{ matrix.runtime_platform }}"
             --arch "${{ matrix.runtime_arch }}"
           )

--- a/Cargo.lock
+++ b/Cargo.lock
@@ -1981,7 +1981,7 @@ checksum = "2304e00983f87ffb38b55b444b5e3b60a884b5d30c0fca7d82fe33449bbe55ea"
 
 [[package]]
 name = "hermes-agent-cn-desktop"
-version = "0.8.0-rc2"
+version = "0.8.0-rc3"
 dependencies = [
  "base64 0.22.1",
  "bytes",

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -1,6 +1,6 @@
 [package]
 name = "hermes-agent-cn-desktop"
-version = "0.8.0-rc2"
+version = "0.8.0-rc3"
 edition = "2021"
 description = "Hermes Agent CN Desktop (Tauri)"
 authors = ["Hermes Agent CN Contributors"]

--- a/README.en-US.md
+++ b/README.en-US.md
@@ -12,7 +12,7 @@ Hermes Agent CN Desktop is a desktop client from the Hermes Agent Chinese commun
 
 Official site and downloads: [desktop.hermesagent.org.cn](https://desktop.hermesagent.org.cn). The desktop app is part of the [Hermes Agent Chinese Community](https://hermesagent.org.cn) ecosystem, where the main site links to Chinese docs, practice guides, community entry points, and more ecosystem projects.
 
-> Current release: `v0.8.0-rc2`. The project is still moving quickly. APIs, packaging, runtime distribution, and UI details may continue to change.
+> Current release: `v0.8.0-rc3`. The project is still moving quickly. APIs, packaging, runtime distribution, and UI details may continue to change.
 
 ## Hermes Agent Chinese Community
 
@@ -95,9 +95,9 @@ Installers are available from the [desktop website](https://desktop.hermesagent.
 
 The current release includes:
 
-- macOS Apple Silicon DMG: `Hermes.Agent.CN.Desktop_0.8.0-rc2_aarch64.dmg`
-- macOS Intel DMG: `Hermes.Agent.CN.Desktop_0.8.0-rc2_x64.dmg`
-- Windows x64 installer: `Hermes.Agent.CN.Desktop_0.8.0-rc2_x64-setup.exe`
+- macOS Apple Silicon DMG: `Hermes.Agent.CN.Desktop_0.8.0-rc3_aarch64.dmg`
+- macOS Intel DMG: `Hermes.Agent.CN.Desktop_0.8.0-rc3_x64.dmg`
+- Windows x64 installer: `Hermes.Agent.CN.Desktop_0.8.0-rc3_x64-setup.exe`
 
 Both the Windows and macOS installers include a bundled `Hermes-CN-Core` runtime. On first launch, the app initializes the local core from the bundled runtime first; managed runtime download/update is only used for upgrades or fallback repair.
 

--- a/README.md
+++ b/README.md
@@ -12,7 +12,7 @@ Hermes Agent CN Desktop 是 Hermes Agent 中文社区推出的桌面客户端，
 
 官网与下载页见 [desktop.hermesagent.org.cn](https://desktop.hermesagent.org.cn)。桌面端隶属于 [Hermes Agent 中文社区](https://hermesagent.org.cn) 生态，社区主站提供中文文档、实践指南、社群入口和更多生态项目。
 
-> 当前版本是 `v0.8.0-rc2`。项目仍在快速迭代，API、打包流程、运行时分发策略和界面细节都可能继续调整。
+> 当前版本是 `v0.8.0-rc3`。项目仍在快速迭代，API、打包流程、运行时分发策略和界面细节都可能继续调整。
 
 ## Hermes Agent 中文社区
 
@@ -96,9 +96,9 @@ Hermes Agent 已经提供本地 Dashboard。本仓库专注于 Dashboard 之外�
 
 当前版本包含：
 
-- macOS Apple Silicon DMG：`Hermes.Agent.CN.Desktop_0.8.0-rc2_aarch64.dmg`
-- macOS Intel DMG：`Hermes.Agent.CN.Desktop_0.8.0-rc2_x64.dmg`
-- Windows x64 安装器：`Hermes.Agent.CN.Desktop_0.8.0-rc2_x64-setup.exe`
+- macOS Apple Silicon DMG：`Hermes.Agent.CN.Desktop_0.8.0-rc3_aarch64.dmg`
+- macOS Intel DMG：`Hermes.Agent.CN.Desktop_0.8.0-rc3_x64.dmg`
+- Windows x64 安装器：`Hermes.Agent.CN.Desktop_0.8.0-rc3_x64-setup.exe`
 
 当前 Windows 与 macOS 安装包都会预置 `Hermes-CN-Core` runtime，安装后优先从包内 runtime 完成本地内核初始化；托管 runtime 下载与更新流程只作为升级或兜底路径使用。
 

--- a/docs/macos-signing-and-notarization.md
+++ b/docs/macos-signing-and-notarization.md
@@ -117,7 +117,7 @@ target/aarch64-apple-darwin/release/bundle/dmg/*.dmg
 如果需要手动公证和 staple，可以对最终 DMG 执行：
 
 ```bash
-DMG="target/aarch64-apple-darwin/release/bundle/dmg/Hermes Agent CN Desktop_0.8.0-rc2_aarch64.dmg"
+DMG="target/aarch64-apple-darwin/release/bundle/dmg/Hermes Agent CN Desktop_0.8.0-rc3_aarch64.dmg"
 
 xcrun notarytool submit "$DMG" \
   --key "$APPLE_API_KEY_PATH" \

--- a/docs/managed-runtime.md
+++ b/docs/managed-runtime.md
@@ -276,7 +276,7 @@ fork CI release-runtime.yml 触发：
 ## 六、桌面端升级
 
 ```
-你 git tag v0.8.0-rc2; git push origin v0.8.0-rc2
+你 git tag v0.8.0-rc3; git push origin v0.8.0-rc3
   ↓
 desktop CI release-desktop.yml 触发：
   matrix: windows-latest / macos-14 (arm64)
@@ -289,7 +289,7 @@ desktop CI release-desktop.yml 触发：
     5. tauri-apps/tauri-action@v0 → 打 .exe / .dmg
        runtime URL + 公钥仍是 baked-in 兜底，不需要 env wire 进 CI
   ↓
-新装包发到 releases/v0.8.0-rc2 → 用户下载装新版
+新装包发到 releases/v0.8.0-rc3 → 用户下载装新版
   ↓
 新版起来后，看到 current.json 已经有 runtime → 不下载 → 直接用。
 全新安装则先使用安装包内置 runtime；除非内置资源缺失或用户主动升级，

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "hermes-agent-cn-desktop",
-  "version": "0.8.0-rc2",
+  "version": "0.8.0-rc3",
   "private": true,
   "author": "Hermes Agent CN Contributors",
   "homepage": "https://hermesagent.org.cn",

--- a/packages/protocol/package.json
+++ b/packages/protocol/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@hermes/protocol",
-  "version": "0.8.0-rc2",
+  "version": "0.8.0-rc3",
   "private": true,
   "type": "module",
   "main": "./src/index.ts",

--- a/packages/shared-ui/package.json
+++ b/packages/shared-ui/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@hermes/shared-ui",
-  "version": "0.8.0-rc2",
+  "version": "0.8.0-rc3",
   "private": true,
   "type": "module",
   "main": "./src/index.ts",

--- a/src/process/dashboard.rs
+++ b/src/process/dashboard.rs
@@ -1013,6 +1013,30 @@ fn spawn_dashboard(
     let gateway_lock_dir = gateway_runtime_dir.join("token-locks");
     let _ = std::fs::create_dir_all(&gateway_lock_dir);
     let _ = std::fs::create_dir_all(&gateway_runtime_dir);
+    if let Some(record) = crate::process::runtime::read_current_record() {
+        match crate::process::gateway::preflight_managed_gateway_restart(
+            &record,
+            &options.hermes_home,
+            &gateway_runtime_dir,
+            &gateway_lock_dir,
+        ) {
+            Ok(report) => {
+                if report.stop_attempted
+                    || report.stale_files_removed > 0
+                    || !report.remaining_pids.is_empty()
+                    || report.lock_active
+                {
+                    log::info!(
+                        "Gateway preflight before dashboard spawn: {}",
+                        report.summary()
+                    );
+                }
+            }
+            Err(err) => {
+                log::warn!("Gateway preflight before dashboard spawn failed: {}", err);
+            }
+        }
+    }
     cmd.args(&prefix_args)
         .env("HERMES_HOME", &options.hermes_home)
         .env(

--- a/src/process/gateway.rs
+++ b/src/process/gateway.rs
@@ -63,6 +63,24 @@ fn gateway_lock_path(runtime_dir: &Path) -> PathBuf {
     runtime_dir.join(GATEWAY_LOCK_FILE)
 }
 
+fn normalize_path_text(path: &Path) -> String {
+    fs::canonicalize(path)
+        .unwrap_or_else(|_| path.to_path_buf())
+        .to_string_lossy()
+        .replace('\\', "/")
+        .to_lowercase()
+}
+
+fn text_contains_path(text: &str, path: &Path) -> bool {
+    let normalized_text = text.replace('\\', "/").to_lowercase();
+    let raw = path.to_string_lossy().replace('\\', "/").to_lowercase();
+    if !raw.is_empty() && normalized_text.contains(&raw) {
+        return true;
+    }
+    let canonical = normalize_path_text(path);
+    !canonical.is_empty() && normalized_text.contains(&canonical)
+}
+
 fn parse_pid_value(value: &Value) -> Option<u32> {
     match value {
         Value::Number(number) => number.as_u64().and_then(|pid| u32::try_from(pid).ok()),
@@ -247,6 +265,93 @@ fn gateway_pid_candidates(runtime_dir: &Path) -> Vec<u32> {
     pids.into_iter().collect()
 }
 
+fn token_lock_paths(gateway_lock_dir: &Path) -> Vec<PathBuf> {
+    let mut paths = Vec::new();
+    let Ok(entries) = fs::read_dir(gateway_lock_dir) else {
+        return paths;
+    };
+    for entry in entries.flatten() {
+        let path = entry.path();
+        if path.extension().is_some_and(|ext| ext == "lock") {
+            paths.push(path);
+        }
+    }
+    paths.sort();
+    paths
+}
+
+fn token_lock_record_matches_managed_runtime(
+    record: &GatewayRuntimeRecord,
+    pid: u32,
+    runtime_root: &Path,
+) -> bool {
+    if !record_looks_like_gateway(record) {
+        return false;
+    }
+    if !record.argv.is_empty() && text_contains_path(&record.argv.join(" "), runtime_root) {
+        return true;
+    }
+    process_command_line(pid)
+        .as_deref()
+        .is_some_and(|command_line| {
+            command_line_looks_like_gateway(command_line)
+                && text_contains_path(command_line, runtime_root)
+        })
+}
+
+fn gateway_token_lock_pid_candidates(gateway_lock_dir: &Path, runtime_root: &Path) -> Vec<u32> {
+    let mut pids = BTreeSet::new();
+    for path in token_lock_paths(gateway_lock_dir) {
+        let Some(record) = read_gateway_runtime_record(&path) else {
+            continue;
+        };
+        let Some(pid) = record.pid else {
+            continue;
+        };
+        if pid_is_running(pid)
+            && token_lock_record_matches_managed_runtime(&record, pid, runtime_root)
+        {
+            pids.insert(pid);
+        }
+    }
+    pids.into_iter().collect()
+}
+
+fn managed_gateway_pid_candidates(
+    runtime_dir: &Path,
+    gateway_lock_dir: &Path,
+    runtime_root: &Path,
+) -> Vec<u32> {
+    let mut pids = BTreeSet::new();
+    pids.extend(gateway_pid_candidates(runtime_dir));
+    pids.extend(gateway_token_lock_pid_candidates(
+        gateway_lock_dir,
+        runtime_root,
+    ));
+    pids.into_iter().collect()
+}
+
+fn cleanup_stale_gateway_token_lock_files(gateway_lock_dir: &Path, _runtime_root: &Path) -> usize {
+    let mut removed = 0;
+    for path in token_lock_paths(gateway_lock_dir) {
+        let remove = match read_gateway_runtime_record(&path) {
+            Some(record) => match record.pid {
+                Some(pid) if pid_is_running(pid) => !record_looks_like_gateway(&record),
+                _ => true,
+            },
+            None => true,
+        };
+        if remove {
+            match fs::remove_file(&path) {
+                Ok(()) => removed += 1,
+                Err(err) if err.kind() == std::io::ErrorKind::NotFound => {}
+                Err(_) => {}
+            }
+        }
+    }
+    removed
+}
+
 fn gateway_runtime_lock_active(runtime_dir: &Path) -> bool {
     let lock_path = gateway_lock_path(runtime_dir);
     if !lock_path.exists() {
@@ -300,11 +405,17 @@ fn wait_for_child_exit(child: &mut Child, timeout: Duration) -> Option<Option<i3
     None
 }
 
-fn wait_for_gateway_runtime_to_settle(runtime_dir: &Path, timeout: Duration) -> bool {
+fn wait_for_gateway_runtime_to_settle(
+    runtime_dir: &Path,
+    gateway_lock_dir: &Path,
+    runtime_root: &Path,
+    timeout: Duration,
+) -> bool {
     let start = Instant::now();
     while start.elapsed() < timeout {
         let _ = cleanup_stale_gateway_runtime_files(runtime_dir);
-        if gateway_pid_candidates(runtime_dir).is_empty()
+        let _ = cleanup_stale_gateway_token_lock_files(gateway_lock_dir, runtime_root);
+        if managed_gateway_pid_candidates(runtime_dir, gateway_lock_dir, runtime_root).is_empty()
             && !gateway_runtime_lock_active(runtime_dir)
         {
             return true;
@@ -409,11 +520,15 @@ pub fn preflight_managed_gateway_restart(
         .map_err(|err| format!("无法创建 Gateway lock 目录：{err}"))?;
 
     let mut report = ManagedGatewayPreflightReport::default();
+    let runtime_root = crate::process::runtime::runtime_root();
+    report.stale_files_removed +=
+        cleanup_stale_gateway_token_lock_files(gateway_lock_dir, &runtime_root);
     let runtime_files_exist = gateway_pid_path(gateway_runtime_dir).exists()
         || gateway_lock_path(gateway_runtime_dir).exists();
 
     if runtime_files_exist
-        || !gateway_pid_candidates(gateway_runtime_dir).is_empty()
+        || !managed_gateway_pid_candidates(gateway_runtime_dir, gateway_lock_dir, &runtime_root)
+            .is_empty()
         || gateway_runtime_lock_active(gateway_runtime_dir)
     {
         report.stop_attempted = true;
@@ -431,31 +546,52 @@ pub fn preflight_managed_gateway_restart(
                 log::warn!("{}", err);
             }
         }
-        let _ = wait_for_gateway_runtime_to_settle(gateway_runtime_dir, GATEWAY_SETTLE_TIMEOUT);
+        let _ = wait_for_gateway_runtime_to_settle(
+            gateway_runtime_dir,
+            gateway_lock_dir,
+            &runtime_root,
+            GATEWAY_SETTLE_TIMEOUT,
+        );
     }
 
     report.stale_files_removed += cleanup_stale_gateway_runtime_files(gateway_runtime_dir);
+    report.stale_files_removed +=
+        cleanup_stale_gateway_token_lock_files(gateway_lock_dir, &runtime_root);
 
-    let remaining = gateway_pid_candidates(gateway_runtime_dir);
+    let remaining =
+        managed_gateway_pid_candidates(gateway_runtime_dir, gateway_lock_dir, &runtime_root);
     if !remaining.is_empty() {
         for pid in &remaining {
             terminate_pid(*pid, false);
         }
-        if !wait_for_gateway_runtime_to_settle(gateway_runtime_dir, GATEWAY_FORCE_SETTLE_TIMEOUT) {
-            for pid in gateway_pid_candidates(gateway_runtime_dir) {
+        if !wait_for_gateway_runtime_to_settle(
+            gateway_runtime_dir,
+            gateway_lock_dir,
+            &runtime_root,
+            GATEWAY_FORCE_SETTLE_TIMEOUT,
+        ) {
+            for pid in
+                managed_gateway_pid_candidates(gateway_runtime_dir, gateway_lock_dir, &runtime_root)
+            {
                 terminate_pid(pid, true);
                 report.force_killed_pids.push(pid);
             }
             let _ = wait_for_gateway_runtime_to_settle(
                 gateway_runtime_dir,
+                gateway_lock_dir,
+                &runtime_root,
                 GATEWAY_FORCE_SETTLE_TIMEOUT,
             );
         }
     }
 
     report.stale_files_removed += cleanup_stale_gateway_runtime_files(gateway_runtime_dir);
-    report.remaining_pids = gateway_pid_candidates(gateway_runtime_dir);
-    report.lock_active = gateway_runtime_lock_active(gateway_runtime_dir);
+    report.stale_files_removed +=
+        cleanup_stale_gateway_token_lock_files(gateway_lock_dir, &runtime_root);
+    report.remaining_pids =
+        managed_gateway_pid_candidates(gateway_runtime_dir, gateway_lock_dir, &runtime_root);
+    report.lock_active = gateway_runtime_lock_active(gateway_runtime_dir)
+        || !gateway_token_lock_pid_candidates(gateway_lock_dir, &runtime_root).is_empty();
     Ok(report)
 }
 
@@ -528,5 +664,74 @@ mod tests {
         assert_eq!(removed, 0);
         assert!(lock_path.exists());
         file.unlock().expect("unlock");
+    }
+
+    #[test]
+    fn cleanup_stale_gateway_token_lock_files_removes_dead_pid() {
+        let temp = tempfile::tempdir().expect("tempdir");
+        let runtime_root = temp.path().join("runtime");
+        fs::create_dir_all(&runtime_root).expect("runtime");
+        let lock_dir = temp.path().join("token-locks");
+        fs::create_dir_all(&lock_dir).expect("locks");
+        let lock_path = lock_dir.join("weixin.lock");
+        fs::write(
+            &lock_path,
+            format!(
+                r#"{{"pid":0,"kind":"hermes-gateway","argv":["{}/versions/old/hermes","gateway","run"]}}"#,
+                runtime_root.display()
+            ),
+        )
+        .expect("lock");
+
+        let removed = cleanup_stale_gateway_token_lock_files(&lock_dir, &runtime_root);
+
+        assert_eq!(removed, 1);
+        assert!(!lock_path.exists());
+    }
+
+    #[test]
+    fn gateway_token_lock_pid_candidates_accepts_managed_runtime_path() {
+        let temp = tempfile::tempdir().expect("tempdir");
+        let runtime_root = temp.path().join("runtime");
+        fs::create_dir_all(&runtime_root).expect("runtime");
+        let lock_dir = temp.path().join("token-locks");
+        fs::create_dir_all(&lock_dir).expect("locks");
+        let pid = std::process::id();
+        fs::write(
+            lock_dir.join("weixin.lock"),
+            format!(
+                r#"{{"pid":{},"kind":"hermes-gateway","argv":["{}/versions/old/hermes","gateway","run","--replace"]}}"#,
+                pid,
+                runtime_root.display()
+            ),
+        )
+        .expect("lock");
+
+        assert_eq!(
+            gateway_token_lock_pid_candidates(&lock_dir, &runtime_root),
+            vec![pid]
+        );
+    }
+
+    #[test]
+    fn gateway_token_lock_pid_candidates_rejects_unrelated_runtime_path() {
+        let temp = tempfile::tempdir().expect("tempdir");
+        let runtime_root = temp.path().join("runtime");
+        let other_root = temp.path().join("other-runtime");
+        fs::create_dir_all(&runtime_root).expect("runtime");
+        fs::create_dir_all(&other_root).expect("other");
+        let lock_dir = temp.path().join("token-locks");
+        fs::create_dir_all(&lock_dir).expect("locks");
+        fs::write(
+            lock_dir.join("weixin.lock"),
+            format!(
+                r#"{{"pid":{},"kind":"hermes-gateway","argv":["{}/versions/old/hermes","gateway","run","--replace"]}}"#,
+                std::process::id(),
+                other_root.display()
+            ),
+        )
+        .expect("lock");
+
+        assert!(gateway_token_lock_pid_candidates(&lock_dir, &runtime_root).is_empty());
     }
 }

--- a/tauri.conf.json
+++ b/tauri.conf.json
@@ -1,7 +1,7 @@
 {
   "$schema": "https://raw.githubusercontent.com/nicegoodthings/tauri-schema/main/tauri.conf.schema.json",
   "productName": "Hermes Agent CN Desktop",
-  "version": "0.8.0-rc2",
+  "version": "0.8.0-rc3",
   "identifier": "cn.org.hermesagent.desktop",
   "build": {
     "beforeDevCommand": "pnpm --filter @hermes/web dev",

--- a/web/package.json
+++ b/web/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@hermes/web",
-  "version": "0.8.0-rc2",
+  "version": "0.8.0-rc3",
   "private": true,
   "type": "module",
   "scripts": {


### PR DESCRIPTION
## 摘要
- dashboard 启动前执行 managed gateway preflight，清理死锁和旧 token lock
- token lock 只处理当前 managed runtime root 可确认的 gateway 进程，避免影响用户全局 Hermes
- 桌面端版本同步到 0.8.0-rc3，release workflow 默认 bundled runtime 改为 runtime-v0.20.0-cn.5

## 测试
- cargo test process::gateway
- cargo check
- cargo fmt --check
- pnpm typecheck
- pnpm test:unit