### PR TITLE
chore: 准备桌面端 0.8.0-rc4

### DIFF
--- a/.github/workflows/release-desktop.yml
+++ b/.github/workflows/release-desktop.yml
@@ -1,5 +1,5 @@
 # Build hermes-agent-cn-desktop installers and attach them to a GitHub
-# Release. Triggers on tags matching `v*` (e.g. `v0.8.0-rc3`).
+# Release. Triggers on tags matching `v*` (e.g. `v0.8.0-rc4`).
 #
 # Desktop release build runs in parallel for Windows, macOS, and Linux. Each job:
 #   1. Installs Node 22 + pnpm + Rust toolchain
@@ -30,7 +30,7 @@ on:
   workflow_dispatch:
     inputs:
       tag:
-        description: "Tag name to associate the build with (e.g. v0.8.0-rc3)"
+        description: "Tag name to associate the build with (e.g. v0.8.0-rc4)"
         required: true
       bundled_runtime_tag:
         description: "Hermes-CN-Core runtime release tag to embed in desktop installers, or latest"

--- a/Cargo.lock
+++ b/Cargo.lock
@@ -1981,7 +1981,7 @@ checksum = "2304e00983f87ffb38b55b444b5e3b60a884b5d30c0fca7d82fe33449bbe55ea"
 
 [[package]]
 name = "hermes-agent-cn-desktop"
-version = "0.8.0-rc3"
+version = "0.8.0-rc4"
 dependencies = [
  "base64 0.22.1",
  "bytes",

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -1,6 +1,6 @@
 [package]
 name = "hermes-agent-cn-desktop"
-version = "0.8.0-rc3"
+version = "0.8.0-rc4"
 edition = "2021"
 description = "Hermes Agent CN Desktop (Tauri)"
 authors = ["Hermes Agent CN Contributors"]

--- a/README.en-US.md
+++ b/README.en-US.md
@@ -12,7 +12,7 @@ Hermes Agent CN Desktop is a desktop client from the Hermes Agent Chinese commun
 
 Official site and downloads: [desktop.hermesagent.org.cn](https://desktop.hermesagent.org.cn). The desktop app is part of the [Hermes Agent Chinese Community](https://hermesagent.org.cn) ecosystem, where the main site links to Chinese docs, practice guides, community entry points, and more ecosystem projects.
 
-> Current release: `v0.8.0-rc3`. The project is still moving quickly. APIs, packaging, runtime distribution, and UI details may continue to change.
+> Current release: `v0.8.0-rc4`. The project is still moving quickly. APIs, packaging, runtime distribution, and UI details may continue to change.
 
 ## Hermes Agent Chinese Community
 
@@ -95,9 +95,9 @@ Installers are available from the [desktop website](https://desktop.hermesagent.
 
 The current release includes:
 
-- macOS Apple Silicon DMG: `Hermes.Agent.CN.Desktop_0.8.0-rc3_aarch64.dmg`
-- macOS Intel DMG: `Hermes.Agent.CN.Desktop_0.8.0-rc3_x64.dmg`
-- Windows x64 installer: `Hermes.Agent.CN.Desktop_0.8.0-rc3_x64-setup.exe`
+- macOS Apple Silicon DMG: `Hermes.Agent.CN.Desktop_0.8.0-rc4_aarch64.dmg`
+- macOS Intel DMG: `Hermes.Agent.CN.Desktop_0.8.0-rc4_x64.dmg`
+- Windows x64 installer: `Hermes.Agent.CN.Desktop_0.8.0-rc4_x64-setup.exe`
 
 Both the Windows and macOS installers include a bundled `Hermes-CN-Core` runtime. On first launch, the app initializes the local core from the bundled runtime first; managed runtime download/update is only used for upgrades or fallback repair.
 

--- a/README.md
+++ b/README.md
@@ -12,7 +12,7 @@ Hermes Agent CN Desktop 是 Hermes Agent 中文社区推出的桌面客户端，
 
 官网与下载页见 [desktop.hermesagent.org.cn](https://desktop.hermesagent.org.cn)。桌面端隶属于 [Hermes Agent 中文社区](https://hermesagent.org.cn) 生态，社区主站提供中文文档、实践指南、社群入口和更多生态项目。
 
-> 当前版本是 `v0.8.0-rc3`。项目仍在快速迭代，API、打包流程、运行时分发策略和界面细节都可能继续调整。
+> 当前版本是 `v0.8.0-rc4`。项目仍在快速迭代，API、打包流程、运行时分发策略和界面细节都可能继续调整。
 
 ## Hermes Agent 中文社区
 
@@ -96,9 +96,9 @@ Hermes Agent 已经提供本地 Dashboard。本仓库专注于 Dashboard 之外�
 
 当前版本包含：
 
-- macOS Apple Silicon DMG：`Hermes.Agent.CN.Desktop_0.8.0-rc3_aarch64.dmg`
-- macOS Intel DMG：`Hermes.Agent.CN.Desktop_0.8.0-rc3_x64.dmg`
-- Windows x64 安装器：`Hermes.Agent.CN.Desktop_0.8.0-rc3_x64-setup.exe`
+- macOS Apple Silicon DMG：`Hermes.Agent.CN.Desktop_0.8.0-rc4_aarch64.dmg`
+- macOS Intel DMG：`Hermes.Agent.CN.Desktop_0.8.0-rc4_x64.dmg`
+- Windows x64 安装器：`Hermes.Agent.CN.Desktop_0.8.0-rc4_x64-setup.exe`
 
 当前 Windows 与 macOS 安装包都会预置 `Hermes-CN-Core` runtime，安装后优先从包内 runtime 完成本地内核初始化；托管 runtime 下载与更新流程只作为升级或兜底路径使用。
 

--- a/docs/macos-signing-and-notarization.md
+++ b/docs/macos-signing-and-notarization.md
@@ -117,7 +117,7 @@ target/aarch64-apple-darwin/release/bundle/dmg/*.dmg
 如果需要手动公证和 staple，可以对最终 DMG 执行：
 
 ```bash
-DMG="target/aarch64-apple-darwin/release/bundle/dmg/Hermes Agent CN Desktop_0.8.0-rc3_aarch64.dmg"
+DMG="target/aarch64-apple-darwin/release/bundle/dmg/Hermes Agent CN Desktop_0.8.0-rc4_aarch64.dmg"
 
 xcrun notarytool submit "$DMG" \
   --key "$APPLE_API_KEY_PATH" \

--- a/docs/managed-runtime.md
+++ b/docs/managed-runtime.md
@@ -276,7 +276,7 @@ fork CI release-runtime.yml 触发：
 ## 六、桌面端升级
 
 ```
-你 git tag v0.8.0-rc3; git push origin v0.8.0-rc3
+你 git tag v0.8.0-rc4; git push origin v0.8.0-rc4
   ↓
 desktop CI release-desktop.yml 触发：
   matrix: windows-latest / macos-14 (arm64)
@@ -289,7 +289,7 @@ desktop CI release-desktop.yml 触发：
     5. tauri-apps/tauri-action@v0 → 打 .exe / .dmg
        runtime URL + 公钥仍是 baked-in 兜底，不需要 env wire 进 CI
   ↓
-新装包发到 releases/v0.8.0-rc3 → 用户下载装新版
+新装包发到 releases/v0.8.0-rc4 → 用户下载装新版
   ↓
 新版起来后，看到 current.json 已经有 runtime → 不下载 → 直接用。
 全新安装则先使用安装包内置 runtime；除非内置资源缺失或用户主动升级，

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "hermes-agent-cn-desktop",
-  "version": "0.8.0-rc3",
+  "version": "0.8.0-rc4",
   "private": true,
   "author": "Hermes Agent CN Contributors",
   "homepage": "https://hermesagent.org.cn",

--- a/packages/protocol/package.json
+++ b/packages/protocol/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@hermes/protocol",
-  "version": "0.8.0-rc3",
+  "version": "0.8.0-rc4",
   "private": true,
   "type": "module",
   "main": "./src/index.ts",

--- a/packages/shared-ui/package.json
+++ b/packages/shared-ui/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@hermes/shared-ui",
-  "version": "0.8.0-rc3",
+  "version": "0.8.0-rc4",
   "private": true,
   "type": "module",
   "main": "./src/index.ts",

--- a/tauri.conf.json
+++ b/tauri.conf.json
@@ -1,7 +1,7 @@
 {
   "$schema": "https://raw.githubusercontent.com/nicegoodthings/tauri-schema/main/tauri.conf.schema.json",
   "productName": "Hermes Agent CN Desktop",
-  "version": "0.8.0-rc3",
+  "version": "0.8.0-rc4",
   "identifier": "cn.org.hermesagent.desktop",
   "build": {
     "beforeDevCommand": "pnpm --filter @hermes/web dev",

--- a/web/package.json
+++ b/web/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@hermes/web",
-  "version": "0.8.0-rc3",
+  "version": "0.8.0-rc4",
   "private": true,
   "type": "module",
   "scripts": {


### PR DESCRIPTION
## 变更

- 将桌面端版本从 `0.8.0-rc3` 同步到 `0.8.0-rc4`
- RC4 包含已合并的会话历史分页上限修复 #550（`4e40823a812108129e99b4dea20f990e645d3cd8`）
- 保持内置 runtime 为明确版本 `runtime-v0.20.0-cn.5`

## 发布边界

- 仅发布 GitHub 预发布版本 `v0.8.0-rc4`
- 不修改 Landing 仓库
- 不更新官网版本或线上 `latest.json`
- 不创建正式版 `v0.8.0`

## 验证

- `pnpm typecheck`
- `pnpm --filter @hermes/web exec vitest run src/hooks/use-sessions.test.ts`（11 tests）
- `cargo check`
- `git diff --check`