### PR TITLE
chore: 发布 v0.8.0-rc5 内测版

### DIFF
--- a/.github/workflows/release-desktop.yml
+++ b/.github/workflows/release-desktop.yml
@@ -1,5 +1,5 @@
 # Build hermes-agent-cn-desktop installers and attach them to a GitHub
-# Release. Triggers on tags matching `v*` (e.g. `v0.8.0-rc4`).
+# Release. Triggers on tags matching `v*` (e.g. `v0.8.0-rc5`).
 #
 # Desktop release build runs in parallel for Windows, macOS, and Linux. Each job:
 #   1. Installs Node 22 + pnpm + Rust toolchain
@@ -30,11 +30,11 @@ on:
   workflow_dispatch:
     inputs:
       tag:
-        description: "Tag name to associate the build with (e.g. v0.8.0-rc4)"
+        description: "Tag name to associate the build with (e.g. v0.8.0-rc5)"
         required: true
       bundled_runtime_tag:
         description: "Hermes-CN-Core runtime release tag to embed in desktop installers, or latest"
-        default: "runtime-v0.20.0-cn.5"
+        default: "runtime-v0.20.0-cn.7"
         required: false
 
 permissions:
@@ -115,7 +115,7 @@ jobs:
         shell: bash
         env:
           BUNDLED_RUNTIME_REPO: Eynzof/Hermes-CN-Core
-          BUNDLED_RUNTIME_TAG: ${{ github.event.inputs.bundled_runtime_tag || 'runtime-v0.20.0-cn.5' }}
+          BUNDLED_RUNTIME_TAG: ${{ github.event.inputs.bundled_runtime_tag || 'runtime-v0.20.0-cn.7' }}
           RUNTIME_PLATFORM: ${{ matrix.runtime_platform }}
           RUNTIME_ARCH: ${{ matrix.runtime_arch }}
         run: |
@@ -173,7 +173,7 @@ jobs:
           args=(
             scripts/stage-bundled-runtime.mjs
             --repo "Eynzof/Hermes-CN-Core"
-            --tag "${{ github.event.inputs.bundled_runtime_tag || 'runtime-v0.20.0-cn.5' }}"
+            --tag "${{ github.event.inputs.bundled_runtime_tag || 'runtime-v0.20.0-cn.7' }}"
             --platform "${{ matrix.runtime_platform }}"
             --arch "${{ matrix.runtime_arch }}"
           )

--- a/Cargo.lock
+++ b/Cargo.lock
@@ -1981,7 +1981,7 @@ checksum = "2304e00983f87ffb38b55b444b5e3b60a884b5d30c0fca7d82fe33449bbe55ea"
 
 [[package]]
 name = "hermes-agent-cn-desktop"
-version = "0.8.0-rc4"
+version = "0.8.0-rc5"
 dependencies = [
  "base64 0.22.1",
  "bytes",

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -1,6 +1,6 @@
 [package]
 name = "hermes-agent-cn-desktop"
-version = "0.8.0-rc4"
+version = "0.8.0-rc5"
 edition = "2021"
 description = "Hermes Agent CN Desktop (Tauri)"
 authors = ["Hermes Agent CN Contributors"]

--- a/README.en-US.md
+++ b/README.en-US.md
@@ -12,7 +12,7 @@ Hermes Agent CN Desktop is a desktop client from the Hermes Agent Chinese commun
 
 Official site and downloads: [desktop.hermesagent.org.cn](https://desktop.hermesagent.org.cn). The desktop app is part of the [Hermes Agent Chinese Community](https://hermesagent.org.cn) ecosystem, where the main site links to Chinese docs, practice guides, community entry points, and more ecosystem projects.
 
-> Current release: `v0.8.0-rc4`. The project is still moving quickly. APIs, packaging, runtime distribution, and UI details may continue to change.
+> Current release: `v0.8.0-rc5`. The project is still moving quickly. APIs, packaging, runtime distribution, and UI details may continue to change.
 
 ## ❤️ Sponsor
 
@@ -104,9 +104,9 @@ Installers are available from the [desktop website](https://desktop.hermesagent.
 
 The current release includes:
 
-- macOS Apple Silicon DMG: `Hermes.Agent.CN.Desktop_0.8.0-rc4_aarch64.dmg`
-- macOS Intel DMG: `Hermes.Agent.CN.Desktop_0.8.0-rc4_x64.dmg`
-- Windows x64 installer: `Hermes.Agent.CN.Desktop_0.8.0-rc4_x64-setup.exe`
+- macOS Apple Silicon DMG: `Hermes.Agent.CN.Desktop_0.8.0-rc5_aarch64.dmg`
+- macOS Intel DMG: `Hermes.Agent.CN.Desktop_0.8.0-rc5_x64.dmg`
+- Windows x64 installer: `Hermes.Agent.CN.Desktop_0.8.0-rc5_x64-setup.exe`
 
 Both the Windows and macOS installers include a bundled `Hermes-CN-Core` runtime. On first launch, the app initializes the local core from the bundled runtime first; managed runtime download/update is only used for upgrades or fallback repair.
 

--- a/README.md
+++ b/README.md
@@ -12,7 +12,7 @@ Hermes Agent CN Desktop 是 Hermes Agent 中文社区推出的桌面客户端，
 
 官网与下载页见 [desktop.hermesagent.org.cn](https://desktop.hermesagent.org.cn)。桌面端隶属于 [Hermes Agent 中文社区](https://hermesagent.org.cn) 生态，社区主站提供中文文档、实践指南、社群入口和更多生态项目。
 
-> 当前版本是 `v0.8.0-rc4`。项目仍在快速迭代，API、打包流程、运行时分发策略和界面细节都可能继续调整。
+> 当前版本是 `v0.8.0-rc5`。项目仍在快速迭代，API、打包流程、运行时分发策略和界面细节都可能继续调整。
 
 ## ❤️赞助商
 
@@ -105,9 +105,9 @@ Hermes Agent 已经提供本地 Dashboard。本仓库专注于 Dashboard 之外�
 
 当前版本包含：
 
-- macOS Apple Silicon DMG：`Hermes.Agent.CN.Desktop_0.8.0-rc4_aarch64.dmg`
-- macOS Intel DMG：`Hermes.Agent.CN.Desktop_0.8.0-rc4_x64.dmg`
-- Windows x64 安装器：`Hermes.Agent.CN.Desktop_0.8.0-rc4_x64-setup.exe`
+- macOS Apple Silicon DMG：`Hermes.Agent.CN.Desktop_0.8.0-rc5_aarch64.dmg`
+- macOS Intel DMG：`Hermes.Agent.CN.Desktop_0.8.0-rc5_x64.dmg`
+- Windows x64 安装器：`Hermes.Agent.CN.Desktop_0.8.0-rc5_x64-setup.exe`
 
 当前 Windows 与 macOS 安装包都会预置 `Hermes-CN-Core` runtime，安装后优先从包内 runtime 完成本地内核初始化；托管 runtime 下载与更新流程只作为升级或兜底路径使用。
 

--- a/docs/macos-signing-and-notarization.md
+++ b/docs/macos-signing-and-notarization.md
@@ -117,7 +117,7 @@ target/aarch64-apple-darwin/release/bundle/dmg/*.dmg
 如果需要手动公证和 staple，可以对最终 DMG 执行：
 
 ```bash
-DMG="target/aarch64-apple-darwin/release/bundle/dmg/Hermes Agent CN Desktop_0.8.0-rc4_aarch64.dmg"
+DMG="target/aarch64-apple-darwin/release/bundle/dmg/Hermes Agent CN Desktop_0.8.0-rc5_aarch64.dmg"
 
 xcrun notarytool submit "$DMG" \
   --key "$APPLE_API_KEY_PATH" \

--- a/docs/managed-runtime.md
+++ b/docs/managed-runtime.md
@@ -276,7 +276,7 @@ fork CI release-runtime.yml 触发：
 ## 六、桌面端升级
 
 ```
-你 git tag v0.8.0-rc4; git push origin v0.8.0-rc4
+你 git tag v0.8.0-rc5; git push origin v0.8.0-rc5
   ↓
 desktop CI release-desktop.yml 触发：
   matrix: windows-latest / macos-14 (arm64)
@@ -289,7 +289,7 @@ desktop CI release-desktop.yml 触发：
     5. tauri-apps/tauri-action@v0 → 打 .exe / .dmg
        runtime URL + 公钥仍是 baked-in 兜底，不需要 env wire 进 CI
   ↓
-新装包发到 releases/v0.8.0-rc4 → 用户下载装新版
+新装包发到 releases/v0.8.0-rc5 → 用户下载装新版
   ↓
 新版起来后，看到 current.json 已经有 runtime → 不下载 → 直接用。
 全新安装则先使用安装包内置 runtime；除非内置资源缺失或用户主动升级，

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "hermes-agent-cn-desktop",
-  "version": "0.8.0-rc4",
+  "version": "0.8.0-rc5",
   "private": true,
   "author": "Hermes Agent CN Contributors",
   "homepage": "https://hermesagent.org.cn",

--- a/packages/protocol/package.json
+++ b/packages/protocol/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@hermes/protocol",
-  "version": "0.8.0-rc4",
+  "version": "0.8.0-rc5",
   "private": true,
   "type": "module",
   "main": "./src/index.ts",

--- a/packages/shared-ui/package.json
+++ b/packages/shared-ui/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@hermes/shared-ui",
-  "version": "0.8.0-rc4",
+  "version": "0.8.0-rc5",
   "private": true,
   "type": "module",
   "main": "./src/index.ts",

--- a/src/update_config.rs
+++ b/src/update_config.rs
@@ -353,6 +353,7 @@ mod tests {
     }
 
     #[test]
+    #[serial_test::serial]
     fn missing_file_falls_back_to_defaults_without_error() {
         let dir = TempDir::new().unwrap();
         let load = load_from(&dir.path().join("nope.json"));
@@ -361,6 +362,7 @@ mod tests {
     }
 
     #[test]
+    #[serial_test::serial]
     fn corrupt_file_falls_back_with_config_error() {
         let dir = TempDir::new().unwrap();
         let path = write_config(&dir, "{ not json");
@@ -371,6 +373,7 @@ mod tests {
     }
 
     #[test]
+    #[serial_test::serial]
     fn parses_user_config_values() {
         let dir = TempDir::new().unwrap();
         let path = write_config(
@@ -401,6 +404,7 @@ mod tests {
     }
 
     #[test]
+    #[serial_test::serial]
     fn env_overrides_file_values() {
         let dir = TempDir::new().unwrap();
         let path = write_config(
@@ -457,6 +461,7 @@ mod tests {
     }
 
     #[test]
+    #[serial_test::serial]
     fn save_writes_atomically_and_loads_back() {
         let dir = TempDir::new().unwrap();
         let path = dir.path().join("sub").join(UPDATE_CONFIG_FILE);

--- a/tauri.conf.json
+++ b/tauri.conf.json
@@ -1,7 +1,7 @@
 {
   "$schema": "https://raw.githubusercontent.com/nicegoodthings/tauri-schema/main/tauri.conf.schema.json",
   "productName": "Hermes Agent CN Desktop",
-  "version": "0.8.0-rc4",
+  "version": "0.8.0-rc5",
   "identifier": "cn.org.hermesagent.desktop",
   "build": {
     "beforeDevCommand": "pnpm --filter @hermes/web dev",

--- a/web/package.json
+++ b/web/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@hermes/web",
-  "version": "0.8.0-rc4",
+  "version": "0.8.0-rc5",
   "private": true,
   "type": "module",
   "scripts": {

--- a/web/src/lib/build-info.ts
+++ b/web/src/lib/build-info.ts
@@ -11,7 +11,7 @@ export const DESKTOP_VERSION = import.meta.env.VITE_HERMES_DESKTOP_VERSION || UN
  * `/api/version` response that does not match this value triggers a fatal
  * compatibility dialog and force-quit.
  */
-export const EXPECTED_BACKEND_VERSION = "0.8.0-rc4";
+export const EXPECTED_BACKEND_VERSION = "0.8.0-rc5";
 export const BUILD_COMMIT = import.meta.env.VITE_HERMES_BUILD_COMMIT || "unknown";
 export const BUILD_DATE = import.meta.env.VITE_HERMES_BUILD_DATE || "unknown";
 


### PR DESCRIPTION
## 内测范围

- 发布版本：`v0.8.0-rc5`
- GitHub Release 必须标记为 prerelease
- 不修改 Landing、官网版本或公共 `latest.json`
- 合并并通过主分支复验后才创建标签

## 变更

- 将桌面端及关联包版本从 `0.8.0-rc4` 同步为 `0.8.0-rc5`
- 将 bundled Core runtime 从 `runtime-v0.20.0-cn.5` 锁定到当前最高 stable `runtime-v0.20.0-cn.7`
- 修复更新配置测试读取全局环境变量时的并行竞态

## 发版预检

- bundle identifier 保持 `cn.org.hermesagent.desktop`
- runtime manifest schema 保持 2
- Core `runtime-v0.20.0-cn.7` 四平台构建、签名 manifest 与 release 均已验证
- macOS 签名/公证/装订流程与所需 secrets 存在
- Windows SmartScreen 提示与覆盖安装前退出提示保留
- 发布前官网 `latest.json` 仍为 stable `v0.7.0`

## 本地验证

- `pnpm typecheck`
- `pnpm test:unit`：1324 项通过
- `cargo check`
- `cargo fmt --all -- --check`
- `cargo clippy --all-features --all-targets -- -D warnings`
- `cargo test --all-features --no-fail-fast --quiet`
- 更新配置相关测试连续 10 轮通过
