### PR TITLE
fix: 集成桌面稳定性修复并准备 RC8

### DIFF
--- a/.codex/skills/desktop-dual-repo-test/SKILL.md
+++ b/.codex/skills/desktop-dual-repo-test/SKILL.md
@@ -23,12 +23,11 @@ Always sync **both** repos to the intended branch before testing. Never assume a
   - Dev (`pnpm tauri:dev`): `…/cn.org.hermesagent.desktop/dev-runtime/`
   - Packaged app: `…/cn.org.hermesagent.desktop/runtime/`
 - If packaged tests show kernel `dev-local` / commit `de3b` while UI is current, the production `current.json` was polluted by an old dev session — run migration (below), not a rebuild.
-- **Git 写操作（fetch / pull / checkout / worktree / branch / commit / push / PR / tag）一律由人执行**，代理绝不自动执行。代理只允许只读 git（`git status` / `git rev-parse` / `git log` / `git diff`）用于核对与报告；若仓库不在目标分支或落后远端，停下来报告给人处理。
 - macOS: detach all stale `Hermes Agent CN Desktop*` DMG volumes before reading or installing a release DMG. Never trust a mounted volume unless `hdiutil info` shows it came from the DMG you just downloaded.
 
-## Step 0 — Sync both repositories (由人执行)
+## Step 0 — Sync both repositories
 
-> 编码代理**不执行** git 同步 / 切分支 / worktree 等写操作（完整同步命令见 `docs/agents/git-workflow.md` §4）。开始测试前确认两个仓库已由**人**同步到目标分支；若仓库不在目标分支或落后远端，**停下来报告给人处理**。
+开始测试前确认两个仓库已同步到目标分支，并在任务专用 worktree 中工作。若状态异常，先核对差异与归属，禁止破坏性重置或覆盖其它工作区。
 
 记录 SHA 用于报告（只读，代理可执行）：
 

--- a/.github/workflows/release-desktop.yml
+++ b/.github/workflows/release-desktop.yml
@@ -1,5 +1,5 @@
 # Build hermes-agent-cn-desktop installers and attach them to a GitHub
-# Release. Triggers on tags matching `v*` (e.g. `v0.8.0-rc7`).
+# Release. Triggers on tags matching `v*` (e.g. `v0.8.0-rc8`).
 #
 # Desktop release build runs in parallel for Windows, macOS, and Linux. Each job:
 #   1. Installs Node 22 + pnpm + Rust toolchain
@@ -30,12 +30,17 @@ on:
   workflow_dispatch:
     inputs:
       tag:
-        description: "Tag name to associate the build with (e.g. v0.8.0-rc7)"
+        description: "Tag name to associate the build with (e.g. v0.8.0-rc8)"
         required: true
       bundled_runtime_tag:
         description: "Hermes-CN-Core runtime release tag to embed in desktop installers, or latest"
-        default: "runtime-v0.20.0-cn.8"
+        default: "runtime-v0.20.0-cn.10"
         required: false
+      bundled_runtime_channel:
+        description: "Manifest channel for the explicitly selected bundled Runtime"
+        default: stable
+        type: choice
+        options: [stable, beta, canary]
 
 permissions:
   contents: write
@@ -115,7 +120,8 @@ jobs:
         shell: bash
         env:
           BUNDLED_RUNTIME_REPO: Eynzof/Hermes-CN-Core
-          BUNDLED_RUNTIME_TAG: ${{ github.event.inputs.bundled_runtime_tag || 'runtime-v0.20.0-cn.8' }}
+          BUNDLED_RUNTIME_TAG: ${{ github.event.inputs.bundled_runtime_tag || 'runtime-v0.20.0-cn.10' }}
+          BUNDLED_RUNTIME_CHANNEL: ${{ inputs.bundled_runtime_channel || 'stable' }}
           RUNTIME_PLATFORM: ${{ matrix.runtime_platform }}
           RUNTIME_ARCH: ${{ matrix.runtime_arch }}
         run: |
@@ -129,7 +135,8 @@ jobs:
               : `https://github.com/${repo}/releases/download/${encodeURIComponent(tag)}`;
             const platform = process.env.RUNTIME_PLATFORM;
             const arch = process.env.RUNTIME_ARCH;
-            const response = await fetch(`${baseUrl}/stable-${platform}-${arch}.json`, {
+            const channel = process.env.BUNDLED_RUNTIME_CHANNEL;
+            const response = await fetch(`${baseUrl}/${channel}-${platform}-${arch}.json`, {
               headers: { "User-Agent": "hermes-agent-cn-desktop-release-workflow" },
             });
             if (!response.ok) {
@@ -173,7 +180,8 @@ jobs:
           args=(
             scripts/stage-bundled-runtime.mjs
             --repo "Eynzof/Hermes-CN-Core"
-            --tag "${{ github.event.inputs.bundled_runtime_tag || 'runtime-v0.20.0-cn.8' }}"
+            --tag "${{ github.event.inputs.bundled_runtime_tag || 'runtime-v0.20.0-cn.10' }}"
+            --channel "${{ inputs.bundled_runtime_channel || 'stable' }}"
             --platform "${{ matrix.runtime_platform }}"
             --arch "${{ matrix.runtime_arch }}"
           )
@@ -275,7 +283,7 @@ jobs:
             如需覆盖 runtime 更新源，可设置 HERMES_RUNTIME_UPDATE_* 环境变量。
           releaseDraft: false
           # Mark SemVer prerelease tags as prerelease on GitHub Releases.
-          prerelease: ${{ contains(github.ref_name, '-alpha') || contains(github.ref_name, '-beta') || contains(github.ref_name, '-rc') }}
+          prerelease: ${{ contains(github.event.inputs.tag || github.ref_name, '-alpha') || contains(github.event.inputs.tag || github.ref_name, '-beta') || contains(github.event.inputs.tag || github.ref_name, '-rc') }}
           args: --target ${{ matrix.target }} --bundles ${{ matrix.bundles }}
 
       - name: Package + upload Windows portable zip

--- a/AGENTS.md
+++ b/AGENTS.md
@@ -67,19 +67,15 @@ UI 对接的是 hermes-agent Dashboard。**不要凭参数名猜后端行为**�
 
 ## 开发流程
 
-### Git 操作边界（铁律）
+### Git 工作流
 
-编码代理**绝不自动执行**任何 Git 写操作：不 `git commit` / `git push` / `git pull` / `git fetch` / `git checkout`、不创建 `git worktree` / 分支、不开 PR、不打 tag、不发布 Release、不同步 landing 仓库。
-
-所有仓库同步、分支 / worktree 隔离、commit、push、PR、tag、Release 与 Landing 同步均由**人**执行（或由 CI/CD 流水线触发）。代理只做只读检查（`git status` / `git diff` / `git log` / `git rev-parse`）用于验证与报告。
-
-完整的人工 Git 工作流（双仓同步 + worktree 预检、收尾 commit → push → PR、Commit 风格、发版 tag 与 Landing 同步）见 `docs/agents/git-workflow.md`。
+Git 操作必须限定在当前任务的独立分支 / worktree，避免破坏性重置或覆盖其它工作区。双仓同步、收尾 commit → push → PR、Commit 风格、发版 tag 与 Landing 同步的完整流程见 `docs/agents/git-workflow.md`。
 
 ### 开发前准备
 
-- 确认当前工作目录位于**人已准备好**的仓库状态（已同步、已开好分支 / worktree）；不要自己 `git checkout` 切分支或同步远端。
-- 需求同时横跨 Desktop 与 Core 时，人会用独立 worktree 隔离两仓改动；代理不要自己创建 / 操作 worktree。
-- 若发现工作区状态异常（脏树、分支不对、落后远端），**报告给人处理**，不要自行 commit / stash / reset / pull。
+- 确认当前工作目录位于已同步的任务分支 / worktree。
+- 需求同时横跨 Desktop 与 Core 时，使用独立 worktree 隔离两仓改动。
+- 若发现工作区状态异常（意外脏树、分支不对或落后远端），先核对差异与归属，禁止破坏性重置或覆盖他人改动。
 
 ### 仓库技能
 
@@ -91,7 +87,7 @@ UI 对接的是 hermes-agent Dashboard。**不要凭参数名猜后端行为**�
 发版、版本号更新、安装包发布或 GitHub Release 相关任务必须按顺序使用仓库内技能：**先过** `.codex/skills/desktop-release-preflight/SKILL.md`（发版前安全闸门：防内核静默降级 / 防 schema 重置 / identifier 不变 / 公证签名 / 国内镜像先有 artifactUrl 再发清单 / 先发 canary），**再做** `.codex/skills/desktop-release-sync-landing/SKILL.md`（版本同步与官网清单）。
 只要桌面端 **stable/正式公开版本** 发生变化，就必须同步处理 `Eynzof/hermes-agent-cn-desktop-landing`，
 更新官网版本与 `https://desktop.hermesagent.org.cn/latest.json` 清单；如果 release 资产尚未生成，
-需要明确说明 Landing 同步被阻塞，不能把正式发版任务当作已经完整结束。**Landing 仓库的 commit / push / PR 由人执行**，代理只负责准备与核对内容、报告阻塞情况（见 `docs/agents/git-workflow.md` §5）。
+需要明确说明 Landing 同步被阻塞，不能把正式发版任务当作已经完整结束（见 `docs/agents/git-workflow.md` §5）。
 **RC / beta / alpha / canary 等预发布或内测版本禁止修改 Landing 仓库，禁止更新官网版本，
 禁止让 `https://desktop.hermesagent.org.cn/latest.json` 指向预发布版本。** 预发布版本只能通过
 GitHub Release、手工分发或明确的内测渠道验证，不能暴露给全量用户的官网入口和自动更新清单。
@@ -169,7 +165,6 @@ pnpm tauri:build:debug     # Debug：带调试信息的 .app / .dmg
 - ❌ 不要直接调 `gateway-client.ts` 的 raw socket — 走 `hooks/use-gateway.ts`
 - ❌ 不要在 `web/src/routes/` 里塞业务逻辑 — 抽到 `hooks/` 或 `lib/`
 - ❌ 不要在组件里写硬编码颜色 — 用 `packages/shared-ui/src/tokens/` 里的 CSS 变量
-- ❌ **不要自动执行任何 Git 写操作**（commit / push / pull / checkout / worktree / 开 PR / 打 tag / 发 Release / 同步 landing）— 全部由人执行，见 `docs/agents/`
 
 ## 端口
 

--- a/Cargo.lock
+++ b/Cargo.lock
@@ -1981,7 +1981,7 @@ checksum = "2304e00983f87ffb38b55b444b5e3b60a884b5d30c0fca7d82fe33449bbe55ea"
 
 [[package]]
 name = "hermes-agent-cn-desktop"
-version = "0.8.0-rc7"
+version = "0.8.0-rc8"
 dependencies = [
  "base64 0.22.1",
  "bytes",

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -1,6 +1,6 @@
 [package]
 name = "hermes-agent-cn-desktop"
-version = "0.8.0-rc7"
+version = "0.8.0-rc8"
 edition = "2021"
 description = "Hermes Agent CN Desktop (Tauri)"
 authors = ["Hermes Agent CN Contributors"]

--- a/README.en-US.md
+++ b/README.en-US.md
@@ -12,7 +12,7 @@ Hermes Agent CN Desktop is a desktop client from the Hermes Agent Chinese commun
 
 Official site and downloads: [desktop.hermesagent.org.cn](https://desktop.hermesagent.org.cn). The desktop app is part of the [Hermes Agent Chinese Community](https://hermesagent.org.cn) ecosystem, where the main site links to Chinese docs, practice guides, community entry points, and more ecosystem projects.
 
-> Current release: `v0.8.0-rc7`. The project is still moving quickly. APIs, packaging, runtime distribution, and UI details may continue to change.
+> Current release: `v0.8.0-rc8`. The project is still moving quickly. APIs, packaging, runtime distribution, and UI details may continue to change.
 
 ## ❤️ Sponsor
 
@@ -104,9 +104,9 @@ Installers are available from the [desktop website](https://desktop.hermesagent.
 
 The current release includes:
 
-- macOS Apple Silicon DMG: `Hermes.Agent.CN.Desktop_0.8.0-rc7_aarch64.dmg`
-- macOS Intel DMG: `Hermes.Agent.CN.Desktop_0.8.0-rc7_x64.dmg`
-- Windows x64 installer: `Hermes.Agent.CN.Desktop_0.8.0-rc7_x64-setup.exe`
+- macOS Apple Silicon DMG: `Hermes.Agent.CN.Desktop_0.8.0-rc8_aarch64.dmg`
+- macOS Intel DMG: `Hermes.Agent.CN.Desktop_0.8.0-rc8_x64.dmg`
+- Windows x64 installer: `Hermes.Agent.CN.Desktop_0.8.0-rc8_x64-setup.exe`
 
 Both the Windows and macOS installers include a bundled `Hermes-CN-Core` runtime. On first launch, the app initializes the local core from the bundled runtime first; managed runtime download/update is only used for upgrades or fallback repair.
 

--- a/README.md
+++ b/README.md
@@ -12,7 +12,7 @@ Hermes Agent CN Desktop 是 Hermes Agent 中文社区推出的桌面客户端，
 
 官网与下载页见 [desktop.hermesagent.org.cn](https://desktop.hermesagent.org.cn)。桌面端隶属于 [Hermes Agent 中文社区](https://hermesagent.org.cn) 生态，社区主站提供中文文档、实践指南、社群入口和更多生态项目。
 
-> 当前版本是 `v0.8.0-rc7`。项目仍在快速迭代，API、打包流程、运行时分发策略和界面细节都可能继续调整。
+> 当前版本是 `v0.8.0-rc8`。项目仍在快速迭代，API、打包流程、运行时分发策略和界面细节都可能继续调整。
 
 ## ❤️赞助商
 
@@ -105,9 +105,9 @@ Hermes Agent 已经提供本地 Dashboard。本仓库专注于 Dashboard 之外�
 
 当前版本包含：
 
-- macOS Apple Silicon DMG：`Hermes.Agent.CN.Desktop_0.8.0-rc7_aarch64.dmg`
-- macOS Intel DMG：`Hermes.Agent.CN.Desktop_0.8.0-rc7_x64.dmg`
-- Windows x64 安装器：`Hermes.Agent.CN.Desktop_0.8.0-rc7_x64-setup.exe`
+- macOS Apple Silicon DMG：`Hermes.Agent.CN.Desktop_0.8.0-rc8_aarch64.dmg`
+- macOS Intel DMG：`Hermes.Agent.CN.Desktop_0.8.0-rc8_x64.dmg`
+- Windows x64 安装器：`Hermes.Agent.CN.Desktop_0.8.0-rc8_x64-setup.exe`
 
 当前 Windows 与 macOS 安装包都会预置 `Hermes-CN-Core` runtime，安装后优先从包内 runtime 完成本地内核初始化；托管 runtime 下载与更新流程只作为升级或兜底路径使用。
 

--- a/docs/macos-signing-and-notarization.md
+++ b/docs/macos-signing-and-notarization.md
@@ -117,7 +117,7 @@ target/aarch64-apple-darwin/release/bundle/dmg/*.dmg
 如果需要手动公证和 staple，可以对最终 DMG 执行：
 
 ```bash
-DMG="target/aarch64-apple-darwin/release/bundle/dmg/Hermes Agent CN Desktop_0.8.0-rc7_aarch64.dmg"
+DMG="target/aarch64-apple-darwin/release/bundle/dmg/Hermes Agent CN Desktop_0.8.0-rc8_aarch64.dmg"
 
 xcrun notarytool submit "$DMG" \
   --key "$APPLE_API_KEY_PATH" \

--- a/docs/managed-runtime.md
+++ b/docs/managed-runtime.md
@@ -276,7 +276,7 @@ fork CI release-runtime.yml 触发：
 ## 六、桌面端升级
 
 ```
-你 git tag v0.8.0-rc7; git push origin v0.8.0-rc7
+你 git tag v0.8.0-rc8; git push origin v0.8.0-rc8
   ↓
 desktop CI release-desktop.yml 触发：
   matrix: windows-latest / macos-14 (arm64)
@@ -289,7 +289,7 @@ desktop CI release-desktop.yml 触发：
     5. tauri-apps/tauri-action@v0 → 打 .exe / .dmg
        runtime URL + 公钥仍是 baked-in 兜底，不需要 env wire 进 CI
   ↓
-新装包发到 releases/v0.8.0-rc7 → 用户下载装新版
+新装包发到 releases/v0.8.0-rc8 → 用户下载装新版
   ↓
 新版起来后，看到 current.json 已经有 runtime → 不下载 → 直接用。
 全新安装则先使用安装包内置 runtime；除非内置资源缺失或用户主动升级，

--- a/e2e/harness/start-backend.mjs
+++ b/e2e/harness/start-backend.mjs
@@ -9,6 +9,8 @@
 // On SIGINT/SIGTERM (or when Playwright tears the webServer down) every child is
 // killed. Run standalone for debugging: `node harness/start-backend.mjs`.
 import { spawn } from "node:child_process";
+import { once } from "node:events";
+import { createServer } from "node:http";
 import { rmSync, mkdirSync, writeFileSync, existsSync } from "node:fs";
 import { resolve } from "node:path";
 import {
@@ -35,7 +37,7 @@ function spawnChild(label, cmd, args, opts) {
   child.stdout?.on("data", (d) => process.stdout.write(`[${label}] ${d}`));
   child.stderr?.on("data", (d) => process.stderr.write(`[${label}] ${d}`));
   child.on("exit", (code) => {
-    if (!shuttingDown) {
+    if (!shuttingDown && !child.expectedExit) {
       console.error(`[harness] ${label} exited unexpectedly (code ${code})`);
       shutdown(1);
     }
@@ -45,9 +47,11 @@ function spawnChild(label, cmd, args, opts) {
 }
 
 let shuttingDown = false;
+let controlServer;
 function shutdown(code = 0) {
   if (shuttingDown) return;
   shuttingDown = true;
+  controlServer?.close();
   for (const c of children) {
     try {
       c.kill("SIGTERM");
@@ -121,26 +125,59 @@ async function main() {
   await waitForHttp(FAKE_MODEL_HEALTH, { timeoutMs: 30_000 });
   console.log(`[harness] fake model ready on :${FAKE_MODEL_PORT}`);
 
-  // 3. Core dashboard. Readiness is the stdout line it prints when serving.
-  const dash = spawnChild(
-    "dashboard",
-    VENV_PY,
-    [
-      "-m",
-      "hermes_cli.main",
+  // 3. Core dashboard. The restart test keeps HERMES_HOME and the model alive
+  // while replacing the actual Core process, including its session registry.
+  function startDashboard() {
+    return spawnChild(
       "dashboard",
-      "--host",
-      "127.0.0.1",
-      "--port",
-      String(DASHBOARD_PORT),
-      "--no-open",
-      "--skip-build",
-    ],
-    { cwd: CORE_DIR, env },
-  );
-  await waitForLine(dash, `HERMES_DASHBOARD_READY port=${DASHBOARD_PORT}`, {
-    timeoutMs: 120_000,
+      VENV_PY,
+      [
+        "-m",
+        "hermes_cli.main",
+        "dashboard",
+        "--host",
+        "127.0.0.1",
+        "--port",
+        String(DASHBOARD_PORT),
+        "--no-open",
+        "--skip-build",
+      ],
+      { cwd: CORE_DIR, env },
+    );
+  }
+  async function waitForDashboard(dash) {
+    await waitForLine(dash, `HERMES_DASHBOARD_READY port=${DASHBOARD_PORT}`, {
+      timeoutMs: 120_000,
+    });
+  }
+  let dash = startDashboard();
+  await waitForDashboard(dash);
+
+  // Test-only loopback control, published inside this harness's runtime dir.
+  controlServer = createServer(async (req, res) => {
+    if (req.method !== "POST" || req.url !== "/restart") {
+      res.writeHead(404).end();
+      return;
+    }
+    try {
+      const previousPid = dash.pid;
+      dash.expectedExit = true;
+      const exited = once(dash, "exit");
+      dash.kill("SIGTERM");
+      await exited;
+      dash = startDashboard();
+      await waitForDashboard(dash);
+      res.writeHead(200, { "Content-Type": "application/json" });
+      res.end(JSON.stringify({ previousPid, pid: dash.pid }));
+    } catch (error) {
+      res.writeHead(500).end(error.message);
+    }
   });
+  controlServer.listen(0, "127.0.0.1");
+  await once(controlServer, "listening");
+  writeFileSync(resolve(RUNTIME_DIR, "control.json"), JSON.stringify({
+    url: `http://127.0.0.1:${controlServer.address().port}`,
+  }));
   // Confirm the REST surface answers before we hand off to the browser tests.
   await waitForHttp(`${DASHBOARD_ORIGIN}/`, { timeoutMs: 30_000 }).catch(() => {});
   console.log(`[harness] dashboard ready on ${DASHBOARD_ORIGIN}`);

--- a/e2e/specs/session-restart.spec.ts
+++ b/e2e/specs/session-restart.spec.ts
@@ -1,0 +1,63 @@
+import { readFileSync } from "node:fs";
+import { resolve } from "node:path";
+import { test, expect } from "@playwright/test";
+import { RUNTIME_DIR } from "../harness/config.mjs";
+
+test("Core restart → resume the same conversation without reloading → switch conversations", async ({ page, request }) => {
+  test.setTimeout(90_000);
+  const promptSessionIds: string[] = [];
+  const resumedSessionIds: string[] = [];
+  page.on("websocket", (socket) => {
+    const resumeRequests = new Set<string | number>();
+    socket.on("framesent", ({ payload }) => {
+      const rpc = JSON.parse(String(payload));
+      if (rpc.method === "prompt.submit") promptSessionIds.push(rpc.params.session_id);
+      if (rpc.method === "session.resume") resumeRequests.add(rpc.id);
+    });
+    socket.on("framereceived", ({ payload }) => {
+      const rpc = JSON.parse(String(payload));
+      if (resumeRequests.has(rpc.id) && rpc.result?.session_id) {
+        resumedSessionIds.push(rpc.result.session_id);
+      }
+    });
+  });
+  const composer = page.getByRole("textbox", { name: "输入消息" });
+  const assistantRows = page.getByRole("log").locator('[data-role="assistant"]:has(button[title="朗读回复"])');
+  async function send(text: string) {
+    await composer.fill(text);
+    await page.getByRole("button", { name: "发送消息" }).click();
+    await expect(assistantRows.last()).toContainText(text);
+    await expect(composer).toHaveValue("");
+  }
+
+  await page.goto("/");
+  await send("restart-before-one");
+  await send("restart-before-two");
+  await expect(assistantRows).toHaveCount(2);
+  const originalUrl = page.url();
+  const previousSessionId = promptSessionIds[0];
+
+  const { url } = JSON.parse(readFileSync(resolve(RUNTIME_DIR, "control.json"), "utf8"));
+  const restart = await request.post(`${url}/restart`, { timeout: 45_000 });
+  expect(restart.ok()).toBe(true);
+  const { previousPid, pid } = await restart.json();
+  expect(pid).not.toBe(previousPid);
+  await expect.poll(() => resumedSessionIds.length).toBeGreaterThan(0);
+  const resumedSessionId = resumedSessionIds.at(-1)!;
+  expect(resumedSessionId).not.toBe(previousSessionId);
+
+  await send("restart-after-three");
+  expect(promptSessionIds.at(-1)).toBe(resumedSessionId);
+  await expect(page).toHaveURL(originalUrl);
+  await expect(assistantRows).toHaveCount(3);
+  await expect(assistantRows.nth(0)).toContainText("restart-before-one");
+  await expect(assistantRows.nth(1)).toContainText("restart-before-two");
+
+  await page.goto("/");
+  await send("restart-new-conversation");
+  expect(promptSessionIds.at(-1)).not.toBe(resumedSessionId);
+  await page.goto(originalUrl);
+  await expect(assistantRows).toHaveCount(3);
+  await send("restart-return-four");
+  await expect(assistantRows).toHaveCount(4);
+});

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "hermes-agent-cn-desktop",
-  "version": "0.8.0-rc7",
+  "version": "0.8.0-rc8",
   "private": true,
   "author": "Hermes Agent CN Contributors",
   "homepage": "https://hermesagent.org.cn",

--- a/packages/protocol/package.json
+++ b/packages/protocol/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@hermes/protocol",
-  "version": "0.8.0-rc7",
+  "version": "0.8.0-rc8",
   "private": true,
   "type": "module",
   "main": "./src/index.ts",

--- a/packages/protocol/src/hermes-api.test.ts
+++ b/packages/protocol/src/hermes-api.test.ts
@@ -97,6 +97,47 @@ describe("Memory provider schemas", () => {
     expect(parsed.fields[1].is_set).toBe(true);
   });
 
+  it("accepts numeric provider fields and normalizes nullable constraints", () => {
+    const parsed = MemoryProviderConfigResponse.parse({
+      name: "openviking",
+      label: "OpenViking",
+      fields: [
+        {
+          key: "recall_limit",
+          label: "Recall Limit",
+          kind: "integer",
+          value: "12",
+          minimum: 1,
+          maximum: 100,
+          step: null,
+        },
+        {
+          key: "recall_score_threshold",
+          label: "Recall Score Threshold",
+          kind: "number",
+          value: "0.42",
+          minimum: 0,
+          maximum: 1,
+          step: 0.01,
+        },
+      ],
+    });
+
+    expect(parsed.fields[0]).toMatchObject({
+      kind: "integer",
+      value: "12",
+      minimum: 1,
+      maximum: 100,
+      step: undefined,
+    });
+    expect(parsed.fields[1]).toMatchObject({
+      kind: "number",
+      minimum: 0,
+      maximum: 1,
+      step: 0.01,
+    });
+  });
+
   it("discriminates OpenViking runtime details", () => {
     const parsed = MemoryProviderRuntimeStatusResponse.parse({
       provider: "openviking",

--- a/packages/protocol/src/hermes-api.ts
+++ b/packages/protocol/src/hermes-api.ts
@@ -487,7 +487,7 @@ export const MemoryProviderConfigOption = z.object({
 export const MemoryProviderConfigField = z.object({
   key: z.string(),
   label: z.string(),
-  kind: z.enum(["text", "secret", "select", "boolean"]),
+  kind: z.enum(["text", "secret", "select", "boolean", "integer", "number"]),
   description: z.string().optional().default(""),
   placeholder: z.string().optional().default(""),
   required: z.boolean().optional().default(false),
@@ -496,6 +496,9 @@ export const MemoryProviderConfigField = z.object({
   options: z.array(MemoryProviderConfigOption).optional().default([]),
   url: z.string().optional().default(""),
   when: z.record(z.unknown()).nullable().optional(),
+  minimum: NullishNumber,
+  maximum: NullishNumber,
+  step: NullishNumber,
 }).passthrough();
 export type MemoryProviderConfigField = z.infer<typeof MemoryProviderConfigField>;
 
@@ -700,6 +703,15 @@ export const SkillContentResponse = z.object({
   path: z.string(),
 });
 export type SkillContentResponse = z.infer<typeof SkillContentResponse>;
+
+export const SkillWriteResponse = z.object({
+  success: z.boolean(),
+  message: z.string().optional(),
+  path: z.string().optional(),
+  skill_md: z.string().optional(),
+  category: z.string().optional(),
+}).passthrough();
+export type SkillWriteResponse = z.infer<typeof SkillWriteResponse>;
 
 // 技能 hub 搜索（GET /api/skills/hub/search?q=&source=&limit=&profile=）。
 // profile builder 的「从 hub 添加」用它；identifier 是安装时的唯一键。

--- a/packages/shared-ui/package.json
+++ b/packages/shared-ui/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@hermes/shared-ui",
-  "version": "0.8.0-rc7",
+  "version": "0.8.0-rc8",
   "private": true,
   "type": "module",
   "main": "./src/index.ts",

--- a/packages/shared-ui/src/tokens/primitive.css
+++ b/packages/shared-ui/src/tokens/primitive.css
@@ -28,17 +28,21 @@
   --h-color-blue-400: #4fc1ff;
   /* PrimeAPP tri-state palette — the only chromatic status hues. */
   --h-color-amber-500: #f59e0b;
+  --h-color-amber-800: #92400e;
   --h-color-green-500: #10b981;
   --h-color-green-600: #10b981;
+  --h-color-green-800: #065f46;
   --h-color-red-500: #ef4444;
   --h-color-red-600: #ef4444;
   --h-color-sky-500: #6e9bd1;
   --h-color-plum-500: #b58dc4;
 
-  --h-palette-success-light-fg: #10b981;
+  /* Darker foregrounds keep small status text at WCAG AA contrast on the
+     translucent light-theme status surfaces; surfaces retain the brand hue. */
+  --h-palette-success-light-fg: var(--h-color-green-800);
   --h-palette-success-light-surface: rgb(16 185 129 / 10%);
   --h-palette-success-light-border: rgb(16 185 129 / 30%);
-  --h-palette-warning-light-fg: #f59e0b;
+  --h-palette-warning-light-fg: var(--h-color-amber-800);
   --h-palette-warning-light-surface: rgb(245 158 11 / 10%);
   --h-palette-warning-light-border: rgb(245 158 11 / 30%);
   --h-palette-danger-light-fg: #ef4444;

--- a/scripts/prepare-local-dev-resources.mjs
+++ b/scripts/prepare-local-dev-resources.mjs
@@ -1,0 +1,117 @@
+import { spawnSync } from "node:child_process";
+import { existsSync, readdirSync, statSync } from "node:fs";
+import { join, resolve } from "node:path";
+
+function isDirectory(path) {
+  try {
+    return statSync(path).isDirectory();
+  } catch {
+    return false;
+  }
+}
+
+function treeContains(dir, predicate) {
+  if (!isDirectory(dir)) return false;
+  for (const entry of readdirSync(dir, { withFileTypes: true })) {
+    const full = join(dir, entry.name);
+    if (entry.isDirectory()) {
+      if (treeContains(full, predicate)) return true;
+    } else if (predicate(entry.name)) {
+      return true;
+    }
+  }
+  return false;
+}
+
+function defaultRunCommand(command, args, options) {
+  const result = spawnSync(command, args, {
+    cwd: options.cwd,
+    stdio: "inherit",
+    shell: process.platform === "win32",
+  });
+  if (result.error) throw result.error;
+  if (result.status !== 0) {
+    throw new Error(`${command} ${args.join(" ")} exited with ${result.status}`);
+  }
+}
+
+function npmCommand() {
+  return process.platform === "win32" ? "npm.cmd" : "npm";
+}
+
+function ensureBuiltAsset({ label, packageDir, valid, runCommand }) {
+  if (valid()) return;
+  if (!existsSync(join(packageDir, "package.json"))) {
+    throw new Error(`${label} package is missing: ${packageDir}`);
+  }
+
+  const npm = npmCommand();
+  if (!isDirectory(join(packageDir, "node_modules"))) {
+    runCommand(npm, ["install", "--no-package-lock"], { cwd: packageDir });
+  }
+  runCommand(npm, ["run", "build"], { cwd: packageDir });
+
+  if (!valid()) {
+    throw new Error(`${label} build did not create the expected output under ${packageDir}`);
+  }
+}
+
+function requireDirectory(path, label) {
+  if (!isDirectory(path)) throw new Error(`${label} directory is missing: ${path}`);
+}
+
+export function prepareLocalDevResources({
+  sourceRoot,
+  nodeExecutable = process.execPath,
+  runCommand = defaultRunCommand,
+}) {
+  const source = resolve(sourceRoot);
+  const node = resolve(nodeExecutable);
+  const dashboardDist = join(source, "hermes_cli", "web_dist");
+  const dashboardPackage = join(source, "web");
+  const tuiDir = join(source, "ui-tui");
+  const skillsDir = join(source, "skills");
+  const pluginsDir = join(source, "plugins");
+  const optionalSkillsDir = join(source, "optional-skills");
+  const optionalMcpsDir = join(source, "optional-mcps");
+
+  if (!existsSync(node)) throw new Error(`Node executable is missing: ${node}`);
+
+  ensureBuiltAsset({
+    label: "Core Dashboard",
+    packageDir: dashboardPackage,
+    valid: () => existsSync(join(dashboardDist, "index.html"))
+      && isDirectory(join(dashboardDist, "assets")),
+    runCommand,
+  });
+  ensureBuiltAsset({
+    label: "Core TUI",
+    packageDir: tuiDir,
+    valid: () => existsSync(join(tuiDir, "dist", "entry.js")),
+    runCommand,
+  });
+
+  requireDirectory(skillsDir, "Bundled skills");
+  if (!treeContains(skillsDir, (name) => name.toLowerCase() === "skill.md")) {
+    throw new Error(`Bundled skills contain no SKILL.md files: ${skillsDir}`);
+  }
+  requireDirectory(pluginsDir, "Bundled plugins");
+  if (!treeContains(pluginsDir, (name) => {
+    const lower = name.toLowerCase();
+    return lower === "plugin.yaml" || lower === "plugin.yml";
+  })) {
+    throw new Error(`Bundled plugins contain no plugin.yaml files: ${pluginsDir}`);
+  }
+  requireDirectory(optionalSkillsDir, "Optional skills");
+  requireDirectory(optionalMcpsDir, "Optional MCP catalog");
+
+  return {
+    HERMES_DESKTOP_DASHBOARD_WEB_DIST_DIR: dashboardDist,
+    HERMES_DESKTOP_BUNDLED_SKILLS_DIR: skillsDir,
+    HERMES_DESKTOP_BUNDLED_PLUGINS_DIR: pluginsDir,
+    HERMES_OPTIONAL_SKILLS: optionalSkillsDir,
+    HERMES_OPTIONAL_MCPS: optionalMcpsDir,
+    HERMES_DESKTOP_NODE_BINARY: node,
+    HERMES_DESKTOP_TUI_DIR: tuiDir,
+  };
+}

--- a/scripts/prepare-local-dev-resources.mjs
+++ b/scripts/prepare-local-dev-resources.mjs
@@ -39,23 +39,6 @@ function npmCommand() {
   return process.platform === "win32" ? "npm.cmd" : "npm";
 }
 
-function ensureBuiltAsset({ label, packageDir, valid, runCommand }) {
-  if (valid()) return;
-  if (!existsSync(join(packageDir, "package.json"))) {
-    throw new Error(`${label} package is missing: ${packageDir}`);
-  }
-
-  const npm = npmCommand();
-  if (!isDirectory(join(packageDir, "node_modules"))) {
-    runCommand(npm, ["install", "--no-package-lock"], { cwd: packageDir });
-  }
-  runCommand(npm, ["run", "build"], { cwd: packageDir });
-
-  if (!valid()) {
-    throw new Error(`${label} build did not create the expected output under ${packageDir}`);
-  }
-}
-
 function requireDirectory(path, label) {
   if (!isDirectory(path)) throw new Error(`${label} directory is missing: ${path}`);
 }
@@ -68,7 +51,6 @@ export function prepareLocalDevResources({
   const source = resolve(sourceRoot);
   const node = resolve(nodeExecutable);
   const dashboardDist = join(source, "hermes_cli", "web_dist");
-  const dashboardPackage = join(source, "web");
   const tuiDir = join(source, "ui-tui");
   const skillsDir = join(source, "skills");
   const pluginsDir = join(source, "plugins");
@@ -77,19 +59,30 @@ export function prepareLocalDevResources({
 
   if (!existsSync(node)) throw new Error(`Node executable is missing: ${node}`);
 
-  ensureBuiltAsset({
-    label: "Core Dashboard",
-    packageDir: dashboardPackage,
-    valid: () => existsSync(join(dashboardDist, "index.html"))
-      && isDirectory(join(dashboardDist, "assets")),
-    runCommand,
-  });
-  ensureBuiltAsset({
-    label: "Core TUI",
-    packageDir: tuiDir,
-    valid: () => existsSync(join(tuiDir, "dist", "entry.js")),
-    runCommand,
-  });
+  const assets = [
+    {
+      workspace: "web",
+      valid: () => existsSync(join(dashboardDist, "index.html"))
+        && isDirectory(join(dashboardDist, "assets")),
+    },
+    { workspace: "ui-tui", valid: () => existsSync(join(tuiDir, "dist", "entry.js")) },
+  ];
+  const missingAssets = assets.filter((asset) => !asset.valid());
+  if (missingAssets.length > 0) {
+    // Core owns a single workspace lockfile. Installing inside each package
+    // ignores its pinned dependency graph and can produce peer conflicts.
+    const npm = npmCommand();
+    runCommand(npm, [
+      "ci", "--workspace=web", "--workspace=ui-tui", "--include-workspace-root=false",
+      "--no-audit", "--no-fund",
+    ], { cwd: source });
+    for (const asset of missingAssets) {
+      runCommand(npm, ["run", "build", `--workspace=${asset.workspace}`], { cwd: source });
+      if (!asset.valid()) {
+        throw new Error(`Core ${asset.workspace} build did not create the expected output`);
+      }
+    }
+  }
 
   requireDirectory(skillsDir, "Bundled skills");
   if (!treeContains(skillsDir, (name) => name.toLowerCase() === "skill.md")) {

--- a/scripts/prepare-local-dev-resources.test.mjs
+++ b/scripts/prepare-local-dev-resources.test.mjs
@@ -61,12 +61,12 @@ test("installs dependencies and builds missing Dashboard and TUI outputs", () =>
     const calls = [];
     const runCommand = (command, args, options) => {
       calls.push({ command, args, cwd: options.cwd });
-      if (args[0] === "install") {
+      if (args[0] === "ci") {
         mkdirSync(join(options.cwd, "node_modules"), { recursive: true });
-      } else if (options.cwd === webDir) {
+      } else if (args.includes("--workspace=web")) {
         write(join(sourceRoot, "hermes_cli", "web_dist", "index.html"), "<main />");
         write(join(sourceRoot, "hermes_cli", "web_dist", "assets", "app.js"), "// app");
-      } else if (options.cwd === tuiDir) {
+      } else if (args.includes("--workspace=ui-tui")) {
         write(join(tuiDir, "dist", "entry.js"), "// tui");
       }
     };
@@ -76,10 +76,9 @@ test("installs dependencies and builds missing Dashboard and TUI outputs", () =>
     assert.deepEqual(
       calls.map(({ args, cwd }) => [args.join(" "), cwd]),
       [
-        ["install --no-package-lock", webDir],
-        ["run build", webDir],
-        ["install --no-package-lock", tuiDir],
-        ["run build", tuiDir],
+        ["ci --workspace=web --workspace=ui-tui --include-workspace-root=false --no-audit --no-fund", sourceRoot],
+        ["run build --workspace=web", sourceRoot],
+        ["run build --workspace=ui-tui", sourceRoot],
       ],
     );
   } finally {

--- a/scripts/prepare-local-dev-resources.test.mjs
+++ b/scripts/prepare-local-dev-resources.test.mjs
@@ -1,0 +1,88 @@
+import assert from "node:assert/strict";
+import { mkdtempSync, mkdirSync, rmSync, writeFileSync } from "node:fs";
+import { tmpdir } from "node:os";
+import { join } from "node:path";
+import test from "node:test";
+
+import { prepareLocalDevResources } from "./prepare-local-dev-resources.mjs";
+
+function write(path, content = "fixture") {
+  mkdirSync(join(path, ".."), { recursive: true });
+  writeFileSync(path, content);
+}
+
+function seedCatalogs(sourceRoot) {
+  write(join(sourceRoot, "skills", "demo", "SKILL.md"), "# demo");
+  write(join(sourceRoot, "plugins", "demo", "plugin.yaml"), "name: demo\n");
+  write(join(sourceRoot, "plugins", "demo", "__init__.py"), "");
+  write(join(sourceRoot, "optional-skills", "demo", "SKILL.md"), "# optional");
+  write(join(sourceRoot, "optional-mcps", "demo", "manifest.yaml"), "name: demo\n");
+}
+
+test("returns every resource path without rebuilding complete Core assets", () => {
+  const root = mkdtempSync(join(tmpdir(), "hermes-local-resources-"));
+  try {
+    const sourceRoot = join(root, "core");
+    write(join(sourceRoot, "hermes_cli", "web_dist", "index.html"), "<main />");
+    write(join(sourceRoot, "hermes_cli", "web_dist", "assets", "app.js"), "// app");
+    write(join(sourceRoot, "ui-tui", "dist", "entry.js"), "// tui");
+    seedCatalogs(sourceRoot);
+
+    const calls = [];
+    const env = prepareLocalDevResources({
+      sourceRoot,
+      nodeExecutable: process.execPath,
+      runCommand: (...args) => calls.push(args),
+    });
+
+    assert.equal(calls.length, 0);
+    assert.equal(env.HERMES_DESKTOP_DASHBOARD_WEB_DIST_DIR, join(sourceRoot, "hermes_cli", "web_dist"));
+    assert.equal(env.HERMES_DESKTOP_BUNDLED_SKILLS_DIR, join(sourceRoot, "skills"));
+    assert.equal(env.HERMES_DESKTOP_BUNDLED_PLUGINS_DIR, join(sourceRoot, "plugins"));
+    assert.equal(env.HERMES_OPTIONAL_SKILLS, join(sourceRoot, "optional-skills"));
+    assert.equal(env.HERMES_OPTIONAL_MCPS, join(sourceRoot, "optional-mcps"));
+    assert.equal(env.HERMES_DESKTOP_NODE_BINARY, process.execPath);
+    assert.equal(env.HERMES_DESKTOP_TUI_DIR, join(sourceRoot, "ui-tui"));
+  } finally {
+    rmSync(root, { recursive: true, force: true });
+  }
+});
+
+test("installs dependencies and builds missing Dashboard and TUI outputs", () => {
+  const root = mkdtempSync(join(tmpdir(), "hermes-local-resources-build-"));
+  try {
+    const sourceRoot = join(root, "core");
+    const webDir = join(sourceRoot, "web");
+    const tuiDir = join(sourceRoot, "ui-tui");
+    write(join(webDir, "package.json"), "{}");
+    write(join(tuiDir, "package.json"), "{}");
+    seedCatalogs(sourceRoot);
+
+    const calls = [];
+    const runCommand = (command, args, options) => {
+      calls.push({ command, args, cwd: options.cwd });
+      if (args[0] === "install") {
+        mkdirSync(join(options.cwd, "node_modules"), { recursive: true });
+      } else if (options.cwd === webDir) {
+        write(join(sourceRoot, "hermes_cli", "web_dist", "index.html"), "<main />");
+        write(join(sourceRoot, "hermes_cli", "web_dist", "assets", "app.js"), "// app");
+      } else if (options.cwd === tuiDir) {
+        write(join(tuiDir, "dist", "entry.js"), "// tui");
+      }
+    };
+
+    prepareLocalDevResources({ sourceRoot, nodeExecutable: process.execPath, runCommand });
+
+    assert.deepEqual(
+      calls.map(({ args, cwd }) => [args.join(" "), cwd]),
+      [
+        ["install --no-package-lock", webDir],
+        ["run build", webDir],
+        ["install --no-package-lock", tuiDir],
+        ["run build", tuiDir],
+      ],
+    );
+  } finally {
+    rmSync(root, { recursive: true, force: true });
+  }
+});

--- a/scripts/stage-bundled-runtime.mjs
+++ b/scripts/stage-bundled-runtime.mjs
@@ -63,6 +63,9 @@ const keepExisting = hasFlag("--keep-existing");
 
 const runtimeName = `hermes-agent-cn-runtime-${platform}-${arch}`;
 const manifestName = `${channel}-${platform}-${arch}.json`;
+// The bundled loader has a fixed filename, independent of the signed update
+// channel. Preserve the manifest bytes so canary signatures remain valid.
+const bundledManifestName = `stable-${platform}-${arch}.json`;
 const zipName = `${runtimeName}.zip`;
 const baseUrl = tag === "latest"
   ? `https://github.com/${repo}/releases/latest/download`
@@ -192,7 +195,7 @@ if (actualSha !== String(manifest.sha256).toLowerCase()) {
   throw new Error(`sha256 mismatch for ${zipName}: expected ${manifest.sha256}, got ${actualSha}`);
 }
 
-writeFileSync(join(outDir, manifestName), manifestBytes);
+writeFileSync(join(outDir, bundledManifestName), manifestBytes);
 const artifactPath = expandArtifact
   ? expandRuntimeZip(zipBytes)
   : join(outDir, zipName);
@@ -209,6 +212,7 @@ writeFileSync(join(outDir, "README.generated.txt"), [
   `kernelVersion=${manifest.kernelVersion}`,
   `runtimeFlavor=${manifest.runtimeFlavor}`,
   `runtimeRevision=${manifest.runtimeRevision}`,
+  `manifestChannel=${manifest.channel}`,
   `sourceRepo=${manifest.sourceRepo}`,
   `sourceCommit=${manifest.sourceCommit}`,
   `sha256=${manifest.sha256}`,
@@ -217,4 +221,4 @@ writeFileSync(join(outDir, "README.generated.txt"), [
 
 console.log(`staged bundled runtime ${manifest.runtimeVersion} at ${outDir}`);
 console.log(`artifact: ${artifactPath}`);
-console.log(`manifest: ${join(outDir, manifestName)}`);
+console.log(`manifest: ${join(outDir, bundledManifestName)}`);

--- a/scripts/tauri-dev-managed.mjs
+++ b/scripts/tauri-dev-managed.mjs
@@ -1,11 +1,29 @@
 #!/usr/bin/env node
 import { spawnSync, spawn } from "node:child_process";
+import { existsSync } from "node:fs";
 import { homedir } from "node:os";
 import { dirname, join, resolve } from "node:path";
 import { fileURLToPath } from "node:url";
+import { prepareLocalDevResources } from "./prepare-local-dev-resources.mjs";
 
 const repoRoot = resolve(dirname(fileURLToPath(import.meta.url)), "..");
 const skipInstall = process.env.HERMES_DESKTOP_SKIP_LOCAL_RUNTIME_INSTALL === "1";
+
+function argValue(flag) {
+  const index = process.argv.indexOf(flag);
+  return index === -1 ? null : process.argv[index + 1] ?? null;
+}
+
+function defaultSourceRoot() {
+  const preferred = resolve(repoRoot, "../Hermes-CN-Core");
+  if (existsSync(preferred)) return preferred;
+  return resolve(repoRoot, "../hermes-agent-cn");
+}
+
+const sourceRoot = resolve(
+  repoRoot,
+  argValue("--source") ?? process.env.HERMES_AGENT_CN_SOURCE ?? defaultSourceRoot(),
+);
 
 function devRuntimeRoot() {
   if (process.env.HERMES_DESKTOP_RUNTIME_ROOT) {
@@ -24,7 +42,9 @@ if (process.argv.includes("--help") || process.argv.includes("-h")) {
   console.log(`Usage: pnpm tauri:dev[:managed] [--source ../Hermes-CN-Core] [--force]
 
 Installs Hermes-CN-Core into the desktop managed runtime folder, then starts
-Tauri dev with external PATH hermes fallback disabled.`);
+Tauri dev with external PATH hermes fallback disabled. Missing Core Dashboard
+and TUI assets are built automatically, and all local resources are injected
+into the managed desktop process.`);
   process.exit(0);
 }
 
@@ -42,24 +62,61 @@ if (!skipInstall) {
   runNodeScript(resolve(repoRoot, "scripts", "install-local-runtime.mjs"), process.argv.slice(2));
 }
 
+const localResources = prepareLocalDevResources({
+  sourceRoot,
+  nodeExecutable: process.execPath,
+});
+
+function envDefault(name, fallback) {
+  return process.env[name] ?? fallback;
+}
+
 const pnpm = process.platform === "win32" ? "pnpm.cmd" : "pnpm";
 const child = spawn(pnpm, ["exec", "tauri", "dev"], {
   cwd: repoRoot,
   stdio: "inherit",
+  // Windows cannot execute .cmd files directly through CreateProcess; without
+  // a command shell Node reports spawn EINVAL before Tauri starts.
+  shell: process.platform === "win32",
   env: {
     ...process.env,
     // Dev kernels live under dev-runtime/ so they never overwrite the packaged
     // app's production runtime/current.json.
-    HERMES_DESKTOP_RUNTIME_ROOT:
-      process.env.HERMES_DESKTOP_RUNTIME_ROOT ?? devRuntimeRoot(),
-    HERMES_DESKTOP_PRESERVE_LOCAL_RUNTIME:
-      process.env.HERMES_DESKTOP_PRESERVE_LOCAL_RUNTIME ?? "1",
+    HERMES_DESKTOP_RUNTIME_ROOT: envDefault("HERMES_DESKTOP_RUNTIME_ROOT", devRuntimeRoot()),
+    HERMES_DESKTOP_PRESERVE_LOCAL_RUNTIME: envDefault("HERMES_DESKTOP_PRESERVE_LOCAL_RUNTIME", "1"),
     // Default dev mode now exercises the same managed runtime path as the
     // packaged app. Use HERMES_DESKTOP_DEV_EXTERNAL_DASHBOARD=1 only when you
     // deliberately want to attach to a separately started dashboard.
-    HERMES_DESKTOP_ALLOW_EXTERNAL_AGENT: process.env.HERMES_DESKTOP_ALLOW_EXTERNAL_AGENT ?? "0",
-    HERMES_DASHBOARD_TUI: process.env.HERMES_DASHBOARD_TUI ?? "1",
+    HERMES_DESKTOP_ALLOW_EXTERNAL_AGENT: envDefault("HERMES_DESKTOP_ALLOW_EXTERNAL_AGENT", "0"),
+    HERMES_DASHBOARD_TUI: envDefault("HERMES_DASHBOARD_TUI", "1"),
+    HERMES_DESKTOP_DASHBOARD_WEB_DIST_DIR: envDefault(
+      "HERMES_DESKTOP_DASHBOARD_WEB_DIST_DIR",
+      localResources.HERMES_DESKTOP_DASHBOARD_WEB_DIST_DIR,
+    ),
+    HERMES_DESKTOP_BUNDLED_SKILLS_DIR: envDefault(
+      "HERMES_DESKTOP_BUNDLED_SKILLS_DIR",
+      localResources.HERMES_DESKTOP_BUNDLED_SKILLS_DIR,
+    ),
+    HERMES_DESKTOP_BUNDLED_PLUGINS_DIR: envDefault(
+      "HERMES_DESKTOP_BUNDLED_PLUGINS_DIR",
+      localResources.HERMES_DESKTOP_BUNDLED_PLUGINS_DIR,
+    ),
+    HERMES_OPTIONAL_SKILLS: envDefault("HERMES_OPTIONAL_SKILLS", localResources.HERMES_OPTIONAL_SKILLS),
+    HERMES_OPTIONAL_MCPS: envDefault("HERMES_OPTIONAL_MCPS", localResources.HERMES_OPTIONAL_MCPS),
+    HERMES_DESKTOP_NODE_BINARY: envDefault(
+      "HERMES_DESKTOP_NODE_BINARY",
+      localResources.HERMES_DESKTOP_NODE_BINARY,
+    ),
+    HERMES_DESKTOP_TUI_DIR: envDefault(
+      "HERMES_DESKTOP_TUI_DIR",
+      localResources.HERMES_DESKTOP_TUI_DIR,
+    ),
   },
+});
+
+child.on("error", (error) => {
+  console.error(`Failed to start Tauri dev: ${error.message}`);
+  process.exit(1);
 });
 
 child.on("exit", (code, signal) => {

--- a/src/commands/config_migration.rs
+++ b/src/commands/config_migration.rs
@@ -3,18 +3,13 @@ use std::fs;
 use std::path::{Path, PathBuf};
 use std::time::{SystemTime, UNIX_EPOCH};
 
-use regex::Regex;
 use serde::{Deserialize, Serialize};
-use std::sync::LazyLock;
 use tauri::State;
 
 use crate::commands::runtime_manager;
 use crate::error::{AppError, AppResult};
+use crate::profile_name::is_valid_profile_name;
 use crate::state::AppState;
-
-static PROFILE_NAME_RE: LazyLock<Regex> = LazyLock::new(|| {
-    Regex::new(r"^[A-Za-z0-9][A-Za-z0-9_-]{0,31}$").expect("valid profile name regex")
-});
 
 const PROFILE_DIRS: &[&str] = &[
     "memories",
@@ -135,10 +130,6 @@ struct SourceHint {
     source_kind: String,
     distro: Option<String>,
     profile_name: Option<String>,
-}
-
-fn is_valid_profile_name(name: &str) -> bool {
-    PROFILE_NAME_RE.is_match(name)
 }
 
 fn active_profile_sticky_path(base: &Path) -> PathBuf {

--- a/src/commands/profiles.rs
+++ b/src/commands/profiles.rs
@@ -9,19 +9,14 @@
 
 use std::fs;
 use std::path::{Path, PathBuf};
-use std::sync::LazyLock;
 
-use regex::Regex;
 use serde::{Deserialize, Serialize};
 use tauri::State;
 
 use crate::commands::restart::{self, RespawnOutcome};
 use crate::error::AppError;
+use crate::profile_name::is_valid_profile_name;
 use crate::state::AppState;
-
-static PROFILE_NAME_RE: LazyLock<Regex> = LazyLock::new(|| {
-    Regex::new(r"^[A-Za-z0-9][A-Za-z0-9_-]{0,31}$").expect("valid profile name regex")
-});
 
 #[derive(Debug, Deserialize)]
 #[serde(rename_all = "camelCase")]
@@ -83,10 +78,6 @@ pub fn read_active_profile_sticky(base: &str) -> String {
         }
         Err(_) => "default".to_string(),
     }
-}
-
-fn is_valid_profile_name(name: &str) -> bool {
-    PROFILE_NAME_RE.is_match(name)
 }
 
 #[tauri::command]
@@ -296,15 +287,15 @@ mod tests {
         // Cannot start with hyphen / underscore
         assert!(!is_valid_profile_name("-leading-hyphen"));
         assert!(!is_valid_profile_name("_leading-underscore"));
-        // Too long (>32 chars)
-        assert!(!is_valid_profile_name(&"a".repeat(33)));
+        // Too long (>64 chars)
+        assert!(!is_valid_profile_name(&"a".repeat(65)));
     }
 
     #[test]
     fn profile_name_length_boundary() {
-        // 32 chars exactly is the max — regex is {0,31} after first char = 32 total
-        assert!(is_valid_profile_name(&"a".repeat(32)));
-        assert!(!is_valid_profile_name(&"a".repeat(33)));
+        // 64 chars exactly is the shared Core/Web maximum.
+        assert!(is_valid_profile_name(&"a".repeat(64)));
+        assert!(!is_valid_profile_name(&"a".repeat(65)));
     }
 
     // -------- read / write active_profile sticky --------

--- a/src/cron_runs.rs
+++ b/src/cron_runs.rs
@@ -12,14 +12,14 @@ use std::io::Read;
 use std::path::{Path, PathBuf};
 use std::sync::LazyLock;
 
+use crate::profile_name::is_valid_profile_name;
+
 const ROUTE_PREFIX: &str = "/__hermes_cron_runs/";
 const DEFAULT_LIMIT: usize = 30;
 const MAX_LIMIT: usize = 100;
 const LIST_PREVIEW_BYTES: u64 = 64 * 1024;
 const DETAIL_MAX_BYTES: u64 = 2 * 1024 * 1024;
 
-static PROFILE_RE: LazyLock<Regex> =
-    LazyLock::new(|| Regex::new(r"^[A-Za-z0-9][A-Za-z0-9_-]{0,31}$").expect("valid profile regex"));
 static JOB_ID_RE: LazyLock<Regex> =
     LazyLock::new(|| Regex::new(r"^[A-Za-z0-9_-]{1,128}$").expect("valid job id regex"));
 static OUTPUT_FILE_RE: LazyLock<Regex> = LazyLock::new(|| {
@@ -35,7 +35,7 @@ fn decode_path_segment(value: &str) -> Option<String> {
 }
 
 fn validate_profile(value: &str) -> Result<(), &'static str> {
-    if PROFILE_RE.is_match(value) {
+    if is_valid_profile_name(value) {
         Ok(())
     } else {
         Err("invalid profile")
@@ -192,29 +192,60 @@ fn first_meaningful_line(content: &str) -> Option<String> {
 }
 
 fn infer_status(content: &str) -> &'static str {
-    let lower = content.to_lowercase();
-    if lower.contains("**status:** blocked")
-        || lower.contains("prompt-injection scanner")
-        || lower.contains("blocked by injection scanner")
+    // Core persists the full Prompt before the Response. Standard cron
+    // guidance mentions [SILENT] and the injection scanner, so status hints
+    // must never be searched across the whole document.
+    let metadata = content
+        .split_once("\n## Prompt")
+        .map(|(head, _)| head)
+        .unwrap_or(content);
+    let metadata_lower = metadata.to_lowercase();
+
+    if metadata_lower.contains("**status:** blocked")
+        || metadata_lower.contains("blocked by prompt-injection scanner")
     {
         return "blocked";
     }
-    if lower.contains("[silent]")
-        || lower.contains("**status:** silent")
-        || lower.contains("silent run")
-        || lower.contains("wakeagent=false")
-        || lower.contains("empty stdout")
-    {
-        return "silent";
-    }
-    if lower.contains("# cron job:") && lower.contains("(failed)")
-        || lower.contains("\n## error")
-        || lower.contains("**status:** script failed")
-        || lower.contains(" script failed")
+    let explicit_failed_status = metadata_lower.lines().any(|line| {
+        let line = line.trim();
+        line.starts_with("**status:**") && line.contains("failed")
+    });
+    if metadata_lower.contains("# cron job:") && metadata_lower.contains("(failed)")
+        || explicit_failed_status
+        || (!content.contains("\n## Prompt") && metadata_lower.contains("\n## error"))
     {
         return "error";
     }
-    if lower.contains("\n## response") || lower.contains("# cron job:") {
+    if metadata_lower.contains("**status:** silent")
+        || metadata_lower.contains("**status:** no_change")
+        || metadata_lower.contains("silent run")
+        || metadata_lower.contains("wakeagent=false")
+        || metadata_lower.contains("empty stdout")
+    {
+        return "silent";
+    }
+
+    // The official Agent document writes Response after Prompt, so the final
+    // marker is the structural delimiter even when user text quotes a heading.
+    if let Some(marker_start) = content.rfind("\n## Response") {
+        let response = &content[marker_start + "\n## Response".len()..];
+        let first = first_meaningful_line(response)
+            .unwrap_or_default()
+            .to_lowercase();
+        if first.is_empty() || first == "[silent]" || first == "(no response generated)" {
+            return "silent";
+        }
+        if first.starts_with("status: silent") || first.starts_with("status: blocked") {
+            return if first.starts_with("status: blocked") {
+                "blocked"
+            } else {
+                "silent"
+            };
+        }
+        return "success";
+    }
+
+    if metadata_lower.contains("# cron job:") {
         return "success";
     }
     "unknown"
@@ -512,7 +543,47 @@ mod tests {
             "blocked"
         );
         assert_eq!(infer_status("**Status:** silent (empty output)"), "silent");
+        assert_eq!(
+            infer_status("# Cron Job: monitor\n\n**Status:** no_change (agent run suppressed)"),
+            "silent"
+        );
+        assert_eq!(
+            infer_status("# Cron Job: monitor\n\n**Status:** monitor source failed\n\ntimeout"),
+            "error"
+        );
         assert_eq!(infer_status("plain text"), "unknown");
+    }
+
+    #[test]
+    fn prompt_protocol_hints_do_not_override_a_substantive_response() {
+        let content = r#"# Cron Job: useful run
+
+**Job ID:** job1
+
+## Prompt
+
+Reply with [SILENT] only when there is nothing to report. The prompt-injection scanner may block unsafe input.
+
+## Response
+
+There is a substantive update for the user.
+"#;
+
+        assert_eq!(infer_status(content), "success");
+    }
+
+    #[test]
+    fn response_silence_markers_remain_silent() {
+        assert_eq!(
+            infer_status("# Cron Job: A\n\n## Prompt\n\nwork\n\n## Response\n\n[SILENT]"),
+            "silent"
+        );
+        assert_eq!(
+            infer_status(
+                "# Cron Job: A\n\n## Prompt\n\nwork\n\n## Response\n\n(No response generated)"
+            ),
+            "silent"
+        );
     }
 
     #[test]

--- a/src/lib.rs
+++ b/src/lib.rs
@@ -11,6 +11,7 @@ pub mod oauth_session;
 pub mod path_resolver;
 pub mod prevent_sleep;
 pub mod process;
+pub(crate) mod profile_name;
 pub mod session_archive;
 pub mod session_log;
 pub mod state;

--- a/src/process/runtime.rs
+++ b/src/process/runtime.rs
@@ -1014,7 +1014,29 @@ pub fn sync_runtime_resources_if_available(
         return Ok(RuntimeResourceSyncResult::default());
     };
 
+    // Bootstrap calls this again after bundled installation. Apply the same
+    // revision rule here so that second sync cannot mix older resources into
+    // the newer runtime we just preserved.
+    if current.source != "local-source" {
+        if let Some(manifest) = bundled_runtime_dir(resource_dir)
+            .and_then(|dir| read_json_file::<RuntimeUpdateManifest>(&bundled_manifest_path(&dir)))
+        {
+            if is_newer_compatible_runtime(&current, &manifest) {
+                return Ok(RuntimeResourceSyncResult::default());
+            }
+        }
+    }
+
     sync_available_runtime_resources_from_resource(resource_dir, Path::new(&current.path))
+}
+
+fn is_newer_compatible_runtime(
+    current: &RuntimeInstallRecord,
+    bundled: &RuntimeUpdateManifest,
+) -> bool {
+    current.kernel_version == bundled.kernel_version
+        && current.runtime_flavor == bundled.runtime_flavor
+        && current.runtime_revision > bundled.runtime_revision
 }
 
 pub fn current_bundled_skills_dir() -> Option<PathBuf> {
@@ -2149,6 +2171,21 @@ pub async fn install_bundled_runtime_if_needed(
                     error: Some(format!("failed to clear local-source current.json: {}", e)),
                 };
             }
+        } else if is_newer_compatible_runtime(&current, &manifest) {
+            // The dashboard contract is tied to the kernel version. Keep a
+            // newer revision of that same kernel/flavor, including its own
+            // resources; copying older bundled plugins would mix releases.
+            log::info!(
+                "Keeping installed runtime {} over older bundled {}",
+                current.runtime_version,
+                manifest.runtime_version
+            );
+            return RuntimeInstallUpdateResult {
+                ok: true,
+                installed: None,
+                previous: Some(current),
+                error: None,
+            };
         } else if current.runtime_version == manifest.runtime_version {
             if let Err(e) =
                 sync_runtime_resources_from_resource(resource_dir, Path::new(&current.path))
@@ -4274,6 +4311,110 @@ mod tests {
             .join("demo")
             .join("SKILL.md")
             .is_file());
+    }
+
+    #[tokio::test]
+    #[serial]
+    #[cfg(unix)]
+    async fn install_bundled_runtime_preserves_newer_compatible_revisions() {
+        use std::os::unix::fs::PermissionsExt;
+
+        for (kernel, flavor, revision, executable_present, should_install) in [
+            ("0.20.0", "cn", 10, true, false),
+            ("0.20.0", "cn", 100, true, false),
+            ("0.20.0", "cn", 9, true, false),
+            ("0.20.0", "cn", 8, true, true),
+            ("0.19.0", "cn", 99, true, true),
+            ("0.21.0", "cn", 1, true, true),
+            ("0.20.0", "other", 10, true, true),
+            ("0.20.0", "cn", 10, false, true),
+        ] {
+            let dir = TempDir::new().unwrap();
+            let runtime_root = dir.path().join("runtime");
+            let resource = dir.path().join("resources");
+            let bundled = resource.join("bundled-runtime");
+            let expanded = bundled_expanded_runtime_dir(&bundled);
+            fs::create_dir_all(&expanded).unwrap();
+            let bundled_exe = expanded.join(primary_runtime_name());
+            fs::write(&bundled_exe, b"#!/bin/sh\nexit 0\n").unwrap();
+            fs::set_permissions(&bundled_exe, fs::Permissions::from_mode(0o755)).unwrap();
+
+            let (key, pem) = test_keypair();
+            let mut bundled_manifest = fixture_manifest();
+            bundled_manifest.kernel_version = "0.20.0".into();
+            bundled_manifest.runtime_version = "0.20.0-cn.9".into();
+            bundled_manifest.runtime_revision = 9;
+            bundled_manifest.platform = current_platform().into();
+            bundled_manifest.arch = current_arch().into();
+            sign_manifest(&key, &mut bundled_manifest);
+            write_json_file(&bundled_manifest_path(&bundled), &bundled_manifest).unwrap();
+
+            let mut current_manifest = bundled_manifest.clone();
+            current_manifest.kernel_version = kernel.into();
+            current_manifest.runtime_flavor = flavor.into();
+            current_manifest.runtime_revision = revision;
+            current_manifest.runtime_version = format!("{kernel}-{flavor}.{revision}");
+            let current_dir = runtime_root
+                .join("versions")
+                .join(&current_manifest.runtime_version);
+            fs::create_dir_all(&current_dir).unwrap();
+            let current_exe = current_dir.join(primary_runtime_name());
+            if executable_present {
+                fs::write(&current_exe, b"installed executable").unwrap();
+            }
+            let current = install_record_from_manifest(
+                &current_manifest,
+                &current_dir,
+                &current_exe,
+                "update",
+                None,
+            );
+            let current_web = current_dir
+                .join("_internal/hermes_cli")
+                .join(DASHBOARD_WEB_DIST_DIR);
+            fs::create_dir_all(&current_web).unwrap();
+            fs::write(current_web.join("index.html"), b"installed dashboard").unwrap();
+            let bundled_web = resource
+                .join(DASHBOARD_RESOURCE_DIR)
+                .join(DASHBOARD_WEB_DIST_DIR);
+            fs::create_dir_all(&bundled_web).unwrap();
+            fs::write(bundled_web.join("index.html"), b"bundled dashboard").unwrap();
+            let bundled_skill = resource.join(BUNDLED_SKILLS_RESOURCE_DIR).join("demo");
+            fs::create_dir_all(&bundled_skill).unwrap();
+            fs::write(bundled_skill.join("SKILL.md"), b"---\nname: demo\n---\n").unwrap();
+
+            std::env::set_var("HERMES_DESKTOP_RUNTIME_ROOT", &runtime_root);
+            std::env::set_var("HERMES_RUNTIME_UPDATE_PUBLIC_KEY_PEM", pem);
+            write_json_file(&current_record_path(), &current).unwrap();
+            let original_record = fs::read(current_record_path()).unwrap();
+            let result = install_bundled_runtime_if_needed(Some(&resource)).await;
+            let sync_result = sync_runtime_resources_if_available(Some(&resource));
+            let after = read_current_record();
+            let after_record = fs::read(current_record_path()).unwrap();
+            std::env::remove_var("HERMES_RUNTIME_UPDATE_PUBLIC_KEY_PEM");
+            std::env::remove_var("HERMES_DESKTOP_RUNTIME_ROOT");
+
+            assert!(
+                result.ok,
+                "{kernel}-{flavor}.{revision}: {:?}",
+                result.error
+            );
+            assert!(sync_result.is_ok(), "{sync_result:?}");
+            assert_eq!(result.installed.is_some(), should_install);
+            let after = after.unwrap();
+            if should_install {
+                assert_eq!(after.runtime_version, bundled_manifest.runtime_version);
+            } else {
+                assert_eq!(after.runtime_version, current.runtime_version);
+                assert_eq!(after_record, original_record);
+                let expected: &[u8] = if revision > 9 {
+                    b"installed dashboard"
+                } else {
+                    b"bundled dashboard"
+                };
+                assert_eq!(fs::read(current_web.join("index.html")).unwrap(), expected);
+            }
+        }
     }
 
     #[tokio::test]

--- a/src/process/runtime.rs
+++ b/src/process/runtime.rs
@@ -1082,17 +1082,33 @@ fn tui_dir_if_present(runtime_dir: &Path) -> Option<PathBuf> {
     tui.join("dist").join("entry.js").is_file().then_some(tui)
 }
 
+fn node_override_if_present(raw: Option<std::ffi::OsString>) -> Option<PathBuf> {
+    let node = PathBuf::from(raw?);
+    node.is_file().then_some(node)
+}
+
+fn tui_override_if_present(raw: Option<std::ffi::OsString>) -> Option<PathBuf> {
+    let tui = PathBuf::from(raw?);
+    tui.join("dist").join("entry.js").is_file().then_some(tui)
+}
+
 /// Directory holding the bundled `node`/`npm`/`npx`, when the current managed
 /// runtime ships one. Prepend to a spawned child's PATH so `shutil.which`
 /// (TUI launch, node-based MCP servers, playwright, `npx tsc`) resolves them
 /// without a host Node install. See FORK_NOTES P-032.
 pub fn current_node_bin_dir() -> Option<PathBuf> {
+    if let Some(node) = node_override_if_present(std::env::var_os("HERMES_DESKTOP_NODE_BINARY")) {
+        return node.parent().map(Path::to_path_buf);
+    }
     node_bin_dir_if_present(Path::new(&read_current_record()?.path))
 }
 
 /// Absolute path to the bundled `node` executable, for the `HERMES_NODE` env
 /// var the frozen runtime prefers when launching the Ink TUI (P-032).
 pub fn current_node_binary() -> Option<PathBuf> {
+    if let Some(node) = node_override_if_present(std::env::var_os("HERMES_DESKTOP_NODE_BINARY")) {
+        return Some(node);
+    }
     node_binary_if_present(Path::new(&read_current_record()?.path))
 }
 
@@ -1100,6 +1116,9 @@ pub fn current_node_binary() -> Option<PathBuf> {
 /// `HERMES_TUI_DIR` so the frozen runtime launches /chat without a ui-tui/
 /// source checkout (P-032).
 pub fn current_tui_dir() -> Option<PathBuf> {
+    if let Some(tui) = tui_override_if_present(std::env::var_os("HERMES_DESKTOP_TUI_DIR")) {
+        return Some(tui);
+    }
     tui_dir_if_present(Path::new(&read_current_record()?.path))
 }
 
@@ -2855,6 +2874,33 @@ mod tests {
 
         std::fs::write(dist.join("entry.js"), b"//tui").unwrap();
         assert_eq!(tui_dir_if_present(root), Some(root.join("tui")));
+    }
+
+    #[test]
+    fn local_dev_resource_overrides_require_usable_paths() {
+        let dir = TempDir::new().unwrap();
+        let node = dir.path().join(if cfg!(target_os = "windows") {
+            "node.exe"
+        } else {
+            "node"
+        });
+        let tui = dir.path().join("ui-tui");
+
+        assert!(node_override_if_present(Some(node.clone().into_os_string())).is_none());
+        assert!(tui_override_if_present(Some(tui.clone().into_os_string())).is_none());
+
+        std::fs::write(&node, b"node").unwrap();
+        std::fs::create_dir_all(tui.join("dist")).unwrap();
+        std::fs::write(tui.join("dist").join("entry.js"), b"// tui").unwrap();
+
+        assert_eq!(
+            node_override_if_present(Some(node.clone().into_os_string())),
+            Some(node)
+        );
+        assert_eq!(
+            tui_override_if_present(Some(tui.clone().into_os_string())),
+            Some(tui)
+        );
     }
 
     #[test]

--- a/src/profile_name.rs
+++ b/src/profile_name.rs
@@ -1,0 +1,37 @@
+//! Shared Desktop-side Profile name validation.
+//!
+//! Core and the renderer accept 1–64 characters. Keeping every native entry
+//! point on this single validator prevents switching, migration, and cron-run
+//! proxy routes from drifting to a narrower limit.
+
+use regex::Regex;
+use std::sync::LazyLock;
+
+static PROFILE_NAME_RE: LazyLock<Regex> = LazyLock::new(|| {
+    Regex::new(r"^[A-Za-z0-9][A-Za-z0-9_-]{0,63}$").expect("valid profile name regex")
+});
+
+pub(crate) fn is_valid_profile_name(name: &str) -> bool {
+    PROFILE_NAME_RE.is_match(name)
+}
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+
+    #[test]
+    fn accepts_the_core_length_boundary() {
+        assert!(is_valid_profile_name(&"a".repeat(64)));
+        assert!(!is_valid_profile_name(&"a".repeat(65)));
+    }
+
+    #[test]
+    fn rejects_unsafe_path_shapes() {
+        for name in ["", "../profile", "a/b", "a b", "-leading", "_leading"] {
+            assert!(
+                !is_valid_profile_name(name),
+                "unexpectedly accepted {name:?}"
+            );
+        }
+    }
+}

--- a/tauri.conf.json
+++ b/tauri.conf.json
@@ -1,7 +1,7 @@
 {
   "$schema": "https://raw.githubusercontent.com/nicegoodthings/tauri-schema/main/tauri.conf.schema.json",
   "productName": "Hermes Agent CN Desktop",
-  "version": "0.8.0-rc7",
+  "version": "0.8.0-rc8",
   "identifier": "cn.org.hermesagent.desktop",
   "build": {
     "beforeDevCommand": "pnpm --filter @hermes/web dev",

--- a/web/package.json
+++ b/web/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@hermes/web",
-  "version": "0.8.0-rc7",
+  "version": "0.8.0-rc8",
   "private": true,
   "type": "module",
   "scripts": {

--- a/web/src/app.tsx
+++ b/web/src/app.tsx
@@ -10,6 +10,7 @@ import { ProfileSwitchOverlay } from "@/components/profile-switch-overlay";
 import { RuntimeUpdateOverlay } from "@/components/runtime-update-overlay";
 import { DesktopUpdateNotifier } from "@/components/desktop-update-notifier";
 import { ConnectionAuthBanner } from "@/components/connection-auth-banner";
+import { WanderMemoryRouteLifecycle } from "@/components/wander-memory/route-lifecycle";
 import { AppShell } from "@/components/app-shell/app-shell";
 import { CommandPalette } from "@/components/command-palette";
 import { runtime } from "@/lib/runtime";
@@ -91,8 +92,10 @@ function withSuspense(node: ReactNode) {
 
 function BackendApp() {
   useBootstrapActiveProfile();
+  const location = useLocation();
   return (
     <>
+      <WanderMemoryRouteLifecycle active={location.pathname.startsWith("/wander-memory")} />
       <AppShell>
         <Suspense fallback={<RouteLoadingFallback />}>
           <Routes>

--- a/web/src/components/app-shell/app-status-bar.tsx
+++ b/web/src/components/app-shell/app-status-bar.tsx
@@ -87,7 +87,7 @@ export function AppStatusBar() {
     : "当前连接状态未知，仍会尝试重启网关";
 
   return (
-    <footer className={s.statusbar} role="status" aria-label="运行状态">
+    <footer className={s.statusbar} aria-label="运行状态">
       <span className={s.gatewayGroup}>
         <button
           type="button"

--- a/web/src/components/app-shell/model-onboarding-dialog.render.test.tsx
+++ b/web/src/components/app-shell/model-onboarding-dialog.render.test.tsx
@@ -1,0 +1,50 @@
+// @vitest-environment jsdom
+import { cleanup, render, screen, waitFor } from "@testing-library/react";
+import { afterEach, describe, expect, it, vi } from "vitest";
+import { MemoryRouter } from "react-router-dom";
+import { ModelOnboardingDialog } from "./model-onboarding-dialog";
+
+vi.mock("@/hooks/use-config", () => ({
+  useModelInfo: () => ({
+    data: { model: "", provider: "", effective_context_length: 0 },
+    isLoading: false,
+    isError: false,
+  }),
+}));
+
+afterEach(() => {
+  cleanup();
+  window.sessionStorage.clear();
+  vi.restoreAllMocks();
+});
+
+describe("ModelOnboardingDialog accessibility", () => {
+  it("binds the first-run dialog to a readable description without Radix warnings", async () => {
+    const warnings: string[] = [];
+    vi.spyOn(console, "warn").mockImplementation((...args: unknown[]) => {
+      warnings.push(args.map(String).join(" "));
+    });
+    vi.spyOn(console, "error").mockImplementation((...args: unknown[]) => {
+      warnings.push(args.map(String).join(" "));
+    });
+
+    render(
+      <MemoryRouter>
+        <ModelOnboardingDialog />
+      </MemoryRouter>,
+    );
+
+    const dialog = screen.getByRole("dialog", { name: "开始使用 Hermes" });
+    const descriptionId = dialog.getAttribute("aria-describedby");
+    expect(descriptionId).toBeTruthy();
+    expect(document.getElementById(descriptionId ?? "")?.textContent).toContain(
+      "配置一个模型后即可开始任务",
+    );
+
+    await waitFor(() => {
+      expect(warnings.filter((message) => (
+        message.includes("Missing Description") || message.includes("aria-describedby")
+      ))).toEqual([]);
+    });
+  });
+});

--- a/web/src/components/app-shell/model-onboarding-dialog.tsx
+++ b/web/src/components/app-shell/model-onboarding-dialog.tsx
@@ -88,10 +88,7 @@ export function ModelOnboardingDialog() {
     >
       <Dialog.Portal>
         <Dialog.Overlay className={s.overlay} />
-        <Dialog.Content
-          className={s.dialog}
-          aria-describedby="model-onboarding-description"
-        >
+        <Dialog.Content className={s.dialog}>
           <header className={s.header}>
             <span className={s.heroIcon} aria-hidden="true">
               <Sparkles size={28} />
@@ -99,7 +96,7 @@ export function ModelOnboardingDialog() {
             <div>
               <p className={s.kicker}>首次使用</p>
               <Dialog.Title className={s.title}>开始使用 Hermes</Dialog.Title>
-              <Dialog.Description id="model-onboarding-description" className={s.description}>
+              <Dialog.Description className={s.description}>
                 内置 Hermes 已经准备好。配置一个模型后即可开始任务；你也可以先浏览工作台，
                 稍后再完成设置。
               </Dialog.Description>

--- a/web/src/components/memory/memory-provider-config.test.tsx
+++ b/web/src/components/memory/memory-provider-config.test.tsx
@@ -1,0 +1,83 @@
+// @vitest-environment jsdom
+import { fireEvent, render, screen, waitFor } from "@testing-library/react";
+import { describe, expect, it, vi } from "vitest";
+import type { MemoryProviderConfigResponse } from "@hermes/protocol";
+import { MemoryProviderConfig } from "./memory-provider-config";
+
+describe("MemoryProviderConfig", () => {
+  it("renders Core integer and number fields with their numeric constraints", async () => {
+    const onSave = vi.fn().mockResolvedValue(undefined);
+    const config = {
+      name: "openviking",
+      label: "OpenViking",
+      fields: [
+        {
+          key: "recall_limit",
+          label: "Recall Limit",
+          kind: "integer",
+          value: "12",
+          minimum: 1,
+          maximum: 100,
+          step: undefined,
+          description: "",
+          placeholder: "",
+          required: false,
+          is_set: true,
+          options: [],
+          url: "",
+        },
+        {
+          key: "recall_score_threshold",
+          label: "Recall Score Threshold",
+          kind: "number",
+          value: "0.4",
+          minimum: 0,
+          maximum: 1,
+          step: 0.01,
+          description: "",
+          placeholder: "",
+          required: false,
+          is_set: true,
+          options: [],
+          url: "",
+        },
+      ],
+      setup: { dependencies_installed: true },
+    } as unknown as MemoryProviderConfigResponse;
+
+    render(
+      <MemoryProviderConfig
+        provider="openviking"
+        config={config}
+        loading={false}
+        saving={false}
+        setupPending={false}
+        onSave={onSave}
+        onSetup={vi.fn().mockResolvedValue(undefined)}
+      />,
+    );
+
+    const integer = screen.getByLabelText(/recall limit/i) as HTMLInputElement;
+    expect(integer.type).toBe("number");
+    expect(integer.min).toBe("1");
+    expect(integer.max).toBe("100");
+    expect(integer.step).toBe("1");
+
+    const decimal = screen.getByLabelText(/recall score threshold/i) as HTMLInputElement;
+    expect(decimal.type).toBe("number");
+    expect(decimal.min).toBe("0");
+    expect(decimal.max).toBe("1");
+    expect(decimal.step).toBe("0.01");
+
+    fireEvent.change(integer, { target: { value: "13" } });
+    fireEvent.change(decimal, { target: { value: "0.42" } });
+    fireEvent.click(screen.getByRole("button", { name: "保存并检测" }));
+
+    await waitFor(() => {
+      expect(onSave).toHaveBeenCalledWith({
+        recall_limit: "13",
+        recall_score_threshold: "0.42",
+      });
+    });
+  });
+});

--- a/web/src/components/memory/memory-provider-config.tsx
+++ b/web/src/components/memory/memory-provider-config.tsx
@@ -64,6 +64,7 @@ export function MemoryProviderConfig({
   const renderField = (field: MemoryProviderConfigResponse["fields"][number], index: number) => {
     const id = `${provider}-${field.key}-${index}`;
     const value = values[field.key];
+    const numeric = field.kind === "integer" || field.kind === "number";
     if (field.kind === "boolean") {
       return (
         <label className={s.booleanField} htmlFor={id} key={id}>
@@ -100,7 +101,11 @@ export function MemoryProviderConfig({
         ) : (
           <input
             id={id}
-            type={field.kind === "secret" ? "password" : "text"}
+            type={numeric ? "number" : field.kind === "secret" ? "password" : "text"}
+            min={numeric ? field.minimum : undefined}
+            max={numeric ? field.maximum : undefined}
+            step={numeric ? field.step ?? (field.kind === "integer" ? 1 : "any") : undefined}
+            inputMode={field.kind === "integer" ? "numeric" : field.kind === "number" ? "decimal" : undefined}
             value={String(value ?? "")}
             placeholder={field.kind === "secret" && field.is_set ? "已保存，留空保持不变" : field.placeholder}
             onChange={(event) => setValues((current) => ({ ...current, [field.key]: event.target.value }))}

--- a/web/src/components/panel/health-grid.tsx
+++ b/web/src/components/panel/health-grid.tsx
@@ -22,6 +22,7 @@ import { useSkills } from "@/hooks/use-skills";
 import { useMcpServers } from "@/hooks/use-mcp-servers";
 import { useOAuthProviders } from "@/hooks/use-oauth-providers";
 import { useLastUsedModel } from "@/lib/last-used-model";
+import { getProviderEntry } from "@/lib/provider-catalog";
 import { DiagnosticCopyButton } from "@/components/ui/diagnostic-copy-button";
 import { Dot } from "@/components/ui/pill";
 import s from "./health-grid.module.css";
@@ -124,6 +125,32 @@ function groupTone(items: HealthItem[]): Tone {
 function providerMap(config: Record<string, unknown> | undefined): Record<string, unknown> {
   const providers = config?.providers;
   return isRecord(providers) ? providers : {};
+}
+
+function nonEmptyString(value: unknown): string {
+  return typeof value === "string" ? value.trim() : "";
+}
+
+function currentInlineCredential(
+  config: Record<string, unknown> | undefined,
+  currentProviderId: string,
+): { source: "model" | "provider"; label: string } | null {
+  const model = isRecord(config?.model) ? config.model : {};
+  const configuredProviderId = nonEmptyString(model.provider);
+  const modelKeyBelongsToCurrentProvider = !currentProviderId
+    || !configuredProviderId
+    || configuredProviderId === currentProviderId;
+  if (modelKeyBelongsToCurrentProvider && nonEmptyString(model.api_key)) {
+    return { source: "model", label: "当前模型内联凭证已保存" };
+  }
+
+  if (!currentProviderId) return null;
+  const provider = getProviderEntry(config, currentProviderId);
+  if (!nonEmptyString(provider.api_key)) return null;
+  return {
+    source: "provider",
+    label: `${nonEmptyString(provider.name) || currentProviderId} 内联凭证已保存`,
+  };
 }
 
 function findInvalidProviderApiKeys(providers: Record<string, unknown>): string[] {
@@ -295,7 +322,8 @@ export function HealthGrid({ variant = "compact" }: HealthGridProps) {
     const currentProviderId = modelInfo?.provider || lastUsedModel?.provider || "";
     const currentOAuthProvider = oauthProviders?.find((provider) => provider.id === currentProviderId);
     const currentOAuthLoggedIn = currentOAuthProvider?.status.logged_in === true;
-    const anyModelCredential = anyTokenSet || currentOAuthLoggedIn;
+    const inlineCredential = currentInlineCredential(config, currentProviderId);
+    const anyModelCredential = anyTokenSet || currentOAuthLoggedIn || inlineCredential !== null;
     const ctxLabel = formatContextLength(
       lastUsedModel?.contextWindow
         ?? modelInfo?.effective_context_length
@@ -366,14 +394,18 @@ export function HealthGrid({ variant = "compact" }: HealthGridProps) {
         value: envQuery.isError ? "读取失败" : env ? (anyModelCredential ? "已配置" : "未配置") : "检测中",
         sub: currentOAuthLoggedIn
           ? `${currentOAuthProvider?.name ?? currentProviderId} OAuth 已连接`
-          : anyTokenSet
-            ? formatTokenNames(setTokens)
-            : "模型调用需要 API Key 或 OAuth 凭证",
+          : inlineCredential
+            ? inlineCredential.label
+            : anyTokenSet
+              ? formatTokenNames(setTokens)
+              : "模型调用需要 API Key 或 OAuth 凭证",
         detail: currentOAuthLoggedIn
           ? "当前主模型使用 OAuth 登录凭证，无需额外 API Token。"
-          : anyTokenSet
-            ? "仅展示已设置的变量名称，不会暴露密钥内容。"
-            : "可在模型设置里补齐 API Key，或完成支持 OAuth 的模型登录。",
+          : inlineCredential
+            ? "凭证保存在当前 Profile 的模型或 Provider 配置中；健康检查只读取是否存在，不会展示密钥内容。"
+            : anyTokenSet
+              ? "仅展示已设置的变量名称，不会暴露密钥内容。"
+              : "可在模型设置里补齐 API Key，或完成支持 OAuth 的模型登录。",
         actionTo: anyModelCredential ? undefined : "/models",
         actionLabel: "配置凭证",
       },

--- a/web/src/components/profiles/profile-editors.test.tsx
+++ b/web/src/components/profiles/profile-editors.test.tsx
@@ -1,0 +1,93 @@
+// @vitest-environment jsdom
+
+import type { ProfileSummary } from "@hermes/protocol";
+import { cleanup, fireEvent, render, screen, waitFor } from "@testing-library/react";
+import { afterEach, beforeEach, describe, expect, it, vi } from "vitest";
+
+const mocks = vi.hoisted(() => ({
+  soul: {
+    data: { content: "cached SOUL", exists: true },
+    error: null,
+    isError: false,
+    isLoading: false,
+  },
+  mutate: vi.fn(),
+}));
+
+vi.mock("@/hooks/use-profiles", () => ({
+  useDescribeProfileAuto: () => ({
+    error: null,
+    isError: false,
+    isPending: false,
+    mutate: vi.fn(),
+  }),
+  useProfileSoul: () => mocks.soul,
+  useSetProfileModel: () => ({ isPending: false, mutate: vi.fn() }),
+  useUpdateProfileDescription: () => ({
+    error: null,
+    isError: false,
+    isPending: false,
+    mutate: vi.fn(),
+  }),
+  useUpdateProfileSoul: () => ({
+    error: null,
+    isError: false,
+    isPending: false,
+    mutate: mocks.mutate,
+  }),
+}));
+
+import { ProfileSoulDialog } from "./profile-editors";
+
+const profile: ProfileSummary = {
+  name: "reviewer",
+  path: "/profiles/reviewer",
+  is_default: false,
+  model: null,
+  provider: null,
+  has_env: false,
+  skill_count: 0,
+  gateway_running: false,
+  description: "",
+  description_auto: false,
+  distribution_name: null,
+  distribution_version: null,
+  distribution_source: null,
+  has_alias: false,
+};
+
+function renderDialog() {
+  return render(<ProfileSoulDialog profile={profile} onClose={vi.fn()} />);
+}
+
+beforeEach(() => {
+  mocks.soul.data = { content: "cached SOUL", exists: true };
+  mocks.mutate.mockReset();
+});
+
+afterEach(cleanup);
+
+describe("ProfileSoulDialog server reconciliation", () => {
+  it("adopts a fresh refetch response while the editor is pristine", async () => {
+    const view = renderDialog();
+    const textbox = screen.getByRole("textbox") as HTMLTextAreaElement;
+    await waitFor(() => expect(textbox.value).toBe("cached SOUL"));
+
+    mocks.soul.data = { content: "fresh SOUL", exists: true };
+    view.rerender(<ProfileSoulDialog profile={profile} onClose={vi.fn()} />);
+
+    await waitFor(() => expect(textbox.value).toBe("fresh SOUL"));
+  });
+
+  it("preserves a local draft when a fresh refetch response arrives", async () => {
+    const view = renderDialog();
+    const textbox = screen.getByRole("textbox") as HTMLTextAreaElement;
+    await waitFor(() => expect(textbox.value).toBe("cached SOUL"));
+    fireEvent.change(textbox, { target: { value: "local draft" } });
+
+    mocks.soul.data = { content: "fresh SOUL", exists: true };
+    view.rerender(<ProfileSoulDialog profile={profile} onClose={vi.fn()} />);
+
+    await waitFor(() => expect(textbox.value).toBe("local draft"));
+  });
+});

--- a/web/src/components/profiles/profile-editors.tsx
+++ b/web/src/components/profiles/profile-editors.tsx
@@ -1,4 +1,4 @@
-import { useEffect, useState } from "react";
+import { useEffect, useRef, useState } from "react";
 import { Button, Field, LoadingState, Textarea } from "@hermes/shared-ui";
 import { Sparkles } from "lucide-react";
 import type { ProfileSummary } from "@hermes/protocol";
@@ -189,11 +189,19 @@ export function ProfileSoulDialog({
   const soul = useProfileSoul(p.name);
   const update = useUpdateProfileSoul();
   const [content, setContent] = useState<string | null>(null);
+  const lastServerContent = useRef<string | null>(null);
 
-  // 内容到达后灌入一次；之后由用户编辑，不再被 refetch 覆盖。
+  // React Query 可能先给出缓存值，再交付 refetch 的最新值。只要编辑器仍然
+  // 保持上一份服务器内容，就安全地跟进新响应；已有本地草稿时则绝不覆盖。
   useEffect(() => {
-    if (content === null && soul.data) setContent(soul.data.content);
-  }, [soul.data, content]);
+    if (!soul.data) return;
+
+    const previousServerContent = lastServerContent.current;
+    setContent((current) =>
+      current === null || current === previousServerContent ? soul.data.content : current,
+    );
+    lastServerContent.current = soul.data.content;
+  }, [soul.data]);
 
   const save = () => {
     if (content === null) return;

--- a/web/src/components/settings/model-combobox.module.css
+++ b/web/src/components/settings/model-combobox.module.css
@@ -34,6 +34,11 @@
   padding: 0;
 }
 
+/* Keep cmdk's listbox mounted so aria-controls never becomes a dangling ID. */
+.panel[data-state="closed"] {
+  display: none;
+}
+
 .list {
   display: flex;
   flex-direction: column;

--- a/web/src/components/settings/model-combobox.test.tsx
+++ b/web/src/components/settings/model-combobox.test.tsx
@@ -1,5 +1,28 @@
-import { describe, expect, it } from "vitest";
+// @vitest-environment jsdom
+
+import { cleanup, fireEvent, render, screen, waitFor } from "@testing-library/react";
+import { afterEach, beforeAll, describe, expect, it } from "vitest";
+import { ModelCombobox } from "./model-combobox";
 import { filterOptions } from "./model-combobox";
+
+beforeAll(() => {
+  class ResizeObserverStub {
+    observe() {}
+    unobserve() {}
+    disconnect() {}
+  }
+
+  Object.defineProperty(globalThis, "ResizeObserver", {
+    configurable: true,
+    value: ResizeObserverStub,
+  });
+  Object.defineProperty(HTMLElement.prototype, "scrollIntoView", {
+    configurable: true,
+    value: () => undefined,
+  });
+});
+
+afterEach(cleanup);
 
 describe("filterOptions", () => {
   const all = ["deepseek-v4-flash", "deepseek-v4-pro", "qwen3-coder-plus", "glm-5.1"];
@@ -15,5 +38,33 @@ describe("filterOptions", () => {
 
   it("returns empty array when nothing matches", () => {
     expect(filterOptions(all, "claude")).toEqual([]);
+  });
+});
+
+describe("ModelCombobox accessibility", () => {
+  it("keeps its list relationship valid and reports the actual expanded state", async () => {
+    render(
+      <ModelCombobox
+        label="默认模型"
+        value="hermes-model"
+        onChange={() => undefined}
+        options={["hermes-model"]}
+      />,
+    );
+
+    const combobox = screen.getByRole("combobox", { name: "默认模型" });
+    const listId = combobox.getAttribute("aria-controls");
+
+    expect(listId).toBeTruthy();
+    expect(document.getElementById(listId!)).not.toBeNull();
+    await waitFor(() => expect(combobox.getAttribute("aria-expanded")).toBe("false"));
+
+    fireEvent.click(combobox);
+    await waitFor(() => expect(combobox.getAttribute("aria-expanded")).toBe("true"));
+    expect(document.getElementById(listId!)).not.toBeNull();
+
+    fireEvent.keyDown(combobox, { key: "Escape" });
+    await waitFor(() => expect(combobox.getAttribute("aria-expanded")).toBe("false"));
+    expect(document.getElementById(listId!)).not.toBeNull();
   });
 });

--- a/web/src/components/settings/model-combobox.tsx
+++ b/web/src/components/settings/model-combobox.tsx
@@ -6,6 +6,7 @@ import s from "./model-combobox.module.css";
 const MAX_VISIBLE = 200;
 
 export interface ModelComboboxProps {
+  label: string;
   value: string;
   onChange: (value: string) => void;
   options: string[];
@@ -20,6 +21,7 @@ export function filterOptions(options: string[], query: string): string[] {
 }
 
 export function ModelCombobox({
+  label,
   value,
   onChange,
   options,
@@ -29,11 +31,19 @@ export function ModelCombobox({
   const [open, setOpen] = useState(false);
   const [query, setQuery] = useState(value);
   const composingRef = useRef(false);
+  const inputRef = useRef<HTMLInputElement>(null);
 
   // Reflect external value changes while the popover is closed.
   useEffect(() => {
     if (!open) setQuery(value);
   }, [value, open]);
+
+  // cmdk assumes its list is always visible and hard-codes aria-expanded=true.
+  // This combobox places that list in a controlled Popover, so keep the DOM
+  // attribute aligned with the actual popup state after each render.
+  useEffect(() => {
+    inputRef.current?.setAttribute("aria-expanded", open ? "true" : "false");
+  }, [open, query]);
 
   const filtered = filterOptions(options, query);
   const visible = filtered.slice(0, MAX_VISIBLE);
@@ -57,6 +67,7 @@ export function ModelCombobox({
 
   return (
     <Command
+      label={label}
       shouldFilter={false}
       loop
       className={s.root}
@@ -80,6 +91,7 @@ export function ModelCombobox({
       <Popover.Root open={open} onOpenChange={handleOpenChange}>
         <Popover.Anchor asChild>
           <Command.Input
+            ref={inputRef}
             className={s.input}
             value={query}
             onValueChange={(next) => {
@@ -101,8 +113,9 @@ export function ModelCombobox({
             autoComplete="off"
           />
         </Popover.Anchor>
-        <Popover.Portal>
+        <Popover.Portal forceMount>
           <Popover.Content
+            forceMount
             className={s.panel}
             align="start"
             sideOffset={4}

--- a/web/src/components/top-bar/top-bar.module.css
+++ b/web/src/components/top-bar/top-bar.module.css
@@ -28,6 +28,7 @@
 }
 
 .title {
+  margin: 0;
   font-size: 13px;
   font-weight: 600;
   color: var(--h-text);

--- a/web/src/components/top-bar/top-bar.tsx
+++ b/web/src/components/top-bar/top-bar.tsx
@@ -15,7 +15,7 @@ export function TopBar({ title, sub, right }: TopBarProps) {
     <div className={s.topBar} data-window-drag data-tauri-drag-region="deep">
       <div className={s.inner}>
         <div className={s.titleGroup}>
-          {title && <span className={s.title}>{title}</span>}
+          {title && <h1 className={s.title}>{title}</h1>}
           {sub && <span className={s.sub}>{sub}</span>}
         </div>
         <span className={s.spacer} />

--- a/web/src/components/wander-memory/route-lifecycle.test.tsx
+++ b/web/src/components/wander-memory/route-lifecycle.test.tsx
@@ -1,0 +1,29 @@
+// @vitest-environment jsdom
+import { cleanup, render, waitFor } from "@testing-library/react";
+import { afterEach, describe, expect, it, vi } from "vitest";
+import { WanderMemoryRouteLifecycle } from "./route-lifecycle";
+
+const clientMocks = vi.hoisted(() => ({
+  dispose: vi.fn(),
+}));
+
+vi.mock("@/lib/wander-memory/client", () => ({
+  disposeWanderMemoryClient: clientMocks.dispose,
+}));
+
+afterEach(() => {
+  cleanup();
+  clientMocks.dispose.mockReset();
+});
+
+describe("WanderMemoryRouteLifecycle", () => {
+  it("keeps the client across Wander routes and disposes it on group exit", async () => {
+    const view = render(<WanderMemoryRouteLifecycle active />);
+
+    view.rerender(<WanderMemoryRouteLifecycle active />);
+    expect(clientMocks.dispose).not.toHaveBeenCalled();
+
+    view.rerender(<WanderMemoryRouteLifecycle active={false} />);
+    await waitFor(() => expect(clientMocks.dispose).toHaveBeenCalledTimes(1));
+  });
+});

--- a/web/src/components/wander-memory/route-lifecycle.tsx
+++ b/web/src/components/wander-memory/route-lifecycle.tsx
@@ -1,0 +1,22 @@
+import { useEffect } from "react";
+
+export interface WanderMemoryRouteLifecycleProps {
+  active: boolean;
+}
+
+/**
+ * Owns the live MemOS singleton for as long as the user stays inside the
+ * Wander route group. The client module remains lazy on non-Wander routes.
+ */
+export function WanderMemoryRouteLifecycle({ active }: WanderMemoryRouteLifecycleProps) {
+  useEffect(() => {
+    if (!active) return;
+    return () => {
+      void import("@/lib/wander-memory/client").then(({ disposeWanderMemoryClient }) => {
+        disposeWanderMemoryClient();
+      });
+    };
+  }, [active]);
+
+  return null;
+}

--- a/web/src/hooks/use-gateway.ts
+++ b/web/src/hooks/use-gateway.ts
@@ -129,9 +129,9 @@ async function reattachActiveSessionAfterReconnect(): Promise<void> {
           ),
         ),
       onResumed: (gatewaySessionId, persistentId) => {
-        store.set(gwSessionIdAtom, gatewaySessionId);
         rememberSessionMapping(gatewaySessionId, persistentId);
         mirrorSessionWorkspaceMapping(gatewaySessionId, persistentId);
+        store.set(gwSessionIdAtom, gatewaySessionId);
       },
       onResumeFailed: (error) => {
         // A timeout or temporarily wedged backend does not mean the persistent
@@ -442,10 +442,10 @@ export function useGateway() {
       "session.resume",
     );
     const resumed = result.resumed ?? persistentSessionId;
-    setGwSessionId(result.session_id);
-    resetChatSession(result.session_id);
     rememberSessionMapping(result.session_id, resumed);
     mirrorSessionWorkspaceMapping(result.session_id, resumed);
+    setGwSessionId(result.session_id);
+    resetChatSession(result.session_id);
     // Compression rotated the conversation onto a new continuation: the backend
     // followed the chain and resumed a different persistent id than we asked
     // for. Record it so the detail route can project onto the live tip instead

--- a/web/src/hooks/use-mcp.test.tsx
+++ b/web/src/hooks/use-mcp.test.tsx
@@ -1,0 +1,53 @@
+// @vitest-environment jsdom
+
+import type { ReactNode } from "react";
+import { act, renderHook } from "@testing-library/react";
+import { QueryClient, QueryClientProvider } from "@tanstack/react-query";
+import { beforeEach, describe, expect, it, vi } from "vitest";
+
+const { deleteJSON } = vi.hoisted(() => ({
+  deleteJSON: vi.fn(async () => ({ ok: true })),
+}));
+
+vi.mock("@/lib/transport", () => ({
+  deleteJSON,
+  fetchJSON: vi.fn(),
+  postJSON: vi.fn(),
+  putJSON: vi.fn(),
+}));
+
+vi.mock("@/hooks/use-profiles", () => ({
+  useActiveProfileName: () => "e2e-director",
+}));
+
+import { useRemoveMcpServer } from "./use-mcp";
+
+function wrapperFor(client: QueryClient) {
+  return function Wrapper({ children }: { children: ReactNode }) {
+    return <QueryClientProvider client={client}>{children}</QueryClientProvider>;
+  };
+}
+
+describe("useRemoveMcpServer", () => {
+  beforeEach(() => deleteJSON.mockClear());
+
+  it("refreshes both installed servers and catalog installation state", async () => {
+    const client = new QueryClient({ defaultOptions: { mutations: { retry: false } } });
+    const invalidate = vi.spyOn(client, "invalidateQueries");
+    const { result } = renderHook(() => useRemoveMcpServer(), {
+      wrapper: wrapperFor(client),
+    });
+
+    await act(async () => {
+      await result.current.mutateAsync("unreal-engine");
+    });
+
+    expect(deleteJSON).toHaveBeenCalledWith(
+      "/api/mcp/servers/unreal-engine",
+      undefined,
+      expect.anything(),
+    );
+    expect(invalidate).toHaveBeenCalledWith({ queryKey: ["mcp-servers-full"] });
+    expect(invalidate).toHaveBeenCalledWith({ queryKey: ["mcp-catalog"] });
+  });
+});

--- a/web/src/hooks/use-mcp.ts
+++ b/web/src/hooks/use-mcp.ts
@@ -60,7 +60,10 @@ export function useRemoveMcpServer() {
   const qc = useQueryClient();
   return useMutation<MutationOkResponse, Error, string>({
     mutationFn: (name) => deleteJSON(mcpPath(name), undefined, MutationOkResponse),
-    onSuccess: () => qc.invalidateQueries({ queryKey: [SERVERS_KEY] }),
+    onSuccess: () => Promise.all([
+      qc.invalidateQueries({ queryKey: [SERVERS_KEY] }),
+      qc.invalidateQueries({ queryKey: [CATALOG_KEY] }),
+    ]),
   });
 }
 

--- a/web/src/hooks/use-profiles.test.ts
+++ b/web/src/hooks/use-profiles.test.ts
@@ -1,5 +1,15 @@
 import { describe, expect, it } from "vitest";
-import { resolveBootstrapProfile } from "./use-profiles";
+import { managementProfileAfterDelete, resolveBootstrapProfile } from "./use-profiles";
+
+describe("managementProfileAfterDelete", () => {
+  it("clears the management scope when that Profile was deleted", () => {
+    expect(managementProfileAfterDelete("reviewer", "reviewer")).toBeNull();
+  });
+
+  it("preserves an unrelated management scope", () => {
+    expect(managementProfileAfterDelete("reviewer", "writer")).toBe("reviewer");
+  });
+});
 
 describe("resolveBootstrapProfile", () => {
   // 核心回归测试（#189/#195）：首次同步完成后，过期的 /api/profiles/active 值

--- a/web/src/hooks/use-profiles.ts
+++ b/web/src/hooks/use-profiles.ts
@@ -247,8 +247,16 @@ export function useCreateProfile() {
   });
 }
 
+export function managementProfileAfterDelete(
+  current: string | null,
+  deletedProfile: string,
+): string | null {
+  return current === deletedProfile ? null : current;
+}
+
 export function useDeleteProfile() {
   const qc = useQueryClient();
+  const setManagement = useSetAtom(managementProfileAtom);
   return useMutation({
     mutationFn: (name: string) =>
       deleteJSON(
@@ -256,7 +264,8 @@ export function useDeleteProfile() {
         undefined,
         MutationOkResponse,
       ),
-    onSuccess: () => {
+    onSuccess: (_response, deletedProfile) => {
+      setManagement((current) => managementProfileAfterDelete(current, deletedProfile));
       qc.invalidateQueries({ queryKey: ["profiles"] });
     },
   });

--- a/web/src/hooks/use-session-resolution.test.ts
+++ b/web/src/hooks/use-session-resolution.test.ts
@@ -96,4 +96,18 @@ describe("resolveSessionRuntime", () => {
     expect(resolved.runtimeIsBusy).toBe(false);
     expect(resolved.isLiveSession).toBe(false);
   });
+
+  it("follows the resumed runtime even when the route and old transcript use the previous gateway id", () => {
+    rememberSessionMapping("gw-old", "persistent-A");
+    rememberSessionMapping("gw-resumed", "persistent-A");
+    const resolved = resolveSessionRuntime("gw-old", "gw-resumed", {
+      "gw-old": runtimeWith("gw-old", "before restart"),
+      "gw-resumed": runtimeWith("gw-resumed", "after restart"),
+    });
+
+    expect(resolved.restSessionId).toBe("persistent-A");
+    expect(resolved.activeMappedGatewaySessionId).toBe("gw-resumed");
+    expect(resolved.runtimeSessionId).toBe("gw-resumed");
+    expect(firstText(resolved.runtime)).toBe("after restart");
+  });
 });

--- a/web/src/hooks/use-session-resolution.ts
+++ b/web/src/hooks/use-session-resolution.ts
@@ -41,14 +41,16 @@ export function resolveSessionRuntime(
     gwSessionId && resolvePersistentSessionId(gwSessionId) === restSessionId
       ? gwSessionId
       : undefined;
-  const mappedGatewaySessionId = liveGatewaySessionId ?? resolveGatewaySessionId(taskId);
+  const mappedGatewaySessionId = liveGatewaySessionId ?? resolveGatewaySessionId(restSessionId);
   const activeMappedGatewaySessionId =
     mappedGatewaySessionId &&
     (gwSessionId === mappedGatewaySessionId || runtimeBySession[mappedGatewaySessionId])
       ? mappedGatewaySessionId
       : undefined;
+  // The route can still contain the gateway ID from before a Core restart.
+  // Once resumed, both rendering and sending must follow the new binding.
   const runtimeSessionId =
-    taskId && runtimeBySession[taskId] ? taskId : activeMappedGatewaySessionId;
+    activeMappedGatewaySessionId ?? (taskId && runtimeBySession[taskId] ? taskId : undefined);
   const runtime = taskId
     ? runtimeBySession[runtimeSessionId ?? taskId] ?? createEmptyChatRuntime()
     : createEmptyChatRuntime();

--- a/web/src/hooks/use-skills.test.ts
+++ b/web/src/hooks/use-skills.test.ts
@@ -1,0 +1,11 @@
+import { describe, expect, it } from "vitest";
+import { replaceSkillFrontmatterName } from "./use-skills";
+
+describe("replaceSkillFrontmatterName", () => {
+  it("renames only the frontmatter identity while preserving the body", () => {
+    const source = "---\r\nname: bundled-skill\r\ndescription: Use bundled-skill safely.\r\n---\r\n# bundled-skill\r\n";
+    expect(replaceSkillFrontmatterName(source, "bundled-skill-custom")).toBe(
+      "---\r\nname: bundled-skill-custom\r\ndescription: Use bundled-skill safely.\r\n---\r\n# bundled-skill\r\n",
+    );
+  });
+});

--- a/web/src/hooks/use-skills.ts
+++ b/web/src/hooks/use-skills.ts
@@ -1,13 +1,39 @@
 import { useQuery, useMutation, useQueryClient } from "@tanstack/react-query";
-import { fetchJSON, putJSON } from "@/lib/transport";
+import { fetchJSON, postJSON, putJSON } from "@/lib/transport";
 import { useActiveProfileName } from "@/hooks/use-profiles";
 import {
   MutationOkResponse,
   SkillContentResponse,
+  SkillWriteResponse,
   SkillsHubSearchResponse,
   SkillsResponse,
   type SkillInfo,
 } from "@hermes/protocol";
+
+export interface CopyBuiltinSkillInput {
+  sourceName: string;
+  name: string;
+  category?: string | null;
+}
+
+export function replaceSkillFrontmatterName(content: string, name: string): string {
+  const bom = content.startsWith("\uFEFF") ? "\uFEFF" : "";
+  const source = bom ? content.slice(1) : content;
+  if (!source.startsWith("---")) {
+    throw new Error("源 Skill 缺少 YAML frontmatter");
+  }
+  const closing = source.slice(3).match(/\r?\n---(?:\r?\n|$)/);
+  if (!closing || closing.index === undefined) {
+    throw new Error("源 Skill 的 YAML frontmatter 未闭合");
+  }
+  const frontmatterEnd = 3 + closing.index;
+  const frontmatter = source.slice(0, frontmatterEnd);
+  if (!/^\s*name\s*:/m.test(frontmatter)) {
+    throw new Error("源 Skill 的 frontmatter 缺少 name 字段");
+  }
+  const renamed = frontmatter.replace(/^([ \t]*name[ \t]*:).*$/m, `$1 ${name}`);
+  return `${bom}${renamed}${source.slice(frontmatterEnd)}`;
+}
 
 // 给路径追加 ?profile=（管理范围 scope）。override 为空时不动 URL，行为与历史一致。
 function scopedPath(path: string, override?: string | null): string {
@@ -41,6 +67,35 @@ export function useToggleSkill(profileOverride?: string | null) {
       ),
     // 失效所有档案的 skills query（含 scoped 与活跃），两边都会重新拉。
     onSuccess: () => qc.invalidateQueries({ queryKey: ["skills"] }),
+  });
+}
+
+export function useCopyBuiltinSkill(profileOverride?: string | null) {
+  const qc = useQueryClient();
+  const active = useActiveProfileName();
+  const effectiveProfile = profileOverride || active;
+  return useMutation({
+    mutationFn: async ({ sourceName, name, category }: CopyBuiltinSkillInput) => {
+      const source = await fetchJSON(
+        scopedPath(`/api/skills/content?name=${encodeURIComponent(sourceName)}`, profileOverride),
+        undefined,
+        SkillContentResponse,
+      );
+      return postJSON(
+        "/api/skills",
+        {
+          name,
+          content: replaceSkillFrontmatterName(source.content, name),
+          category: category || undefined,
+          profile: profileOverride || undefined,
+        },
+        SkillWriteResponse,
+      );
+    },
+    onSuccess: (_result, input) => Promise.all([
+      qc.invalidateQueries({ queryKey: ["skills", effectiveProfile] }),
+      qc.invalidateQueries({ queryKey: ["skill-markdown", effectiveProfile, input.name] }),
+    ]),
   });
 }
 

--- a/web/src/hooks/use-wander-memory.test.tsx
+++ b/web/src/hooks/use-wander-memory.test.tsx
@@ -159,6 +159,26 @@ describe('wander-memory query hooks', () => {
     expect(backends.result.current.data?.devices.length).toBeGreaterThan(0);
     expect(qc.getQueryState(WANDER_MEMORY_QUERY_KEYS.backends)?.status).toBe('success');
   });
+
+  it('status introspection hooks override application retry defaults', async () => {
+    setDemoClient();
+    const qc = new QueryClient({
+      defaultOptions: { queries: { retry: 5 } },
+    });
+
+    const health = renderHook(() => useWanderMemoryHealth(), { wrapper: wrapperFor(qc) });
+    const models = renderHook(() => useWanderMemoryModels(), { wrapper: wrapperFor(qc) });
+    const backends = renderHook(() => useWanderMemoryBackends(), { wrapper: wrapperFor(qc) });
+
+    expect(qc.getQueryCache().find({ queryKey: WANDER_MEMORY_QUERY_KEYS.health })?.options.retry).toBe(false);
+    expect(qc.getQueryCache().find({ queryKey: WANDER_MEMORY_QUERY_KEYS.models })?.options.retry).toBe(false);
+    expect(qc.getQueryCache().find({ queryKey: WANDER_MEMORY_QUERY_KEYS.backends })?.options.retry).toBe(false);
+
+    health.unmount();
+    models.unmount();
+    backends.unmount();
+    qc.clear();
+  });
 });
 
 // ── mutations: call the client + invalidate list/search ─────────────────────

--- a/web/src/hooks/use-wander-memory.ts
+++ b/web/src/hooks/use-wander-memory.ts
@@ -96,6 +96,7 @@ export function useWanderMemoryModels() {
   return useQuery<ModelsResponse, ApiError>({
     queryKey: WANDER_MEMORY_QUERY_KEYS.models,
     queryFn: ({ signal }) => raceAbort(getWanderMemoryClient().models(), signal),
+    retry: false,
   });
 }
 
@@ -103,6 +104,7 @@ export function useWanderMemoryBackends() {
   return useQuery<BackendsResponse, ApiError>({
     queryKey: WANDER_MEMORY_QUERY_KEYS.backends,
     queryFn: ({ signal }) => raceAbort(getWanderMemoryClient().backends(), signal),
+    retry: false,
   });
 }
 

--- a/web/src/lib/analytics.test.ts
+++ b/web/src/lib/analytics.test.ts
@@ -100,6 +100,32 @@ describe("buildAnalyticsViewModel", () => {
     expect(vm.models[0]?.share).toBeCloseTo(0.666, 2);
   });
 
+  it("keeps model identities distinct when providers share a model name", () => {
+    const sharedModel = {
+      model: "shared",
+      input_tokens: 100,
+      output_tokens: 0,
+      cache_read_tokens: 0,
+      cache_write_tokens: 0,
+      reasoning_tokens: 0,
+      sessions: 1,
+      api_calls: 1,
+    };
+    const vm = buildAnalyticsViewModel(response({
+      totals: totals({ total_tokens: 200, total_sessions: 2 }),
+      by_model: [
+        { ...sharedModel, provider: "provider-a" },
+        { ...sharedModel, provider: "provider-b" },
+      ],
+    }));
+
+    expect(vm.models.map((model) => model.id)).toEqual([
+      "provider-a:shared",
+      "provider-b:shared",
+    ]);
+    expect(new Set(vm.models.map((model) => model.id)).size).toBe(2);
+  });
+
   it("sorts top sessions by tokens then api calls", () => {
     const vm = buildAnalyticsViewModel(response({
       totals: totals({ total_tokens: 500, total_sessions: 2 }),

--- a/web/src/lib/composer-prompt.test.ts
+++ b/web/src/lib/composer-prompt.test.ts
@@ -62,6 +62,47 @@ describe("composer prompt preparation", () => {
     expect(result.displayText).toBe("看看这张图\n\n附件：pasted.png");
   });
 
+  it("keeps the browser image's original display name when Core renames the stored file", async () => {
+    vi.stubGlobal("FileReader", FakeFileReader);
+    const file = {
+      name: "e2e-red-dot.png",
+      type: "image/png",
+      arrayBuffer: async () => new Uint8Array([1, 2, 3, 4]).buffer,
+    } as unknown as File;
+    const attachImageBytes = vi.fn(async () => ({
+      attached: true,
+      text: "[User attached image: upload_20260824_120000_1.png]",
+      name: "upload_20260824_120000_1.png",
+      path: "/img/upload_20260824_120000_1.png",
+    }));
+
+    const result = await prepareComposerPrompt(
+      "s1",
+      {
+        text: "看看这张图",
+        attachments: [{
+          id: "a1",
+          source: "browser",
+          file,
+          name: "e2e-red-dot.png",
+          kind: "image",
+          status: "ready",
+          mimeType: "image/png",
+        }],
+      },
+      { attachImage: vi.fn(), attachImageBytes, detectDroppedPath: vi.fn() },
+    );
+
+    expect(result.promptText).toContain("name=e2e-red-dot.png");
+    expect(result.displayImages).toEqual([
+      expect.objectContaining({
+        name: "e2e-red-dot.png",
+        alt: "e2e-red-dot.png",
+        title: "e2e-red-dot.png",
+      }),
+    ]);
+  });
+
   it("in remote mode, a path-only image uploads its bytes (image.attach_bytes), not the path", async () => {
     const readImageBytes = vi.fn(async () => ({
       contentBase64: "QUJD",

--- a/web/src/lib/composer-prompt.ts
+++ b/web/src/lib/composer-prompt.ts
@@ -374,7 +374,10 @@ export async function prepareComposerPrompt(
         }
 
         if (attached.text?.trim()) {
-          const label = attached.name || uploadedName || attachment.name || fileNameFromPath(path);
+          // Core deliberately renames byte uploads to a collision-safe storage
+          // filename. Keep the user-facing source name in the persisted UI
+          // marker so a history reload can pair that label with the safe path.
+          const label = attachment.name || uploadedName || attached.name || fileNameFromPath(path);
           parts.push([
             IMAGE_BLOCK_START,
             `name=${sanitizeContextValue(label)}`,
@@ -383,7 +386,7 @@ export async function prepareComposerPrompt(
             IMAGE_BLOCK_END,
           ].join("\n"));
         }
-        const label = attached.name || uploadedName || attachment.name || fileNameFromPath(path);
+        const label = attachment.name || uploadedName || attached.name || fileNameFromPath(path);
         displayImages.push({
           url: await imageDisplayUrl(attachment, attached.path || path),
           alt: label,

--- a/web/src/lib/debug-redact.test.ts
+++ b/web/src/lib/debug-redact.test.ts
@@ -41,6 +41,7 @@ describe("redact", () => {
     ]) as any[];
     expect(out[0].user).toBe("claw");
     expect(out[0].password).toBe("***");
+    expect(out[1].token).toBe("***");
     expect(out[1].foo).toBe("bar");
   });
 
@@ -68,5 +69,13 @@ describe("redactSummary", () => {
   it("masks sensitive key-value fragments in log text", () => {
     expect(redactSummary("gateway failed token=secret-value api_key='sk-abcdefghijklmnop1234567890'"))
       .toBe("gateway failed token=*** api_key='***'");
+  });
+  it("masks quoted JSON keys and their complete values", () => {
+    const summary = 'console marker {"api_key":"e2e-debug-panel-secret","password":"two words","token":1234,"safe":"visible"}';
+    const out = redactSummary(summary);
+
+    expect(out).toBe('console marker {"api_key":"***","password":"***","token":***,"safe":"visible"}');
+    expect(out).not.toContain("e2e-debug-panel-secret");
+    expect(out).not.toContain("two words");
   });
 });

--- a/web/src/lib/debug-redact.ts
+++ b/web/src/lib/debug-redact.ts
@@ -7,6 +7,7 @@ const SENSITIVE_KEYS = [
   "session_token",
   "sessiontoken",
   "session-token",
+  "token",
   "secret",
   "password",
   "access_token",
@@ -17,14 +18,13 @@ const SENSITIVE_KEYS = [
 ];
 
 const SENSITIVE_KEY_SET = new Set(SENSITIVE_KEYS.map((k) => k.toLowerCase()));
-const SENSITIVE_TEXT_KEYS = [...SENSITIVE_KEYS, "token"] as const;
 
 const BEARER_RE = /(Bearer\s+)([A-Za-z0-9_.\-+/=]{8,})/gi;
 const LONG_TOKEN_RE = /\b(sk-[A-Za-z0-9_\-]{16,}|gh[pous]_[A-Za-z0-9_]{20,}|xox[abprsu]-[A-Za-z0-9-]{10,})\b/g;
 const SENSITIVE_TEXT_KEY_RE = new RegExp(
-  `(^|[\\s,{\\[])(` +
-    SENSITIVE_TEXT_KEYS.map((key) => key.replace(/[.*+?^${}()|[\]\\]/g, "\\$&")).join("|") +
-    `)(\\s*[:=]\\s*)(["']?)([^"'\\s,;&}]+)(["']?)`,
+  `(^|[\\s,{\\[])(["']?)(` +
+    SENSITIVE_KEYS.map((key) => key.replace(/[.*+?^${}()|[\]\\]/g, "\\$&")).join("|") +
+    `)\\2(\\s*[:=]\\s*)(?:(["'])((?:\\\\.|(?!\\5)[^\\\\])*)\\5|([^"'\\s,;&}\\]]+))`,
   "gi",
 );
 
@@ -35,9 +35,9 @@ function maskString(value: string): string {
   return value
     .replace(BEARER_RE, (_, prefix) => `${prefix}${MASK}`)
     .replace(LONG_TOKEN_RE, MASK)
-    .replace(SENSITIVE_TEXT_KEY_RE, (_match, prefix, key, sep, openQuote, _secret, closeQuote) => {
-      const quote = openQuote && closeQuote ? openQuote : "";
-      return `${prefix}${key}${sep}${quote}${MASK}${quote}`;
+    .replace(SENSITIVE_TEXT_KEY_RE, (_match, prefix, keyQuote, key, sep, valueQuote) => {
+      const quote = valueQuote ?? "";
+      return `${prefix}${keyQuote}${key}${keyQuote}${sep}${quote}${MASK}${quote}`;
     });
 }
 

--- a/web/src/lib/gateway-reconnect.test.ts
+++ b/web/src/lib/gateway-reconnect.test.ts
@@ -71,6 +71,27 @@ describe("reattachAfterReconnect", () => {
     expect(onResumed).not.toHaveBeenCalled();
     expect(onResumeFailed).toHaveBeenCalledTimes(1);
   });
+
+  it.each([false, true])("does not overwrite a newly activated session when the old resume settles (failure=%s)", async (fails) => {
+    let activeSessionId = "gw-old";
+    let finish!: () => void;
+    const waiting = new Promise<void>((resolve) => { finish = resolve; });
+    const { deps, onResumed, onResumeFailed } = makeDeps({
+      getActiveSessionId: () => activeSessionId,
+      resume: async () => {
+        await waiting;
+        if (fails) throw new Error("Session not found");
+        return { session_id: "gw-resumed" };
+      },
+    });
+    const reattaching = reattachAfterReconnect(deps);
+    activeSessionId = "gw-new-conversation";
+    finish();
+    await reattaching;
+
+    expect(onResumed).not.toHaveBeenCalled();
+    expect(onResumeFailed).not.toHaveBeenCalled();
+  });
 });
 
 describe("isDefinitiveMissingSessionError", () => {

--- a/web/src/lib/gateway-reconnect.ts
+++ b/web/src/lib/gateway-reconnect.ts
@@ -50,12 +50,15 @@ export async function reattachAfterReconnect(deps: ReattachAfterReconnectDeps): 
   const persistentId = deps.resolvePersistentId(activeSessionId);
   try {
     const result = await deps.resume(persistentId);
+    // A new conversation may have been activated while resume was in flight.
+    if (deps.getActiveSessionId() !== activeSessionId) return;
     if (!result?.session_id) {
       deps.onResumeFailed(new Error("session.resume returned no session_id"));
       return;
     }
     deps.onResumed(result.session_id, result.resumed ?? persistentId);
   } catch (error) {
+    if (deps.getActiveSessionId() !== activeSessionId) return;
     deps.onResumeFailed(error);
   }
 }

--- a/web/src/lib/transport.test.ts
+++ b/web/src/lib/transport.test.ts
@@ -258,6 +258,41 @@ describe("transport · debug-bus integration", () => {
     expect(globalThis.fetch).not.toHaveBeenCalled();
   });
 
+  it("fetchExternalJSON aborts a pending desktop externalRequest", async () => {
+    type ExternalResult = {
+      ok: boolean;
+      status: number;
+      statusText: string;
+      headers: Record<string, string>;
+      body: string;
+    };
+    let finish: ((value: ExternalResult) => void) | undefined;
+    const externalRequest = vi.fn((): Promise<ExternalResult> => new Promise((resolve) => {
+      finish = resolve;
+    }));
+    window.__HERMES_RUNTIME__ = { platform: "tauri" };
+    window.hermesDesktop = {
+      windowType: "tauri",
+      request: vi.fn(),
+      externalRequest,
+    };
+    const controller = new AbortController();
+
+    const request = fetchExternalJSON("http://127.0.0.1:18400/v1/health", {
+      signal: controller.signal,
+    });
+    controller.abort();
+    finish?.({
+      ok: true,
+      status: 200,
+      statusText: "OK",
+      headers: {},
+      body: "{}",
+    });
+
+    await expect(request).rejects.toMatchObject({ name: "AbortError" });
+  });
+
   it("uploadAttachmentFile uses desktop uploadFile capability on Tauri", async () => {
     const uploadFile = vi.fn(async () => ({
       ok: true,

--- a/web/src/lib/transport.ts
+++ b/web/src/lib/transport.ts
@@ -217,12 +217,18 @@ export async function fetchExternalJSON<T>(
   const headers = (init?.headers as Record<string, string>) ?? {};
   const externalRequest = window.hermesDesktop?.externalRequest;
   if (externalRequest) {
-    const result = await externalRequest({
-      path: url,
-      method: init?.method,
-      headers,
-      body: typeof init?.body === "string" ? init.body : null,
-    });
+    const signal = init?.signal ?? null;
+    throwIfAborted(signal);
+    const result = await raceAbort(
+      externalRequest({
+        path: url,
+        method: init?.method,
+        headers,
+        body: typeof init?.body === "string" ? init.body : null,
+      }),
+      signal,
+    );
+    throwIfAborted(signal);
     if (!result.ok) {
       reportRestFailure(init?.method ?? "GET", url, result.status, result.body);
       throw new Error(`HTTP ${result.status}: ${result.body}`);

--- a/web/src/lib/wander-memory/client-lifecycle.test.ts
+++ b/web/src/lib/wander-memory/client-lifecycle.test.ts
@@ -1,0 +1,20 @@
+import { describe, expect, it, vi } from "vitest";
+import type { WanderMemoryClient } from "./client";
+import {
+  __resetWanderMemoryClientForTests,
+  disposeWanderMemoryClient,
+  resetWanderMemoryClient,
+} from "./client";
+
+describe("Wander Memory singleton lifecycle", () => {
+  it("disposes the active client and clears the singleton", () => {
+    const dispose = vi.fn();
+    const client = { mode: "demo", dispose } as unknown as WanderMemoryClient;
+    resetWanderMemoryClient(client);
+
+    disposeWanderMemoryClient();
+
+    expect(dispose).toHaveBeenCalledTimes(1);
+    __resetWanderMemoryClientForTests();
+  });
+});

--- a/web/src/lib/wander-memory/client.ts
+++ b/web/src/lib/wander-memory/client.ts
@@ -151,6 +151,12 @@ export function resetWanderMemoryClient(next?: WanderMemoryClient | null): Wande
   return singleton;
 }
 
+/** Stop all background work and make the next Wander route create a fresh client. */
+export function disposeWanderMemoryClient(): void {
+  singleton?.dispose?.();
+  singleton = null;
+}
+
 /** Test hook: drop the singleton without disposing (e.g. after a disposed stub). */
 export function __resetWanderMemoryClientForTests(): void {
   singleton = null;

--- a/web/src/lib/wander-memory/index.ts
+++ b/web/src/lib/wander-memory/index.ts
@@ -68,6 +68,7 @@ export {
   getWanderMemoryClient,
   getWanderMemoryClientAsync,
   resetWanderMemoryClient,
+  disposeWanderMemoryClient,
 } from './client';
 export type { WanderMemoryClient } from './client';
 

--- a/web/src/lib/wander-memory/rest.test.ts
+++ b/web/src/lib/wander-memory/rest.test.ts
@@ -213,6 +213,17 @@ describe('error + edge-body handling', () => {
     expect(err.message).toContain('Failed to fetch');
   });
 
+  it('native HTTP 0 response is an offline network failure with startup guidance', async () => {
+    transportMocks.fetchExternalJSON.mockRejectedValue(
+      new Error('HTTP 0: error sending request for url (http://127.0.0.1:18400/v1/health)'),
+    );
+    const err = await new MemOsRestClient('http://api.test').health().catch((e) => e);
+    expect(err).toBeInstanceOf(ApiError);
+    expect(err).toMatchObject({ code: 'network_failure', status: null });
+    expect(err.message).toContain('start MemOS');
+    expect(err.message).toContain('endpoint settings');
+  });
+
   it('DELETE with an empty 204 body (SyntaxError from transport) is success-with-no-payload', async () => {
     transportMocks.fetchExternalJSON.mockRejectedValue(new SyntaxError('Unexpected end of JSON input'));
     await expect(new MemOsRestClient('http://api.test').delete('m1')).resolves.toBeUndefined();
@@ -229,11 +240,15 @@ describe('error + edge-body handling', () => {
 });
 
 describe('timeout policy (§5.2)', () => {
-  it('no-LLM endpoints pass a client AbortSignal (10 s)', async () => {
-    await new MemOsRestClient('http://api.test').health();
-    const { init } = lastSent(transportMocks.fetchExternalJSON);
-    expect(init.signal).toBeInstanceOf(AbortSignal);
-    expect(init.signal!.aborted).toBe(false);
+  it('status introspection endpoints use a fast 3 s client timeout', async () => {
+    const signal = new AbortController().signal;
+    const timeout = vi.spyOn(AbortSignal, 'timeout').mockReturnValue(signal);
+    const client = new MemOsRestClient('http://api.test');
+
+    await Promise.all([client.health(), client.models(), client.backends()]);
+
+    expect(timeout).toHaveBeenCalledTimes(3);
+    expect(timeout.mock.calls).toEqual([[3_000], [3_000], [3_000]]);
   });
 
   it('/chat and /dialogues have NO client timeout', async () => {

--- a/web/src/lib/wander-memory/rest.ts
+++ b/web/src/lib/wander-memory/rest.ts
@@ -36,6 +36,7 @@ import type {
 
 export const DEFAULT_API_ORIGIN = 'http://127.0.0.1:18400';
 const NO_LLM_TIMEOUT_MS = 10_000;
+const INTROSPECTION_TIMEOUT_MS = 3_000;
 
 /**
  * Join an origin ("" | "/v1" | "http://host:port" | "http://host:port/v1") with
@@ -75,6 +76,13 @@ export function adaptTransportError(err: unknown, hint?: string): ApiError {
     if (m) {
       const status = Number(m[1]);
       const body = m[2];
+      if (status === 0 || status === 408) {
+        return new ApiError(
+          'network_failure',
+          'MemOS service is offline — start MemOS or update endpoint settings below',
+          null,
+        );
+      }
       try {
         const parsed = JSON.parse(body) as { error?: { code?: unknown; message?: unknown } } | null;
         if (parsed && typeof parsed === 'object' && parsed.error && typeof parsed.error.code === 'string') {
@@ -138,15 +146,15 @@ export class MemOsRestClient {
 
   // ── §4.1 endpoints ────────────────────────────────────────────────────────
   health(): Promise<HealthResponse> {
-    return this.request('GET', '/health');
+    return this.request('GET', '/health', undefined, INTROSPECTION_TIMEOUT_MS);
   }
 
   backends(): Promise<BackendsResponse> {
-    return this.request('GET', '/backends');
+    return this.request('GET', '/backends', undefined, INTROSPECTION_TIMEOUT_MS);
   }
 
   models(): Promise<ModelsResponse> {
-    return this.request('GET', '/models');
+    return this.request('GET', '/models', undefined, INTROSPECTION_TIMEOUT_MS);
   }
 
   /** LLM path: extraction + N collision calls — no client timeout (§5.2). */

--- a/web/src/lib/wander-memory/ws.test.ts
+++ b/web/src/lib/wander-memory/ws.test.ts
@@ -1,0 +1,51 @@
+import { afterEach, describe, expect, it, vi } from "vitest";
+import { MemOsWsClient } from "./ws";
+
+class FakeWebSocket {
+  static readonly CONNECTING = 0;
+  static readonly OPEN = 1;
+  static readonly CLOSING = 2;
+  static readonly CLOSED = 3;
+  static readonly instances: FakeWebSocket[] = [];
+
+  readyState = FakeWebSocket.CONNECTING;
+  onopen: ((event: Event) => void) | null = null;
+  onmessage: ((event: MessageEvent) => void) | null = null;
+  onclose: ((event: CloseEvent) => void) | null = null;
+  onerror: ((event: Event) => void) | null = null;
+
+  constructor(readonly url: string) {
+    FakeWebSocket.instances.push(this);
+  }
+
+  close(): void {
+    this.readyState = FakeWebSocket.CLOSED;
+    queueMicrotask(() => this.onclose?.({} as CloseEvent));
+  }
+
+  send(): void {}
+}
+
+afterEach(() => {
+  vi.clearAllTimers();
+  vi.useRealTimers();
+  vi.unstubAllGlobals();
+  FakeWebSocket.instances.length = 0;
+});
+
+describe("MemOsWsClient lifecycle", () => {
+  it("does not reconnect after an intentional disconnect", async () => {
+    vi.useFakeTimers();
+    vi.stubGlobal("WebSocket", FakeWebSocket);
+    const client = new MemOsWsClient("ws://127.0.0.1:18401/v1/ws");
+
+    client.connect();
+    expect(FakeWebSocket.instances).toHaveLength(1);
+    client.disconnect();
+    await Promise.resolve();
+    await vi.runAllTimersAsync();
+
+    expect(FakeWebSocket.instances).toHaveLength(1);
+    expect(client.connectionState).toBe("closed");
+  });
+});

--- a/web/src/lib/wander-memory/ws.ts
+++ b/web/src/lib/wander-memory/ws.ts
@@ -52,6 +52,7 @@ export class MemOsWsClient {
   private deadTimer: ReturnType<typeof setInterval> | null = null;
   private reconnectAttempts = 0;
   private reconnectTimer: ReturnType<typeof setTimeout> | null = null;
+  private reconnectEnabled = false;
   private state: ConnectionState = 'closed';
   private stateListeners = new Set<(s: ConnectionState) => void>();
   readonly url: string;
@@ -76,6 +77,7 @@ export class MemOsWsClient {
 
   connect(): void {
     if (this.socket && (this.socket.readyState === WebSocket.OPEN || this.socket.readyState === WebSocket.CONNECTING)) return;
+    this.reconnectEnabled = true;
     this.setState('connecting');
     let ws: WebSocket;
     try {
@@ -107,7 +109,7 @@ export class MemOsWsClient {
 
     ws.onclose = () => {
       this.handleSocketDown();
-      this.scheduleReconnect();
+      if (this.reconnectEnabled) this.scheduleReconnect();
     };
 
     ws.onerror = () => {
@@ -116,10 +118,14 @@ export class MemOsWsClient {
   }
 
   disconnect(): void {
+    this.reconnectEnabled = false;
     if (this.reconnectTimer !== null) clearTimeout(this.reconnectTimer);
     this.reconnectTimer = null;
     this.stopKeepalive();
-    this.socket?.close();
+    if (this.socket) {
+      this.socket.onclose = null;
+      this.socket.close();
+    }
     this.handleSocketDown();
   }
 
@@ -134,6 +140,7 @@ export class MemOsWsClient {
   }
 
   private scheduleReconnect(): void {
+    if (!this.reconnectEnabled) return;
     if (this.reconnectTimer !== null) return;
     const exp = Math.min(BACKOFF_MAX_MS, BACKOFF_MIN_MS * 2 ** this.reconnectAttempts);
     const jittered = exp * (0.75 + Math.random() * 0.5);

--- a/web/src/main.tsx
+++ b/web/src/main.tsx
@@ -1,7 +1,7 @@
 import { StrictMode } from "react";
 import { createRoot } from "react-dom/client";
 import { BrowserRouter, HashRouter } from "react-router-dom";
-import { Provider as JotaiProvider, createStore } from "jotai";
+import { Provider as JotaiProvider, getDefaultStore } from "jotai";
 import { QueryClientProvider } from "@tanstack/react-query";
 import { DEFAULT_THEME_CONFIG, applyPlatformToDOM, applyThemeToDOM, normalizeThemeConfig, themeAtom, type ThemeConfig } from "@hermes/shared-ui";
 import { queryClient } from "./lib/query-client";
@@ -52,7 +52,9 @@ async function bootstrap() {
   applyThemeToDOM(initialTheme);
   // Seed the shared jotai store so `useTheme()` (and the appearance controls)
   // start from the persisted theme/density/scale instead of the defaults.
-  const jotaiStore = createStore();
+  // Imperative gateway reconnects and transport profile lookups use this same
+  // store. A separate Provider store leaves the rendered session on its old ID.
+  const jotaiStore = getDefaultStore();
   jotaiStore.set(themeAtom, initialTheme);
 
   await fetchDevToken();

--- a/web/src/routes/analytics.tsx
+++ b/web/src/routes/analytics.tsx
@@ -51,6 +51,7 @@ const MODEL_COLORS = [
   "var(--h-err)",
   "var(--h-text-3)",
 ];
+const POSITIVE_CHART_INITIAL_DIMENSION = { width: 1, height: 1 };
 
 const TOP_SESSIONS_PAGE_SIZE = 8;
 const DAILY_PAGE_SIZE = 10;
@@ -325,7 +326,7 @@ function TokenTrendChart({ daily }: { daily: AnalyticsDailyPoint[] }) {
         </div>
       </div>
       <div className={s.chartBox}>
-        <ResponsiveContainer width="100%" height="100%">
+        <ResponsiveContainer width="100%" height="100%" initialDimension={POSITIVE_CHART_INITIAL_DIMENSION}>
           <ComposedChart data={daily} margin={{ top: 8, right: 8, bottom: 0, left: 0 }}>
             <CartesianGrid stroke="var(--h-line-soft)" vertical={false} />
             <XAxis dataKey="label" stroke="var(--h-text-3)" tickLine={false} axisLine={false} minTickGap={18} />
@@ -345,6 +346,7 @@ function TokenTrendChart({ daily }: { daily: AnalyticsDailyPoint[] }) {
 
 function ModelTokenChart({ models }: { models: AnalyticsModelView[] }) {
   const data = models.slice(0, 7).map((model, index) => ({
+    id: model.id,
     name: model.model,
     provider: model.provider,
     value: model.totalTokens,
@@ -367,10 +369,10 @@ function ModelTokenChart({ models }: { models: AnalyticsModelView[] }) {
       ) : (
         <div className={s.modelChartLayout}>
           <div className={s.pieBox}>
-            <ResponsiveContainer width="100%" height="100%">
+            <ResponsiveContainer width="100%" height="100%" initialDimension={POSITIVE_CHART_INITIAL_DIMENSION}>
               <PieChart>
                 <Pie data={data} dataKey="value" nameKey="name" innerRadius={54} outerRadius={82} paddingAngle={2}>
-                  {data.map((entry) => <Cell key={entry.name} fill={entry.color} />)}
+                  {data.map((entry) => <Cell key={entry.id} fill={entry.color} />)}
                 </Pie>
                 <Tooltip content={<ModelTooltip />} />
               </PieChart>
@@ -378,7 +380,7 @@ function ModelTokenChart({ models }: { models: AnalyticsModelView[] }) {
           </div>
           <div className={s.modelLegend}>
             {data.map((item) => (
-              <div key={`${item.provider}:${item.name}`} className={s.modelLegendRow}>
+              <div key={item.id} className={s.modelLegendRow}>
                 <span className={s.legendDot} style={{ background: item.color }} />
                 <span className={s.legendName} title={`${item.provider} · ${item.name}`}>{item.name}</span>
                 <span className={s.legendValue}>{(item.share * 100).toFixed(1)}%</span>
@@ -405,7 +407,7 @@ function CachePerformanceChart({ daily }: { daily: AnalyticsPerformanceDailyPoin
         </div>
       </div>
       <div className={s.chartBox}>
-        <ResponsiveContainer width="100%" height="100%">
+        <ResponsiveContainer width="100%" height="100%" initialDimension={POSITIVE_CHART_INITIAL_DIMENSION}>
           <ComposedChart data={data} margin={{ top: 8, right: 8, bottom: 0, left: 0 }}>
             <CartesianGrid stroke="var(--h-line-soft)" vertical={false} />
             <XAxis dataKey="label" stroke="var(--h-text-3)" tickLine={false} axisLine={false} minTickGap={18} />

--- a/web/src/routes/detail.tsx
+++ b/web/src/routes/detail.tsx
@@ -325,7 +325,9 @@ export function DetailRoute() {
 
   const ensureGatewaySession = useCallback(async (): Promise<string> => {
     if (!taskId) throw new Error("缺少会话 ID");
-    if (restSessionId && taskId === restSessionId && !activeMappedGatewaySessionId) {
+    if (restSessionId && !activeMappedGatewaySessionId) {
+      // Old deep links can still use a gateway ID from a previous process.
+      // Resolve that alias to its persistent ID before resuming, too.
       // No URL navigate after the resume — atom + gwSessionIdAtom hold
       // the authoritative state; downstream callers go through
       // resolveGatewaySessionId / resolvePersistentSessionId helpers

--- a/web/src/routes/im-onboarding.test.ts
+++ b/web/src/routes/im-onboarding.test.ts
@@ -1,4 +1,4 @@
-import { describe, expect, it } from "vitest";
+import { afterEach, describe, expect, it, vi } from "vitest";
 import {
   buildImDiagnosticBundle,
   buildImDiagnosticPrompt,
@@ -10,13 +10,60 @@ import {
   FEISHU_REQUIRED_SCOPES,
   railPanels,
   sectionFromPath,
+  startSerialPolling,
   statusText,
+  uniqueAllowedUserCount,
 } from "./im-onboarding";
 
+afterEach(() => {
+  vi.useRealTimers();
+});
+
 describe("im onboarding routing helpers", () => {
+  it("waits for an in-flight onboarding poll before scheduling the next one", async () => {
+    vi.useFakeTimers();
+    const releases: Array<() => void> = [];
+    let started = 0;
+    let inFlight = 0;
+    let maxInFlight = 0;
+
+    const stop = startSerialPolling(async () => {
+      started += 1;
+      inFlight += 1;
+      maxInFlight = Math.max(maxInFlight, inFlight);
+      await new Promise<void>((resolve) => releases.push(resolve));
+      inFlight -= 1;
+    }, 1_500);
+
+    await vi.advanceTimersByTimeAsync(1_500);
+    expect(started).toBe(1);
+
+    await vi.advanceTimersByTimeAsync(15_000);
+    expect(started).toBe(1);
+    expect(maxInFlight).toBe(1);
+
+    releases.shift()?.();
+    await vi.advanceTimersByTimeAsync(1_499);
+    expect(started).toBe(1);
+    await vi.advanceTimersByTimeAsync(1);
+    expect(started).toBe(2);
+    expect(maxInFlight).toBe(1);
+
+    stop();
+    releases.shift()?.();
+    await vi.advanceTimersByTimeAsync(10_000);
+    expect(started).toBe(2);
+  });
+
   it("maps /im to the Feishu page by default", () => {
     expect(sectionFromPath("/im")).toBe("feishu");
     expect(sectionFromPath("/im/")).toBe("feishu");
+  });
+
+  it("counts allowlist users with the same deduplication used by save", () => {
+    expect(uniqueAllowedUserCount("id_alpha, id_alpha  id_beta，id_beta"))
+      .toBe(2);
+    expect(uniqueAllowedUserCount("  ")).toBe(0);
   });
 
   it("maps platform subroutes and rejects unrelated paths", () => {

--- a/web/src/routes/im-onboarding.tsx
+++ b/web/src/routes/im-onboarding.tsx
@@ -67,6 +67,38 @@ export const FEISHU_RECOMMENDED_SCOPES = [
 ] as const;
 const FEISHU_RECEIVE_EVENT = "im.message.receive_v1";
 
+export function startSerialPolling(
+  task: () => Promise<unknown>,
+  delayMs: number,
+  onError?: (error: unknown) => void,
+): () => void {
+  let stopped = false;
+  let timer: ReturnType<typeof setTimeout> | null = null;
+
+  const schedule = () => {
+    timer = globalThis.setTimeout(() => {
+      timer = null;
+      void run();
+    }, delayMs);
+  };
+  const run = async () => {
+    try {
+      await task();
+    } catch (error) {
+      onError?.(error);
+    } finally {
+      if (!stopped) schedule();
+    }
+  };
+
+  schedule();
+  return () => {
+    stopped = true;
+    if (timer !== null) globalThis.clearTimeout(timer);
+    timer = null;
+  };
+}
+
 export function sectionFromPath(pathname: string): ImSection | null {
   if (pathname === "/im" || pathname === "/im/") return "feishu";
   if (pathname === "/im/feishu") return "feishu";
@@ -100,6 +132,10 @@ function compactList(items: string[]): string {
     out.push(trimmed);
   }
   return out.join(",");
+}
+
+export function uniqueAllowedUserCount(value: string): number {
+  return new Set(splitAllowedUsers(value)).size;
 }
 
 export function statusText(status?: string): string {
@@ -841,7 +877,7 @@ function FeishuRoute() {
       restartGateway: true,
     }, { onSuccess: setResult });
   };
-  const manualAllowedCount = splitAllowedUsers(allowedUsers).length;
+  const manualAllowedCount = uniqueAllowedUserCount(allowedUsers);
   const useScannedOpenId = Boolean(scannedOpenId) && (dmPolicy === "scanned" || (dmPolicy === "allowlist" && includeScannedOpenId));
   const allowPolicyReady = dmPolicy === "scanned"
     ? Boolean(scannedOpenId)
@@ -1044,6 +1080,7 @@ function WeixinRoute() {
   const [diagnosticPending, setDiagnosticPending] = useState(false);
   const [diagnosticError, setDiagnosticError] = useState<string | null>(null);
   const qrAnchorRef = useRef<HTMLDivElement>(null);
+  const pollInFlightRef = useRef(false);
   const configured = stateQuery.data?.configured ?? {};
   const status = pollResult?.status ?? flow?.status;
   const credential = pollResult?.credentialSummary;
@@ -1068,14 +1105,40 @@ function WeixinRoute() {
     });
   };
   const pollOnce = () => {
-    if (!flow?.flowId) return;
-    poll.mutate({ platform: "weixin", flowId: flow.flowId }, { onSuccess: setPollResult });
+    const flowId = flow?.flowId;
+    if (!flowId || pollInFlightRef.current) return;
+    pollInFlightRef.current = true;
+    poll.mutate(
+      { platform: "weixin", flowId },
+      {
+        onSuccess: setPollResult,
+        onSettled: () => {
+          pollInFlightRef.current = false;
+        },
+      },
+    );
   };
   useEffect(() => {
-    if (!flow?.flowId || pollResult?.status === "confirmed" || pollResult?.status === "expired") return;
-    const id = window.setInterval(pollOnce, 1500);
-    return () => window.clearInterval(id);
-  }, [flow?.flowId, pollResult?.status]);
+    const flowId = flow?.flowId;
+    if (!flowId || pollResult?.status === "confirmed" || pollResult?.status === "expired") return;
+
+    let active = true;
+    const stop = startSerialPolling(async () => {
+      if (pollInFlightRef.current) return;
+      pollInFlightRef.current = true;
+      try {
+        const next = await poll.mutateAsync({ platform: "weixin", flowId });
+        if (active) setPollResult(next);
+      } finally {
+        pollInFlightRef.current = false;
+      }
+    }, 1_500);
+
+    return () => {
+      active = false;
+      stop();
+    };
+  }, [flow?.flowId, poll.mutateAsync, pollResult?.status]);
   useEffect(() => {
     if (pollResult?.status === "confirmed" && scannedUserId && dmPolicy === "pairing") {
       setDmPolicy("allowlist");
@@ -1084,7 +1147,7 @@ function WeixinRoute() {
 
   const shouldAutoWeixinHomeChannel = Boolean(scannedUserId) && !homeChannel.trim();
   const useScannedUserId = Boolean(scannedUserId) && dmPolicy === "allowlist";
-  const manualAllowedCount = splitAllowedUsers(allowedUsers).length;
+  const manualAllowedCount = uniqueAllowedUserCount(allowedUsers);
   const allowPolicyReady = dmPolicy === "open" || dmPolicy === "pairing" || Boolean(useScannedUserId || manualAllowedCount > 0);
   const dmPolicyValue = dmPolicy === "open" ? "open" : dmPolicy === "pairing" ? "pairing" : "allowlist";
   const settings = () => {

--- a/web/src/routes/panel.tsx
+++ b/web/src/routes/panel.tsx
@@ -104,7 +104,7 @@ export function PanelRoute() {
   };
 
   return (
-    <div className={s.pageWrap} data-page-texture="pinhole">
+    <main className={s.pageWrap} data-page-texture="pinhole">
       <div className={s.pageContent}>
         <PanelHero
           activeCount={active.length}
@@ -160,6 +160,6 @@ export function PanelRoute() {
           <QuickStart />
         </Section>
       </div>
-    </div>
+    </main>
   );
 }

--- a/web/src/routes/profiles.test.tsx
+++ b/web/src/routes/profiles.test.tsx
@@ -1,0 +1,93 @@
+// @vitest-environment jsdom
+
+import type { ProfileSummary } from "@hermes/protocol";
+import { cleanup, fireEvent, render, screen } from "@testing-library/react";
+import { MemoryRouter } from "react-router-dom";
+import { afterEach, beforeEach, describe, expect, it, vi } from "vitest";
+
+const mocks = vi.hoisted(() => ({
+  mutate: vi.fn(),
+  profile: {
+    name: "reviewer",
+    path: "/profiles/reviewer",
+    is_default: false,
+    model: null,
+    provider: null,
+    has_env: false,
+    skill_count: 0,
+    gateway_running: false,
+    description: "",
+    description_auto: false,
+    distribution_name: null,
+    distribution_version: null,
+    distribution_source: null,
+    has_alias: false,
+  },
+}));
+
+vi.mock("@/hooks/use-profiles", () => ({
+  useActiveProfile: () => ({
+    data: { active: "default", current: "default" },
+    error: null,
+    isError: false,
+    isLoading: false,
+  }),
+  useProfiles: () => ({
+    data: [mocks.profile],
+    error: null,
+    isError: false,
+    isLoading: false,
+  }),
+  useProfileSetupCommand: () => ({ mutateAsync: vi.fn() }),
+  useSetActiveProfile: () => ({
+    isPending: false,
+    mutate: mocks.mutate,
+    variables: undefined,
+  }),
+}));
+
+vi.mock("@/lib/runtime", () => ({
+  runtime: {
+    isAttached: () => false,
+    platform: "win32",
+  },
+}));
+
+vi.mock("@/components/profiles", () => ({
+  ActiveCurrentBanner: () => null,
+  ProfileCard: ({ profile: item, onSetActive }: {
+    profile: ProfileSummary;
+    onSetActive: () => void;
+  }) => <button onClick={onSetActive}>切换到 {item.name}</button>,
+  ProfileCreateDialog: () => null,
+  ProfileDeleteDialog: () => null,
+  ProfileDescriptionDialog: () => null,
+  ProfileModelDialog: () => null,
+  ProfileRenameDialog: () => null,
+  ProfileSoulDialog: () => null,
+}));
+
+import { ProfilesRoute } from "./profiles";
+
+beforeEach(() => {
+  mocks.mutate.mockReset();
+});
+
+afterEach(cleanup);
+
+describe("ProfilesRoute switching feedback", () => {
+  it("surfaces a native switch rejection to the user", () => {
+    mocks.mutate.mockImplementation((_name, options) => {
+      options.onError(new Error("native switch rejected"));
+    });
+    render(
+      <MemoryRouter>
+        <ProfilesRoute />
+      </MemoryRouter>,
+    );
+
+    fireEvent.click(screen.getByRole("button", { name: "切换到 reviewer" }));
+
+    expect(screen.getByText("native switch rejected")).toBeTruthy();
+  });
+});

--- a/web/src/routes/profiles.tsx
+++ b/web/src/routes/profiles.tsx
@@ -63,6 +63,9 @@ export function ProfilesRoute() {
       onSuccess: (result) => {
         if (result.mode === "web-sticky") setRestartHint(name);
       },
+      onError: (error) => {
+        setSwitchError(error.message || "切换档案失败，请重试。");
+      },
     });
   };
 

--- a/web/src/routes/project-detail.module.css
+++ b/web/src/routes/project-detail.module.css
@@ -117,7 +117,7 @@
   min-width: 0;
 }
 
-.heroMeta h1 {
+.heroMeta h2 {
   margin: 0 0 4px;
   font-size: 18px;
   color: var(--h-text);

--- a/web/src/routes/project-detail.tsx
+++ b/web/src/routes/project-detail.tsx
@@ -256,7 +256,7 @@ export function ProjectDetailRoute() {
               <Folder size={24} />
             </span>
             <div className={s.heroMeta}>
-              <h1>{project.name}</h1>
+              <h2>{project.name}</h2>
               <div className={s.heroPath}>{project.path}</div>
               <div className={s.heroDates}>
                 创建于 {formatTimestampDate(project.createdAt / 1000)} · 更新于{" "}

--- a/web/src/routes/settings-moa-panel.tsx
+++ b/web/src/routes/settings-moa-panel.tsx
@@ -69,6 +69,7 @@ function SlotEditor({
       <div className={s.providerFormGrid}>
         <Field label="服务商" className={s.fieldRow}>
           <Select
+            aria-label="服务商"
             value={slot.provider}
             onChange={(event) => onChange({ provider: event.target.value, model: "" })}
           >
@@ -79,15 +80,16 @@ function SlotEditor({
             ))}
           </Select>
         </Field>
-        <label className={s.fieldRow}>
+        <div className={s.fieldRow}>
           <div className={s.fieldLabel}>模型</div>
           <ModelCombobox
+            label="模型"
             value={slot.model}
             onChange={(next) => onChange({ model: next })}
             options={current?.models ?? []}
             placeholder="搜索或输入模型 ID"
           />
-        </label>
+        </div>
       </div>
     </div>
   );

--- a/web/src/routes/settings-models-section.tsx
+++ b/web/src/routes/settings-models-section.tsx
@@ -1762,6 +1762,7 @@ export function ModelsSection() {
                     <div className={s.providerFormGrid}>
                       <Field label={selectedProvider.apiKeyLabel} className={s.fieldRow}>
                         <Input
+                          aria-label={selectedProvider.apiKeyLabel}
                           mono
                           type="password"
                           value={providerForm.apiKey}
@@ -1777,6 +1778,7 @@ export function ModelsSection() {
                       </Field>
                       <Field label="Base URL" className={s.fieldRow}>
                         <Input
+                          aria-label="Base URL"
                           mono
                           value={providerForm.baseUrl}
                           onChange={(event) => setProviderForm((prev) => ({ ...prev, baseUrl: event.target.value }))}
@@ -1787,10 +1789,11 @@ export function ModelsSection() {
                           请求将发送到 <code>{selectedProviderEndpointPreview}</code>
                         </div>
                       )}
-                      <label className={s.fieldRow}>
+                      <div className={s.fieldRow}>
                         <div className={s.fieldLabel}>模型</div>
                         <div className={s.modelPickerRow}>
                           <ModelCombobox
+                            label="模型"
                             value={providerForm.model}
                             onChange={(next) => setProviderForm((prev) => ({ ...prev, model: next }))}
                             options={mergedModelOptions}
@@ -1807,7 +1810,7 @@ export function ModelsSection() {
                             </Button>
                           ) : null}
                         </div>
-                      </label>
+                      </div>
                       {!supportsModelListing && (
                         <div className={s.modelPickerHint}>此服务商不提供 /models 端点，使用预设模型或手动输入即可</div>
                       )}
@@ -1816,6 +1819,7 @@ export function ModelsSection() {
                       )}
                       <Field label="上下文窗口" className={s.fieldRow}>
                         <Input
+                          aria-label="上下文窗口"
                           mono
                           inputMode="numeric"
                           placeholder={
@@ -2055,6 +2059,7 @@ export function ModelsSection() {
               )}
               <Field label="名称" className={s.fieldRow}>
                 <Input
+                  aria-label="名称"
                   value={customForm.name}
                   placeholder={customProviderPlaceholders.name}
                   autoFocus
@@ -2087,6 +2092,7 @@ export function ModelsSection() {
               )}
               <Field label="Base URL" className={s.fieldRow}>
                 <Input
+                  aria-label="Base URL"
                   mono
                   value={customForm.baseUrl}
                   placeholder={customProviderPlaceholders.baseUrl}
@@ -2119,6 +2125,7 @@ export function ModelsSection() {
               )}
               <Field label="API Key" className={s.fieldRow}>
                 <Input
+                  aria-label="API Key"
                   mono
                   type="password"
                   value={customForm.apiKey}
@@ -2129,10 +2136,11 @@ export function ModelsSection() {
               <div className={s.modelPickerHint}>
                 部分模型服务商需要先填写有效的 API Key，才能获取模型列表。
               </div>
-              <label className={s.fieldRow}>
+              <div className={s.fieldRow}>
                 <div className={s.fieldLabel}>默认模型</div>
                 <div className={s.modelPickerRow}>
                   <ModelCombobox
+                    label="默认模型"
                     value={customForm.model}
                     options={customModelOptions}
                     placeholder={customProviderPlaceholders.model}
@@ -2149,7 +2157,7 @@ export function ModelsSection() {
                     {customRefreshLabel}
                   </Button>
                 </div>
-              </label>
+              </div>
               {customRefreshErrorText && (
                 <div className={s.modelPickerError}>{customRefreshErrorText}</div>
               )}
@@ -2160,6 +2168,7 @@ export function ModelsSection() {
                 <>
                   <Field label="上下文窗口" className={s.fieldRow}>
                     <Input
+                      aria-label="上下文窗口"
                       mono
                       inputMode="numeric"
                       value={customForm.contextWindow}
@@ -2444,6 +2453,7 @@ function AuxiliaryModelsPanel({
           <div className={s.providerFormGrid}>
             <Field label="服务商" className={s.fieldRow}>
               <Select
+                aria-label="服务商"
                 value={form.provider}
                 onChange={(event) => updateForm({
                   provider: event.target.value,
@@ -2462,19 +2472,21 @@ function AuxiliaryModelsPanel({
               </div>
             </Field>
 
-            <label className={s.fieldRow}>
+            <div className={s.fieldRow}>
               <div className={s.fieldLabel}>模型</div>
               <ModelCombobox
+                label="模型"
                 value={form.model}
                 onChange={(next) => updateForm({ model: next })}
                 options={modelOptions}
                 placeholder={isAutoProvider ? "自动模式下不需要填写模型" : "搜索或输入辅助模型 ID"}
                 disabled={isAutoProvider}
               />
-            </label>
+            </div>
 
             <Field label="调用超时（秒）" className={s.fieldRow}>
               <Input
+                aria-label="调用超时（秒）"
                 mono
                 value={form.timeout}
                 inputMode="numeric"
@@ -2506,6 +2518,7 @@ function AuxiliaryModelsPanel({
             <div className={s.auxAdvancedGrid}>
               <Field label="Base URL" className={s.fieldRow}>
                 <Input
+                  aria-label="Base URL"
                   mono
                   value={form.baseUrl}
                   placeholder="可选，自定义 OpenAI-compatible endpoint"
@@ -2515,6 +2528,7 @@ function AuxiliaryModelsPanel({
               </Field>
               <Field label="内联 API Key" className={s.fieldRow}>
                 <Input
+                  aria-label="内联 API Key"
                   mono
                   type="password"
                   value={form.apiKey}
@@ -2526,6 +2540,7 @@ function AuxiliaryModelsPanel({
               {selectedTask === "vision" && (
                 <Field label="图片下载超时（秒）" className={s.fieldRow}>
                   <Input
+                    aria-label="图片下载超时（秒）"
                     mono
                     value={form.downloadTimeout}
                     inputMode="numeric"

--- a/web/src/routes/skills.module.css
+++ b/web/src/routes/skills.module.css
@@ -812,6 +812,68 @@
   justify-content: center;
 }
 
+.emptyStateMessage {
+  margin-top: 12px;
+  max-width: 560px;
+  color: var(--h-text-muted);
+  font-size: 12px;
+  line-height: 20px;
+}
+
+.copyDialog {
+  width: min(520px, calc(100vw - 32px));
+}
+
+.copyDialogHeader {
+  padding: 20px 24px 16px;
+  border-bottom: 1px solid var(--h-line);
+}
+
+.copyDialogTitle {
+  color: var(--h-text);
+  font-size: 18px;
+  font-weight: 600;
+  line-height: 24px;
+}
+
+.copyDialogDescription {
+  margin-top: 8px;
+  color: var(--h-text-muted);
+  font-size: 13px;
+  line-height: 20px;
+}
+
+.copyDialogBody {
+  display: grid;
+  gap: 16px;
+  padding: 20px 24px;
+}
+
+.copyField {
+  display: grid;
+  gap: 8px;
+  color: var(--h-text);
+  font-size: 12px;
+  font-weight: 600;
+}
+
+.copyDialogError {
+  padding: 8px 12px;
+  border: 1px solid color-mix(in srgb, var(--h-err) 40%, var(--h-line));
+  background: color-mix(in srgb, var(--h-err) 8%, transparent);
+  color: var(--h-err);
+  font-size: 12px;
+  line-height: 20px;
+}
+
+.copyDialogActions {
+  display: flex;
+  justify-content: flex-end;
+  gap: 8px;
+  padding: 16px 24px 20px;
+  border-top: 1px solid var(--h-line);
+}
+
 /* loading / error 占位 */
 .statePane {
   width: 100%;

--- a/web/src/routes/skills.test.tsx
+++ b/web/src/routes/skills.test.tsx
@@ -12,6 +12,13 @@ vi.mock("@/hooks/use-skills", () => ({
     refetch: vi.fn(),
   }),
   useToggleSkill: () => ({ mutate: vi.fn(), isPending: false }),
+  useCopyBuiltinSkill: () => ({
+    error: null,
+    isError: false,
+    isPending: false,
+    mutateAsync: vi.fn(),
+    reset: vi.fn(),
+  }),
   useSkillMarkdown: () => ({ data: null, isLoading: false }),
 }));
 
@@ -22,7 +29,12 @@ vi.mock("@/hooks/use-profiles", () => ({
   useSetManagementProfile: () => vi.fn(),
 }));
 
-import { SkillsRoute } from "./skills";
+import {
+  childPath,
+  resolveSkillsManagementScope,
+  SkillsRoute,
+  suggestedSkillCopyName,
+} from "./skills";
 
 describe("SkillsRoute tabs", () => {
   it("places statistics between Skill market and My Skills", () => {
@@ -39,5 +51,33 @@ describe("SkillsRoute tabs", () => {
     expect(html).toContain('role="tablist" aria-label="技能页面"');
     expect(html.match(/role="tab"/g)).toHaveLength(4);
     expect(html.match(/aria-selected="true"/g)).toHaveLength(1);
+  });
+});
+
+describe("My Skills actions", () => {
+  it("resolves the selected profile's real skills directory", () => {
+    expect(childPath("C:\\Users\\mason\\.hermes\\profiles\\reviewer\\", "skills"))
+      .toBe("C:\\Users\\mason\\.hermes\\profiles\\reviewer\\skills");
+    expect(childPath("/home/mason/.hermes/", "skills"))
+      .toBe("/home/mason/.hermes/skills");
+  });
+
+  it("suggests a valid unique copy name within the Core limit", () => {
+    expect(suggestedSkillCopyName("github-auth", ["github-auth-custom"]))
+      .toBe("github-auth-custom-2");
+    expect(suggestedSkillCopyName("a".repeat(64), []))
+      .toMatch(/^[a-z0-9][a-z0-9._-]{0,63}$/);
+  });
+});
+
+describe("Skills management scope", () => {
+  it("falls back after the managed Profile disappears from a loaded list", () => {
+    expect(resolveSkillsManagementScope("deleted", "default", ["default"], true)).toBeNull();
+  });
+
+  it("keeps a valid scope and does not reject it while Profiles are loading", () => {
+    expect(resolveSkillsManagementScope("reviewer", "default", ["default", "reviewer"], true))
+      .toBe("reviewer");
+    expect(resolveSkillsManagementScope("reviewer", "default", [], false)).toBe("reviewer");
   });
 });

--- a/web/src/routes/skills.tsx
+++ b/web/src/routes/skills.tsx
@@ -15,8 +15,21 @@ import {
   User,
 } from "lucide-react";
 import type { SkillInfo } from "@hermes/protocol";
-import { LoadingState, PageTabs, type PageTabItem } from "@hermes/shared-ui";
-import { useSkillMarkdown, useSkills, useToggleSkill } from "@/hooks/use-skills";
+import {
+  Button,
+  Dialog,
+  Input as UiInput,
+  LoadingState,
+  PageTabs,
+  Select as UiSelect,
+  type PageTabItem,
+} from "@hermes/shared-ui";
+import {
+  useCopyBuiltinSkill,
+  useSkillMarkdown,
+  useSkills,
+  useToggleSkill,
+} from "@/hooks/use-skills";
 import {
   useActiveProfileName,
   useManagementProfile,
@@ -104,6 +117,36 @@ function markdownWithoutFrontmatter(content: string): string {
   return normalized.slice(match[0].length).replace(/^\s+/, "");
 }
 
+export function childPath(parent: string | undefined, child: string): string | null {
+  const normalized = parent?.trim().replace(/[\\/]+$/, "");
+  if (!normalized) return null;
+  const separator = normalized.includes("\\") ? "\\" : "/";
+  return `${normalized}${separator}${child}`;
+}
+
+export function suggestedSkillCopyName(source: string, existing: readonly string[]): string {
+  const occupied = new Set(existing);
+  const base = `${source}-custom`.slice(0, 64).replace(/[._-]+$/, "") || "custom-skill";
+  if (!occupied.has(base)) return base;
+  for (let suffix = 2; suffix < 10_000; suffix += 1) {
+    const marker = `-${suffix}`;
+    const candidate = `${base.slice(0, 64 - marker.length).replace(/[._-]+$/, "")}${marker}`;
+    if (!occupied.has(candidate)) return candidate;
+  }
+  return "custom-skill";
+}
+
+export function resolveSkillsManagementScope(
+  managementProfile: string | null,
+  activeProfile: string,
+  profileNames: readonly string[],
+  profilesLoaded: boolean,
+): string | null {
+  if (!managementProfile || managementProfile === activeProfile) return null;
+  if (profilesLoaded && !profileNames.includes(managementProfile)) return null;
+  return managementProfile;
+}
+
 export function SkillsRoute() {
   const [searchParams, setSearchParams] = useSearchParams();
   // 管理范围：/skills?profile=X 深链或档案页「管理技能」会设它。scope ≠ 活跃档案时，
@@ -111,20 +154,34 @@ export function SkillsRoute() {
   const active = useActiveProfileName();
   const mgmt = useManagementProfile();
   const setMgmt = useSetManagementProfile();
-  const scope = mgmt && mgmt !== active ? mgmt : null;
   const profilesQuery = useProfiles();
-  const profileNames = (profilesQuery.data ?? []).map((p) => p.name);
+  const profileNames = useMemo(
+    () => (profilesQuery.data ?? []).map((profile) => profile.name),
+    [profilesQuery.data],
+  );
+  const scope = resolveSkillsManagementScope(
+    mgmt,
+    active,
+    profileNames,
+    profilesQuery.isSuccess,
+  );
   const urlProfile = searchParams.get("profile");
   useEffect(() => {
     if (urlProfile) setMgmt(urlProfile);
   }, [urlProfile, setMgmt]);
+
+  useEffect(() => {
+    if (mgmt && profilesQuery.isSuccess && !profileNames.includes(mgmt)) {
+      setMgmt(null);
+    }
+  }, [mgmt, profileNames, profilesQuery.isSuccess, setMgmt]);
 
   // Sync management scope TO the URL whenever it changes, so the scope
   // survives page refresh (Bug #4 fix — URL-Driven Scope).
   // Handles both onSelect changes and external clearing (active-profile switch).
   useEffect(() => {
     setSearchParams((prev) => {
-      const current = mgmt && mgmt !== active ? mgmt : null;
+      const current = scope;
       const inUrl = prev.get("profile");
       if (current && current !== inUrl) {
         prev.set("profile", current);
@@ -135,15 +192,21 @@ export function SkillsRoute() {
       }
       return prev;
     }, { replace: true });
-  }, [mgmt, active, setSearchParams]);
+  }, [scope, setSearchParams]);
 
   const { data: skills, isLoading, isFetching, isError, error, refetch } = useSkills(scope);
   const toggleSkill = useToggleSkill(scope);
+  const copyBuiltinSkill = useCopyBuiltinSkill(scope);
   const [tab, setTab] = useState<Tab>("builtin");
   const [filter, setFilter] = useState<Filter>("all");
   const [search, setSearch] = useState("");
   const [selectedName, setSelectedName] = useState<string | null>(null);
   const [lang, setLang] = useState<Lang>("zh");
+  const [copyDialogOpen, setCopyDialogOpen] = useState(false);
+  const [copySourceName, setCopySourceName] = useState("");
+  const [copyName, setCopyName] = useState("");
+  const [copyValidationError, setCopyValidationError] = useState("");
+  const [userActionMessage, setUserActionMessage] = useState("");
   const selectedFromQuery = searchParams.get("skill");
 
   const { builtin, user } = useMemo(() => {
@@ -156,6 +219,79 @@ export function SkillsRoute() {
 
   const currentList = tab === "builtin" ? builtin : tab === "user" ? user : [];
   const enabledCount = (skills ?? []).filter((sk) => sk.enabled).length;
+  const managedProfileName = scope || active;
+  const managedProfilePath = profilesQuery.data?.find(
+    (profile) => profile.name === managedProfileName,
+  )?.path;
+  const userSkillsPath = childPath(managedProfilePath, "skills");
+
+  const selectCopySource = (sourceName: string) => {
+    setCopySourceName(sourceName);
+    setCopyName(suggestedSkillCopyName(sourceName, (skills ?? []).map((skill) => skill.name)));
+    setCopyValidationError("");
+    copyBuiltinSkill.reset();
+  };
+
+  const openCopyDialog = () => {
+    const first = builtin[0];
+    if (!first) return;
+    selectCopySource(first.name);
+    setCopyDialogOpen(true);
+  };
+
+  const openUserSkillsDirectory = async () => {
+    setUserActionMessage("");
+    if (!userSkillsPath) {
+      setUserActionMessage("尚未读取到当前档案目录，请刷新后重试。");
+      return;
+    }
+    if (!window.hermesDesktop?.openWorkspacePath) {
+      setUserActionMessage("当前环境不支持打开本机目录。");
+      return;
+    }
+    try {
+      const result = await window.hermesDesktop.openWorkspacePath({ path: userSkillsPath });
+      if (!result.ok) {
+        setUserActionMessage(result.body || result.statusText || "打开 Skills 目录失败。");
+      }
+    } catch (error) {
+      setUserActionMessage(error instanceof Error ? error.message : "打开 Skills 目录失败。");
+    }
+  };
+
+  const submitSkillCopy = async () => {
+    const name = copyName.trim();
+    if (!/^[a-z0-9][a-z0-9._-]{0,63}$/.test(name)) {
+      setCopyValidationError("名称需为 1–64 位小写字母、数字、点、下划线或连字符，并以字母或数字开头。");
+      return;
+    }
+    if ((skills ?? []).some((skill) => skill.name === name)) {
+      setCopyValidationError("这个 Skill 名称已存在，请换一个名称。");
+      return;
+    }
+    const source = builtin.find((skill) => skill.name === copySourceName);
+    if (!source) {
+      setCopyValidationError("请选择一个可复制的内置 Skill。");
+      return;
+    }
+    setCopyValidationError("");
+    try {
+      await copyBuiltinSkill.mutateAsync({
+        sourceName: source.name,
+        name,
+        category: source.category,
+      });
+      await refetch();
+      setSelectedName(name);
+      setFilter("all");
+      setSearch("");
+      setTab("user");
+      setCopyDialogOpen(false);
+      setUserActionMessage(`已创建 ${name}，现在可以在文件系统中继续编辑。`);
+    } catch {
+      // Mutation state renders the backend's validated error below.
+    }
+  };
 
   useEffect(() => {
     if (!selectedFromQuery || !skills?.length) return;
@@ -287,7 +423,13 @@ export function SkillsRoute() {
           技能加载失败：{error instanceof Error ? error.message : "unknown error"}
         </div>
       ) : tab === "user" && user.length === 0 ? (
-        <UserEmptyState />
+        <UserEmptyState
+          canCopy={builtin.length > 0}
+          canOpen={Boolean(userSkillsPath && window.hermesDesktop?.openWorkspacePath)}
+          message={userActionMessage}
+          onCopy={openCopyDialog}
+          onOpen={() => void openUserSkillsDirectory()}
+        />
       ) : (
         <div className={s.split}>
           <aside className={s.listSide}>
@@ -380,6 +522,80 @@ export function SkillsRoute() {
           )}
         </div>
       )}
+
+      <Dialog.Root
+        open={copyDialogOpen}
+        onOpenChange={(open) => {
+          setCopyDialogOpen(open);
+          if (!open) {
+            setCopyValidationError("");
+            copyBuiltinSkill.reset();
+          }
+        }}
+      >
+        <Dialog.Portal>
+          <Dialog.Overlay />
+          <Dialog.Content className={s.copyDialog} aria-describedby="copy-skill-description">
+            <div className={s.copyDialogHeader}>
+              <Dialog.Title className={s.copyDialogTitle}>基于内置 Skill 复制</Dialog.Title>
+              <Dialog.Description id="copy-skill-description" className={s.copyDialogDescription}>
+                选择模板并为你的副本指定唯一 ID。副本写入当前管理档案，可以安全修改。
+              </Dialog.Description>
+            </div>
+            <div className={s.copyDialogBody}>
+              <label className={s.copyField} htmlFor="copy-skill-source">
+                <span>内置 Skill</span>
+                <UiSelect
+                  id="copy-skill-source"
+                  value={copySourceName}
+                  onChange={(event) => selectCopySource(event.target.value)}
+                >
+                  {builtin.map((skill) => (
+                    <option key={skill.name} value={skill.name}>
+                      {translateSkill(skill.name, skill.description).displayName} · {skill.name}
+                    </option>
+                  ))}
+                </UiSelect>
+              </label>
+              <label className={s.copyField} htmlFor="copy-skill-name">
+                <span>副本 ID</span>
+                <UiInput
+                  id="copy-skill-name"
+                  value={copyName}
+                  onChange={(event) => {
+                    setCopyName(event.target.value);
+                    setCopyValidationError("");
+                    copyBuiltinSkill.reset();
+                  }}
+                  autoComplete="off"
+                  spellCheck={false}
+                  mono
+                />
+              </label>
+              {(copyValidationError || copyBuiltinSkill.isError) && (
+                <div className={s.copyDialogError} role="alert">
+                  {copyValidationError || (copyBuiltinSkill.error instanceof Error
+                    ? copyBuiltinSkill.error.message
+                    : "复制 Skill 失败。")}
+                </div>
+              )}
+            </div>
+            <div className={s.copyDialogActions}>
+              <Dialog.Close asChild>
+                <Button variant="ghost">取消</Button>
+              </Dialog.Close>
+              <Button
+                variant="solid"
+                tone="accent"
+                loading={copyBuiltinSkill.isPending}
+                onClick={() => void submitSkillCopy()}
+              >
+                创建副本
+              </Button>
+            </div>
+          </Dialog.Content>
+        </Dialog.Portal>
+      </Dialog.Root>
     </main>
   );
 }
@@ -663,7 +879,19 @@ function SkillDetail({
 
 /* ── 「我的 Skills」空状态 ─────────────────────────────────── */
 
-function UserEmptyState() {
+function UserEmptyState({
+  canCopy,
+  canOpen,
+  message,
+  onCopy,
+  onOpen,
+}: {
+  canCopy: boolean;
+  canOpen: boolean;
+  message: string;
+  onCopy: () => void;
+  onOpen: () => void;
+}) {
   return (
     <div className={s.emptyState}>
       <div className={s.emptyStateIcon}>
@@ -675,18 +903,19 @@ function UserEmptyState() {
         放到 <code>~/.hermes/skills/&lt;分类&gt;/&lt;名称&gt;/</code> 目录下，
         刷新就会出现在这里。
         <br />
-        在线编辑器规划中——目前请通过文件系统手动管理。
+        复制模板后，可通过文件系统继续编辑。
       </p>
       <div className={s.emptyStateActions}>
-        <button type="button" className={s.btn}>
+        <button type="button" className={s.btn} onClick={onOpen} disabled={!canOpen}>
           <Folder size={12} />
           打开 ~/.hermes/skills/
         </button>
-        <button type="button" className={s.btnPrimary}>
+        <button type="button" className={s.btnPrimary} onClick={onCopy} disabled={!canCopy}>
           <Plus size={12} />
           基于内置 Skill 复制
         </button>
       </div>
+      {message && <div className={s.emptyStateMessage} role="status">{message}</div>}
     </div>
   );
 }

--- a/web/src/routes/wander-memory/status.test.ts
+++ b/web/src/routes/wander-memory/status.test.ts
@@ -1,0 +1,43 @@
+import { describe, expect, it } from "vitest";
+import { ApiError } from "@/lib/wander-memory";
+import {
+  serverStatusPresentation,
+  wanderStatusErrorText,
+} from "./status";
+
+describe("Wander Memory server status presentation", () => {
+  it("distinguishes client mode from actual server connectivity", () => {
+    expect(serverStatusPresentation({
+      mode: "live",
+      loading: true,
+      hasData: false,
+      hasError: false,
+    })).toEqual({ label: "checking", tone: "neutral" });
+    expect(serverStatusPresentation({
+      mode: "live",
+      loading: false,
+      hasData: false,
+      hasError: true,
+    })).toEqual({ label: "offline", tone: "danger" });
+    expect(serverStatusPresentation({
+      mode: "live",
+      loading: false,
+      hasData: true,
+      hasError: false,
+    })).toEqual({ label: "live", tone: "success" });
+    expect(serverStatusPresentation({
+      mode: "demo",
+      loading: false,
+      hasData: true,
+      hasError: false,
+    })).toEqual({ label: "demo", tone: "warning" });
+  });
+
+  it("turns network failures into actionable offline copy", () => {
+    expect(wanderStatusErrorText(new ApiError(
+      "network_failure",
+      "no response from server",
+      null,
+    ))).toBe("offline — start MemOS or update endpoint settings below");
+  });
+});

--- a/web/src/routes/wander-memory/status.tsx
+++ b/web/src/routes/wander-memory/status.tsx
@@ -43,6 +43,36 @@ import {
 import type { ApiError, WanderMemoryEndpoints } from "@/lib/wander-memory";
 import s from "./status.module.css";
 
+interface ServerStatusPresentationInput {
+  mode: "live" | "demo";
+  loading: boolean;
+  hasData: boolean;
+  hasError: boolean;
+}
+
+export function serverStatusPresentation({
+  mode,
+  loading,
+  hasData,
+  hasError,
+}: ServerStatusPresentationInput): {
+  label: "checking" | "offline" | "live" | "demo";
+  tone: "neutral" | "danger" | "success" | "warning";
+} {
+  if (mode === "demo") return { label: "demo", tone: "warning" };
+  if (hasError) return { label: "offline", tone: "danger" };
+  if (hasData) return { label: "live", tone: "success" };
+  if (loading) return { label: "checking", tone: "neutral" };
+  return { label: "offline", tone: "danger" };
+}
+
+export function wanderStatusErrorText(error: ApiError): string {
+  if (error.code === "network_failure") {
+    return "offline — start MemOS or update endpoint settings below";
+  }
+  return `${error.code}: ${error.message}`;
+}
+
 function StatusPage() {
   const qc = useQueryClient();
   const toast = useWanderMemoryToast();
@@ -79,17 +109,21 @@ function StatusPage() {
   };
 
   const introspectError = health.error ?? models.error ?? backends.error;
+  const introspectLoading = [health, models, backends].some(
+    (query) => query.isLoading && !query.data,
+  );
+  const serverStatus = serverStatusPresentation({
+    mode,
+    loading: introspectLoading,
+    hasData: Boolean(health.data),
+    hasError: Boolean(introspectError),
+  });
 
-  const modeBadge =
-    mode === "live" ? (
-      <Badge tone="success" variant="outline" size="sm">
-        live
-      </Badge>
-    ) : (
-      <Badge tone="warning" variant="outline" size="sm">
-        demo
-      </Badge>
-    );
+  const modeBadge = (
+    <Badge tone={serverStatus.tone} variant="outline" size="sm">
+      {serverStatus.label}
+    </Badge>
+  );
 
   return (
     <div className={s.page}>
@@ -107,7 +141,7 @@ function StatusPage() {
           {health.isLoading && !health.data ? (
             <p className={s.cardMuted}>loading…</p>
           ) : health.error ? (
-            <p className={s.cardError}>{health.error.code}: {health.error.message}</p>
+            <p className={s.cardError}>{wanderStatusErrorText(health.error)}</p>
           ) : health.data ? (
             <dl className={s.defList}>
               <div className={s.defRow}>
@@ -141,7 +175,7 @@ function StatusPage() {
           {models.isLoading && !models.data ? (
             <p className={s.cardMuted}>loading…</p>
           ) : models.error ? (
-            <p className={s.cardError}>{models.error.code}: {models.error.message}</p>
+            <p className={s.cardError}>{wanderStatusErrorText(models.error)}</p>
           ) : models.data ? (
             <>
               <dl className={s.defList}>
@@ -170,7 +204,7 @@ function StatusPage() {
           {backends.isLoading && !backends.data ? (
             <p className={s.cardMuted}>loading…</p>
           ) : backends.error ? (
-            <p className={s.cardError}>{backends.error.code}: {backends.error.message}</p>
+            <p className={s.cardError}>{wanderStatusErrorText(backends.error)}</p>
           ) : backends.data ? (
             backends.data.remote || backends.data.devices.length === 0 ? (
               <p className={s.cardMuted}>remote backend — no llama.cpp devices</p>
@@ -204,7 +238,7 @@ function StatusPage() {
 
       {introspectError ? (
         <Alert tone="danger" size="sm">
-          introspection failed: {introspectError.code}: {introspectError.message}
+          introspection failed: {wanderStatusErrorText(introspectError)}
         </Alert>
       ) : null}
 


### PR DESCRIPTION
本次集成桌面回归修复并准备 0.8.0-rc8 候选。修复内核停止并重启后旧会话无法续聊的问题：界面与重连回调使用同一 Jotai store，恢复后跟随新 gateway ID，并支持旧会话链接及会话切换。覆盖安装和启动后的资源同步都会保留同一内核版本、同一 flavor 下更高修订的有效 Runtime，防止二进制保留却被旧插件或 Dashboard 资源覆盖。

- 包含既有档案名称/切换、模型配置、技能/MCP、Wander 记忆连接、会话/运行状态及本地开发资源修复。
- 保持相同 Runtime 的资源同步、旧版升级、缺失可执行文件后的安装、开发环境 local-source 和显式回滚入口。
- 版本文件同步为 0.8.0-rc8；目标 bundled Runtime 明确为 0.20.0-cn.10。发布工作流支持选择 canary manifest，stager 保留签名原文并使用现有 bundled 文件名；手动构建时按输入标签判定 prerelease，避免 RC 被标记为正式版本。
- 保持 cn.org.hermesagent.desktop、manifest schema 2、EXPECTED_BACKEND_VERSION=0.20.0；RC 不修改 Landing/latest.json。
- 沿用此 PR 原有的任务 worktree Git 工作流说明调整；热更新 #592 和 Portal 不纳入。

验证（2026-09-06）：

- Runtime 安装相关 Rust 测试 5/5 通过，其中新增用例覆盖 8 种当前版本/修订/文件状态，并检查安装后的第二次资源同步。
- cargo clippy --lib -D warnings、cargo fmt、pnpm typecheck、RC8 version:check 通过。
- 会话解析、重连、映射及传输相关单测 43/43 通过，资源准备脚本测试 2/2 通过，pnpm typecheck 通过。
- 全新 Core main 工作区按根 package-lock.json 安装 web/ui-tui workspaces 并完成资源构建，标准 tauri:dev 启动成功，锁文件未改写。
- 新增真实 Core 进程重启 E2E：保持页面不刷新，旧会话续聊、创建新会话、返回旧会话继续发送均通过。
- macOS 原生开发模式验证通过：两轮中文对话、停止内核、重新启动、旧会话第三轮、新会话、切回旧会话第四轮、正常退出。Core PID 8194 → 28662，原会话完整保留 8 条消息，正常退出清理 owned Core。
- canary manifest staging 行为检查通过，签名字段和原始字节不改写。
- cn.10 实际 Mac arm64 候选 ZIP 通过现有 Desktop 解压器测试，内置公钥验签及 1 个 framework / 193 个 Mach-O 签名检查通过。
- 最终提交 77f823e0bea57bb0cea98da8bfc9e8e154a17fba 的 Rust、Web、Web E2E CI 全部通过；Web E2E 共 23 项通过。实际 checkout 的 Core 为 87eabb059ba9fdbbcc2da410b531aa23e44a85af，包含已合并的 Core #166；Wander-Memory 固定为 efea8c6b0ea8c16cf1593082a93905acd7a055e3。

Core #166 已合并，最终本地原生与远端 E2E 均使用上述 Core main。聊天验证使用本地确定性 fake model。旧桌面壳独立升级、RC7/0.7.0 覆盖安装和 Windows 冻结现场尚待真机；测试机 primelab-win 当前离线。代码合并和候选构建不表示上述安装包验收已完成，也不触发 stable Runtime 或官网更新。

