### PR TITLE
fix: 修复会话历史请求超出内核分页上限

### DIFF
--- a/web/src/hooks/use-sessions.test.ts
+++ b/web/src/hooks/use-sessions.test.ts
@@ -3,6 +3,7 @@ import type { MessagesResponse, SearchResult, SessionsResponse, SessionSummary }
 import { fetchJSON } from "@/lib/transport";
 import {
   deleteSessionsInBatches,
+  fetchSessionsList,
   fetchSessionMessages,
   withoutSearchResults,
   withoutSessions,
@@ -36,6 +37,15 @@ function sessionsResponse(ids: string[]): SessionsResponse {
     total: ids.length,
     limit: 50,
     offset: 0,
+  };
+}
+
+function sessionsPage(ids: string[], total: number, limit: number, offset: number): SessionsResponse {
+  return {
+    sessions: ids.map(session),
+    total,
+    limit,
+    offset,
   };
 }
 
@@ -89,6 +99,69 @@ describe("deleteSessionsInBatches", () => {
     expect(result.failed).toEqual([{ id: "s2", error: "boom" }]);
     expect(result.successCount).toBe(2);
     expect(result.failureCount).toBe(1);
+  });
+});
+
+describe("fetchSessionsList", () => {
+  beforeEach(() => {
+    mockFetchJSON.mockReset();
+  });
+
+  it("keeps requests within the Core page-size cap", async () => {
+    mockFetchJSON.mockImplementation(async (path: string) => {
+      if (path === "/api/sessions?limit=100&offset=0&include_archived=true") {
+        return sessionsPage(Array.from({ length: 100 }, (_, i) => `s${i}`), 150, 100, 0);
+      }
+      if (path === "/api/sessions?limit=50&offset=100&include_archived=true") {
+        return sessionsPage(Array.from({ length: 50 }, (_, i) => `s${i + 100}`), 150, 50, 100);
+      }
+      throw new Error(`unexpected ${path}`);
+    });
+
+    const result = await fetchSessionsList(200, 0, { includeArchived: true });
+
+    expect(result.sessions).toHaveLength(150);
+    expect(result.sessions[0]?.id).toBe("s0");
+    expect(result.sessions[149]?.id).toBe("s149");
+    expect(result.total).toBe(150);
+    expect(result.limit).toBe(200);
+    expect(result.offset).toBe(0);
+    expect(mockFetchJSON.mock.calls.map((call) => call[0])).toEqual([
+      "/api/sessions?limit=100&offset=0&include_archived=true",
+      "/api/sessions?limit=50&offset=100&include_archived=true",
+    ]);
+  });
+
+  it("preserves requested offset when aggregating multiple pages", async () => {
+    mockFetchJSON.mockImplementation(async (path: string) => {
+      if (path === "/api/sessions?limit=100&offset=20") {
+        return sessionsPage(Array.from({ length: 100 }, (_, i) => `s${i + 20}`), 300, 100, 20);
+      }
+      if (path === "/api/sessions?limit=50&offset=120") {
+        return sessionsPage(Array.from({ length: 50 }, (_, i) => `s${i + 120}`), 300, 50, 120);
+      }
+      throw new Error(`unexpected ${path}`);
+    });
+
+    const result = await fetchSessionsList(150, 20);
+
+    expect(result.sessions).toHaveLength(150);
+    expect(result.sessions[0]?.id).toBe("s20");
+    expect(result.sessions[149]?.id).toBe("s169");
+    expect(result.total).toBe(300);
+    expect(result.limit).toBe(150);
+    expect(result.offset).toBe(20);
+  });
+
+  it("uses a single request when the requested limit fits the backend cap", async () => {
+    mockFetchJSON.mockResolvedValue(sessionsPage(["s1", "s2"], 2, 50, 0));
+
+    const result = await fetchSessionsList(50, 0);
+
+    expect(result.sessions.map((item) => item.id)).toEqual(["s1", "s2"]);
+    expect(mockFetchJSON.mock.calls.map((call) => call[0])).toEqual([
+      "/api/sessions?limit=50&offset=0",
+    ]);
   });
 });
 

--- a/web/src/hooks/use-sessions.ts
+++ b/web/src/hooks/use-sessions.ts
@@ -12,6 +12,7 @@ import {
 } from "@hermes/protocol";
 
 export const DELETE_SESSION_CONCURRENCY = 3;
+export const SESSIONS_API_PAGE_LIMIT = 100;
 
 export interface DeleteSessionsFailure {
   id: string;
@@ -76,17 +77,77 @@ export interface UseSessionsOptions {
   includeArchived?: boolean;
 }
 
+interface FetchSessionsOptions extends UseSessionsOptions {
+  signal?: AbortSignal;
+}
+
+function sessionsPath(limit: number, offset: number, includeArchived: boolean): string {
+  return `/api/sessions?limit=${limit}&offset=${offset}${includeArchived ? "&include_archived=true" : ""}`;
+}
+
+function normalizePageNumber(value: number, fallback: number): number {
+  if (!Number.isFinite(value)) return fallback;
+  return Math.max(0, Math.floor(value));
+}
+
+export async function fetchSessionsList(
+  limit = 50,
+  offset = 0,
+  opts: FetchSessionsOptions = {},
+): Promise<SessionsResponse> {
+  const requestedLimit = normalizePageNumber(limit, 50);
+  const requestedOffset = normalizePageNumber(offset, 0);
+  const includeArchived = opts.includeArchived ?? false;
+
+  const firstLimit = Math.min(requestedLimit, SESSIONS_API_PAGE_LIMIT);
+  const first = await fetchJSON(
+    sessionsPath(firstLimit, requestedOffset, includeArchived),
+    { signal: opts.signal },
+    SessionsResponse,
+  );
+
+  if (requestedLimit <= SESSIONS_API_PAGE_LIMIT) return first;
+
+  const sessions = [...first.sessions];
+  let total = first.total;
+  let nextOffset = requestedOffset + sessions.length;
+  let remaining = Math.min(
+    requestedLimit - sessions.length,
+    Math.max(0, total - nextOffset),
+  );
+
+  while (remaining > 0) {
+    const pageLimit = Math.min(remaining, SESSIONS_API_PAGE_LIMIT);
+    const page = await fetchJSON(
+      sessionsPath(pageLimit, nextOffset, includeArchived),
+      { signal: opts.signal },
+      SessionsResponse,
+    );
+    total = page.total;
+    if (page.sessions.length === 0) break;
+    sessions.push(...page.sessions);
+    nextOffset += page.sessions.length;
+    remaining = Math.min(
+      requestedLimit - sessions.length,
+      Math.max(0, total - nextOffset),
+    );
+  }
+
+  return {
+    ...first,
+    sessions,
+    total,
+    limit: requestedLimit,
+    offset: requestedOffset,
+  };
+}
+
 export function useSessions(limit = 50, offset = 0, opts: UseSessionsOptions = {}) {
   const profile = useActiveProfileName();
   const includeArchived = opts.includeArchived ?? false;
   return useQuery<SessionsResponse>({
     queryKey: ["sessions", profile, limit, offset, includeArchived ? "all" : "active"],
-    queryFn: ({ signal }) =>
-      fetchJSON(
-        `/api/sessions?limit=${limit}&offset=${offset}${includeArchived ? "&include_archived=true" : ""}`,
-        { signal },
-        SessionsResponse,
-      ),
+    queryFn: ({ signal }) => fetchSessionsList(limit, offset, { includeArchived, signal }),
   });
 }
 


### PR DESCRIPTION
## Summary\n- 修复历史页 / 项目页 / 命令面板请求 useSessions(200) 时超过 Core /api/sessions limit<=100 的问题\n- 在 useSessions 公共层按 100 分页聚合，保留调用方请求 150/200 条的语义\n- 增加单测覆盖 include_archived 与 offset 聚合路径\n\n## Diagnosis\n- rc3 历史页请求 /api/sessions?limit=200&offset=0&include_archived=true\n- runtime-v0.20.0-cn.5 Core 返回 422: limit must be <= 100\n- 当前本机 /api/sessions?limit=100&include_archived=true 返回 200，数据未丢失\n\n## Tests\n- pnpm install --frozen-lockfile\n- pnpm --dir web test:unit -- use-sessions.test.ts\n- pnpm --dir web typecheck\n- git diff --check