### PR TITLE
fix: 修复外部后端恢复与版本校验

### DIFF
--- a/web/src/lib/debug-install.ts
+++ b/web/src/lib/debug-install.ts
@@ -1,6 +1,7 @@
 import { LogsResponse } from "@hermes/protocol";
 import { debugBus, type DebugEntryLevel } from "./debug-bus";
 import { getGatewayClient } from "./gateway-client";
+import { runtime } from "./runtime";
 import { fetchJSON } from "./transport";
 
 let installed = false;
@@ -66,6 +67,7 @@ function startBackendLogTail(): () => void {
   const tick = async () => {
     if (stopped) return;
     if (typeof document !== "undefined" && document.hidden) return;
+    if (!runtime.isBackendReady()) return;
     await Promise.all(LOG_TAIL_FILES.map(pollBackendLogFile));
   };
 

--- a/web/src/lib/runtime.test.ts
+++ b/web/src/lib/runtime.test.ts
@@ -1,7 +1,13 @@
 import { afterEach, beforeEach, describe, expect, it } from "vitest";
 import { runtime } from "./runtime";
+import {
+  deferBackendVersionCheckForOfflineRuntime,
+  getVersionCheckState,
+  resetVersionCheck,
+} from "./version-check";
 
 beforeEach(() => {
+  resetVersionCheck();
   (globalThis as any).window = {
     __HERMES_RUNTIME__: {
       platform: "tauri",
@@ -152,10 +158,48 @@ describe("managed runtime control state", () => {
 
     expect(window.__HERMES_RUNTIME__).toMatchObject({
       backendReady: false,
+      backendRecoveryReason: "managed-runtime-offline",
       guideState: "deferred",
       managedRuntimeDesiredState: "uninstalled",
       managedRuntimeLifecycleState: "uninstalled",
     });
+    expect(getVersionCheckState()).toEqual({
+      kind: "deferred",
+      reason: "managed-runtime-offline",
+    });
     expect(window.__HERMES_RUNTIME__?.apiBaseUrl).toBe("http://old");
+  });
+
+  it("does not overwrite an attached backend recovery gate with managed control state", () => {
+    window.__HERMES_RUNTIME__ = {
+      platform: "tauri",
+      connectionMode: "remote",
+      apiBaseUrl: "https://remote.example.com",
+      backendReady: false,
+      backendRecoveryReason: "external-backend-auth-required",
+    };
+    deferBackendVersionCheckForOfflineRuntime();
+
+    runtime.applyRuntimeControlResult({
+      ok: true,
+      guideState: "completed",
+      desiredState: "running",
+      lifecycleState: "stopped",
+      installed: true,
+      running: false,
+      backendReady: true,
+    });
+
+    expect(window.__HERMES_RUNTIME__).toMatchObject({
+      connectionMode: "remote",
+      backendReady: false,
+      backendRecoveryReason: "external-backend-auth-required",
+      managedRuntimeDesiredState: "running",
+      managedRuntimeLifecycleState: "stopped",
+    });
+    expect(getVersionCheckState()).toEqual({
+      kind: "deferred",
+      reason: "managed-runtime-offline",
+    });
   });
 });

--- a/web/src/lib/runtime.ts
+++ b/web/src/lib/runtime.ts
@@ -1,4 +1,8 @@
-import { resetVersionCheck } from "./version-check";
+import {
+  deferBackendVersionCheckForOfflineRuntime,
+  resetVersionCheck,
+  type BackendRecoveryReason,
+} from "./version-check";
 import type {
   ApplyConnectionResult,
   BackupExportResult,
@@ -439,6 +443,8 @@ declare global {
       /** "managed" for desktop-owned runtime, "local"/"remote" for attached backends. */
       connectionMode?: ConnectionMode;
       backendReady?: boolean;
+      /** Why only the offline repair shell is mounted instead of the backend UI. */
+      backendRecoveryReason?: BackendRecoveryReason;
       guideState?: import("@hermes/protocol").GuideState;
       managedRuntimeDesiredState?: import("@hermes/protocol").ManagedRuntimeDesiredState;
       managedRuntimeLifecycleState?: import("@hermes/protocol").ManagedRuntimeLifecycleState;
@@ -623,10 +629,21 @@ export const runtime = {
 
   applyRuntimeControlResult(result: RuntimeControlResult): void {
     if (!window.__HERMES_RUNTIME__) return;
-    // A control result may indicate the managed runtime restarted/stopped; force
-    // a fresh version check before the next REST/WebSocket operation.
-    resetVersionCheck();
-    window.__HERMES_RUNTIME__.backendReady = result.backendReady;
+    // Managed-runtime control snapshots are also shown while attached to an
+    // external backend. In that mode they must not overwrite the external
+    // backend's readiness/recovery gate. For managed mode, preserve the
+    // intentional-offline exemption after stop/uninstall refreshes.
+    if (window.__HERMES_RUNTIME__.connectionMode !== "local"
+      && window.__HERMES_RUNTIME__.connectionMode !== "remote") {
+      resetVersionCheck();
+      window.__HERMES_RUNTIME__.backendReady = result.backendReady;
+      if (!result.backendReady && result.desiredState !== "running") {
+        deferBackendVersionCheckForOfflineRuntime();
+        window.__HERMES_RUNTIME__.backendRecoveryReason = "managed-runtime-offline";
+      } else {
+        window.__HERMES_RUNTIME__.backendRecoveryReason = undefined;
+      }
+    }
     window.__HERMES_RUNTIME__.guideState = result.guideState;
     window.__HERMES_RUNTIME__.managedRuntimeDesiredState = result.desiredState;
     window.__HERMES_RUNTIME__.managedRuntimeLifecycleState = result.lifecycleState;

--- a/web/src/lib/tauri-bridge.test.ts
+++ b/web/src/lib/tauri-bridge.test.ts
@@ -46,6 +46,15 @@ beforeEach(() => {
         currentProfile: "default",
       });
     }
+    if (command === "api_request") {
+      return Promise.resolve({
+        ok: true,
+        status: 200,
+        statusText: "OK",
+        headers: { "content-type": "application/json" },
+        body: JSON.stringify({ version: EXPECTED_BACKEND_VERSION, name: "hermes-agent" }),
+      });
+    }
     return Promise.resolve({ command, args });
   });
   (globalThis as any).window = {};
@@ -237,6 +246,7 @@ describe("isTauriDevMode", () => {
   });
 
   it("mounts the renderer without waiting when the managed runtime is intentionally offline", async () => {
+    (globalThis as any).window.__TAURI_INTERNALS__ = {};
     mockInvoke.mockImplementation((command: string) => {
       if (command === "get_runtime_config") {
         return Promise.resolve({
@@ -257,11 +267,82 @@ describe("isTauriDevMode", () => {
 
     expect(window.__HERMES_RUNTIME__).toMatchObject({
       backendReady: false,
+      backendRecoveryReason: "managed-runtime-offline",
       guideState: "pending",
       managedRuntimeDesiredState: "stopped",
       managedRuntimeLifecycleState: "stopped",
     });
     expect(mockInvoke).not.toHaveBeenCalledWith("runtime_info", undefined);
+    expect(mockInvoke).not.toHaveBeenCalledWith("api_request", expect.anything());
+  });
+
+  it("mounts the offline repair shell when an attached backend is unreachable", async () => {
+    (globalThis as any).window.__TAURI_INTERNALS__ = {};
+    mockInvoke.mockImplementation((command: string) => {
+      if (command === "get_runtime_config") {
+        return Promise.resolve({
+          apiBaseUrl: "http://127.0.0.1:9559",
+          gatewayUrl: "ws://127.0.0.1:9559/api/ws",
+          currentProfile: "default",
+          connectionMode: "local",
+          backendReady: true,
+          guideState: "completed",
+        });
+      }
+      if (command === "api_request") {
+        return Promise.reject({
+          code: "dashboard_unreachable",
+          kind: "dashboard",
+          message: "Dashboard not reachable at http://127.0.0.1:9559",
+        });
+      }
+      return Promise.resolve({});
+    });
+
+    await installTauriBridge();
+
+    expect(window.__HERMES_RUNTIME__).toMatchObject({
+      connectionMode: "local",
+      backendReady: false,
+      backendRecoveryReason: "external-backend-unreachable",
+      apiBaseUrl: "http://127.0.0.1:9559",
+      dashboardApiBaseUrl: "http://127.0.0.1:9559",
+    });
+  });
+
+  it("mounts the auth repair shell when an attached backend rejects credentials", async () => {
+    (globalThis as any).window.__TAURI_INTERNALS__ = {};
+    mockInvoke.mockImplementation((command: string) => {
+      if (command === "get_runtime_config") {
+        return Promise.resolve({
+          apiBaseUrl: "https://remote.example.com",
+          gatewayUrl: "wss://remote.example.com/api/ws",
+          currentProfile: "default",
+          connectionMode: "remote",
+          backendReady: true,
+          guideState: "completed",
+        });
+      }
+      if (command === "api_request") {
+        return Promise.resolve({
+          ok: false,
+          status: 401,
+          statusText: "Unauthorized",
+          headers: { "content-type": "application/json" },
+          body: JSON.stringify({ error: "unauthenticated" }),
+        });
+      }
+      return Promise.resolve({});
+    });
+
+    await installTauriBridge();
+
+    expect(window.__HERMES_RUNTIME__).toMatchObject({
+      connectionMode: "remote",
+      backendReady: false,
+      backendRecoveryReason: "external-backend-auth-required",
+      dashboardApiBaseUrl: "https://remote.example.com",
+    });
   });
 
   it("waits for apiBaseUrl when managed runtime is still starting", () => {
@@ -305,17 +386,15 @@ describe("isTauriDevMode", () => {
 
   it("verifies backend version before mounting the runtime in Tauri mode", async () => {
     (globalThis as any).window.__TAURI_INTERNALS__ = {};
-    const fetchSpy = vi.fn(async () =>
-      new Response(JSON.stringify({ version: EXPECTED_BACKEND_VERSION, name: "hermes-agent" }), {
-        status: 200,
-        headers: { "Content-Type": "application/json" },
-      }),
-    );
+    const fetchSpy = vi.fn();
     (globalThis as any).fetch = fetchSpy;
 
     await installTauriBridge();
 
-    expect(fetchSpy).toHaveBeenCalledWith("http://127.0.0.1:9120/api/version");
+    expect(mockInvoke).toHaveBeenCalledWith("api_request", {
+      input: { path: "/api/version", method: "GET" },
+    });
+    expect(fetchSpy).not.toHaveBeenCalled();
     expect(window.__HERMES_RUNTIME__).toMatchObject({
       platform: "tauri",
       // In dev mode with managed connection the runtime hides apiBaseUrl so
@@ -338,19 +417,26 @@ describe("isTauriDevMode", () => {
           connectionMode: "managed",
         });
       }
+      if (command === "api_request") {
+        return Promise.resolve({
+          ok: true,
+          status: 200,
+          statusText: "OK",
+          headers: { "content-type": "application/json" },
+          body: JSON.stringify({ version: "0.20.0", name: "hermes-agent" }),
+        });
+      }
       return Promise.resolve({});
     });
-    const fetchSpy = vi.fn(async () =>
-      new Response(JSON.stringify({ version: "0.20.0", name: "hermes-agent" }), {
-        status: 200,
-        headers: { "Content-Type": "application/json" },
-      }),
-    );
+    const fetchSpy = vi.fn();
     (globalThis as any).fetch = fetchSpy;
 
     await installTauriBridge();
 
-    expect(fetchSpy).toHaveBeenCalledWith("http://127.0.0.1:9120/api/version");
+    expect(mockInvoke).toHaveBeenCalledWith("api_request", {
+      input: { path: "/api/version", method: "GET" },
+    });
+    expect(fetchSpy).not.toHaveBeenCalled();
     expect(window.__HERMES_RUNTIME__).toMatchObject({
       kernelVersion: "0.20.0",
       dashboardApiBaseUrl: "http://127.0.0.1:9120",

--- a/web/src/lib/tauri-bridge.ts
+++ b/web/src/lib/tauri-bridge.ts
@@ -85,9 +85,11 @@ import type {
 import { BUILD_COMMIT, DESKTOP_VERSION, versionLabel } from "./build-info";
 import {
   assertCompatible,
+  deferBackendVersionCheckForOfflineRuntime,
   recordRuntimeKernelVersion,
   resetVersionCheck,
   verifyBackendVersion,
+  type BackendRecoveryReason,
 } from "./version-check";
 import hermesLogo from "@/assets/hermes-default-avatar.png";
 
@@ -1170,17 +1172,30 @@ export async function installTauriBridge(): Promise<void> {
   // explicitly because window.__HERMES_RUNTIME__ is not populated yet.
   resetVersionCheck();
   recordRuntimeKernelVersion(config.kernelVersion);
-  const versionState = await verifyBackendVersion(config.apiBaseUrl);
-  if (versionState.kind !== "ok") {
-    assertCompatible();
-    throw new Error("version check failed during bridge installation");
+  const connectionMode = config.connectionMode ?? "managed";
+  const managedRuntimeIntentionallyOffline =
+    connectionMode === "managed" &&
+    config.backendReady === false &&
+    !config.apiBaseUrl &&
+    (config.managedRuntimeDesiredState ?? "running") !== "running";
+  let backendRecoveryReason: BackendRecoveryReason | undefined;
+  if (managedRuntimeIntentionallyOffline) {
+    deferBackendVersionCheckForOfflineRuntime();
+    backendRecoveryReason = "managed-runtime-offline";
+  } else {
+    const versionState = await verifyBackendVersion(config.apiBaseUrl, { connectionMode });
+    if (versionState.kind === "deferred") {
+      backendRecoveryReason = versionState.reason;
+    } else if (versionState.kind !== "ok") {
+      assertCompatible();
+      throw new Error("version check failed during bridge installation");
+    }
   }
 
   // Attached local/remote mode must keep the real URLs even in Vite dev: the
   // Vite proxy targets the managed dashboard port (9120), so relative URLs
   // would route traffic to the wrong backend. Managed dev still hides URLs and
   // uses the proxy as before.
-  const connectionMode = config.connectionMode ?? "managed";
   const hideUrlsForViteProxy = isDevMode && connectionMode === "managed";
 
   window.__HERMES_RUNTIME__ = {
@@ -1193,7 +1208,10 @@ export async function installTauriBridge(): Promise<void> {
     currentProfile: config.currentProfile,
     connectionMode,
     portable: config.portable ?? false,
-    backendReady: config.backendReady ?? Boolean(config.apiBaseUrl),
+    backendReady: backendRecoveryReason
+      ? false
+      : config.backendReady ?? Boolean(config.apiBaseUrl),
+    backendRecoveryReason,
     guideState: config.guideState ?? "completed",
     managedRuntimeDesiredState: config.managedRuntimeDesiredState ?? "running",
     managedRuntimeLifecycleState: config.managedRuntimeLifecycleState ?? "running",

--- a/web/src/lib/transport.test.ts
+++ b/web/src/lib/transport.test.ts
@@ -68,19 +68,23 @@ describe("transport · debug-bus integration", () => {
     resetVersionCheck();
     window.__HERMES_RUNTIME__ = { platform: "tauri" };
     window.__TAURI_INTERNALS__ = {};
-    globalThis.fetch = vi.fn(async () =>
-      new Response(
-        JSON.stringify({ version: EXPECTED_BACKEND_VERSION, name: "hermes-agent" }),
-        { status: 200, headers: { "Content-Type": "application/json" } },
-      ),
-    ) as unknown as typeof globalThis.fetch;
+    const request = vi.fn(async () => ({
+      ok: true,
+      status: 200,
+      statusText: "OK",
+      headers: { "content-type": "application/json" },
+      body: JSON.stringify({ version: EXPECTED_BACKEND_VERSION, name: "hermes-agent" }),
+    }));
+    window.hermesDesktop = { windowType: "tauri", request };
+    globalThis.fetch = vi.fn() as unknown as typeof globalThis.fetch;
 
     await expect(fetchJSON("/api/x")).rejects.toThrow(/backend version check has not completed/);
 
-    // The version probe was issued, but the actual /api/x request was not.
-    const calls = (globalThis.fetch as ReturnType<typeof vi.fn>).mock.calls as [string][];
-    expect(calls.some(([url]) => url.includes("/api/x"))).toBe(false);
-    expect(calls.some(([url]) => url.includes("/api/version"))).toBe(true);
+    // The version probe went through Rust IPC, but the actual /api/x request
+    // was not issued while compatibility was still unchecked.
+    expect(request).toHaveBeenCalledTimes(1);
+    expect(request).toHaveBeenCalledWith({ path: "/api/version", method: "GET" });
+    expect(globalThis.fetch).not.toHaveBeenCalled();
   });
 
   it("fetchJSON pushes a REST entry on non-ok response", async () => {

--- a/web/src/lib/version-check.test.ts
+++ b/web/src/lib/version-check.test.ts
@@ -1,6 +1,7 @@
 import { afterEach, beforeEach, describe, expect, it, vi } from "vitest";
 import {
   assertCompatible,
+  deferBackendVersionCheckForOfflineRuntime,
   expectedBackendVersion,
   getVersionCheckState,
   recordRuntimeKernelVersion,
@@ -9,10 +10,32 @@ import {
 } from "./version-check";
 import { EXPECTED_BACKEND_VERSION } from "./build-info";
 
-function stubFetch(response: unknown, status = 200) {
-  globalThis.fetch = vi.fn(async () =>
-    new Response(JSON.stringify(response), { status, headers: { "Content-Type": "application/json" } }),
-  ) as unknown as typeof globalThis.fetch;
+function stubDesktopRequest(response: unknown, status = 200) {
+  const request = vi.fn(async () => ({
+    ok: status >= 200 && status < 300,
+    status,
+    statusText: status === 200 ? "OK" : "Not Found",
+    headers: { "content-type": "application/json" },
+    body: JSON.stringify(response),
+  }));
+  window.hermesDesktop = {
+    ...window.hermesDesktop,
+    windowType: "tauri",
+    request,
+  };
+  return request;
+}
+
+function stubDesktopRequestError(error: Error & { code?: string; kind?: string }) {
+  const request = vi.fn(async () => {
+    throw error;
+  });
+  window.hermesDesktop = {
+    ...window.hermesDesktop,
+    windowType: "tauri",
+    request,
+  };
+  return request;
 }
 
 describe("version-check", () => {
@@ -53,19 +76,20 @@ describe("version-check", () => {
     });
 
     it("returns ok when backend version matches", async () => {
-      stubFetch({ version: EXPECTED_BACKEND_VERSION, name: "hermes-agent" });
+      const request = stubDesktopRequest({ version: EXPECTED_BACKEND_VERSION, name: "hermes-agent" });
 
       const state = await verifyBackendVersion();
 
       expect(state.kind).toBe("ok");
       expect(state).toMatchObject({ backendVersion: EXPECTED_BACKEND_VERSION });
-      expect(globalThis.fetch).toHaveBeenCalledWith("http://127.0.0.1:9120/api/version");
+      expect(request).toHaveBeenCalledWith({ path: "/api/version", method: "GET" });
+      expect(globalThis.fetch).not.toHaveBeenCalled();
     });
 
     it("returns mismatch when backend version differs", async () => {
-      stubFetch({ version: "0.18.0", name: "hermes-agent" });
+      stubDesktopRequest({ version: "0.18.0", name: "hermes-agent" });
 
-      const state = await verifyBackendVersion();
+      const state = await verifyBackendVersion(undefined, { connectionMode: "remote" });
 
       expect(state.kind).toBe("mismatch");
       expect(state).toMatchObject({
@@ -75,7 +99,7 @@ describe("version-check", () => {
     });
 
     it("returns unavailable when /api/version is missing or unreachable", async () => {
-      globalThis.fetch = vi.fn(async () => new Response("not found", { status: 404 })) as unknown as typeof globalThis.fetch;
+      stubDesktopRequest({ detail: "not found" }, 404);
 
       const state = await verifyBackendVersion();
 
@@ -83,16 +107,91 @@ describe("version-check", () => {
       expect(getVersionCheckState()).toMatchObject({ kind: "unavailable" });
     });
 
+    it.each([401, 403])("opens external auth recovery on HTTP %s", async (status) => {
+      stubDesktopRequest({ detail: "authentication required" }, status);
+
+      const state = await verifyBackendVersion(undefined, { connectionMode: "remote" });
+
+      expect(state).toEqual({
+        kind: "deferred",
+        reason: "external-backend-auth-required",
+      });
+      expect(() => assertCompatible()).not.toThrow();
+    });
+
+    it("opens external connection recovery for a machine-readable reachability failure", async () => {
+      const error = Object.assign(new Error("Dashboard not reachable"), {
+        code: "dashboard_unreachable",
+        kind: "dashboard",
+      });
+      stubDesktopRequestError(error);
+
+      const state = await verifyBackendVersion(undefined, { connectionMode: "local" });
+
+      expect(state).toEqual({
+        kind: "deferred",
+        reason: "external-backend-unreachable",
+      });
+      expect(() => assertCompatible()).not.toThrow();
+    });
+
+    it("keeps the same reachability failure fatal for managed runtime", async () => {
+      const error = Object.assign(new Error("Dashboard not reachable"), {
+        code: "dashboard_unreachable",
+        kind: "dashboard",
+      });
+      stubDesktopRequestError(error);
+
+      const state = await verifyBackendVersion(undefined, { connectionMode: "managed" });
+
+      expect(state).toMatchObject({
+        kind: "unavailable",
+        reason: "Dashboard not reachable",
+      });
+    });
+
+    it("keeps a reachable external backend without /api/version fatal", async () => {
+      stubDesktopRequest({ detail: "not found" }, 404);
+
+      const state = await verifyBackendVersion(undefined, { connectionMode: "remote" });
+
+      expect(state).toMatchObject({ kind: "unavailable", reason: expect.stringContaining("HTTP 404") });
+    });
+
+    it("preserves external recovery semantics when an unchecked request triggers revalidation", async () => {
+      const fatalErrorAndExit = vi.fn(() => new Promise<never>(() => {}));
+      vi.stubGlobal("window", {
+        __TAURI_INTERNALS__: {},
+        __HERMES_RUNTIME__: {
+          platform: "tauri",
+          connectionMode: "remote",
+          apiBaseUrl: "https://remote.example.com",
+        },
+        hermesDesktop: { windowType: "tauri", fatalErrorAndExit },
+        location: { href: "hermesui://localhost/index.html", protocol: "hermesui:" },
+      });
+      stubDesktopRequest({ error: "unauthenticated" }, 401);
+
+      expect(() => assertCompatible()).toThrow("backend version check has not completed");
+      await vi.waitFor(() => {
+        expect(getVersionCheckState()).toEqual({
+          kind: "deferred",
+          reason: "external-backend-auth-required",
+        });
+      });
+      expect(fatalErrorAndExit).not.toHaveBeenCalled();
+    });
+
     it("assertCompatible throws on mismatch and invokes fatal dialog", async () => {
       const fatalErrorAndExit = vi.fn(() => new Promise<never>(() => {}));
       vi.stubGlobal("window", {
         __TAURI_INTERNALS__: {},
         __HERMES_RUNTIME__: { platform: "tauri", apiBaseUrl: "http://127.0.0.1:9120" },
-        hermesDesktop: { fatalErrorAndExit },
+        hermesDesktop: { windowType: "tauri", fatalErrorAndExit },
         location: { href: "http://localhost:9545/", protocol: "http:" },
       });
 
-      stubFetch({ version: "0.18.0", name: "hermes-agent" });
+      stubDesktopRequest({ version: "0.18.0", name: "hermes-agent" });
       await verifyBackendVersion();
 
       expect(() => assertCompatible()).toThrow(/backend version mismatch/);
@@ -107,11 +206,11 @@ describe("version-check", () => {
       vi.stubGlobal("window", {
         __TAURI_INTERNALS__: {},
         __HERMES_RUNTIME__: { platform: "tauri", apiBaseUrl: "http://127.0.0.1:9120" },
-        hermesDesktop: { fatalErrorAndExit },
+        hermesDesktop: { windowType: "tauri", fatalErrorAndExit },
         location: { href: "http://localhost:9545/", protocol: "http:" },
       });
 
-      globalThis.fetch = vi.fn(async () => new Response("not found", { status: 404 })) as unknown as typeof globalThis.fetch;
+      stubDesktopRequest({ detail: "not found" }, 404);
       await verifyBackendVersion();
 
       expect(() => assertCompatible()).toThrow(/backend version unavailable/);
@@ -122,7 +221,7 @@ describe("version-check", () => {
     });
 
     it("resetVersionCheck resets state to unchecked", async () => {
-      stubFetch({ version: EXPECTED_BACKEND_VERSION, name: "hermes-agent" });
+      stubDesktopRequest({ version: EXPECTED_BACKEND_VERSION, name: "hermes-agent" });
       await verifyBackendVersion();
       expect(getVersionCheckState().kind).toBe("ok");
 
@@ -131,17 +230,34 @@ describe("version-check", () => {
       expect(getVersionCheckState()).toEqual({ kind: "unchecked" });
     });
 
+    it("allows recovery UI calls while the managed runtime is intentionally offline", () => {
+      deferBackendVersionCheckForOfflineRuntime();
+
+      expect(getVersionCheckState()).toEqual({
+        kind: "deferred",
+        reason: "managed-runtime-offline",
+      });
+      expect(() => assertCompatible()).not.toThrow();
+    });
+
     it("prefers the recorded runtime kernel version over the baked constant", async () => {
       // Unified self-update: after a backend update the kernel version equals
       // the manifest version (0.8.0), which may differ from the baked constant.
       recordRuntimeKernelVersion("0.8.0");
       expect(expectedBackendVersion()).toBe("0.8.0");
-      stubFetch({ version: "0.8.0", name: "hermes-agent" });
+      stubDesktopRequest({ version: "0.8.0", name: "hermes-agent" });
 
       const state = await verifyBackendVersion();
 
       expect(state.kind).toBe("ok");
       expect(state).toMatchObject({ backendVersion: "0.8.0" });
+    });
+
+    it("does not fall back to a CORS-bound browser fetch when the IPC bridge is missing", async () => {
+      const state = await verifyBackendVersion();
+
+      expect(state).toEqual({ kind: "unavailable", reason: "desktop IPC bridge unavailable" });
+      expect(globalThis.fetch).not.toHaveBeenCalled();
     });
 
     it("falls back to the baked constant when no kernel version is recorded", () => {

--- a/web/src/lib/version-check.ts
+++ b/web/src/lib/version-check.ts
@@ -1,16 +1,28 @@
 import { runtime } from "./runtime";
 import { EXPECTED_BACKEND_VERSION } from "./build-info";
+import type { ConnectionMode } from "@hermes/protocol";
 
 export interface BackendVersionInfo {
   version: string;
   name?: string;
 }
 
+export type BackendRecoveryReason =
+  | "managed-runtime-offline"
+  | "external-backend-unreachable"
+  | "external-backend-auth-required";
+
 export type VersionCheckState =
   | { kind: "unchecked" }
+  | { kind: "deferred"; reason: BackendRecoveryReason }
   | { kind: "ok"; backendVersion: string }
   | { kind: "mismatch"; backendVersion: string; expectedVersion: string }
   | { kind: "unavailable"; reason: string };
+
+export interface VersionCheckOptions {
+  connectionMode?: ConnectionMode;
+  expectedVersion?: string;
+}
 
 let state: VersionCheckState = { kind: "unchecked" };
 
@@ -41,6 +53,15 @@ export function resetVersionCheck(): void {
   runtimeKernelVersion = null;
 }
 
+/**
+ * Allow the recovery UI to mount while the user has explicitly stopped or
+ * uninstalled the managed runtime. Runtime control results reset this state
+ * before a subsequently started backend can serve REST or WebSocket traffic.
+ */
+export function deferBackendVersionCheckForOfflineRuntime(): void {
+  state = { kind: "deferred", reason: "managed-runtime-offline" };
+}
+
 function isDevBypassEnabled(): boolean {
   try {
     return import.meta.env.DEV === true && import.meta.env.VITE_HERMES_SKIP_VERSION_CHECK === "1";
@@ -49,30 +70,79 @@ function isDevBypassEnabled(): boolean {
   }
 }
 
-/**
- * Fetch /api/version directly, bypassing the transport layer so the version
- * check itself does not recurse into assertCompatible(). The endpoint is
- * public and requires no auth header.
- */
-async function fetchBackendVersion(apiBaseUrl?: string): Promise<BackendVersionInfo> {
-  const url = apiBaseUrl
-    ? `${apiBaseUrl.replace(/\/$/, "")}/api/version`
-    : runtime.getApiUrl("/api/version");
-  const response = await fetch(url);
-  if (!response.ok) {
-    throw new Error(`HTTP ${response.status}: ${await response.text()}`);
-  }
-  const data = await response.json();
-  if (typeof data?.version !== "string") {
+function parseBackendVersion(data: unknown): BackendVersionInfo {
+  if (!data || typeof data !== "object" || typeof (data as { version?: unknown }).version !== "string") {
     throw new Error("backend version response missing version string");
   }
   return data as BackendVersionInfo;
 }
 
+class BackendVersionHttpError extends Error {
+  constructor(
+    readonly status: number,
+    body: string,
+  ) {
+    super(`HTTP ${status}: ${body}`);
+  }
+}
+
+function isExternalConnection(mode: ConnectionMode | undefined): boolean {
+  return mode === "local" || mode === "remote";
+}
+
+function ipcErrorCode(error: unknown): string | undefined {
+  if (!error || typeof error !== "object") return undefined;
+  const code = (error as { code?: unknown }).code;
+  return typeof code === "string" ? code : undefined;
+}
+
+function isExternalBackendUnreachable(error: unknown): boolean {
+  const code = ipcErrorCode(error);
+  if (code === "dashboard_unreachable") return true;
+
+  // reqwest reports a response timeout as api_proxy/proxy_error rather than a
+  // connect error. It is still an unreachable target from the recovery UI's
+  // perspective, while all other proxy errors remain strict.
+  return code === "proxy_error"
+    && error instanceof Error
+    && error.message.includes("Request timed out");
+}
+
+/**
+ * Fetch /api/version without going through the compatibility-gated transport
+ * helper. Tauri must use its Rust HTTP proxy: release WebViews load from a
+ * custom protocol origin (`hermesui:` on macOS/Linux and
+ * `http://hermesui.localhost` on Windows), so a native browser fetch would be
+ * rejected by the dashboard's intentionally narrow localhost CORS policy.
+ */
+async function fetchBackendVersion(apiBaseUrl?: string): Promise<BackendVersionInfo> {
+  if (runtime.platform === "tauri") {
+    const request = window.hermesDesktop?.request;
+    if (!request) {
+      throw new Error("desktop IPC bridge unavailable");
+    }
+    const response = await request({ path: "/api/version", method: "GET" });
+    if (!response.ok) {
+      throw new BackendVersionHttpError(response.status, response.body);
+    }
+    return parseBackendVersion(JSON.parse(response.body));
+  }
+
+  const url = apiBaseUrl
+    ? `${apiBaseUrl.replace(/\/$/, "")}/api/version`
+    : runtime.getApiUrl("/api/version");
+  const response = await fetch(url);
+  if (!response.ok) {
+    throw new BackendVersionHttpError(response.status, await response.text());
+  }
+  return parseBackendVersion(await response.json());
+}
+
 export async function verifyBackendVersion(
   apiBaseUrl?: string,
-  expected = expectedBackendVersion(),
+  options: VersionCheckOptions = {},
 ): Promise<VersionCheckState> {
+  const expected = options.expectedVersion ?? expectedBackendVersion();
   if (runtime.platform === "web") {
     // Web/browser-companion mode: no managed runtime; skip the gate.
     state = { kind: "ok", backendVersion: "web" };
@@ -97,6 +167,16 @@ export async function verifyBackendVersion(
     state = { kind: "ok", backendVersion: info.version };
     return state;
   } catch (error) {
+    if (isExternalConnection(options.connectionMode)) {
+      if (error instanceof BackendVersionHttpError && (error.status === 401 || error.status === 403)) {
+        state = { kind: "deferred", reason: "external-backend-auth-required" };
+        return state;
+      }
+      if (isExternalBackendUnreachable(error)) {
+        state = { kind: "deferred", reason: "external-backend-unreachable" };
+        return state;
+      }
+    }
     state = {
       kind: "unavailable",
       reason: error instanceof Error ? error.message : String(error),
@@ -122,7 +202,7 @@ async function fatalErrorAndExit(title: string, message: string): Promise<never>
 }
 
 export function assertCompatible(): void {
-  if (state.kind === "ok") return;
+  if (state.kind === "ok" || state.kind === "deferred") return;
 
   // Web/browser-companion mode has no managed runtime; skip the gate.
   if (runtime.platform === "web") {
@@ -152,8 +232,8 @@ export function assertCompatible(): void {
 
   // unchecked: trigger the async verification. The current call must still
   // fail fast so callers don't proceed against an unchecked backend.
-  void verifyBackendVersion().then((s) => {
-    if (s.kind !== "ok") assertCompatible();
+  void verifyBackendVersion(undefined, { connectionMode: runtime.getConnectionMode() }).then((s) => {
+    if (s.kind !== "ok" && s.kind !== "deferred") assertCompatible();
   });
   throw new Error("backend version check has not completed");
 }

--- a/web/src/routes/offline-shell.test.tsx
+++ b/web/src/routes/offline-shell.test.tsx
@@ -1,0 +1,44 @@
+import ReactDOMServer from "react-dom/server";
+import { MemoryRouter } from "react-router-dom";
+import { afterEach, expect, it, vi } from "vitest";
+import { OfflineShell } from "./offline-shell";
+
+function renderRecovery(reason: "external-backend-unreachable" | "external-backend-auth-required") {
+  vi.stubGlobal("window", {
+    __HERMES_RUNTIME__: {
+      platform: "tauri",
+      connectionMode: "remote",
+      backendReady: false,
+      backendRecoveryReason: reason,
+      dashboardApiBaseUrl: "https://remote.example.com",
+    },
+    location: { hash: "#/" },
+  });
+
+  return ReactDOMServer.renderToStaticMarkup(
+    <MemoryRouter initialEntries={["/"]}>
+      <OfflineShell />
+    </MemoryRouter>,
+  );
+}
+
+afterEach(() => {
+  vi.restoreAllMocks();
+  vi.unstubAllGlobals();
+});
+
+it("explains how to repair an unreachable external backend", () => {
+  const html = renderRecovery("external-backend-unreachable");
+
+  expect(html).toContain("外部 Hermes 暂时无法连接");
+  expect(html).toContain("https://remote.example.com");
+  expect(html).toContain("检查连接");
+});
+
+it("explains how to repair external backend authentication", () => {
+  const html = renderRecovery("external-backend-auth-required");
+
+  expect(html).toContain("外部 Hermes 需要重新认证");
+  expect(html).toContain("凭证需要修复");
+  expect(html).toContain("修复认证");
+});

--- a/web/src/routes/offline-shell.tsx
+++ b/web/src/routes/offline-shell.tsx
@@ -18,6 +18,38 @@ function OfflinePage({ title, sub, children }: { title: string; sub: string; chi
 }
 
 function OfflineHome() {
+  const runtimeConfig = window.__HERMES_RUNTIME__;
+  const recoveryReason = runtimeConfig?.backendRecoveryReason;
+  const externalTarget = runtimeConfig?.dashboardApiBaseUrl
+    ?? runtimeConfig?.apiBaseUrl
+    ?? "已保存的外部目标";
+
+  if (recoveryReason === "external-backend-auth-required") {
+    return (
+      <OfflinePage title="外部 Hermes 需要重新认证" sub={`${externalTarget} 已响应，但当前认证未通过。`}>
+        <div className={s.empty}>
+          <Globe2 size={32} />
+          <h2>连接地址有效，凭证需要修复</h2>
+          <p>请重新登录或更新访问令牌。认证完成后，桌面端会重新校验后端版本再进入工作台。</p>
+          <div><Button variant="solid" tone="accent" onClick={() => { window.location.hash = "#/connection"; }}><Globe2 size={12} />修复认证</Button></div>
+        </div>
+      </OfflinePage>
+    );
+  }
+
+  if (recoveryReason === "external-backend-unreachable") {
+    return (
+      <OfflinePage title="外部 Hermes 暂时无法连接" sub={`当前无法访问 ${externalTarget}。`}>
+        <div className={s.empty}>
+          <CircleOff size={32} />
+          <h2>目标地址没有响应</h2>
+          <p>请检查后端进程、网络和保存的地址。修复后在连接页重新测试并应用。</p>
+          <div><Button variant="solid" tone="accent" onClick={() => { window.location.hash = "#/connection"; }}><Globe2 size={12} />检查连接</Button></div>
+        </div>
+      </OfflinePage>
+    );
+  }
+
   return (
     <OfflinePage title="当前没有正在使用的 Hermes 后端" sub="内置内核已停止或卸载。你仍然可以连接外部 Hermes，或恢复内置内核。">
       <div className={s.empty}>

--- a/web/src/routes/settings-connection-section.test.tsx
+++ b/web/src/routes/settings-connection-section.test.tsx
@@ -1,0 +1,35 @@
+import ReactDOMServer from "react-dom/server";
+import { afterEach, expect, it, vi } from "vitest";
+
+vi.mock("./managed-runtime-panel", () => ({
+  ManagedRuntimePanel: () => <div>MANAGED_PANEL_MOUNTED</div>,
+}));
+
+import { ConnectionSection } from "./settings-connection-section";
+
+afterEach(() => {
+  vi.restoreAllMocks();
+  vi.unstubAllGlobals();
+});
+
+it("starts in the active remote mode without transiently mounting managed controls", () => {
+  vi.stubGlobal("window", {
+    __HERMES_RUNTIME__: {
+      platform: "tauri",
+      connectionMode: "remote",
+      backendReady: false,
+      backendRecoveryReason: "external-backend-auth-required",
+      dashboardApiBaseUrl: "https://remote.example.com",
+    },
+    hermesDesktop: {
+      windowType: "tauri",
+      getConnectionConfig: vi.fn(),
+    },
+  });
+
+  const html = ReactDOMServer.renderToStaticMarkup(<ConnectionSection showHeading={false} />);
+
+  expect(html).toContain("远程地址");
+  expect(html).toContain("会话令牌");
+  expect(html).not.toContain("MANAGED_PANEL_MOUNTED");
+});

--- a/web/src/routes/settings-connection-section.tsx
+++ b/web/src/routes/settings-connection-section.tsx
@@ -20,6 +20,7 @@ import type {
 } from "@hermes/protocol";
 import { Alert, Button, Input, LoadingIndicator } from "@hermes/shared-ui";
 import { notifyConnectionAuthRestored } from "@/lib/connection-auth-events";
+import { runtime } from "@/lib/runtime";
 import { SettingsHero } from "./settings-hero";
 import { ManagedRuntimePanel } from "./managed-runtime-panel";
 import s from "./settings.module.css";
@@ -108,11 +109,15 @@ export function ConnectionSection({
   const desktop = typeof window !== "undefined" ? window.hermesDesktop : undefined;
   const supported = Boolean(desktop?.getConnectionConfig);
   const browserCompanion = Boolean(window.__HERMES_RUNTIME__?.browserCompanion);
+  const runtimeMode = runtime.getConnectionMode();
+  const initialMode = externalOnly && runtimeMode === "managed" ? "local" : runtimeMode;
 
   const [config, setConfig] = useState<ConnectionConfigView | null>(null);
   const [loadError, setLoadError] = useState("");
-  const [mode, setMode] = useState<ConnectionMode>(externalOnly ? "local" : "managed");
-  const [externalKind, setExternalKind] = useState<Exclude<ConnectionMode, "managed">>("local");
+  const [mode, setMode] = useState<ConnectionMode>(initialMode);
+  const [externalKind, setExternalKind] = useState<Exclude<ConnectionMode, "managed">>(
+    initialMode === "remote" ? "remote" : "local",
+  );
   const [localUrl, setLocalUrl] = useState(DEFAULT_LOCAL_URL);
   const [remoteUrl, setRemoteUrl] = useState("");
   // The saved token never round-trips; this holds only what the user types.


### PR DESCRIPTION
## 改动

- 桌面端版本检查统一通过 Rust IPC，避免 WebView CORS 失败
- 外部 Local/Remote 后端不可达或返回 401/403 时允许进入受限修复页
- 保留版本不匹配、404 和异常响应的严格门禁
- 修复进入连接设置后恢复状态被 Managed Runtime 状态覆盖的问题
- 后端未就绪时暂停无意义的日志轮询

## 验证

- `pnpm typecheck`
- `pnpm test:unit`：Protocol 72/72，Web 1267/1267
- `cargo check`
- macOS 打包态外部后端 401 与完全不可达路径实机测试通过

## 尚未覆盖

- Windows 共用相同代码路径，但尚未完成 Windows 实机打包测试
