### PR TITLE
docs: 记录 rc 禁止同步官网清单规则

### DIFF
--- a/.codex/skills/desktop-dual-repo-test/SKILL.md
+++ b/.codex/skills/desktop-dual-repo-test/SKILL.md
@@ -167,4 +167,5 @@ Wait for kernel ready (dashboard **9120** returns 200), then:
 
 - **PR merged, considering tag** → 路线 A on both repos' latest `main` (or integration branch).
 - **Tag pushed, GHA green** → 路线 B on release asset; 路线 A results do not replace B for runtime badge or macOS relay.
-- **Formal public release** → also run `.codex/skills/desktop-release-sync-landing/SKILL.md` for landing / `latest.json`.
+- **Stable/formal public release** → also run `.codex/skills/desktop-release-sync-landing/SKILL.md` for landing / `latest.json`.
+- **RC / beta / alpha / canary prerelease** → do not modify the landing repository and do not point public `latest.json` at the prerelease; distribute and validate through GitHub Release or a dedicated internal channel.

--- a/.codex/skills/desktop-release-preflight/SKILL.md
+++ b/.codex/skills/desktop-release-preflight/SKILL.md
@@ -1,13 +1,13 @@
 ---
 name: desktop-release-preflight
-description: Use BEFORE preparing or publishing any Hermes Agent CN Desktop release (new installer, version bump, GitHub Release, or pushing a new build to users). This is the release safety gate that prevents in-place overwrite-upgrade regressions for existing users (live users are mainly on v0.3.2 and upgrade by downloading the new installer over the old one). Covers the managed-runtime reconcile traps (silent kernel downgrade via bundled_runtime_tag, schemaVersion re-bootstrap, the load-bearing stable bundle identifier), the China-mirror "artifactUrl-before-signing" rule, the cnb.cool vs GitHub Actions build-location decision, signing / notarization / Authenticode gates, and shipping to a canary channel first. Complements desktop-release-sync-landing (which handles version sync + the landing latest.json) — run this one FIRST.
+description: Use BEFORE preparing or publishing any Hermes Agent CN Desktop release (new installer, version bump, GitHub Release, or pushing a new build to users). This is the release safety gate that prevents in-place overwrite-upgrade regressions for existing users (live users are mainly on v0.3.2 and upgrade by downloading the new installer over the old one). Covers the managed-runtime reconcile traps (silent kernel downgrade via bundled_runtime_tag, schemaVersion re-bootstrap, the load-bearing stable bundle identifier), the China-mirror "artifactUrl-before-signing" rule, the cnb.cool vs GitHub Actions build-location decision, signing / notarization / Authenticode gates, and shipping to a canary channel first. Complements desktop-release-sync-landing for stable/public releases only (which handles version sync + the landing latest.json) — run this one FIRST.
 ---
 
 # Desktop Release Preflight（发版前预检）
 
 ## Overview
 
-线上用户主力是 **v0.3.2**，外壳尚无自更新（热更新轨道 C 未建），所以用户升级 = **下载新安装包直接覆盖装**。这套机制**默认是安全的**——用户的内核 runtime 树和所有设置都在 app-data、不在安装目录，覆盖装不动它们；启动时 `install_bundled_runtime_if_needed` 自动 reconcile。**但有两个坑会在不经意间伤到老用户，必须每次发版主动防。** 本技能就是发版前的安全闸门，先于 `desktop-release-sync-landing` 执行。
+线上用户主力是 **v0.3.2**，外壳尚无自更新（热更新轨道 C 未建），所以用户升级 = **下载新安装包直接覆盖装**。这套机制**默认是安全的**——用户的内核 runtime 树和所有设置都在 app-data、不在安装目录，覆盖装不动它们；启动时 `install_bundled_runtime_if_needed` 自动 reconcile。**但有两个坑会在不经意间伤到老用户，必须每次发版主动防。** 本技能就是发版前的安全闸门；只有 stable/正式公开版本才在本技能之后执行 `desktop-release-sync-landing`。
 
 完整设计见 `docs/hot-update-impl-plan.md`（§12 覆盖升级安全性、§2.5 构建/分发后端、§11 灰度通道）。
 
@@ -37,7 +37,7 @@ description: Use BEFORE preparing or publishing any Hermes Agent CN Desktop rele
 6. ☑️ **版本号同步**：改根 `package.json` "version" 后 `pnpm run version:sync`，`pnpm version:check` 通过（这步与 `desktop-release-sync-landing` 重叠，以那篇为准）。
 7. ☑️ **发版说明提示"安装前先退出正在运行的桌面端"**（外壳 .exe/.app 文件锁；dashboard 子进程在 app-data 不被锁）。
 8. ☑️ **先发 canary 给开发团队覆盖装验证**（见下"灰度优先"），确认 reconcile 行为符合预期，再放 stable。
-9. ☑️ 发完后转 `desktop-release-sync-landing`：同步 landing 官网版本 + `https://desktop.hermesagent.org.cn/latest.json`。
+9. ☑️ stable/正式公开版本发完后转 `desktop-release-sync-landing`：同步 landing 官网版本 + `https://desktop.hermesagent.org.cn/latest.json`。RC / beta / alpha / canary 等预发布或内测版本禁止同步 Landing，禁止让官网或 public `latest.json` 指向预发布版本。
 
 ## 两个必须主动防的坑（深入）
 
@@ -81,6 +81,6 @@ Ed25519 私钥放执行签名的那个平台 secret，**永不上分发服务器
 
 ## 相关技能 / 文档
 
-- 版本同步 + landing `latest.json`：`.codex/skills/desktop-release-sync-landing/SKILL.md`（本技能之后执行）。
+- stable/正式公开版本同步 landing `latest.json`：`.codex/skills/desktop-release-sync-landing/SKILL.md`（本技能之后执行）。RC / beta / alpha / canary 等预发布或内测版本不要执行该同步。
 - 双仓库启动/打包态补验：`.codex/skills/desktop-dual-repo-test/SKILL.md`。
 - 完整热更新方案：`docs/hot-update-impl-plan.md`（§2.5 / §11 / §12）。

--- a/.codex/skills/desktop-release-sync-landing/SKILL.md
+++ b/.codex/skills/desktop-release-sync-landing/SKILL.md
@@ -1,13 +1,17 @@
 ---
 name: desktop-release-sync-landing
-description: Use when working in the Hermes Agent CN Desktop repository on a desktop release, version bump, GitHub Release, installer packaging, release notes, or any task that changes the public desktop version. Ensures the desktop repo version is synchronized and the separate landing repository updates its website version and https://desktop.hermesagent.org.cn/latest.json manifest for the same release.
+description: Use only for stable/public Hermes Agent CN Desktop releases that should be visible to all users. Ensures the desktop repo version is synchronized and the separate landing repository updates its website version and https://desktop.hermesagent.org.cn/latest.json manifest for the same stable release. Do not use for rc, beta, alpha, canary, or other internal prereleases.
 ---
 
 # Desktop Release Sync Landing
 
 ## Overview
 
-Use this skill whenever a desktop release is prepared, published, fixed, or documented. A release is not complete until the landing repository has been updated so `/latest.json` points at the same version and users can download the matching installers.
+Use this skill only when a **stable/public** desktop release is prepared, published, fixed, or documented. A stable release is not complete until the landing repository has been updated so `/latest.json` points at the same version and users can download the matching installers.
+
+## Prerelease Rule
+
+**RC / beta / alpha / canary and any other prerelease or internal-test version must not touch the landing repository.** Do not create a landing worktree, do not update website copy, and do not point `https://desktop.hermesagent.org.cn/latest.json` at a prerelease. Prerelease builds are distributed through GitHub Release, manual download, or a dedicated internal channel only; the public website and update manifest must continue to represent the latest stable release.
 
 ## Release workflow
 
@@ -20,6 +24,7 @@ Use this skill whenever a desktop release is prepared, published, fixed, or docu
    ```
 
    Do not invent `size`, `sha256`, `publishedAt`, or installer URLs. If the release job has not produced assets yet, stop and state that the landing sync is blocked on release assets.
+   If `$VERSION` contains a prerelease suffix such as `-rc`, `-beta`, `-alpha`, or `-canary`, stop here and report that landing sync is intentionally forbidden for prereleases.
 4. Open or create a separate worktree/branch for `Eynzof/hermes-agent-cn-desktop-landing`. Prefer a `codex/` branch, for example `codex/update-desktop-latest-json`.
 5. In the landing repo, update the public release state for the same desktop version:
 
@@ -40,6 +45,8 @@ Use this skill whenever a desktop release is prepared, published, fixed, or docu
 
 ## Guardrails
 
-Do not close a release task by only updating this desktop repository when the public version changed. Either update landing in the same work session or explicitly report that landing sync is pending and why.
+Do not close a stable/public release task by only updating this desktop repository when the public version changed. Either update landing in the same work session or explicitly report that landing sync is pending and why.
+
+For prerelease tasks, the correct outcome is the opposite: explicitly state that landing/latest.json was not changed because prereleases must not be visible through the public website or public update manifest.
 
 Do not change the release repository identity in landing just because GitHub redirects between `Eynzof/hermes-agent-cn-desktop` and `Eynzof/Hermes-CN-Desktop`; trust `gh release view` and preserve the canonical repository used by the current landing manifest unless live release metadata proves otherwise.

--- a/.codex/skills/desktop-release-sync-landing/agents/openai.yaml
+++ b/.codex/skills/desktop-release-sync-landing/agents/openai.yaml
@@ -1,4 +1,4 @@
 interface:
   display_name: "桌面端发版同步 Landing"
-  short_description: "桌面端发版时同步 landing 官网版本和 latest.json 清单。"
-  default_prompt: "协助完成 Hermes Agent CN 桌面端发版，并同步更新 landing 仓库的官网版本与 latest.json 清单。"
+  short_description: "stable 正式发版时同步 landing 官网版本和 latest.json 清单；预发布禁止同步。"
+  default_prompt: "协助完成 Hermes Agent CN 桌面端 stable 正式发版，并同步更新 landing 仓库的官网版本与 latest.json 清单。RC、beta、alpha、canary 等预发布或内测版本禁止修改 landing 仓库，禁止更新 public latest.json。"

--- a/AGENTS.md
+++ b/AGENTS.md
@@ -86,9 +86,12 @@ Hermes CN 的需求与 bug 修复通常**同时横跨 Desktop 与 Core 两个仓
 `.codex/skills/desktop-dual-repo-test/SKILL.md`。
 
 发版、版本号更新、安装包发布或 GitHub Release 相关任务必须按顺序使用仓库内技能：**先过** `.codex/skills/desktop-release-preflight/SKILL.md`（发版前安全闸门：防内核静默降级 / 防 schema 重置 / identifier 不变 / 公证签名 / 国内镜像先有 artifactUrl 再发清单 / 先发 canary），**再做** `.codex/skills/desktop-release-sync-landing/SKILL.md`（版本同步与官网清单）。
-只要桌面端公开版本发生变化，就必须同步处理 `Eynzof/hermes-agent-cn-desktop-landing`，
+只要桌面端 **stable/正式公开版本** 发生变化，就必须同步处理 `Eynzof/hermes-agent-cn-desktop-landing`，
 更新官网版本与 `https://desktop.hermesagent.org.cn/latest.json` 清单；如果 release 资产尚未生成，
-需要明确说明 Landing 同步被阻塞，不能把桌面端发版任务当作已经完整结束。
+需要明确说明 Landing 同步被阻塞，不能把正式发版任务当作已经完整结束。
+**RC / beta / alpha / canary 等预发布或内测版本禁止修改 Landing 仓库，禁止更新官网版本，
+禁止让 `https://desktop.hermesagent.org.cn/latest.json` 指向预发布版本。** 预发布版本只能通过
+GitHub Release、手工分发或明确的内测渠道验证，不能暴露给全量用户的官网入口和自动更新清单。
 
 ### 启动顺序
 


### PR DESCRIPTION
## Summary\n- 明确 RC / beta / alpha / canary 等预发布版本禁止修改 Landing 仓库\n- 明确 public latest.json 只允许指向 stable/正式公开版本\n- 同步更新 release preflight、landing sync、dual repo test 和子代理提示\n\n## Tests\n- git diff --check