### PR TITLE
feat: 新增护眼浅绿/浅黄主题（soft-green / soft-warm）

### DIFF
--- a/packages/shared-ui/src/hooks/use-theme.ts
+++ b/packages/shared-ui/src/hooks/use-theme.ts
@@ -6,7 +6,9 @@ export type ThemeVariant =
   | "dark"
   | "dark-modern"
   | "dracula"
-  | "catppuccin-mocha";
+  | "catppuccin-mocha"
+  | "soft-green"
+  | "soft-warm";
 export type DensityVariant = "comfortable" | "compact";
 /** Global interface scale steps. Maps to a single CSS `zoom` on the document
  *  root so text, spacing and icons enlarge together — see {@link SCALE_FACTORS}. */
@@ -46,6 +48,8 @@ const THEME_VARIANTS = new Set<ThemeVariant>([
   "dark-modern",
   "dracula",
   "catppuccin-mocha",
+  "soft-green",
+  "soft-warm",
 ]);
 const SCALE_VARIANTS = new Set<ScaleVariant>(["sm", "md", "lg", "xl", "2xl"]);
 

--- a/packages/shared-ui/src/tokens/colors.css
+++ b/packages/shared-ui/src/tokens/colors.css
@@ -235,12 +235,72 @@
   --rust: #f38ba8;
 }
 
+[data-theme="soft-green"] {
+  /* Eye-friendly green: classic bean-green canvas, dark green text. */
+  --h-bg-app: #c7edcc;
+  --h-bg-pane: #d9f2dc;
+  --h-bg-soft: #cfe8d3;
+  --h-bg-input: #eaf7eb;
+  --h-bg-chip: #bde4c2;
+  --h-bg-code: #d2ecd6;
+  --h-line: #9dcba3;
+  --h-line-soft: #b4dcb9;
+  --h-text: #1e3b1e;
+  --h-text-2: #365736;
+  --h-text-3: #557455;
+  --h-text-4: #7c9a7c;
+  --h-shadow: none;
+  --h-shadow-l: none;
+  --h-shadow-soft: none;
+  --h-sidebar-stripe: #c7edcc;
+  --h-accent: #2e7d32;
+  --h-accent-contrast: #ffffff;
+  --h-accent-soft: rgba(46, 125, 50, 0.14);
+  --h-accent-border: #7cb882;
+  --sky: #4c7a9c;
+  --plum: #8e44ad;
+  --amber: #9d6b00;
+  --moss: #2e7d32;
+  --rust: #c4554d;
+}
+
+[data-theme="soft-warm"] {
+  /* Eye-friendly warm: solarized-style cream canvas, warm brown text. */
+  --h-bg-app: #fdf6e3;
+  --h-bg-pane: #fff9ec;
+  --h-bg-soft: #f8f0d9;
+  --h-bg-input: #fefbf2;
+  --h-bg-chip: #f0e6c9;
+  --h-bg-code: #f7eed6;
+  --h-line: #e0d3b6;
+  --h-line-soft: #ebe0c6;
+  --h-text: #4a3b2a;
+  --h-text-2: #66533d;
+  --h-text-3: #87745c;
+  --h-text-4: #a6967f;
+  --h-shadow: none;
+  --h-shadow-l: none;
+  --h-shadow-soft: none;
+  --h-sidebar-stripe: #fdf6e3;
+  --h-accent: #8a6d3b;
+  --h-accent-contrast: #ffffff;
+  --h-accent-soft: rgba(138, 109, 59, 0.14);
+  --h-accent-border: #c4ab7d;
+  --sky: #4c7a9c;
+  --plum: #8e44ad;
+  --amber: #b58900;
+  --moss: #6b8e5a;
+  --rust: #c4554d;
+}
+
 /* ── PrimeAPP tri-state status palette
    Black / white / grey remain the structural palette. Operational states use
    only PrimeAPP green, yellow and red across every theme. */
 :root,
 [data-theme="light"],
-[data-theme="light-modern"] {
+[data-theme="light-modern"],
+[data-theme="soft-green"],
+[data-theme="soft-warm"] {
   --h-ok: var(--h-palette-success-light-fg);
   --h-ok-soft: var(--h-palette-success-light-surface);
   --h-ok-border: var(--h-palette-success-light-border);

--- a/web/src/lib/theme-defaults.test.ts
+++ b/web/src/lib/theme-defaults.test.ts
@@ -17,6 +17,8 @@ describe("theme defaults", () => {
     expect(normalizeThemeConfig({ theme: "dark-modern" })).toEqual({ theme: "dark-modern", density: "comfortable", scale: "md" });
     expect(normalizeThemeConfig({ theme: "dracula" })).toEqual({ theme: "dracula", density: "comfortable", scale: "md" });
     expect(normalizeThemeConfig({ theme: "catppuccin-mocha" })).toEqual({ theme: "catppuccin-mocha", density: "comfortable", scale: "md" });
+    expect(normalizeThemeConfig({ theme: "soft-green" })).toEqual({ theme: "soft-green", density: "comfortable", scale: "md" });
+    expect(normalizeThemeConfig({ theme: "soft-warm" })).toEqual({ theme: "soft-warm", density: "comfortable", scale: "md" });
   });
 
   it("falls back to modern light for unsupported stored skins", () => {

--- a/web/src/routes/settings.tsx
+++ b/web/src/routes/settings.tsx
@@ -440,6 +440,26 @@ const THEME_SKINS: Array<{
     text: "#cdd6f4",
     accent: "#cba6f7",
   },
+  {
+    value: "soft-green",
+    label: "护眼浅绿",
+    sub: "豆沙绿低刺激",
+    bg: "#c7edcc",
+    pane: "#d9f2dc",
+    soft: "#cfe8d3",
+    text: "#1e3b1e",
+    accent: "#2e7d32",
+  },
+  {
+    value: "soft-warm",
+    label: "护眼浅黄",
+    sub: "暖米黄低刺激",
+    bg: "#fdf6e3",
+    pane: "#fff9ec",
+    soft: "#f8f0d9",
+    text: "#4a3b2a",
+    accent: "#8a6d3b",
+  },
 ];
 
 function AppearanceRow({


### PR DESCRIPTION
# feat: 新增「护眼浅绿 / 护眼浅黄」主题（soft-green / soft-warm）

## 背景

当前桌面版仅有 6 种主题（浅色 / 社区浅色 / 经典深色 / 社区深色 / Dracula / Catppuccin Mocha），缺少主流护眼浅色背景（浅绿 / 浅黄）。长时间使用深色高对比或纯白背景容易视疲劳，社区常见的护眼方案是低饱和浅绿（豆沙绿）与暖米黄（Solarized 系）背景。

本 PR 新增两个低刺激护眼主题，与现有主题体系完全一致（`data-theme` + 设计令牌），**不改变任何现有主题行为**。

## 改动

| 文件 | 改动 |
|---|---|
| `packages/shared-ui/src/hooks/use-theme.ts` | `ThemeVariant` 联合类型 + `THEME_VARIANTS` 集合新增 `soft-green` / `soft-warm` |
| `packages/shared-ui/src/tokens/colors.css` | 新增两个 `[data-theme=...]` 令牌块；并将二者加入浅色状态色组（light 组）选择器 |
| `web/src/routes/settings.tsx` | `THEME_SKINS` 新增两个皮肤卡片（预览色 + 中文标签） |
| `web/src/lib/theme-defaults.test.ts` | `normalizeThemeConfig` 增加两个新主题的断言 |

## 配色

### soft-green（护眼浅绿 / 豆沙绿）
- 画布 `#c7edcc`（经典豆沙绿），面板 `#d9f2dc`
- 正文 `#1e3b1e`（深墨绿，对比度 ≈ 7.5:1）
- 强调色 `#2e7d32`（Material Green 800）

### soft-warm（护眼浅黄 / 暖米黄）
- 画布 `#fdf6e3`（Solarized base3），面板 `#fff9ec`
- 正文 `#4a3b2a`（深暖棕，对比度 ≈ 9.5:1）
- 强调色 `#8a6d3b`（深琥珀）

两套主题均保留完整 `--h-*` 令牌（含状态色、accent、border 等），并继承浅色组的 PrimeAPP 三态状态色。

## 测试

- `pnpm test:unit`（vitest）：`theme-defaults.test.ts` 新增两条断言已包含（`normalizeThemeConfig` 接受新主题、未知值仍回退 `light-modern`）
- 本地已用 Node 复刻 `normalizeThemeConfig` 逻辑验证：`soft-green` / `soft-warm` 均被正确接受，`legacy` 等未知值正常回退

## 截图

（可在本地 `pnpm dev` 后于 设置 → 主题 中查看）
