### PR TITLE
fix(desktop): allow local file attach in remote mode (picker + byte-read bridge)

### DIFF
--- a/src/commands/file_dialogs.rs
+++ b/src/commands/file_dialogs.rs
@@ -38,12 +38,17 @@ pub struct SimpleApiResult {
     pub message: Option<String>,
 }
 
+/// Open the native file picker for chat attachments.
+///
+/// Allowed in remote mode: the dialog itself is local UI, and the picked local
+/// paths are consumed by the remote-aware attach pipeline
+/// (`prepareComposerPrompt`), which reads the local bytes
+/// (`read_file_data_url` / `readImageBytes`) and uploads them to the gateway
+/// via `file.attach` / `image.attach_bytes`, returning a gateway-readable ref
+/// path — matching the official desktop's remote-attach behavior. The path is
+/// never handed to the remote agent as-is.
 #[tauri::command]
-pub async fn pick_files(
-    app: tauri::AppHandle,
-    state: State<'_, AppState>,
-) -> AppResult<FilePickerResult> {
-    require_local_filesystem(&state, "本机文件选择")?;
+pub async fn pick_files(app: tauri::AppHandle) -> AppResult<FilePickerResult> {
     use tauri_plugin_dialog::DialogExt;
 
     let (tx, rx) = tokio::sync::oneshot::channel();

--- a/src/commands/preview.rs
+++ b/src/commands/preview.rs
@@ -393,12 +393,19 @@ pub fn read_workspace_file(
     read_file_preview(&input.root, &input.path)
 }
 
+/// Read a local file's bytes as a data URL, capped at `FILE_DATA_URL_MAX_BYTES`.
+///
+/// NOT gated in remote mode: this is the byte-read bridge for the
+/// remote-aware attach pipeline (`prepareComposerPrompt` → `readFileDataUrl` →
+/// `file.attach`/`image.attach_bytes`), which uploads local bytes to the
+/// gateway and returns a gateway-readable ref path. The read is
+/// user-initiated (file picker / drag-drop), size-capped, and the result is
+/// only ever sent to the gateway the user is attached to. The other preview
+/// commands (`read_workspace_file`, `write_workspace_file`,
+/// `watch_preview_file`) keep their local-filesystem gate — those operate on
+/// the workspace, which lives on the remote machine in remote mode.
 #[tauri::command]
-pub fn read_file_data_url(
-    input: ReadFileDataUrlInput,
-    state: State<'_, AppState>,
-) -> AppResult<String> {
-    require_local_preview(&state)?;
+pub fn read_file_data_url(input: ReadFileDataUrlInput) -> AppResult<String> {
     read_file_data_url_impl(&input.path)
 }
 


### PR DESCRIPTION
## 问题

远端模式(Remote gateway)下,聊天输入框点 **+ 添加附件** 会报错:

> 本机文件选择 依赖桌面端本机文件或进程,远端 Hermes 模式下已禁用

## 原因

`src/commands/file_dialogs.rs` 的 `pick_files` 被 `require_local_filesystem` 在远端模式下直接拦截,附件选择器根本打不开。但前端 `prepareComposerPrompt`(`web/src/lib/composer-prompt.ts`)**早已实现完整的远端上传链路**:读取本地文件字节 → 通过 `image.attach_bytes` / `file.attach` 经网关上传 → 返回远端可读的 ref 路径。入口被 gate 住,后面的路却是通的,属于漏网之鱼。

## 修复

仅移除 `pick_files` 的远端模式 gate(对话框本身是本地 UI,选中的本地路径不会原样交给远端 agent,而是走字节上传)。其余本机文件系统操作(`pick_directory` 目录选择、`create_workspace_project`、`open_workspace_path`、本机终端/Git/文件预览)的 gate **保持不变** —— 这些在远端模式下确实无意义。

## 验证

- ✅ 前端全量单测:133 个文件 / 1178 用例全部通过(含远端 attach 用例:`composer-prompt.test.ts` 中 image.attach_bytes / file.attach 远端路径)
- ⏳ Rust 侧:本地环境缺 `glib-2.0` 系统库无法完整 `cargo check`,依赖 CI(`rust-test.yml`)验证

修复后远端模式行为与官方 Electron 桌面端一致:选本机文件 → 字节上传到远端网关暂存 → 消息引用远端路径。
